### PR TITLE
Faster Record using HashMap and List instead of ListMap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,13 +30,14 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   }
 }
 
+lazy val Benchmark = config("bench") extend Test
+
 val defaultVersions = Map("firrtl" -> "1.2-SNAPSHOT")
 
 lazy val commonSettings = Seq (
   organization := "edu.berkeley.cs",
-//  version := "3.2-SNAPSHOT",
-  version := "3.3-SNAPSHOT",
-  git.remoteRepo := "git@github.com:tdb-alcorn/chisel3.git",
+  version := "3.2-SNAPSHOT",
+  git.remoteRepo := "git@github.com:freechipsproject/chisel3.git",
   autoAPIMappings := true,
   scalaVersion := "2.12.6",
   crossScalaVersions := Seq("2.12.6", "2.11.12"),
@@ -97,7 +98,8 @@ lazy val chiselSettings = Seq (
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-    "com.github.scopt" %% "scopt" % "3.7.0"
+    "com.github.scopt" %% "scopt" % "3.7.0",
+    "com.storm-enroute" %% "scalameter" % "0.10" % "bench"
   ),
 
   // Tests from other projects may still run concurrently
@@ -105,6 +107,10 @@ lazy val chiselSettings = Seq (
   // Another option would be to experiment with:
   //  concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
   Test / parallelExecution := !sys.props.contains("minimalResources"),
+
+  testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
+  parallelExecution in Benchmark := false,
+  logBuffered := false,
 
   javacOptions ++= javacOptionsVersion(scalaVersion.value)
 )
@@ -132,6 +138,12 @@ lazy val chisel = (project in file(".")).
   settings(commonSettings: _*).
   settings(chiselSettings: _*).
   settings(publishSettings: _*).
+  configs(
+    Benchmark
+  ).
+  settings(
+    inConfig(Benchmark)(Defaults.testSettings): _*
+  ).
   // Prevent separate JARs from being generated for coreMacros and chiselFrontend.
   dependsOn(coreMacros % "compile-internal;test-internal").
   dependsOn(chiselFrontend % "compile-internal;test-internal").

--- a/build.sbt
+++ b/build.sbt
@@ -34,8 +34,9 @@ val defaultVersions = Map("firrtl" -> "1.2-SNAPSHOT")
 
 lazy val commonSettings = Seq (
   organization := "edu.berkeley.cs",
-  version := "3.2-SNAPSHOT",
-  git.remoteRepo := "git@github.com:freechipsproject/chisel3.git",
+//  version := "3.2-SNAPSHOT",
+  version := "3.3-SNAPSHOT",
+  git.remoteRepo := "git@github.com:tdb-alcorn/chisel3.git",
   autoAPIMappings := true,
   scalaVersion := "2.12.6",
   crossScalaVersions := Seq("2.12.6", "2.11.12"),

--- a/src/main/scala/chisel3/package.scala
+++ b/src/main/scala/chisel3/package.scala
@@ -121,6 +121,7 @@ package object chisel3 {    // scalastyle:ignore package.object.name
   type Bundle = chisel3.core.Bundle
   type IgnoreSeqInBundle = chisel3.core.IgnoreSeqInBundle
   type Record = chisel3.core.Record
+  type FastRecord = chisel3.core.FastRecord
 
   val assert = chisel3.core.assert
 

--- a/src/test/scala/chiselTests/benchmarks/RecordBench.scala
+++ b/src/test/scala/chiselTests/benchmarks/RecordBench.scala
@@ -58,7 +58,9 @@ object RecordBench extends Bench.LocalTime {
     }
     measure method "random access" in {
       using(records) in {
-        r => r.randomElement
+        r => for (i <- 0 until 100) {
+          r.randomElement
+        }
       }
     }
   }
@@ -76,7 +78,9 @@ object RecordBench extends Bench.LocalTime {
     }
     measure method "random access" in {
       using(fastRecords) in {
-        r => r.randomElement
+        r => for (i <- 0 until 100) {
+          r.randomElement
+        }
       }
     }
   }

--- a/src/test/scala/chiselTests/benchmarks/RecordBench.scala
+++ b/src/test/scala/chiselTests/benchmarks/RecordBench.scala
@@ -1,0 +1,84 @@
+package chiselTests.benchmarks
+
+import chisel3._
+import org.scalameter.api._
+
+import scala.collection.immutable.{HashMap, ListMap}
+import scala.util.Random
+
+
+class MyRecord(size: Int) extends Record {
+  def key(i: Int): String = "elt_" + i.toString
+
+  val builder = ListMap.newBuilder[String, Data]
+  for (i <- 0 until size) {
+    builder += key(i) -> 0.U(32.W)
+  }
+  val elements = builder.result
+
+  override def cloneType: MyRecord.this.type = new MyRecord(size).asInstanceOf[this.type]
+
+  def randomElement: Data = elements(key(Random.nextInt(size)))
+}
+
+class MyFastRecord(size: Int) extends FastRecord {
+  def key(i: Int): String = "elt_" + i.toString
+
+  val orderBuilder = List.newBuilder[String]
+  val hashBuilder = HashMap.newBuilder[String, Data]
+  for (i <- 0 until size) {
+    orderBuilder += key(i)
+    hashBuilder += key(i) -> 0.U(32.W)
+  }
+
+  val elementsOrder = orderBuilder.result
+  val elementsHash = hashBuilder.result
+
+  override def cloneType: MyFastRecord.this.type = new MyFastRecord(size).asInstanceOf[this.type]
+
+  def randomElement: Data = elementsHash(key(Random.nextInt(size)))
+}
+
+
+object RecordBench extends Bench.LocalTime {
+  val sizes = Gen.range("size")(100, 2000, 100)
+  val records = for {size <- sizes} yield new MyRecord(size)
+  val fastRecords = for {size <- sizes} yield new MyFastRecord(size)
+
+  performance of "Record" in {
+    measure method "instantiate" in {
+      using(sizes) in {
+        s => new MyRecord(s)
+      }
+    }
+    measure method "getElements" in {
+      using(records) in {
+        r => r.getElements
+      }
+    }
+    measure method "random access" in {
+      using(records) in {
+        r => r.randomElement
+      }
+    }
+  }
+
+  performance of "FastRecord" in {
+    measure method "instantiate" in {
+      using(sizes) in {
+        s => new MyFastRecord(s)
+      }
+    }
+    measure method "getElements" in {
+      using(fastRecords) in {
+        r => r.getElements
+      }
+    }
+    measure method "random access" in {
+      using(fastRecords) in {
+        r => r.randomElement
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

I'm opening this pull request to start a discussion. I found that when working with 1000s of elements, the Record class was bottlenecked on ListMap appends and accesses, which are both O(n), so I decided to rewrite it with HashMap and List in order to separate the concerns of storing/accessing elements and maintaining an ordering.

My question is: does Chisel want this and if so, what is the appropriate place for it? Its interface is exactly the same as Record so I think it could be a drop in replacement, but are there any other considerations that I'm not aware of?

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
