### PR TITLE
Add Instance.suggestName

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
@@ -54,8 +54,9 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si
     record.forceName(default = this.desiredName, namespace)
     // Now take the Ref that forceName set and convert it to the correct Arg
     val instName = record.getRef match {
-      case Ref(name) => name
-      case bad       => throwException(s"Internal Error! Cloned-module Record $record has unexpected ref $bad")
+      case Ref(name)              => name
+      case ModuleCloneIO(_, name) => namespace.name(name)
+      case bad                    => throwException(s"Internal Error! Cloned-module Record $record has unexpected ref $bad")
     }
     // Set both the record and the module to have the same instance name
     val ref = ModuleCloneIO(getProto, instName)
@@ -70,5 +71,10 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si
     }
 
     this.setRef(Ref(instName))
+  }
+
+  def suggestName(name: String): Unit = {
+    _portsRecord.setRef(ModuleCloneIO(getProto, name)) // force because we did .forceName first
+    this.setRef(Ref(name))
   }
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
@@ -54,9 +54,8 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si
     record.forceName(default = this.desiredName, namespace)
     // Now take the Ref that forceName set and convert it to the correct Arg
     val instName = record.getRef match {
-      case Ref(name)              => name
-      case ModuleCloneIO(_, name) => namespace.name(name)
-      case bad                    => throwException(s"Internal Error! Cloned-module Record $record has unexpected ref $bad")
+      case Ref(name) => name
+      case bad       => throwException(s"Internal Error! Cloned-module Record $record has unexpected ref $bad")
     }
     // Set both the record and the module to have the same instance name
     val ref = ModuleCloneIO(getProto, instName)
@@ -73,8 +72,9 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si
     this.setRef(Ref(instName))
   }
 
