### PR TITLE
Move Cat function to chisel3 package

### DIFF
--- a/docs/src/cookbooks/verilog-vs-chisel.md
+++ b/docs/src/cookbooks/verilog-vs-chisel.md
@@ -15,7 +15,7 @@ This page serves as a quick introduction to Chisel for those familiar with Veril
 import chisel3._
 import chisel3.util.{switch, is}
 import circt.stage.ChiselStage
-import chisel3.util.{Cat, Fill, DecoupledIO}
+import chisel3.util.{Fill, DecoupledIO}
 ```
 
 <body>

--- a/src/main/scala/chisel3/Cat.scala
+++ b/src/main/scala/chisel3/Cat.scala
@@ -1,12 +1,9 @@
-// SPDX-License-Identifier: Apache-2.0
+package chisel3
 
-package chisel3.util
-
-import scala.language.experimental.macros
-
-import chisel3._
 import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.SourceInfoTransform
+
+import scala.language.experimental.macros
 
 /** Concatenates elements of the input, in order, together.
   *
@@ -18,7 +15,6 @@ import chisel3.internal.sourceinfo.SourceInfoTransform
   * Cat(mySeqOfBits)
   * }}}
   */
-@deprecated("Use chisel3.Cat instead", since = "Chisel 3.6.x")
 object Cat {
 
   /** Concatenates the argument data elements, in argument order, together. The first argument

--- a/src/main/scala/chisel3/compatibility.scala
+++ b/src/main/scala/chisel3/compatibility.scala
@@ -608,7 +608,7 @@ package object Chisel {
   val Reverse = chisel3.util.Reverse
 
   @deprecated("Chisel compatibility mode is deprecated. Use the chisel3 package instead.", "Chisel 3.6")
-  val Cat = chisel3.util.Cat
+  val Cat = chisel3.Cat
 
   @deprecated("Chisel compatibility mode is deprecated. Use the chisel3 package instead.", "Chisel 3.6")
   val Log2 = chisel3.util.Log2

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -4,7 +4,6 @@ package chiselTests.util
 
 import chisel3._
 import chisel3.experimental.noPrefix
-import chisel3.util.Cat
 import chiselTests.ChiselFlatSpec
 import circt.stage.ChiselStage
 
@@ -23,7 +22,7 @@ class CatSpec extends ChiselFlatSpec {
 
   import CatSpec._
 
-  behavior.of("util.Cat")
+  behavior.of("chisel3.Cat")
 
   it should "not fail to elaborate a zero-element Vec" in {
 

--- a/src/test/scala/chiselTests/util/random/LFSRSpec.scala
+++ b/src/test/scala/chiselTests/util/random/LFSRSpec.scala
@@ -4,7 +4,7 @@ package chiselTests.util.random
 
 import chisel3._
 import circt.stage.ChiselStage
-import chisel3.util.{Cat, Counter, Enum}
+import chisel3.util.Counter
 import chisel3.util.random._
 import chisel3.testers.{BasicTester, TesterDriver}
 import chiselTests.{ChiselFlatSpec, Utils}


### PR DESCRIPTION
Move Cat function to chisel3 package
from chisel3.util

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code cleanup
- 
#### API Impact

Cat import has moved to chisel3. util.Cat is deprecated

#### Backend Code Generation Impact

No changes

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference. 

#### Release Notes
The Cat operator has been moved to the chisel3 package. The util.Cat operator has been deprecated
 
### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.4.x`, [small] API extension: `3.5.x`, API modification or big change: `3.6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
