### PR TITLE
Add test for fixed-width addition for FixedPoint.

### DIFF
--- a/src/test/scala/chiselTests/FixedPointSpec.scala
+++ b/src/test/scala/chiselTests/FixedPointSpec.scala
@@ -131,6 +131,23 @@ class FixedPointLitExtractTester extends BasicTester {
   stop()
 }
 
+class FixedPointInferenceTester extends BasicTester {
+  val start = WireInit(1.0.F(10.W, 5.BP))
+
+  val blankWire = Wire(FixedPoint())
+
+  blankWire := start // should be inferred in FIRRTL backend
+
+  val sumGrow = blankWire +& blankWire
+  val sumFixed = blankWire +% blankWire
+
+  assert(sumGrow === 2.F(4.W, 0.BP))
+  assert(start +% start === 2.F(4.W, 0.BP))
+  assert(sumFixed === 2.F(4.W, 0.BP))
+
+  stop()
+}
+
 class FixedPointSpec extends ChiselPropSpec {
   property("should allow set binary point") {
     assertTesterPasses { new SBPTester }
@@ -146,5 +163,8 @@ class FixedPointSpec extends ChiselPropSpec {
   }
   property("Bit extraction on literals should work for all non-negative indices") {
     assertTesterPasses(new FixedPointLitExtractTester)
+  }
+  property("Unspecified widths and BPs should work") {
+    assertTesterPasses(new FixedPointInferenceTester)
   }
 }


### PR DESCRIPTION
This is a failing test! It shouldn't fail, though.

The way that fixed-width addition works relies on having a defined binary point. This is an unfortunate limitation, and should be fixed.

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: bug report

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: test demonstrating bug

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
