### PR TITLE
Enhance chiselName for anonymous Modules and Companion Objects

### DIFF
--- a/core/src/main/scala/chisel3/internal/Namer.scala
+++ b/core/src/main/scala/chisel3/internal/Namer.scala
@@ -87,7 +87,7 @@ class NamingContext extends NamingContextInterface {
   }
 
   def name[T](obj: T, name: String): T = {
-    assert(!closed, "Can't name elements after name_prefix called")
+    assert(!closed, "Can't name elements after namePrefix called")
     obj match {
       case _: NoChiselNamePrefix => // Don't name things with NoChiselNamePrefix
       case ref: AnyRef => items += ((ref, name))

--- a/src/test/scala/chiselTests/NamingAnnotationTest.scala
+++ b/src/test/scala/chiselTests/NamingAnnotationTest.scala
@@ -177,9 +177,25 @@ object NonNamedHelper {
   }
 }
 
+object AllNamedHelper {
+  case class Blah(u: UInt)
+  @chiselName
+  def NamedFunction(): Blah = { // scalastyle:ignore method.name
+    val myVal = 1.U + 2.U
+    Blah(myVal)
+  }
+
+}
+
 @chiselName
 class NonNamedFunction extends NamedModuleTester {
   val test = NonNamedHelper.NamedFunction()
+}
+
+@chiselName
+class AllNamedFunction extends NamedModuleTester {
+  val test = AllNamedHelper.NamedFunction()
+  expectName(test.u, "test")
 }
 
 /** Ensure broken links in the chain are simply dropped
@@ -271,5 +287,11 @@ class NamingAnnotationSpec extends ChiselPropSpec {
     var module: NoChiselNamePrefixTester = null
     elaborate { module = new NoChiselNamePrefixTester; module }
     assert(module.getNameFailures().isEmpty)
+  }
+
+  property("All helper functions in annotated object should give names") {
+    var module: AllNamedFunction = null
+    elaborate { module = new AllNamedFunction; module }
+    assert(module.getNameFailures() == Nil)
   }
 }


### PR DESCRIPTION
<!--
Please select the item best describing the pull request in each category and delete the other items.
-->
**Related issue**: <!-- if applicable -->
Related to: https://github.com/freechipsproject/chisel3/issues/646

<!-- choose one -->
**Type of change**: feature requestt

<!-- choose one -->
**Impact**: API addition (no impact on existing code)

<!-- choose one -->
**Development Phase**: implementation

**Release Notes**
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Enables `@chiselName` to work on (1) on companion objects, which basically just applies the annotation to all functions in the object, and (2) on `@chiselName lazy val module = new LazyModuleImpl(this) {...}`
