### PR TITLE
Create ChiselEnum1H where elements have one-hot encoding IDs

### DIFF
--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -233,6 +233,9 @@ abstract class EnumType(private val factory: EnumFactory, selfAnnotating: Boolea
   def toPrintable: Printable = FullName(this) // TODO: Find a better pretty printer
 }
 
+trait EnumFactory1H extends EnumFactory{
+  override val oneHot: Boolean = true
+}
 
 abstract class EnumFactory {
   class Type extends EnumType(this)
@@ -242,6 +245,7 @@ abstract class EnumFactory {
 
   private var id: BigInt = 0
   private[chisel3] var width: Width = 0.W
+  val oneHot: Boolean = false
 
   private case class EnumRecord(inst: Type, name: String)
   private val enumRecords = mutable.ArrayBuffer.empty[EnumRecord]
@@ -275,13 +279,13 @@ abstract class EnumFactory {
   protected def do_Value(name: String): Type = {
     val result = new Type
 
+    val resId = if (!oneHot) id else BigInt(1 << id.toInt)
+
     // We have to use UnknownWidth here, because we don't actually know what the final width will be
-    result.bindToLiteral(id, UnknownWidth())
-
-    enumRecords.append(EnumRecord(result, name))
-
-    width = (1 max id.bitLength).W
+    result.bindToLiteral(resId, UnknownWidth())
+    width = (1 max resId.bitLength).W
     id += 1
+    enumRecords.append(EnumRecord(result, name))
 
     result
   }
@@ -343,7 +347,6 @@ abstract class EnumFactory {
     (t, t.isValid)
   }
 }
-
 
 private[chisel3] object EnumMacros {
   def ValImpl(c: Context) : c.Tree = {

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -279,7 +279,7 @@ abstract class EnumFactory {
   protected def do_Value(name: String): Type = {
     val result = new Type
 
-    val resId = if (!oneHot) id else BigInt(1 << id.toInt)
+    val resId = if (!oneHot) id else BigInt(1) << id.toInt
 
     // We have to use UnknownWidth here, because we don't actually know what the final width will be
     result.bindToLiteral(resId, UnknownWidth())

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -234,7 +234,7 @@ abstract class EnumType(private val factory: EnumFactory, selfAnnotating: Boolea
 }
 
 trait EnumFactory1H extends EnumFactory{
-  override val oneHot: Boolean = true
+  final override val oneHot: Boolean = true
 }
 
 abstract class EnumFactory {
@@ -245,7 +245,7 @@ abstract class EnumFactory {
 
   private var id: BigInt = 0
   private[chisel3] var width: Width = 0.W
-  val oneHot: Boolean = false
+  private[chisel3] val oneHot: Boolean = false
 
   private case class EnumRecord(inst: Type, name: String)
   private val enumRecords = mutable.ArrayBuffer.empty[EnumRecord]

--- a/core/src/main/scala/chisel3/StrongEnum.scala
+++ b/core/src/main/scala/chisel3/StrongEnum.scala
@@ -86,6 +86,10 @@ abstract class EnumType(private val factory: EnumFactory, selfAnnotating: Boolea
     }
   }
 
+  def toIndex: Int = {
+    factory.all.indexOf(this)
+  }
+
   override def cloneType: this.type = factory().asInstanceOf[this.type]
 
   private[chisel3] def compop(sourceInfo: SourceInfo, op: PrimOp, other: EnumType): Bool = {

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -24,6 +24,13 @@ package object experimental {
 
   type ChiselEnum = EnumFactory
 
+  /**
+   * ChiselEnum1H extends the ChiselEnum type for creating enums with
+   * one-hot encoding IDs.
+   * This enum type pairs well with [[Mux1H]] for parallel mux processing.
+   */
+  type ChiselEnum1H = EnumFactory1H
+
   // Rocket Chip-style clonemodule
 
   /** A record containing the results of CloneModuleAsRecord

--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -45,8 +45,9 @@ object Mux1H {
   def apply[T <: Data](in: Iterable[(Bool, T)]): T = SeqUtils.oneHotMux(in)
   def apply[T <: Data](sel: UInt, in: Seq[T]): T =
     apply((0 until in.size).map(sel(_)), in)
-  def apply[T <: Data](sel: EnumType, in: Seq[T]): T =
-    apply(sel.litValue.U(sel.getWidth.W), in)
+  def apply[T <: Data](sel: EnumType, in: Seq[T]): T = {
+    apply(sel.asUInt, in)
+  }
   def apply(sel: UInt, in: UInt): Bool = (sel & in).orR
 }
 

--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -6,6 +6,8 @@
 package chisel3.util
 
 import chisel3._
+import chisel3.experimental.ChiselEnum1H
+import chisel3.experimental.EnumType
 
 /** Builds a Mux tree out of the input signal vector using a one hot encoded
   * select signal. Returns the output of the Mux tree.
@@ -24,15 +26,15 @@ import chisel3._
   * object selector extends chisel3.experimental.ChiselEnum1H {
   *   val s0, s1, s2, s3 = Value
   * }
-  * val selectorVal = Wire(UInt(selector.getWidth.W))
-  * selectorVal := selector.s1.asUInt
-  * val hotValue = chisel3.util.Mux1H(selectorVal.asUInt,
+  * val selectorVal = selector.s1
+  * val hotValue = chisel3.util.Mux1H(selectorVal,
       Seq(
   *     2.U,
   *     4.U,
   *     8.U,
   *     16.U,
   *   ))
+  * // hotValue is 4.U
   * }}}
   *
   * @note results unspecified unless exactly one select signal is high
@@ -43,6 +45,8 @@ object Mux1H {
   def apply[T <: Data](in: Iterable[(Bool, T)]): T = SeqUtils.oneHotMux(in)
   def apply[T <: Data](sel: UInt, in: Seq[T]): T =
     apply((0 until in.size).map(sel(_)), in)
+  def apply[T <: Data](sel: EnumType, in: Seq[T]): T =
+    apply(sel.litValue.U(sel.getWidth.W), in)
   def apply(sel: UInt, in: UInt): Bool = (sel & in).orR
 }
 

--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -9,6 +9,7 @@ import chisel3._
 
 /** Builds a Mux tree out of the input signal vector using a one hot encoded
   * select signal. Returns the output of the Mux tree.
+  * Pairs well with [[ChiselEnum1H]] to create a one hot encoded select signal.
   *
   * @example {{{
   * val hotValue = chisel3.util.Mux1H(Seq(
@@ -17,6 +18,21 @@ import chisel3._
   *  io.selector(2) -> 8.U,
   *  io.selector(4) -> 11.U,
   * ))
+  *
+  * // or using ChiselEnum1H
+  *
+  * object selector extends chisel3.experimental.ChiselEnum1H {
+  *   val s0, s1, s2, s3 = Value
+  * }
+  * val selectorVal = Wire(UInt(selector.getWidth.W))
+  * selectorVal := selector.s1.asUInt
+  * val hotValue = chisel3.util.Mux1H(selectorVal.asUInt,
+      Seq(
+  *     2.U,
+  *     4.U,
+  *     8.U,
+  *     11.U,
+  *   ))
   * }}}
   *
   * @note results unspecified unless exactly one select signal is high

--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -16,7 +16,7 @@ import chisel3._
   *  io.selector(0) -> 2.U,
   *  io.selector(1) -> 4.U,
   *  io.selector(2) -> 8.U,
-  *  io.selector(4) -> 11.U,
+  *  io.selector(4) -> 16.U,
   * ))
   *
   * // or using ChiselEnum1H
@@ -31,7 +31,7 @@ import chisel3._
   *     2.U,
   *     4.U,
   *     8.U,
-  *     11.U,
+  *     16.U,
   *   ))
   * }}}
   *
@@ -54,7 +54,7 @@ object Mux1H {
   *  io.selector(0) -> 2.U,
   *  io.selector(1) -> 4.U,
   *  io.selector(2) -> 8.U,
-  *  io.selector(4) -> 11.U,
+  *  io.selector(4) -> 16.U,
   * ))
   * }}}
   * Returns the output of the Mux tree.

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -321,7 +321,7 @@ class OneHotEnumMux1HTester extends BasicTester {
        2.U,
        4.U,
        8.U,
-       11.U,
+       16.U,
      ))
     assert(hotValue === 4.U)
 

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -314,9 +314,9 @@ class OneHotEnumMux1HTester extends BasicTester {
    object selector extends ChiselEnum1H {
      val s0, s1, s2, s3 = Value
    }
-   val selectorVal = Wire(UInt(selector.getWidth.W))
-   selectorVal := selector.s1.asUInt
-   val hotValue = chisel3.util.Mux1H(selectorVal.asUInt,
+
+   val selectorVal = selector.s1
+   val hotValue = chisel3.util.Mux1H(selectorVal,
       Seq(
        2.U,
        4.U,

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -8,6 +8,7 @@ import chisel3.experimental.ChiselEnum1H
 import chisel3.internal.ChiselException
 import chisel3.testers.BasicTester
 import chisel3.util.{Mux1H, UIntToOH}
+import chisel3.stage.ChiselStage
 import org.scalatest._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -312,18 +313,22 @@ class UIntToOHTester extends BasicTester {
 
 class OneHotEnumMux1HTester extends BasicTester {
    object selector extends ChiselEnum1H {
-     val s0, s1, s2, s3 = Value
+     val S0, S1, S2, S3 = Value
    }
 
-   val selectorVal = selector.s1
-   val hotValue = chisel3.util.Mux1H(selectorVal,
-      Seq(
-       2.U,
-       4.U,
-       8.U,
-       16.U,
-     ))
-    assert(hotValue === 4.U)
+   class MyModule extends Module {
+      val selectorVal = selector.S1
+      val hotValue = chisel3.util.Mux1H(selectorVal,
+         Seq(
+          2.U,
+          4.U,
+          8.U,
+          16.U,
+        ))
+       assert(hotValue === 4.U)
+    }
+
+    ChiselStage.elaborate(new MyModule)
 
     stop()
   }

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.FixedPoint
+import chisel3.experimental.ChiselEnum1H
 import chisel3.internal.ChiselException
 import chisel3.testers.BasicTester
 import chisel3.util.{Mux1H, UIntToOH}
@@ -50,6 +51,9 @@ class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselRunners {
         val out = UIntToOH(0.U, 0)
       })
     }
+  }
+  "one hot mux with OneHotEnum should work" in {
+    assertTesterPasses(new OneHotEnumMux1HTester)
   }
 
 }
@@ -304,3 +308,22 @@ class UIntToOHTester extends BasicTester {
 
   stop()
 }
+
+
+class OneHotEnumMux1HTester extends BasicTester {
+   object selector extends ChiselEnum1H {
+     val s0, s1, s2, s3 = Value
+   }
+   val selectorVal = Wire(UInt(selector.getWidth.W))
+   selectorVal := selector.s1.asUInt
+   val hotValue = chisel3.util.Mux1H(selectorVal.asUInt,
+      Seq(
+       2.U,
+       4.U,
+       8.U,
+       11.U,
+     ))
+    assert(hotValue === 4.U)
+
+    stop()
+  }

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -13,6 +13,7 @@ import chisel3.testers.BasicTester
 import org.scalatest.Assertion
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalactic.One
 
 object EnumExample extends ChiselEnum {
   val e0, e1, e2 = Value
@@ -525,6 +526,16 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
       assert(enumVal.litValue === r)
       r = r << 1
     }
+  }
+
+  it should "check OneHot enum index" in {
+    object OneHotEnum extends ChiselEnum1H {
+	    val VAL1, VAL2, VAL3 = Value
+    }
+
+    assert(OneHotEnum.VAL1.toIndex === 0)
+    assert(OneHotEnum.VAL2.toIndex === 1)
+    assert(OneHotEnum.VAL3.toIndex === 2)
   }
 }
 

--- a/src/test/scala/chiselTests/StrongEnum.scala
+++ b/src/test/scala/chiselTests/StrongEnum.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.ChiselEnum
+import chisel3.experimental.ChiselEnum1H
 import chisel3.internal.firrtl.UnknownWidth
 import chisel3.internal.naming.chiselName
 import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
@@ -512,6 +513,18 @@ class StrongEnumSpec extends ChiselFlatSpec with Utils {
 
   it should "correctly check if the enumeration is one of the values in a given sequence" in {
     assertTesterPasses(new IsOneOfTester)
+  }
+
+  it should "check OneHot enums values" in {
+    object OneHotEnum extends ChiselEnum1H {
+	    val VAL1, VAL2, VAL3 = Value
+    }
+
+    var r = 1
+    for (enumVal <- OneHotEnum.all) {
+      assert(enumVal.litValue === r)
+      r = r << 1
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a One-Hot encoded ChiselEnum where the elements have 1H instead of sequential IDs:

```scala
// It simplifies:
object InstructionType extends ChiselEnum {
  val INST_I = Value((1 << 0).U)
  val INST_S = Value((1 << 1).U)
  val INST_B = Value((1 << 2).U)
  val INST_U = Value((1 << 3).U)
  val INST_J = Value((1 << 4).U)
  val INST_Z = Value((1 << 5).U)
  val INST_R = Value((1 << 6).U)
  val IN_ERR = Value((1 << 7).U)
}

// into:

object InstructionType extends ChiselEnum1H {
	val INST_I, INST_S, INST_U, INST_B, INST_J, INST_Z, INST_R, IN_ERR = Value
}

// Allowing the use in Mux1H for example as:
  val selectorVal = Wire(UInt(InstructionType.getWidth.W))
  selectorVal := InstructionType.INST_I.asUInt
  val hotValue = chisel3.util.Mux1H(
    selectorVal,
    Seq(
      2.U,
      4.U,
      8.U,
      11.U,
      15.U
    )
  )
```

The PR is for discussion and in case of greenlit, I'll add test cases for it.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- documentation
- new feature/API

#### API Impact

The PR creates a ChiselEnum where elements have One-Hot IDs.

#### Backend Code Generation Impact

None.

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes

This PR adds a One-Hot encoded ChiselEnum where the elements have One-Hot IDs instead of sequential. This change pairs well with `Mux1H`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.3.x`, [small] API extension: `3.4.x`, API modification or big change: `3.5.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you mark as `Please Merge`?
