### PR TITLE
Chisel5 publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Binary compatibility
         # TODO either make this also check the plugin or decide that we don't
         #      support binary compatibility for the plugin
-        run: sbt ++${{ matrix.scala }} unipublish / mimaReportBinaryIssues
+        run: sbt ++${{ matrix.scala }} unipublish/mimaReportBinaryIssues
 
   doc:
     name: Formatting
@@ -184,8 +184,8 @@ jobs:
       - name: Publish
         run: sbt ci-release
         env:
-          CI_SNAPSHOT_RELEASE: '+ unipublish / publish'
-          CI_SONATYPE_RELEASE: '+ unipublish / publishSigned'
+          CI_SNAPSHOT_RELEASE: "+unipublish/publish"
+          CI_SONATYPE_RELEASE: "+unipublish/publishSigned"
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.CHIPSALLIANCE_SONATYPE_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,8 +182,10 @@ jobs:
       - name: Setup GPG (for Publish)
         uses: olafurpg/setup-gpg@v3
       - name: Publish
-        run: sbt -DdisableFatalWarnings ci-release
+        run: sbt ci-release
         env:
+          CI_SNAPSHOT_RELEASE: '+ unipublish / publish'
+          CI_SONATYPE_RELEASE: '+ unipublish / publishSigned'
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.CHIPSALLIANCE_SONATYPE_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Test
         run: sbt ++${{ matrix.scala }} test
       - name: Binary compatibility
-        run: sbt ++${{ matrix.scala }} mimaReportBinaryIssues
+        # TODO either make this also check the plugin or decide that we don't
+        #      support binary compatibility for the plugin
+        run: sbt ++${{ matrix.scala }} unipublish / mimaReportBinaryIssues
 
   doc:
     name: Formatting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - 3.5.x
       - 3.4.x
       - 3.3.x
@@ -165,7 +165,8 @@ jobs:
   publish:
     needs: [all_tests_passed]
     runs-on: ubuntu-20.04
-    if: (github.event_name == 'push' && github.ref_name != 'website-test')
+    # TODO uncomment the below
+    #if: github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -183,15 +184,15 @@ jobs:
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.CHIPSALLIANCE_SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.CHIPSALLIANCE_SONATYPE_USERNAME }}
 
 
   deploy_website:
     name: Deploy Website
     runs-on: ubuntu-latest
     needs: [all_tests_passed]
-    if: (github.event_name == 'push') && (github.ref_type == 'branch') && ((github.ref_name == 'website-test') || (github.ref_name == 'master'))
+    if: github.event_name == 'push'
     steps:
       - name: Download built website
         uses: actions/download-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,8 +167,7 @@ jobs:
   publish:
     needs: [all_tests_passed]
     runs-on: ubuntu-20.04
-    # TODO uncomment the below
-    #if: github.event_name == 'push'
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -196,7 +195,8 @@ jobs:
     name: Deploy Website
     runs-on: ubuntu-latest
     needs: [all_tests_passed]