-  def suggestName(name: String): Unit = {
-    _portsRecord.setRef(ModuleCloneIO(getProto, name)) // force because we did .forceName first
-    this.setRef(Ref(name))
+  override def suggestName(seed: => String): this.type = {
+    // Forward the suggestName to the underlying _portsRecord
+    _portsRecord.suggestName(seed)
+    this
   }
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -93,6 +93,10 @@ object Instance extends SourceInfoDoc {
       case Clone(x: IsClone[_] with BaseModule) => x.toAbsoluteTarget
       case _ => throw new InternalErrorException("Match error: i.underlying=${i.underlying}")
     }
+
+    def suggestName(name: String): Unit = {
+      i.getInnerDataContext.get.asInstanceOf[ModuleClone[T]].suggestName(name)
+    }
   }
 
   /** A constructs an [[Instance]] from a [[Definition]]

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -6,7 +6,7 @@ import scala.language.experimental.macros
 import chisel3._
 import chisel3.experimental.hierarchy.{InstantiableClone, ModuleClone}
 import chisel3.internal.{throwException, Builder}
-import chisel3.experimental.{BaseModule, ExtModule, SourceInfo}
+import chisel3.experimental.{BaseModule, ExtModule, SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal.sourceinfo.InstanceTransform
 import chisel3.internal.firrtl.{Component, DefBlackBox, DefClass, DefIntrinsicModule, DefModule, Port}
 import firrtl.annotations.IsModule
@@ -94,8 +94,10 @@ object Instance extends SourceInfoDoc {
       case _ => throw new InternalErrorException("Match error: i.underlying=${i.underlying}")
     }
 
-    def suggestName(name: String): Unit = {
-      i.getInnerDataContext.get.asInstanceOf[ModuleClone[T]].suggestName(name)
+    def suggestName(name: String): Unit = i.underlying match {
+      case Clone(m: BaseModule) => m.suggestName(name)
+      case Proto(m) => m.suggestName(name)
+      case x        => Builder.exception(s"Cannot call .suggestName on $x")(UnlocatableSourceInfo)
     }
   }
 

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -1229,7 +1229,7 @@ class InstanceSpec extends ChiselFunSpec with Utils {
     val (chirrtl, _) = getFirrtlAndAnnos(new Top)
     chirrtl.serialize should include("inst potato of AddOne")
   }
-  it("11.2 suggestName with sanitization") {
+  it("11.3 suggestName with sanitization") {
     class Top extends Module {
       val definition = Definition(new AddOne)
       val inst0 = Instance(definition)
@@ -1240,5 +1240,14 @@ class InstanceSpec extends ChiselFunSpec with Utils {
     val (chirrtl, _) = getFirrtlAndAnnos(new Top)
     chirrtl.serialize should include("inst potato of AddOne")
     chirrtl.serialize should include("inst potato_1 of AddOne")
+  }
+  it("11.4 suggestName with multi-def collision sanitization") {
+    class Top extends Module {
+      val inst0 = Module(new AddOne()).suggestName("potato")
+      val inst1 = Instance(Definition(new AddOne)).suggestName("potato")
+    }
+    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
+    chirrtl.serialize should include("inst potato of AddOne")
+    chirrtl.serialize should include("inst potato_1 of AddOne_1")
   }
 }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -1218,10 +1218,13 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       class Top extends Module {
         val definition = Definition(new AddOne)
         val inst0 = Instance(definition)
+        val inst1 = Module(new AddOne).toInstance
         inst0.suggestName("potato")
+        inst1.suggestName("potato")
       }
       val chirrtl = emitCHIRRTL(new Top)
       chirrtl should include("inst potato of AddOne")
+      chirrtl should include("inst potato_1 of AddOne_1")
     }
     it("11.2 suggestName at instantiation") {
       class Top extends Module {

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 package experimental.hierarchy
 
+import circt.stage.ChiselStage.emitCHIRRTL
 import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
@@ -453,7 +454,6 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       }
       def f(i: Seq[Instance[AddTwo]]): Data = i.head.i0.innerWire
       val (c, annos) = getFirrtlAndAnnos(new Top)
-      println(c.serialize)
       //TODO: Should this be ~Top|Top... ??
       annos.collect { case c: MarkAnnotation => c } should contain(
         MarkAnnotation("~Top|AddTwo/i0:AddOne>innerWire".rt, "blah")
@@ -1213,41 +1213,45 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       getFirrtlAndAnnos(new HasMultipleTypeParamsInside, Seq(aspect))
     }
   }
-  it("11.1 suggestName for Instances") {
-    class Top extends Module {
-      val definition = Definition(new AddOne)
-      val inst0 = Instance(definition)
-      inst0.suggestName("potato")
+  describe("(11) .suggestName") {
+    it("11.1 suggestName for Instances") {
+      class Top extends Module {
+        val definition = Definition(new AddOne)
+        val inst0 = Instance(definition)
+        inst0.suggestName("potato")
+      }
+      val chirrtl = emitCHIRRTL(new Top)
+      chirrtl should include("inst potato of AddOne")
     }
-    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
-    chirrtl.serialize should include("inst potato of AddOne")
-  }
-  it("11.2 suggestName at instantiation") {
-    class Top extends Module {
-      val k = Instance(Definition(new AddOne)).suggestName("potato")
+    it("11.2 suggestName at instantiation") {
+      class Top extends Module {
+        val k = Instance(Definition(new AddOne)).suggestName("potato")
+      }
+      val chirrtl = emitCHIRRTL(new Top)
+      chirrtl should include("inst potato of AddOne")
     }
-    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
-    chirrtl.serialize should include("inst potato of AddOne")
-  }
-  it("11.3 suggestName with sanitization") {
-    class Top extends Module {
-      val definition = Definition(new AddOne)
-      val inst0 = Instance(definition)
-      val inst1 = Instance(definition)
-      inst0.suggestName("potato")
-      inst1.suggestName("potato")
+    it("11.3 suggestName with sanitization") {
+      class Top extends Module {
+        val definition = Definition(new AddOne)
+        val inst0 = Instance(definition)
+        val inst1 = Instance(definition)
+        inst0.suggestName("potato")
+        inst1.suggestName("potato")
+      }
+      val chirrtl = emitCHIRRTL(new Top)
+      chirrtl should include("inst potato of AddOne")
+      chirrtl should include("inst potato_1 of AddOne")
     }
-    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
-    chirrtl.serialize should include("inst potato of AddOne")
-    chirrtl.serialize should include("inst potato_1 of AddOne")
-  }
-  it("11.4 suggestName with multi-def collision sanitization") {
-    class Top extends Module {
-      val inst0 = Module(new AddOne()).suggestName("potato")
-      val inst1 = Instance(Definition(new AddOne)).suggestName("potato")
+    it("11.4 suggestName with multi-def collision sanitization") {
+      class Top extends Module {
+        val potato = Wire(UInt(8.W))
+        val inst0 = Module(new AddOne()).suggestName("potato")
+        val inst1 = Instance(Definition(new AddOne)).suggestName("potato")
+      }
+      val chirrtl = emitCHIRRTL(new Top)
+      chirrtl should include("wire potato : UInt<8>")
+      chirrtl should include("inst potato_1 of AddOne")
+      chirrtl should include("inst potato_2 of AddOne_1")
     }
-    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
-    chirrtl.serialize should include("inst potato of AddOne")
-    chirrtl.serialize should include("inst potato_1 of AddOne_1")
   }
 }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -1213,4 +1213,32 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       getFirrtlAndAnnos(new HasMultipleTypeParamsInside, Seq(aspect))
     }
   }
+  it("11.1 suggestName for Instances") {
+    class Top extends Module {
+      val definition = Definition(new AddOne)
+      val inst0 = Instance(definition)
+      inst0.suggestName("potato")
+    }
+    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
+    chirrtl.serialize should include("inst potato of AddOne")
+  }
+  it("11.2 suggestName at instantiation") {
+    class Top extends Module {
+      val k = Instance(Definition(new AddOne)).suggestName("potato")
+    }
+    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
+    chirrtl.serialize should include("inst potato of AddOne")
+  }
+  it("11.2 suggestName with sanitization") {
+    class Top extends Module {
+      val definition = Definition(new AddOne)
+      val inst0 = Instance(definition)
+      val inst1 = Instance(definition)
+      inst0.suggestName("potato")
+      inst1.suggestName("potato")
+    }
+    val (chirrtl, _) = getFirrtlAndAnnos(new Top)
+    chirrtl.serialize should include("inst potato of AddOne")
+    chirrtl.serialize should include("inst potato_1 of AddOne")
+  }
 }


### PR DESCRIPTION
Status: instance names are colliding, [causing the new tests 11.3 and 11.4 to fail](https://github.com/chipsalliance/chisel3/actions/runs/3680952208/jobs/6227099986#step:8:1289). Need to figure that out and fix it.

This supersedes #2414, which I think is abandoned. Resolves #2366.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
- new feature/API

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Adds `suggestName` API for hierarchy instances.

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

Allows users to control Verilog module instance names.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
- Squash: The PR will be squashed and merged (choose this if you have no preference.
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Adds `suggestName` API for hierarchy instances.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
