### PR TITLE
Aggregate Literals

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,11 +54,7 @@ lazy val commonSettings = Seq (
         //  otherwise let sbt fetch the appropriate version.
         "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
     }
-  },
-  resolvers ++= Seq (
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases")
-  ),
+  }
 )
 
 lazy val publishSettings = Seq (

--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,11 @@ lazy val commonSettings = Seq (
         //  otherwise let sbt fetch the appropriate version.
         "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
     }
-  }
+  },
+  resolvers ++= Seq (
+    Resolver.sonatypeRepo("snapshots"),
+    Resolver.sonatypeRepo("releases")
+  ),
 )
 
 lazy val publishSettings = Seq (

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -20,8 +20,24 @@ sealed abstract class Aggregate extends Data {
     binding = target
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
-    for (child <- getElements) {
-      child.bind(ChildBinding(this), resolvedDirection)
+    (this, target) match {
+      case (r: Record, BundleLitBinding(BundleLit(lm))) =>
+        val litMap = lm.toMap
+        for ((n: String, d) <- r.elements) {
+          litMap.get(n) match {
+            case Some(litArg) =>
+              d.bind(LitBinding(litArg), resolvedDirection)
+            case None =>
+              d.bind(DontCareBinding(), resolvedDirection)
+          }
+        }
+      case (v: Vec[_], VectorLitBinding(VectorLit(litSeq))) =>
+        for ((child, litArg) <- getElements zip litSeq) {
+          child.bind(LitBinding(litArg), resolvedDirection)
+        }
+      case _ => for (child <- getElements) {
+        child.bind(ChildBinding(this), resolvedDirection)
+      }
     }
 
     // Check that children obey the directionality rules.

--- a/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Aggregate.scala
@@ -21,6 +21,7 @@ sealed abstract class Aggregate extends Data {
 
     val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
     (this, target) match {
+      // Records that have a bundleLitBinding bind all children with lit bindings
       case (r: Record, BundleLitBinding(BundleLit(lm))) =>
         val litMap = lm.toMap
         for ((n: String, d) <- r.elements) {
@@ -31,10 +32,12 @@ sealed abstract class Aggregate extends Data {
               d.bind(DontCareBinding(), resolvedDirection)
           }
         }
+        // Vecs that have a VectorLitBinding bind all elements with lit bindings
       case (v: Vec[_], VectorLitBinding(VectorLit(litSeq))) =>
         for ((child, litArg) <- getElements zip litSeq) {
           child.bind(LitBinding(litArg), resolvedDirection)
         }
+      // Everything else gets a child binding
       case _ => for (child <- getElements) {
         child.bind(ChildBinding(this), resolvedDirection)
       }

--- a/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
@@ -2,7 +2,7 @@ package chisel3.core
 
 import chisel3.internal.ChiselException
 import chisel3.internal.Builder.{forcedModule}
-import chisel3.internal.firrtl.LitArg
+import chisel3.internal.firrtl.{AggregateLitArg, BitsLitArg, LitArg}
 
 object Binding {
   class BindingException(message: String) extends ChiselException(message)
@@ -110,7 +110,16 @@ case class ChildBinding(parent: Data) extends Binding {
 case class DontCareBinding() extends UnconstrainedBinding
 
 sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
+object LitBinding {
+  def unapply(lb: LitBinding): Some[LitArg] = lb match {
+    case ElementLitBinding(litArg) => Some(litArg)
+    case AggregateLitBinding(litArg) => Some(litArg)
+  }
+}
 // Literal binding attached to a element that is not part of a Bundle.
-case class ElementLitBinding(litArg: LitArg) extends LitBinding
+case class ElementLitBinding(litArg: BitsLitArg) extends LitBinding
 // Literal binding attached to the root of a Bundle, containing literal values of its children.
-case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
+case class AggregateLitBinding(litArg: AggregateLitArg) extends LitBinding
+object AggregateLitBinding {
+  def apply(litMap: Map[Data, LitArg]): AggregateLitBinding = AggregateLitBinding(AggregateLitArg(litMap))
+}

--- a/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
@@ -2,7 +2,7 @@ package chisel3.core
 
 import chisel3.internal.ChiselException
 import chisel3.internal.Builder.{forcedModule}
-import chisel3.internal.firrtl.{AggregateLit, BitsLitArg, LitArg}
+import chisel3.internal.firrtl.{BitsLitArg, BundleLit, LitArg, VectorLit}
 
 object Binding {
   class BindingException(message: String) extends ChiselException(message)
@@ -113,13 +113,19 @@ sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
 object LitBinding {
   def unapply(lb: LitBinding): Some[LitArg] = lb match {
     case ElementLitBinding(litArg) => Some(litArg)
-    case AggregateLitBinding(litArg) => Some(litArg)
+    case BundleLitBinding(litArg) => Some(litArg)
+    case VectorLitBinding(litArg) => Some(litArg)
   }
 }
 // Literal binding attached to a element that is not part of a Bundle.
 case class ElementLitBinding(litArg: BitsLitArg) extends LitBinding
 // Literal binding attached to the root of a Bundle, containing literal values of its children.
-case class AggregateLitBinding(litArg: AggregateLit) extends LitBinding
-object AggregateLitBinding {
-  def apply(litMap: Seq[(String, Data, LitArg)]): AggregateLitBinding = AggregateLitBinding(AggregateLit(litMap))
+case class BundleLitBinding(litArg: BundleLit) extends LitBinding
+object BundleLitBinding {
+  def apply(litMap: Seq[(String, LitArg)]): BundleLitBinding = BundleLitBinding(BundleLit(litMap))
+}
+
+case class VectorLitBinding(litArg: VectorLit) extends LitBinding
+object VectorLitBinding {
+  def apply(litSeq: Seq[LitArg]): VectorLitBinding = VectorLitBinding(VectorLit(litSeq))
 }

--- a/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
@@ -2,7 +2,7 @@ package chisel3.core
 
 import chisel3.internal.ChiselException
 import chisel3.internal.Builder.{forcedModule}
-import chisel3.internal.firrtl.{AggregateLitArg, BitsLitArg, LitArg}
+import chisel3.internal.firrtl.{AggregateLit, BitsLitArg, LitArg}
 
 object Binding {
   class BindingException(message: String) extends ChiselException(message)
@@ -119,7 +119,7 @@ object LitBinding {
 // Literal binding attached to a element that is not part of a Bundle.
 case class ElementLitBinding(litArg: BitsLitArg) extends LitBinding
 // Literal binding attached to the root of a Bundle, containing literal values of its children.
-case class AggregateLitBinding(litArg: AggregateLitArg) extends LitBinding
+case class AggregateLitBinding(litArg: AggregateLit) extends LitBinding
 object AggregateLitBinding {
-  def apply(litMap: Map[Data, LitArg]): AggregateLitBinding = AggregateLitBinding(AggregateLitArg(litMap))
+  def apply(litMap: Seq[(String, Data, LitArg)]): AggregateLitBinding = AggregateLitBinding(AggregateLit(litMap))
 }

--- a/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Binding.scala
@@ -111,6 +111,11 @@ case class DontCareBinding() extends UnconstrainedBinding
 
 sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
 object LitBinding {
+  def apply(la: LitArg): LitBinding = la match {
+    case e: BitsLitArg => ElementLitBinding(e)
+    case b: BundleLit => BundleLitBinding(b)
+    case v: VectorLit => VectorLitBinding(v)
+  }
   def unapply(lb: LitBinding): Some[LitArg] = lb match {
     case ElementLitBinding(litArg) => Some(litArg)
     case BundleLitBinding(litArg) => Some(litArg)

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -34,16 +34,6 @@ abstract class Element extends Data {
     }
   }
 
-  private[core] override def topBindingOpt: Option[TopBinding] = super.topBindingOpt match {
-    // Translate Bundle lit bindings to Element lit bindings
-    // case Some(BundleLitBinding(litArg)) => litArg.litMap.collectFirst({ case (_, d, v) if d == this => v }) match {
-    //   case Some(VectorLitBinding(litSeq)) => Nonde
-    //   case Some(litArg: BitsLitArg) => Some(ElementLitBinding(litArg))
-    //   case _ => Some(DontCareBinding())
-    // }
-    case topBindingOpt => topBindingOpt
-  }
-
   private[core] def litArgOption: Option[BitsLitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
     case _ => None

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -36,7 +36,7 @@ abstract class Element extends Data {
 
   private[core] override def topBindingOpt: Option[TopBinding] = super.topBindingOpt match {
     // Translate Bundle lit bindings to Element lit bindings
-    case Some(AggregateLitBinding(litArg)) => litArg.litMap.get(this) match {
+    case Some(AggregateLitBinding(litArg)) => litArg.litMap.collectFirst({ case (_, d, v) if d == this => v }) match {
       case Some(litArg: BitsLitArg) => Some(ElementLitBinding(litArg))
       case _ => Some(DontCareBinding())
     }

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -36,14 +36,14 @@ abstract class Element extends Data {
 
   private[core] override def topBindingOpt: Option[TopBinding] = super.topBindingOpt match {
     // Translate Bundle lit bindings to Element lit bindings
-    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
-      case Some(litArg) => Some(ElementLitBinding(litArg))
+    case Some(AggregateLitBinding(litArg)) => litArg.litMap.get(this) match {
+      case Some(litArg: BitsLitArg) => Some(ElementLitBinding(litArg))
       case _ => Some(DontCareBinding())
     }
     case topBindingOpt => topBindingOpt
   }
 
-  private[core] def litArgOption: Option[LitArg] = topBindingOpt match {
+  private[core] def litArgOption: Option[BitsLitArg] = topBindingOpt match {
     case Some(ElementLitBinding(litArg)) => Some(litArg)
     case _ => None
   }
@@ -53,11 +53,7 @@ abstract class Element extends Data {
 
   // provide bits-specific literal handling functionality here
   override private[chisel3] def ref: Arg = topBindingOpt match {
-    case Some(ElementLitBinding(litArg)) => litArg
-    case Some(BundleLitBinding(litMap)) => litMap.get(this) match {
-      case Some(litArg) => litArg
-      case _ => throwException(s"internal error: DontCare should be caught before getting ref")
-    }
+    case Some(LitBinding(litArg)) => litArg
     case _ => super.ref
   }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Bits.scala
@@ -36,10 +36,11 @@ abstract class Element extends Data {
 
   private[core] override def topBindingOpt: Option[TopBinding] = super.topBindingOpt match {
     // Translate Bundle lit bindings to Element lit bindings
-    case Some(AggregateLitBinding(litArg)) => litArg.litMap.collectFirst({ case (_, d, v) if d == this => v }) match {
-      case Some(litArg: BitsLitArg) => Some(ElementLitBinding(litArg))
-      case _ => Some(DontCareBinding())
-    }
+    // case Some(BundleLitBinding(litArg)) => litArg.litMap.collectFirst({ case (_, d, v) if d == this => v }) match {
+    //   case Some(VectorLitBinding(litSeq)) => Nonde
+    //   case Some(litArg: BitsLitArg) => Some(ElementLitBinding(litArg))
+    //   case _ => Some(DontCareBinding())
+    // }
     case topBindingOpt => topBindingOpt
   }
 

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -410,8 +410,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   @chiselRuntimeDeprecated
   @deprecated("litArg is deprecated, use litOption or litTo*Option", "chisel3.2")
   def litArg(): Option[LitArg] = topBindingOpt match {
-    case Some(ElementLitBinding(litArg)) => Some(litArg)
-    case Some(BundleLitBinding(litMap)) => None  // this API does not support Bundle literals
+    case Some(LitBinding(litArg)) => Some(litArg)
     case _ => None
   }
   @chiselRuntimeDeprecated

--- a/chiselFrontend/src/main/scala/chisel3/core/Data.scala
+++ b/chiselFrontend/src/main/scala/chisel3/core/Data.scala
@@ -410,7 +410,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   @chiselRuntimeDeprecated
   @deprecated("litArg is deprecated, use litOption or litTo*Option", "chisel3.2")
   def litArg(): Option[LitArg] = topBindingOpt match {
-    case Some(LitBinding(litArg)) => Some(litArg)
+    case Some(ElementLitBinding(litArg)) => Some(litArg)
     case _ => None
   }
   @chiselRuntimeDeprecated

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -71,10 +71,6 @@ sealed trait LitArg extends Arg {
   override def fullName(ctx: Component): String = name
 
   protected[internal] def minWidth: Int
-  // if (forcedWidth) {
-  //   require(widthArg.get >= minWidth,
-  //     s"The literal value ${display} was elaborated with a specified width of ${widthArg.get} bits, but at least ${minWidth} bits are required.")
-  // }
 }
 
 sealed trait BitsLitArg extends LitArg {

--- a/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/chiselFrontend/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -88,22 +88,27 @@ sealed trait BitsLitArg extends LitArg {
   }
 }
 
-class AggregateLit(val litMap: Seq[(String, Data, LitArg)]) extends LitArg {
-  def name: String = "{" + (litMap.map({case (n, d, l) => s"$n : ${l.name}" }) mkString ", ") + "}"
+case class VectorLit(val litSeq: Seq[LitArg]) extends LitArg {
+  def name: String = "[" + litSeq.map(_.name).mkString(", ") + "]"
   def bindLitArg[T <: Data](elem: T): T = {
-    elem.bind(AggregateLitBinding(this))
+    elem.bind(VectorLitBinding(this))
     elem.setRef(this)
     elem
   }
-  protected[internal] def minWidth = litMap.map(_._3.minWidth).sum
+  protected[internal] def minWidth = litSeq.map(_.minWidth).sum
   val widthArg = UnknownWidth()
 }
 
-object AggregateLit {
-  def apply(litMap: Seq[(String, Data, LitArg)]): AggregateLit = new AggregateLit(litMap)
-  def unapply(l: AggregateLit): Some[Seq[(String, Data, LitArg)]] = Some(l.litMap)
+case class BundleLit(val litMap: Seq[(String, LitArg)]) extends LitArg {
+  def name: String = "{" + (litMap.map({case (n, l) => s"$n : ${l.name}" }) mkString ", ") + "}"
+  def bindLitArg[T <: Data](elem: T): T = {
+    elem.bind(BundleLitBinding(this))
+    elem.setRef(this)
+    elem
+  }
+  protected[internal] def minWidth = litMap.map(_._2.minWidth).sum
+  val widthArg = UnknownWidth()
 }
-
 
 case class ILit(n: BigInt) extends Arg {
   def name: String = n.toString

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -8,6 +8,7 @@ import chisel3.experimental.{RawModule, RunFirrtlTransform}
 
 import java.io._
 import net.jcazevedo.moultingyaml._
+import scala.collection.JavaConverters._
 
 import internal.firrtl._
 import firrtl._
@@ -192,7 +193,7 @@ object Driver extends BackendCompilationUtilities {
           ce.printStackTrace(new PrintWriter(sw))
           sw.toString
         }
-        stackTrace.lines.foreach(line => println(s"${ErrorLog.errTag} $line"))
+        stackTrace.lines.iterator().asScala.foreach(line => println(s"${ErrorLog.errTag} $line"))
         None
     }
 

--- a/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -56,10 +56,14 @@ private[chisel3] object Converter {
     case ModuleIO(mod, name) =>
       if (mod eq ctx.id) fir.Reference(name, fir.UnknownType)
       else fir.SubField(fir.Reference(mod.getRef.name, fir.UnknownType), name, fir.UnknownType)
-    case a @ AggregateLit(map) =>
-      fir.BundleLiteral(map.map({ case (n, _, v) => convert(v, ctx) match {
+    case BundleLit(map) =>
+      fir.BundleLiteral(map.map({ case (n, v) => convert(v, ctx) match {
         case l: fir.Literal => (n, l)
       }}))
+    case VectorLit(list) =>
+      fir.VectorExpression(list.map { e => convert(e, ctx) match {
+        case l: fir.Literal => l
+      }}, fir.UnknownType)
     case u @ ULit(n, UnknownWidth()) =>
       fir.UIntLiteral(n, fir.IntWidth(u.minWidth))
     case ULit(n, w) =>

--- a/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -56,6 +56,10 @@ private[chisel3] object Converter {
     case ModuleIO(mod, name) =>
       if (mod eq ctx.id) fir.Reference(name, fir.UnknownType)
       else fir.SubField(fir.Reference(mod.getRef.name, fir.UnknownType), name, fir.UnknownType)
+    case a @ AggregateLit(map) =>
+      fir.BundleLiteral(map.map({ case (n, _, v) => convert(v, ctx) match {
+        case l: fir.Literal => (n, l)
+      }}))
     case u @ ULit(n, UnknownWidth()) =>
       fir.UIntLiteral(n, fir.IntWidth(u.minWidth))
     case ULit(n, w) =>

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -20,21 +20,41 @@ class BundleLiteralSpec extends ChiselFlatSpec {
     // Full bundle literal constructor
     def Lit(aVal: UInt, bVal: Bool): MyBundle = {
       val clone = cloneType
-      clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
-        clone.a -> litArgOfBits(aVal),
-        clone.b -> litArgOfBits(bVal)
-      )))
+      clone.selfBind(AggregateLitBinding(clone.elements.map(_ match {
+        case (n, clone.a) => (n, clone.a, litArgOfBits(aVal))
+        case (n, clone.b) => (n, clone.b, litArgOfBits(bVal))
+      }).toSeq))
       clone
     }
     // Partial bundle literal constructor
     def Lit(aVal: UInt): MyBundle = {
       val clone = cloneType
-      clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
-        clone.a -> litArgOfBits(aVal)
-      )))
+      clone.selfBind(AggregateLitBinding(clone.elements.flatMap(_ match {
+        case (n, clone.a) => Some((n, clone.a, litArgOfBits(aVal)))
+        case _ => None
+      }).toSeq))
       clone
     }
   }
+
+  class MyOuterBundle extends Bundle {
+    val c = UInt(8.W)
+    val d = new MyBundle
+
+    // Bundle literal constructor code, which will be auto-generated using macro annotations in
+    // the future.
+    import chisel3.core.AggregateLitBinding
+    import chisel3.internal.firrtl.{AggregateLit, LitArg, ULit, Width}
+    // Full bundle literal constructor
+    def Lit(aVal: UInt, bVal: Bool, cVal: UInt): MyOuterBundle = {
+      val clone = cloneType
+      AggregateLit(clone.elements.map(_ match {
+        case (n, clone.c) => (n, clone.c, litArgOfBits(cVal))
+        case (n, clone.d) => (n, clone.d, (new MyBundle).Lit(aVal, bVal).litArg.get)
+      }).toSeq).bindLitArg(clone)
+    }
+  }
+
 
   "bundle literals" should "work in RTL" in {
     val outsideBundleLit = (new MyBundle).Lit(42.U, true.B)
@@ -69,6 +89,26 @@ class BundleLiteralSpec extends ChiselFlatSpec {
       bundleWire := bundleLit
 
       chisel3.assert(bundleWire.a === 42.U)
+
+      stop()
+    } }
+  }
+
+  "bundles inside of bundles" should "work in RTL" in {
+    assertTesterPasses{ new BasicTester{
+      val bundleLit = (new MyOuterBundle).Lit(42.U, true.B, 22.U)
+      chisel3.assert(bundleLit.c === 22.U)
+      // TODO!!!
+      // chisel3.assert(bundleLit.d.a === 42.U)
+      // chisel3.assert(bundleLit.d.b === true.B)
+
+      val bundleWire = Wire(new MyOuterBundle)
+      bundleWire := bundleLit
+
+      chisel3.assert(bundleWire.c === 22.U)
+      // TODO!!!
+      // chisel3.assert(bundleWire.d.a === 42.U)
+      // chisel3.assert(bundleWire.d.b === true.B)
 
       stop()
     } }

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -15,24 +15,23 @@ class BundleLiteralSpec extends ChiselFlatSpec {
 
     // Bundle literal constructor code, which will be auto-generated using macro annotations in
     // the future.
-    import chisel3.core.AggregateLitBinding
+    import chisel3.core.BundleLitBinding
     import chisel3.internal.firrtl.{LitArg, ULit, Width}
     // Full bundle literal constructor
     def Lit(aVal: UInt, bVal: Bool): MyBundle = {
       val clone = cloneType
-      clone.selfBind(AggregateLitBinding(clone.elements.map(_ match {
-        case (n, clone.a) => (n, clone.a, litArgOfBits(aVal))
-        case (n, clone.b) => (n, clone.b, litArgOfBits(bVal))
-      }).toSeq))
+      clone.selfBind(BundleLitBinding(Seq(
+        ("a", litArgOfBits(aVal)),
+        ("b", litArgOfBits(bVal))
+      )))
       clone
     }
     // Partial bundle literal constructor
     def Lit(aVal: UInt): MyBundle = {
       val clone = cloneType
-      clone.selfBind(AggregateLitBinding(clone.elements.flatMap(_ match {
-        case (n, clone.a) => Some((n, clone.a, litArgOfBits(aVal)))
-        case _ => None
-      }).toSeq))
+      clone.selfBind(BundleLitBinding(Seq(
+        ("a", litArgOfBits(aVal))
+      )))
       clone
     }
   }
@@ -43,15 +42,15 @@ class BundleLiteralSpec extends ChiselFlatSpec {
 
     // Bundle literal constructor code, which will be auto-generated using macro annotations in
     // the future.
-    import chisel3.core.AggregateLitBinding
-    import chisel3.internal.firrtl.{AggregateLit, LitArg, ULit, Width}
+    import chisel3.core.BundleLitBinding
+    import chisel3.internal.firrtl.{BundleLit, LitArg, ULit, Width}
     // Full bundle literal constructor
     def Lit(aVal: UInt, bVal: Bool, cVal: UInt): MyOuterBundle = {
       val clone = cloneType
-      AggregateLit(clone.elements.map(_ match {
-        case (n, clone.c) => (n, clone.c, litArgOfBits(cVal))
-        case (n, clone.d) => (n, clone.d, (new MyBundle).Lit(aVal, bVal).litArg.get)
-      }).toSeq).bindLitArg(clone)
+      BundleLit(Seq(
+        ("c", litArgOfBits(cVal)),
+        ("d", (new MyBundle).Lit(aVal, bVal).litArg.get)
+      )).bindLitArg(clone)
     }
   }
 

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -97,17 +97,15 @@ class BundleLiteralSpec extends ChiselFlatSpec {
     assertTesterPasses{ new BasicTester{
       val bundleLit = (new MyOuterBundle).Lit(42.U, true.B, 22.U)
       chisel3.assert(bundleLit.c === 22.U)
-      // TODO!!!
-      // chisel3.assert(bundleLit.d.a === 42.U)
-      // chisel3.assert(bundleLit.d.b === true.B)
+      chisel3.assert(bundleLit.d.a === 42.U)
+      chisel3.assert(bundleLit.d.b === true.B)
 
       val bundleWire = Wire(new MyOuterBundle)
       bundleWire := bundleLit
 
       chisel3.assert(bundleWire.c === 22.U)
-      // TODO!!!
-      // chisel3.assert(bundleWire.d.a === 42.U)
-      // chisel3.assert(bundleWire.d.b === true.B)
+      chisel3.assert(bundleWire.d.a === 42.U)
+      chisel3.assert(bundleWire.d.b === true.B)
 
       stop()
     } }

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -15,12 +15,12 @@ class BundleLiteralSpec extends ChiselFlatSpec {
 
     // Bundle literal constructor code, which will be auto-generated using macro annotations in
     // the future.
-    import chisel3.core.BundleLitBinding
-    import chisel3.internal.firrtl.{ULit, Width}
+    import chisel3.core.AggregateLitBinding
+    import chisel3.internal.firrtl.{LitArg, ULit, Width}
     // Full bundle literal constructor
     def Lit(aVal: UInt, bVal: Bool): MyBundle = {
       val clone = cloneType
-      clone.selfBind(BundleLitBinding(Map(
+      clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
         clone.a -> litArgOfBits(aVal),
         clone.b -> litArgOfBits(bVal)
       )))
@@ -29,7 +29,7 @@ class BundleLiteralSpec extends ChiselFlatSpec {
     // Partial bundle literal constructor
     def Lit(aVal: UInt): MyBundle = {
       val clone = cloneType
-      clone.selfBind(BundleLitBinding(Map(
+      clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
         clone.a -> litArgOfBits(aVal)
       )))
       clone

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -3,7 +3,8 @@
 package chiselTests
 
 import chisel3._
-import chisel3.core.FixedPoint
+import chisel3.core.{BundleLitBinding, FixedPoint}
+import chisel3.internal.firrtl.BundleLit
 import chisel3.experimental.RawModule
 import chisel3.testers.BasicTester
 import org.scalatest._
@@ -17,21 +18,23 @@ class BundleLiteralSpec extends ChiselFlatSpec {
     // the future.
     import chisel3.core.BundleLitBinding
     import chisel3.internal.firrtl.{LitArg, ULit, Width}
+    def LitArg(aVal: UInt, bVal: Bool): BundleLit = BundleLit(Seq(
+        ("a", litArgOfBits(aVal)),
+        ("b", litArgOfBits(bVal))
+      ))
+    def LitArg(aVal: UInt): BundleLit = BundleLit(Seq(
+        ("a", litArgOfBits(aVal))
+      ))
     // Full bundle literal constructor
     def Lit(aVal: UInt, bVal: Bool): MyBundle = {
       val clone = cloneType
-      clone.selfBind(BundleLitBinding(Seq(
-        ("a", litArgOfBits(aVal)),
-        ("b", litArgOfBits(bVal))
-      )))
+      clone.selfBind(BundleLitBinding(LitArg(aVal, bVal)))
       clone
     }
     // Partial bundle literal constructor
     def Lit(aVal: UInt): MyBundle = {
       val clone = cloneType
-      clone.selfBind(BundleLitBinding(Seq(
-        ("a", litArgOfBits(aVal))
-      )))
+      clone.selfBind(BundleLitBinding(LitArg(aVal)))
       clone
     }
   }
@@ -49,7 +52,7 @@ class BundleLiteralSpec extends ChiselFlatSpec {
       val clone = cloneType
       BundleLit(Seq(
         ("c", litArgOfBits(cVal)),
-        ("d", (new MyBundle).Lit(aVal, bVal).litArg.get)
+        ("d", (new MyBundle).LitArg(aVal, bVal))
       )).bindLitArg(clone)
     }
   }

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -66,10 +66,10 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       import chisel3.internal.firrtl.LitArg
       def Lit(aVal: SInt, bVal: FixedPoint): InsideBundle = {
         val clone = cloneType
-        clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
-          clone.x -> litArgOfBits(aVal),
-          clone.y -> litArgOfBits(bVal)
-        )))
+        clone.selfBind(AggregateLitBinding(clone.elements.map(_ match {
+          case (n, clone.x) => (n, clone.x, litArgOfBits(aVal))
+          case (n, clone.y) => (n, clone.y, litArgOfBits(bVal))
+        }).toSeq))
         clone
       }
     }
@@ -110,10 +110,10 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       import chisel3.internal.firrtl.LitArg
       def Lit(aVal: UInt, bVal: Bool): MyBundle = {
         val clone = cloneType
-        clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
-          clone.a -> litArgOfBits(aVal),
-          clone.b -> litArgOfBits(bVal)
-        )))
+        clone.selfBind(AggregateLitBinding(clone.elements.map(_ match {
+          case (n, clone.a) => (n, clone.a, litArgOfBits(aVal))
+          case (n, clone.b) => (n, clone.b, litArgOfBits(bVal))
+        }).toSeq))
         clone
       }
     }

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -62,10 +62,11 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       val x = SInt(8.W)
       val y = FixedPoint(8.W, 4.BP)
 
-      import chisel3.core.BundleLitBinding
+      import chisel3.core.AggregateLitBinding
+      import chisel3.internal.firrtl.LitArg
       def Lit(aVal: SInt, bVal: FixedPoint): InsideBundle = {
         val clone = cloneType
-        clone.selfBind(BundleLitBinding(Map(
+        clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
           clone.x -> litArgOfBits(aVal),
           clone.y -> litArgOfBits(bVal)
         )))
@@ -105,11 +106,11 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
 
       // Bundle literal constructor code, which will be auto-generated using macro annotations in
       // the future.
-      import chisel3.core.BundleLitBinding
-      import chisel3.internal.firrtl.{ULit, Width}
+      import chisel3.core.AggregateLitBinding
+      import chisel3.internal.firrtl.LitArg
       def Lit(aVal: UInt, bVal: Bool): MyBundle = {
         val clone = cloneType
-        clone.selfBind(BundleLitBinding(Map(
+        clone.selfBind(AggregateLitBinding(Map[Data, LitArg](
           clone.a -> litArgOfBits(aVal),
           clone.b -> litArgOfBits(bVal)
         )))

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -62,14 +62,14 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       val x = SInt(8.W)
       val y = FixedPoint(8.W, 4.BP)
 
-      import chisel3.core.AggregateLitBinding
+      import chisel3.core.BundleLitBinding
       import chisel3.internal.firrtl.LitArg
-      def Lit(aVal: SInt, bVal: FixedPoint): InsideBundle = {
+      def Lit(xVal: SInt, yVal: FixedPoint): InsideBundle = {
         val clone = cloneType
-        clone.selfBind(AggregateLitBinding(clone.elements.map(_ match {
-          case (n, clone.x) => (n, clone.x, litArgOfBits(aVal))
-          case (n, clone.y) => (n, clone.y, litArgOfBits(bVal))
-        }).toSeq))
+        clone.selfBind(BundleLitBinding(Seq(
+          ("x", litArgOfBits(xVal)),
+          ("y", litArgOfBits(yVal))
+        )))
         clone
       }
     }
@@ -106,14 +106,14 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
 
       // Bundle literal constructor code, which will be auto-generated using macro annotations in
       // the future.
-      import chisel3.core.AggregateLitBinding
+      import chisel3.core.BundleLitBinding
       import chisel3.internal.firrtl.LitArg
       def Lit(aVal: UInt, bVal: Bool): MyBundle = {
         val clone = cloneType
-        clone.selfBind(AggregateLitBinding(clone.elements.map(_ match {
-          case (n, clone.a) => (n, clone.a, litArgOfBits(aVal))
-          case (n, clone.b) => (n, clone.b, litArgOfBits(bVal))
-        }).toSeq))
+        clone.selfBind(BundleLitBinding(Seq(
+          ("a", litArgOfBits(aVal)),
+          ("b", litArgOfBits(bVal))
+        )))
         clone
       }
     }

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -43,14 +43,12 @@ class OneHotMuxSpec extends FreeSpec with Matchers with ChiselRunners {
   "UIntToOH with output width greater than 2^(input width)" in {
     assertTesterPasses(new UIntToOHTester)
   }
-  "UIntToOH should not accept width of zero (until zero-width wires are fixed" in {
-    intercept[java.lang.IllegalArgumentException] {
-      assertTesterPasses(new BasicTester {
-        val out = UIntToOH(0.U, 0)
-      })
-    }
+  "UIntToOH should work with a width of zero" in {
+    assertTesterPasses(new BasicTester {
+      val out = UIntToOH(0.U, 0)
+      stop()
+    })
   }
-
 }
 
 class SimpleOneHotTester extends BasicTester {


### PR DESCRIPTION
This (in addition to a FIRRTL PR) is another stab at adding genuine bundle literals. It also broadens the names of things slightly- I think the bindings should probably be on aggregates rather than bundles so Records and Vecs can get in on the party.

The tests are dying in FIRRTL right now, but it seems to be generating FIRRTL that should work. The firrtl it generates should be cleaner, e.g.
```
{ a : { b : UInt<4>("h0") } }.a.b
```
should just be `UInt<4>("h0")`.

The API is a bit clunky and could definitely be polished more, but I wanted to get feedback on this and firrtl stuff before going to far down that road.

**Related issue**: [This FIRRTL PR](https://github.com/freechipsproject/firrtl/pull/929) and #805 

<!-- choose one -->
**Type of change**: feature request

<!-- choose one -->
**Impact**: API modification

<!-- choose one -->
**Development Phase**: implementation