-    if: github.event_name == 'push'
+    # Only Deploy website on pushes to main, may change to a stable branch
+    if: (github.event_name == 'push') && (github.ref_name == 'main')
     steps:
       - name: Download built website
         uses: actions/download-artifact@v3

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,8 @@ enablePlugins(SiteScaladocPlugin)
 lazy val commonSettings = Seq(
   resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
-  organization := "edu.berkeley.cs",
-  version := "3.6-SNAPSHOT",
+  organization := "org.chipsalliance",
+  version := "5.0-SNAPSHOT",
   autoAPIMappings := true,
   scalaVersion := "2.13.10",
   crossScalaVersions := Seq("2.13.10", "2.12.17"),
@@ -54,25 +54,18 @@ lazy val warningSuppression = Seq(
 )
 
 lazy val publishSettings = Seq(
-  versionScheme := Some("pvp"),
+  versionScheme := Some("semver-spec"),
   publishMavenStyle := true,
   Test / publishArtifact := false,
   pomIncludeRepository := { x => false },
-  pomExtra := <url>http://chisel.eecs.berkeley.edu/</url>
+  pomExtra := <url>https://www.chisel-lang.org</url>
     <licenses>
       <license>
         <name>apache-v2</name>
         <url>https://opensource.org/licenses/Apache-2.0</url>
         <distribution>repo</distribution>
       </license>
-    </licenses>
-    <developers>
-      <developer>
-        <id>jackbackrack</id>
-        <name>Jonathan Bachrach</name>
-        <url>http://www.eecs.berkeley.edu/~jrb/</url>
-      </developer>
-    </developers>,
+    </licenses>,
   publishTo := {
     val v = version.value
     val nexus = "https://oss.sonatype.org/"
@@ -183,7 +176,7 @@ lazy val firrtl = (project in file("firrtl"))
   .settings(fatalWarningsSettings: _*)
 
 lazy val chiselSettings = Seq(
-  name := "chisel3",
+  name := "chisel",
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.2.15" % "test",
     "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test",
@@ -237,7 +230,7 @@ lazy val pluginScalaVersions = Seq(
 )
 
 lazy val plugin = (project in file("plugin"))
-  .settings(name := "chisel3-plugin")
+  .settings(name := "chisel-plugin")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(
@@ -269,7 +262,7 @@ lazy val usePluginSettings = Seq(
 )
 
 lazy val macros = (project in file("macros"))
-  .settings(name := "chisel3-macros")
+  .settings(name := "chisel-macros")
   .settings(commonSettings: _*)
   .settings(publishSettings: _*)
   .settings(mimaPreviousArtifacts := Set())
@@ -287,7 +280,7 @@ lazy val core = (project in file("core"))
   .settings(warningSuppression: _*)
   .settings(fatalWarningsSettings: _*)
   .settings(
-    name := "chisel3-core",
+    name := "chisel-core",
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "upickle" % "2.0.0",
       "com.lihaoyi" %% "os-lib" % "0.8.1"
@@ -349,12 +342,12 @@ lazy val chisel = (project in file("."))
           } else {
             s"v${version.value}"
           }
-        s"https://github.com/chipsalliance/chisel3/tree/$branch€{FILE_PATH_EXT}#L€{FILE_LINE}"
+        s"https://github.com/chipsalliance/chisel/tree/$branch€{FILE_PATH_EXT}#L€{FILE_LINE}"
       },
       "-language:implicitConversions"
     ) ++
       // Suppress compiler plugin for source files in core
-      // We don't need this in regular compile because we just don't add the chisel3-plugin to core's scalacOptions
+      // We don't need this in regular compile because we just don't add the chisel-plugin to core's scalacOptions
       // This works around an issue where unidoc uses the exact same arguments for all source files.
       // This is probably fundamental to how ScalaDoc works so there may be no solution other than this workaround.
       // See https://github.com/sbt/sbt-unidoc/issues/107

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,8 @@ lazy val publishSettings = Seq(
         <distribution>repo</distribution>
       </license>
     </licenses>,
+  sonatypeCredentialHost := "s01.oss.sonatype.org",
+  sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
   publishTo := {
     val v = version.value
     val nexus = "https://s01.oss.sonatype.org/"

--- a/build.sbt
+++ b/build.sbt
@@ -326,6 +326,9 @@ lazy val chisel = (project in file("."))
   .aggregate(macros, core, plugin, firrtl)
   .settings(warningSuppression: _*)
   .settings(fatalWarningsSettings: _*)
+  .settings(
+    Test / scalacOptions ++= Seq("-language:reflectiveCalls")
+  )
 
 
 def addUnipublishDeps(proj: Project)(deps: Project*): Project =
@@ -357,7 +360,6 @@ lazy val unipublish =
     mimaPreviousArtifacts := Set("org.chipsalliance" %% "chisel" % "5.0-SNAPSHOT"),
     // This is a pseudo-project with no class files, use the package jar instead
     mimaCurrentClassfiles := (Compile / packageBin).value,
-    Test / scalacOptions ++= Seq("-language:reflectiveCalls"),
     // Forward doc command to unidoc
     Compile / doc := (ScalaUnidoc / doc).value,
     // Include unidoc as the ScalaDoc for publishing

--- a/website/build.sbt
+++ b/website/build.sbt
@@ -22,19 +22,19 @@ lazy val micrositeSettings = Seq(
   micrositeName := "Chisel/FIRRTL",
   micrositeDescription := "Chisel/FIRRTL\nHardware Compiler Framework",
   micrositeUrl := "https://chipsalliance.github.io/",
-  micrositeBaseUrl := "chisel3",
+  micrositeBaseUrl := "chisel",
   micrositeConfigYaml := ConfigYml(
     yamlCustomProperties = Map("plugins" -> Seq("jekyll-redirect-from"))
   ),
   micrositeAuthor := "the Chisel/FIRRTL Developers",
   micrositeTwitter := "@chisel_lang",
   micrositeGithubOwner := "chipsalliance",
-  micrositeGithubRepo := "chisel3",
+  micrositeGithubRepo := "chisel",
   micrositeGithubLinks := false,
   micrositeShareOnSocial := false,
   micrositeDocumentationUrl := "chisel3/",
   micrositeDocumentationLabelDescription := "Documentation",
-  micrositeGitterChannelUrl := "chipsalliance/chisel3",
+  micrositeGitterChannelUrl := "chipsalliance/chisel",
   micrositeHighlightLanguages ++= Seq("verilog"),
   mdocIn := file("docs/src/main/tut"),
   /* Copy markdown files from each of the submodules to build out the website:
@@ -70,7 +70,7 @@ lazy val micrositeSettings = Seq(
   ghpagesNoJekyll := false,
   ghpagesRepository := file("build/gh-pages"),
   ghpagesBranch := "gh-pages",
-  git.remoteRepo := "git@github.com:chipsalliance/chisel3.git",
+  git.remoteRepo := "git@github.com:chipsalliance/chisel.git",
   includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.yml" | "*.md" |
     "*.svg" | "*.woff" | "*.ttf",
   includeFilter in Jekyll := (includeFilter in makeSite).value,
@@ -94,7 +94,7 @@ lazy val contributors =
         val uniqueContributors =
           // Even though we no longer host all these projects,
           // we still honor their contributions
-          Seq( GitHubRepository("chipsalliance", "chisel3"),
+          Seq( GitHubRepository("chipsalliance", "chisel"),
                GitHubRepository("chipsalliance", "firrtl"),
                GitHubRepository("chipsalliance", "treadle"),
                GitHubRepository("ucb-bar", "chiseltest"),


### PR DESCRIPTION
Setup initial Chisel 5 SNAPSHOT publishing

~This _almost works_, but I think `sbt-ci-release` only publishes the plugin and not the new `unipublish` project so I need to get that working before we can merge.~ This is now ready to go.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [NA] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

  - new feature/API

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Change published artifact from edu.berkeley.cs::chisel3 to org.chipsalliance::chisel. Set up automated publishing for 5.0-SNAPSHOT (to s01.oss.sonatype.org because Chips Alliance is a relatively new Sonatype organization). Merge old `firrtl`, `chisel3-macros`, `chisel3-core`, and `chisel3` artifacts into a single artifact: `chisel`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
