### PR TITLE
Let sbt-dynver control the SBT version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,11 @@
 name: Continuous Integration
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
+    tags:
+      - '*'
     branches:
       - main
       - 3.6.x

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ lazy val commonSettings = Seq(
   resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
   resolvers ++= Resolver.sonatypeOssRepos("releases"),
   organization := "org.chipsalliance",
-  version := "5.0-SNAPSHOT",
   autoAPIMappings := true,
   scalaVersion := "2.13.10",
   crossScalaVersions := Seq("2.13.10", "2.12.17"),
@@ -88,7 +87,6 @@ lazy val isAtLeastScala213 = Def.setting {
 
 lazy val firrtlSettings = Seq(
   name := "firrtl",
-  version := "1.6-SNAPSHOT",
   addCompilerPlugin(scalafixSemanticdb),
   scalacOptions := Seq(
     "-deprecation",


### PR DESCRIPTION
Pushes to main will now have SNAPSHOTs based on `git describe --tag`. Also run CI workflow (which includes publishing) on push to any tag and enable workflow_dispatch.

Earlier today, I pushed `v5.0.0-M1` (https://github.com/chipsalliance/chisel/releases/tag/v5.0.0-M1) which gives us a tag in the history to use for deriving versions.

Using this commit and an extra dummy commit, Maven artifact ordering does appear to be correct for the versions given by SBT dynver.

For example,
```scala
import org.apache.maven.artifact.versioning.ComparableVersion

val x = new ComparableVersion("5.0.0-M1+1-c3a34983-SNAPSHOT")

val y = new ComparableVersion("5.0.0-M1+2-c345858d-SNAPSHOT")

x.compareTo(y) // -1
y.compareTo(x) // 1
```

See Scastie: https://scastie.scala-lang.org/l13ZLA0DSOu8hw63fSCuAA
See API docs for ComparableVersion: https://maven.apache.org/ref/3.3.3/maven-artifact/apidocs/org/apache/maven/artifact/versioning/ComparableVersion.html

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Release automation

#### API Impact

We will no longer be publishing 5.0-SNAPSHOT and just publishing over it, instead SNAPSHOTS will be unique per push of the form: `5.0.0-M1+1-c3a34983-SNAPSHOT`
These sorts of versions are derived from `git describe --tag`.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes

Change SNAPSHOT versioning scheme to be derived from `git describe --tag`. SNAPSHOTs will now be unique per push to main.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
