### PR TITLE
Ensure that Elaborate only runs once

### DIFF
--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -14,9 +14,14 @@ import firrtl.stage.{FirrtlCircuitAnnotation, RunFirrtlTransformAnnotation}
   *   - Extracts all [[firrtl.annotations.Annotation]]s from the [[chisel3.internal.firrtl.Circuit]]
   *   - Generates any needed [[RunFirrtlTransformAnnotation]]s from extracted [[firrtl.annotations.Annotation]]s
   */
-class Convert extends Phase with PreservesAll[Phase] {
+class Convert extends Phase {
 
   override val prerequisites = Seq(Dependency[Elaborate])
+
+  override def invalidates(phase: Phase): Boolean = phase match {
+    case _: Elaborate => true
+    case _ => false
+  }
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselCircuitAnnotation =>


### PR DESCRIPTION
Fixes a bug where Chisel elaboration would run twice. Specifically this PR is fixing two problems:

1. The `Convert` phase deletes the `ChiselCircuitAnnotation` and therefore must invalidate `Elaborate`. While `Emitter` must not invalidate `Elaborate` because it preserves the `ChiselCircuitAnnotation`. Previously this was reversed.
2. This makes `ChiselStage` solve a smaller sub-problem that does not include `Elaborate`. This results in a better ordering that does not cause `Elaborate` to run twice.

Note: there appears to be a performance bug in the `DependencyManager` with a test case available in https://github.com/freechipsproject/firrtl/pull/1538. 

<!-- choose one -->
**Type of change**: bug fix

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

- Fix bug where elaboration runs twice