### PR TITLE
Add an annotation for specifying module port conventions

### DIFF
--- a/src/main/scala/circt/Convention.scala
+++ b/src/main/scala/circt/Convention.scala
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package circt
+
+import chisel3.experimental.{annotate, BaseModule, ChiselAnnotation}
+import firrtl.annotations.{ModuleTarget, SingleTargetAnnotation}
+import firrtl.FirrtlUserException
+
+/** Annotation to specify a module's port convention.
+  * The port convention defines how the ports of a module are transformed while
+  * lowering to verilog.
+  */
+case class ConventionAnnotation(target: ModuleTarget, convention: String) extends SingleTargetAnnotation[ModuleTarget] {
+  override def duplicate(target: ModuleTarget): ConventionAnnotation =
+    ConventionAnnotation(target, convention)
+}
+
+/** Utilities for annotating modules with a port convention.
+  * The port convention defines how the ports of a module are transformed while
+  * lowering to verilog.
+  *
+  * @example {{{
+  * class Inner extends Module {
+  *   val io = IO(new Bundle{})
+  * }
+  *
+  * class Top extends Module {
+  *   val inner = Module(new Inner)
+  *   convention.scalarized(inner)
+  * }
+  * }}}
+  */
+object convention {
+  private def apply[T <: BaseModule](data: T, convention: String): Unit =
+    annotate(new ChiselAnnotation {
+      def toFirrtl = ConventionAnnotation(data.toTarget, convention)
+    })
+
+  /** Annotate a module as having the "scalarized" port convention.
+    * With this port convention, the aggregate ports of the module will be
+    * fully scalarized.
+    */
+  def scalarized[T <: BaseModule](data: T): Unit =
+    apply(data, "scalarized")
+}

--- a/src/test/scala/circtTests/ConventionSpec.scala
+++ b/src/test/scala/circtTests/ConventionSpec.scala
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package circtTests
+
+import chisel3._
+import circt.convention
+import circt.stage.ChiselStage
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConventionSpec extends AnyFunSpec with Matchers {
+  describe("convention.scalarized") {
+    it("should scalarize the ports of a module") {
+      class PassThrough extends RawModule {
+        val i = IO(Input(new Bundle {
+          val x = UInt(16.W)
+          val y = UInt(16.W)
+        }))
+        val o = IO(Output(new Bundle {
+          val x = UInt(16.W)
+          val y = UInt(16.W)
+        }))
+        o := i
+      }
+
+      def makePassThrough() = {
+        val p = new PassThrough
+        convention.scalarized(p)
+        p
+      }
+
+      val expected = Array(
+        "input  [15:0] i_x,",
+        "input  [15:0] i_y,",
+        "output [15:0] o_x,",
+        "output [15:0] o_y",
+        "assign o_x = i_x;",
+        "assign o_y = i_y;"
+      )
+
+      val options = Array(
+        "--preserve-aggregate=all",
+        "--strip-debug-info",
+        "--scalarize-top-module=false",
+        "--lowering-options=disallowPortDeclSharing"
+      )
+
+      val actual = ChiselStage.emitSystemVerilog(makePassThrough(), Array(), options).split("\n").map(_.trim)
+      expected.foreach { e => actual should contain(e) }
+    }
+  }
+}


### PR DESCRIPTION
This annotation is being handled in mfc via:
  https://github.com/llvm/circt/pull/4665

The convention lets users define how ports with aggregate types are lowered to verilog.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following: -->
<!--   - bug fix                            -->
<!--   - performance improvement            -->
<!--   - documentation                      -->
<!--   - code refactoring                   -->
<!--   - code cleanup                       -->
<!--   - backend code generation            -->
<!--   - new feature/API                    -->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are: -->
<!--   - Squash: The PR will be squashed and merged (choose this if you have no preference. -->
<!--   - Rebase: You will rebase the PR onto master and it will be merged with a merge commit. -->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
