### PR TITLE
Remove Cat from util

### DIFF
--- a/src/main/scala/chisel3/util/util.scala
+++ b/src/main/scala/chisel3/util/util.scala
@@ -11,7 +11,4 @@ package object util {
   type ValidIO[+T <: Data] = chisel3.util.Valid[T]
   val ValidIO = chisel3.util.Valid
   val DecoupledIO = chisel3.util.Decoupled
-
-  @deprecated("Use chisel3.Cat instead", since = "Chisel 3.6.x")
-  val Cat = chisel3.Cat
 }


### PR DESCRIPTION
This bug(not so sure if is a bug) was introduced by #3062.  
There are a lot of projects importing `chisel.util._`, when user have this importing, `Cat` will become ambiguous, for example:
```
[error] /tmp/playground/dependencies/berkeley-hardfloat/src/main/scala/AddRecFN.scala:94:9: reference to Cat is ambiguous;
[error] it is imported twice in the same scope by
[error] import chisel3.util._
[error] and import chisel3._
```
However if merging this, any codes importing `chisel3.util.Cat` will break.


### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix

#### API Impact
Remove `chisel3.util.Cat` 


#### Backend Code Generation Impact
None

#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
chisel3.util.Cat is removed

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
