### PR TITLE
Bool: add implication operator |->

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -1169,6 +1169,16 @@ sealed class Bool() extends UInt(1.W) with Reset {
   /** @group SourceInfoTransformMacro */
   def do_asAsyncReset(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): AsyncReset =
     pushOp(DefPrim(sourceInfo, AsyncReset(), AsAsyncResetOp, ref))
+
+  /** Implication operator
+   *
+   * @param that a boolean signal
+   * @return [[!this || that]]
+   */
+  def |-> (that: Bool): Bool = macro SourceInfoTransform.thatArg
+
+  /** @group SourceInfoTransformMacro */
+  def do_|-> (that: Bool)(implicit sourceInfo: SourceInfo, compileOptions: CompileOptions): Bool = (!this) | that
 }
 
 package experimental {

--- a/src/test/scala/chiselTests/BoolSpec.scala
+++ b/src/test/scala/chiselTests/BoolSpec.scala
@@ -1,0 +1,22 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.testers.BasicTester
+
+
+class BoolSpec extends ChiselFlatSpec with Utils {
+
+  "implication" should "work in RTL" in {
+    assertTesterPasses {
+      new BasicTester {
+        chisel3.assert((false.B |-> false.B) === true.B,  "0 -> 0 = 1")
+        chisel3.assert((false.B |-> true.B)  === true.B,  "0 -> 1 = 1")
+        chisel3.assert((true.B  |-> false.B) === false.B, "1 -> 0 = 0")
+        chisel3.assert((true.B  |-> true.B)  === true.B,  "1 -> 1 = 1")
+        stop()
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Related issue**: https://github.com/freechipsproject/chisel3/pull/1499

**Type of change**: new operator

**Impact**:  API addition (no impact on existing code)

**Development Phase**: implementation

**Release Notes**
- Bool: now supports the implication operator `a |-> b` as a short hand for `!a || b`
