### PR TITLE
Add SourceInfo to chisel3.util gadgets

### DIFF
--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -4,6 +4,7 @@
   *  while moving to the more standard package naming convention `chisel3` (lowercase c).
   */
 import chisel3._    // required for implicit conversions.
+import chisel3.internal.sourceinfo.SourceInfo
 
 package object Chisel {     // scalastyle:ignore package.object.name number.of.types number.of.methods
   import chisel3.internal.firrtl.Width
@@ -489,8 +490,8 @@ package object Chisel {     // scalastyle:ignore package.object.name number.of.t
   type Queue[T <: Data] = QueueCompatibility[T]
 
   sealed class QueueCompatibility[T <: Data](gen: T, entries: Int, pipe: Boolean = false, flow: Boolean = false)
-                                 (implicit compileOptions: chisel3.CompileOptions)
-      extends chisel3.util.Queue[T](gen, entries, pipe, flow)(compileOptions) {
+                                 (implicit sourceInfo: SourceInfo, compileOptions: chisel3.CompileOptions)
+      extends chisel3.util.Queue[T](gen, entries, pipe, flow)(sourceInfo, compileOptions) {
 
     def this(gen: T, entries: Int, pipe: Boolean, flow: Boolean, override_reset: Option[Bool]) = {
       this(gen, entries, pipe, flow)

--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -44,7 +44,7 @@ object BitPat {
     * @note legal characters are '0', '1', and '?', as well as '_' and white
     * space (which are ignored)
     */
-  def apply(n: String): BitPat = {
+  def apply(n: String)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): BitPat = {
     val (bits, mask, width) = parse(n)
     new BitPat(bits, mask, width)
   }
@@ -72,7 +72,7 @@ object BitPat {
     *
     * @note the UInt must be a literal
     */
-  def apply(x: UInt): BitPat = {
+  def apply(x: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): BitPat = {
     val len = if (x.isWidthKnown) x.getWidth else 0
     apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
   }

--- a/src/main/scala/chisel3/util/Cat.scala
+++ b/src/main/scala/chisel3/util/Cat.scala
@@ -3,6 +3,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.sourceinfo.SourceInfo
 
 /** Concatenates elements of the input, in order, together.
   *
@@ -18,7 +19,8 @@ object Cat {
   /** Concatenates the argument data elements, in argument order, together. The first argument
     * forms the most significant bits, while the last argument forms the least significant bits.
     */
-  def apply[T <: Bits](a: T, r: T*): UInt = apply(a :: r.toList)
+  def apply[T <: Bits](a: T, r: T*)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    apply(a :: r.toList)
 
   /** Concatenates the data elements of the input sequence, in reverse sequence order, together.
     * The first element of the sequence forms the most significant bits, while the last element
@@ -26,5 +28,6 @@ object Cat {
     *
     * Equivalent to r(0) ## r(1) ## ... ## r(n-1).
     */
-  def apply[T <: Bits](r: Seq[T]): UInt = SeqUtils.asUInt(r.reverse)
+  def apply[T <: Bits](r: Seq[T])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    SeqUtils.asUInt(r.reverse)
 }

--- a/src/main/scala/chisel3/util/CircuitMath.scala
+++ b/src/main/scala/chisel3/util/CircuitMath.scala
@@ -6,7 +6,8 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
+import chisel3.internal.naming.chiselName
+import chisel3.internal.sourceinfo.SourceInfo  // can't use chisel3_ version because of compile order
 
 /** Returns the base-2 integer logarithm of an UInt.
   *
@@ -23,7 +24,7 @@ object Log2 {
   /** Returns the base-2 integer logarithm of the least-significant `width` bits of an UInt.
     */
   @chiselName
-  def apply(x: Bits, width: Int): UInt = {
+  def apply(x: Bits, width: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = {
     if (width < 2) {
       0.U
     } else if (width == 2) {
@@ -39,7 +40,7 @@ object Log2 {
     }
   }
 
-  def apply(x: Bits): UInt = apply(x, x.getWidth)
+  def apply(x: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = apply(x, x.getWidth)
 
   private def divideAndConquerThreshold = 4
 }

--- a/src/main/scala/chisel3/util/Counter.scala
+++ b/src/main/scala/chisel3/util/Counter.scala
@@ -3,7 +3,8 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
+import chisel3.internal.naming.chiselName
+import chisel3.internal.sourceinfo.SourceInfo  // can't use chisel3_ version because of compile order
 
 /** Used to generate an inline (logic directly in the containing Module, no internal Module is created)
   * hardware counter.
@@ -24,7 +25,7 @@ import chisel3.internal.naming.chiselName  // can't use chisel3_ version because
   * maximum output value of the counter), need not be a power of two
   */
 @chiselName
-class Counter(val n: Int) {
+class Counter(val n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) {
   require(n >= 0, s"Counter value must be nonnegative, got: $n")
   val value = if (n > 1) RegInit(0.U(log2Ceil(n).W)) else 0.U
 
@@ -51,7 +52,7 @@ object Counter
 {
   /** Instantiate a [[Counter! counter]] with the specified number of counts.
     */
-  def apply(n: Int): Counter = new Counter(n)
+  def apply(n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Counter = new Counter(n)
 
   /** Instantiate a [[Counter! counter]] with the specified number of counts and a gate.
    *
@@ -61,7 +62,7 @@ object Counter
     * maximum and the condition is true).
     */
   @chiselName
-  def apply(cond: Bool, n: Int): (UInt, Bool) = {
+  def apply(cond: Bool, n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): (UInt, Bool) = {
     val c = new Counter(n)
     val wrap = WireInit(false.B)
     when (cond) { wrap := c.inc() }

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -7,8 +7,8 @@ package chisel3.util
 
 import chisel3._
 import chisel3.experimental.{DataMirror, Direction, requireIsChiselType}
-import chisel3.internal.naming._
-import chisel3.internal.sourceinfo.SourceInfo  // can't use chisel3_ version because of compile order
+import chisel3.internal.naming._  // can't use chisel3_ version because of compile order
+import chisel3.internal.sourceinfo.SourceInfo
 
 /** An I/O Bundle containing 'valid' and 'ready' signals that handshake
   * the transfer of data stored in the 'bits' subfield.
@@ -147,23 +147,20 @@ object Irrevocable
   * @param gen The type of data to enqueue
   */
 object EnqIO {
-  def apply[T<:Data](gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): DecoupledIO[T] =
-    Decoupled(gen)
+  def apply[T<:Data](gen: T): DecoupledIO[T] = Decoupled(gen)
 }
 /** Consumer - drives (outputs) ready, inputs valid and bits.
   * @param gen The type of data to dequeue
   */
 object DeqIO {
-  def apply[T<:Data](gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): DecoupledIO[T] =
-    Flipped(Decoupled(gen))
+  def apply[T<:Data](gen: T): DecoupledIO[T] = Flipped(Decoupled(gen))
 }
 
 /** An I/O Bundle for Queues
   * @param gen The type of data to queue
   * @param entries The max number of entries in the queue.
   */
-class QueueIO[T <: Data](private val gen: T, val entries: Int)
-                        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) extends Bundle
+class QueueIO[T <: Data](private val gen: T, val entries: Int) extends Bundle
 { // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
 
   /* These may look inverted, because the names (enq/deq) are from the perspective of the client,

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -7,7 +7,8 @@ package chisel3.util
 
 import chisel3._
 import chisel3.experimental.{DataMirror, Direction, requireIsChiselType}
-import chisel3.internal.naming._  // can't use chisel3_ version because of compile order
+import chisel3.internal.naming._
+import chisel3.internal.sourceinfo.SourceInfo  // can't use chisel3_ version because of compile order
 
 /** An I/O Bundle containing 'valid' and 'ready' signals that handshake
   * the transfer of data stored in the 'bits' subfield.
@@ -37,13 +38,13 @@ object ReadyValidIO {
 
     /** Indicates if IO is both ready and valid
      */
-    def fire(): Bool = target.ready && target.valid
+    def fire()(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = target.ready && target.valid
 
     /** Push dat onto the output bits of this interface to let the consumer know it has happened.
       * @param dat the values to assign to bits.
       * @return    dat.
       */
-    def enq(dat: T): T = {
+    def enq(dat: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
       target.valid := true.B
       target.bits := dat
       dat
@@ -52,7 +53,7 @@ object ReadyValidIO {
     /** Indicate no enqueue occurs. Valid is set to false, and bits are
       * connected to an uninitialized wire.
       */
-    def noenq(): Unit = {
+    def noenq()(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
       target.valid := false.B
       target.bits := DontCare
     }
@@ -61,14 +62,14 @@ object ReadyValidIO {
       * This is typically used when valid has been asserted by the producer side.
       * @return The data bits.
       */
-    def deq(): T = {
+    def deq()(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
       target.ready := true.B
       target.bits
     }
 
     /** Indicate no dequeue occurs. Ready is set to false.
       */
-    def nodeq(): Unit = {
+    def nodeq()(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Unit = {
       target.ready := false.B
     }
   }
@@ -90,14 +91,16 @@ class DecoupledIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen)
 object Decoupled
 {
   /** Wraps some Data with a DecoupledIO interface. */
-  def apply[T <: Data](gen: T): DecoupledIO[T] = new DecoupledIO(gen)
+  def apply[T <: Data](gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): DecoupledIO[T] =
+    new DecoupledIO(gen)
 
   /** Downconverts an IrrevocableIO output to a DecoupledIO, dropping guarantees of irrevocability.
     *
     * @note unsafe (and will error) on the producer (input) side of an IrrevocableIO
     */
   @chiselName
-  def apply[T <: Data](irr: IrrevocableIO[T]): DecoupledIO[T] = {
+  def apply[T <: Data](irr: IrrevocableIO[T])
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): DecoupledIO[T] = {
     require(DataMirror.directionOf(irr.bits) == Direction.Output, "Only safe to cast produced Irrevocable bits to Decoupled.") // scalastyle:ignore line.size.limit
     val d = Wire(new DecoupledIO(irr.bits))
     d.bits := irr.bits
@@ -121,14 +124,16 @@ class IrrevocableIO[+T <: Data](gen: T) extends ReadyValidIO[T](gen)
 /** Factory adds an irrevocable handshaking protocol to a data bundle. */
 object Irrevocable
 {
-  def apply[T <: Data](gen: T): IrrevocableIO[T] = new IrrevocableIO(gen)
+  def apply[T <: Data](gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): IrrevocableIO[T] =
+    new IrrevocableIO(gen)
 
   /** Upconverts a DecoupledIO input to an IrrevocableIO, allowing an IrrevocableIO to be used
     * where a DecoupledIO is expected.
     *
     * @note unsafe (and will error) on the consumer (output) side of an DecoupledIO
     */
-  def apply[T <: Data](dec: DecoupledIO[T]): IrrevocableIO[T] = {
+  def apply[T <: Data](dec: DecoupledIO[T])
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): IrrevocableIO[T] = {
     require(DataMirror.directionOf(dec.bits) == Direction.Input, "Only safe to cast consumed Decoupled bits to Irrevocable.") // scalastyle:ignore line.size.limit
     val i = Wire(new IrrevocableIO(dec.bits))
     dec.bits := i.bits
@@ -142,20 +147,23 @@ object Irrevocable
   * @param gen The type of data to enqueue
   */
 object EnqIO {
-  def apply[T<:Data](gen: T): DecoupledIO[T] = Decoupled(gen)
+  def apply[T<:Data](gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): DecoupledIO[T] =
+    Decoupled(gen)
 }
 /** Consumer - drives (outputs) ready, inputs valid and bits.
   * @param gen The type of data to dequeue
   */
 object DeqIO {
-  def apply[T<:Data](gen: T): DecoupledIO[T] = Flipped(Decoupled(gen))
+  def apply[T<:Data](gen: T)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): DecoupledIO[T] =
+    Flipped(Decoupled(gen))
 }
 
 /** An I/O Bundle for Queues
   * @param gen The type of data to queue
   * @param entries The max number of entries in the queue.
   */
-class QueueIO[T <: Data](private val gen: T, val entries: Int) extends Bundle
+class QueueIO[T <: Data](private val gen: T, val entries: Int)
+                        (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions) extends Bundle
 { // See github.com/freechipsproject/chisel3/issues/765 for why gen is a private val and proposed replacement APIs.
 
   /* These may look inverted, because the names (enq/deq) are from the perspective of the client,
@@ -189,7 +197,7 @@ class Queue[T <: Data](gen: T,
                        val entries: Int,
                        pipe: Boolean = false,
                        flow: Boolean = false)
-                      (implicit compileOptions: chisel3.CompileOptions)
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions)
     extends Module() {
   require(entries > -1, "Queue must have non-negative number of entries")
   require(entries != 0, "Use companion object Queue.apply for zero entries")
@@ -276,7 +284,7 @@ object Queue
       enq: ReadyValidIO[T],
       entries: Int = 2,
       pipe: Boolean = false,
-      flow: Boolean = false): DecoupledIO[T] = {
+      flow: Boolean = false)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): DecoupledIO[T] = {
     if (entries == 0) {
       val deq = Wire(new DecoupledIO(chiselTypeOf(enq.bits)))
       deq.valid := enq.valid
@@ -302,7 +310,7 @@ object Queue
       enq: ReadyValidIO[T],
       entries: Int = 2,
       pipe: Boolean = false,
-      flow: Boolean = false): IrrevocableIO[T] = {    
+      flow: Boolean = false)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): IrrevocableIO[T] = {
     val deq = apply(enq, entries, pipe, flow)
     require(entries > 0, "Zero-entry queues don't guarantee Irrevocability")
     val irr = Wire(new IrrevocableIO(chiselTypeOf(deq.bits)))

--- a/src/main/scala/chisel3/util/Enum.scala
+++ b/src/main/scala/chisel3/util/Enum.scala
@@ -7,6 +7,7 @@ package chisel3.util
 
 import chisel3._
 import chisel3.internal.chiselRuntimeDeprecated
+import chisel3.internal.sourceinfo.SourceInfo
 
 /** Defines a set of unique UInt constants
   *
@@ -28,7 +29,7 @@ import chisel3.internal.chiselRuntimeDeprecated
   */
 trait Enum {
   /** Returns a sequence of Bits subtypes with values from 0 until n. Helper method. */
-  protected def createValues(n: Int): Seq[UInt] =
+  protected def createValues(n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[UInt] =
     (0 until n).map(_.U((1 max log2Ceil(n)).W))
 
   /** Returns n unique UInt values
@@ -36,7 +37,8 @@ trait Enum {
     * @param n Number of unique UInt constants to enumerate
     * @return Enumerated constants
     */
-  def apply(n: Int): List[UInt] = createValues(n).toList
+  def apply(n: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): List[UInt] =
+    createValues(n).toList
 }
 
 object Enum extends Enum

--- a/src/main/scala/chisel3/util/LFSR.scala
+++ b/src/main/scala/chisel3/util/LFSR.scala
@@ -6,7 +6,8 @@
 package chisel3.util
 
 import chisel3._
-import chisel3.internal.naming.chiselName  // can't use chisel3_ version because of compile order
+import chisel3.internal.naming.chiselName
+import chisel3.internal.sourceinfo.SourceInfo
 import chisel3.util.random.FibonacciLFSR
 
 /** LFSR16 generates a 16-bit linear feedback shift register, returning the register contents.
@@ -35,7 +36,7 @@ object LFSR16 {
     */
   @deprecated("Use chisel3.util.random.LFSR(16) for a 16-bit LFSR", "3.2")
   @chiselName
-  def apply(increment: Bool = true.B): UInt =
+  def apply(increment: Bool = true.B)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
     VecInit( FibonacciLFSR
               .maxPeriod(16, increment, seed = Some(BigInt(1) << 15))
               .asBools

--- a/src/main/scala/chisel3/util/Lookup.scala
+++ b/src/main/scala/chisel3/util/Lookup.scala
@@ -3,6 +3,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.sourceinfo.SourceInfo
 
 /** For each element in a list, muxes (looks up) between cases (one per list element) based on a
   * common address.
@@ -27,7 +28,8 @@ import chisel3._
   * }}}
   */
 object ListLookup {
-  def apply[T <: Data](addr: UInt, default: List[T], mapping: Array[(BitPat, List[T])]): List[T] = {
+  def apply[T <: Data](addr: UInt, default: List[T], mapping: Array[(BitPat, List[T])])
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): List[T] = {
     val map = mapping.map(m => (m._1 === addr, m._2))
     default.zipWithIndex map { case (d, i) =>
       map.foldRight(d)((m, n) => Mux(m._1, m._2(i), n))
@@ -48,6 +50,7 @@ object ListLookup {
   *          output value if the BitPat matches
   */
 object Lookup {
-  def apply[T <: Bits](addr: UInt, default: T, mapping: Seq[(BitPat, T)]): T =
+  def apply[T <: Bits](addr: UInt, default: T, mapping: Seq[(BitPat, T)])
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T =
     ListLookup(addr, List(default), mapping.map(m => (m._1, List(m._2))).toArray).head
 }

--- a/src/main/scala/chisel3/util/OneHot.scala
+++ b/src/main/scala/chisel3/util/OneHot.scala
@@ -6,6 +6,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.sourceinfo.SourceInfo
 
 /** Returns the bit position of the sole high bit of the input bitvector.
   *
@@ -18,11 +19,14 @@ import chisel3._
   * @note assumes exactly one high bit, results undefined otherwise
   */
 object OHToUInt {
-  def apply(in: Seq[Bool]): UInt = apply(Cat(in.reverse), in.size)
-  def apply(in: Vec[Bool]): UInt = apply(in.asUInt, in.size)
-  def apply(in: Bits): UInt = apply(in, in.getWidth)
+  def apply(in: Seq[Bool])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    apply(Cat(in.reverse), in.size)
+  def apply(in: Vec[Bool])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    apply(in.asUInt, in.size)
+  def apply(in: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    apply(in, in.getWidth)
 
-  def apply(in: Bits, width: Int): UInt = {
+  def apply(in: Bits, width: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = {
     if (width <= 2) {
       Log2(in, width)
     } else {
@@ -43,8 +47,10 @@ object OHToUInt {
   * Multiple bits may be high in the input.
   */
 object PriorityEncoder {
-  def apply(in: Seq[Bool]): UInt = PriorityMux(in, (0 until in.size).map(_.asUInt))
-  def apply(in: Bits): UInt = apply(in.asBools)
+  def apply(in: Seq[Bool])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    PriorityMux(in, (0 until in.size).map(_.asUInt))
+  def apply(in: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    apply(in.asBools)
 }
 
 /** Returns the one hot encoding of the input UInt.
@@ -55,8 +61,9 @@ object PriorityEncoder {
   *
   */
 object UIntToOH {
-  def apply(in: UInt): UInt = 1.U << in
-  def apply(in: UInt, width: Int): UInt = width match {
+  def apply(in: UInt)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    1.U << in
+  def apply(in: UInt, width: Int)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = width match {
     case 0 => 0.U(0.W)
     case 1 => 1.U(1.W)
     case _ =>
@@ -74,13 +81,14 @@ object UIntToOH {
   * }}}
   */
 object PriorityEncoderOH {
-  private def encode(in: Seq[Bool]): UInt = {
+  private def encode(in: Seq[Bool])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt = {
     val outs = Seq.tabulate(in.size)(i => (BigInt(1) << i).asUInt(in.size.W))
     PriorityMux(in :+ true.B, outs :+ 0.U(in.size.W))
   }
-  def apply(in: Seq[Bool]): Seq[Bool] = {
+  def apply(in: Seq[Bool])(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Seq[Bool] = {
     val enc = encode(in)
     Seq.tabulate(in.size)(enc(_))
   }
-  def apply(in: Bits): UInt = encode((0 until in.getWidth).map(i => in(i)))
+  def apply(in: Bits)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): UInt =
+    encode((0 until in.getWidth).map(i => in(i)))
 }

--- a/src/main/scala/chisel3/util/Reg.scala
+++ b/src/main/scala/chisel3/util/Reg.scala
@@ -3,6 +3,7 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.internal.sourceinfo.SourceInfo
 
 object RegEnable {
   /** Returns a register with the specified next, update enable gate, and no reset initialization.
@@ -11,7 +12,7 @@ object RegEnable {
     * val regWithEnable = RegEnable(nextVal, ena)
     * }}}
     */
-  def apply[T <: Data](next: T, enable: Bool): T = {
+  def apply[T <: Data](next: T, enable: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val r = Reg(chiselTypeOf(next))
     when (enable) { r := next }
     r
@@ -23,7 +24,8 @@ object RegEnable {
     * val regWithEnableAndReset = RegEnable(nextVal, 0.U, ena)
     * }}}
     */
-  def apply[T <: Data](next: T, init: T, enable: Bool): T = {
+  def apply[T <: Data](next: T, init: T, enable: Bool)
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     val r = RegInit(init)
     when (enable) { r := next }
     r
@@ -42,7 +44,8 @@ object ShiftRegister
     * val regDelayTwo = ShiftRegister(nextVal, 2, ena)
     * }}}
     */
-  def apply[T <: Data](in: T, n: Int, en: Bool = true.B): T = {
+  def apply[T <: Data](in: T, n: Int, en: Bool = true.B)
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     // The order of tests reflects the expected use cases.
     if (n != 0) {
       RegEnable(apply(in, n-1, en), en)
@@ -62,7 +65,8 @@ object ShiftRegister
     * val regDelayTwoReset = ShiftRegister(nextVal, 2, 0.U, ena)
     * }}}
     */
-  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool): T = {
+  def apply[T <: Data](in: T, n: Int, resetData: T, en: Bool)
+                      (implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): T = {
     // The order of tests reflects the expected use cases.
     if (n != 0) {
       RegEnable(apply(in, n-1, resetData, en), resetData, en)


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->

<!-- choose one -->
**Type of change**: other enhancement

<!-- choose one -->
**Impact**: no functional change

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->
Adding `SourceInfo` to `chisel3.util` utilities so that the generated Verilog/FIRRTL can be easily traced to user's design.