### PR TITLE
Add/use findCause Exception Cause Search Utility

### DIFF
--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -49,13 +49,12 @@ class DontTouchSpec extends ChiselFlatSpec {
       verilog should include (signal)
     }
   }
-  "Dont touch" should "only work on bound hardware" in {
-    a [chisel3.BindingException] should be thrownBy {
+  "Dont touch" should "only work on bound hardware" in new Utils {
+    containsCause[BindingException] {
       elaborate(new Module {
-        val io = IO(new Bundle { })
-        dontTouch(new Bundle { val a = UInt(32.W) } )
-      })
-    }
+                  val io = IO(new Bundle { })
+                  dontTouch(new Bundle { val a = UInt(32.W) } )
+                })
+    } should not be (empty)
   }
 }
-

--- a/src/test/scala/chiselTests/ResetSpec.scala
+++ b/src/test/scala/chiselTests/ResetSpec.scala
@@ -85,11 +85,11 @@ class ResetSpec extends ChiselFlatSpec {
     fir should include ("input reset : AsyncReset")
   }
 
-  "Chisel" should "error if sync and async modules are nested" in {
-    a [ChiselException] shouldBe thrownBy {
+  "Chisel" should "error if sync and async modules are nested" in new Utils {
+    containsCause[ChiselException] {
       elaborate(new MultiIOModule with RequireAsyncReset {
         val mod = Module(new MultiIOModule with RequireSyncReset)
       })
-    }
+    } should not be (empty)
   }
 }


### PR DESCRIPTION
This adds a utility, `chiselTest.Util.findCause[A <: Throwable]`, that can be used to look for a polymorphic exception anywhere in the stack trace returning an `Option[A]` if found and `None` if not.

This is intended to get out ahead of some future changes to testing infrastructure to move off of `Driver` and onto `ChiselStage` where exceptions may wind up wrapped in a `StageError`.

Two tests are migrated to use this (as these fail when migrating).

<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: None

<!-- choose one -->
**Type of change**: feature request | other enhancement

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

None.