### PR TITLE
Remove ImplicitInvalidate

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -918,9 +918,6 @@ trait WireFactory {
     x.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen))
 
     pushCommand(DefWire(sourceInfo, x))
-    if (Builder.currentModule.get.isInstanceOf[ImplicitInvalidate]) {
-      pushCommand(DefInvalid(sourceInfo, x.ref))
-    }
 
     x
   }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -234,11 +234,6 @@ package internal {
       clonePorts.bind(PortBinding(cloneParent))
       clonePorts.setAllParents(Some(cloneParent))
       cloneParent._portsRecord = clonePorts
-      // Normally handled during Module construction but ClonePorts really lives in its parent's parent
-      if (Builder.currentModule.get.isInstanceOf[ImplicitInvalidate]) {
-        // FIXME This almost certainly doesn't work since clonePorts is not a real thing...
-        pushCommand(DefInvalid(sourceInfo, clonePorts.ref))
-      }
       if (proto.isInstanceOf[Module]) {
         clonePorts("clock") := Module.clock
         clonePorts("reset") := Module.reset

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -98,27 +98,12 @@ abstract class RawModule extends BaseModule {
 
     // Generate IO invalidation commands to initialize outputs as unused,
     //  unless the client wants explicit control over their generation.
-    val invalidateCommands = {
-      if (this.isInstanceOf[ImplicitInvalidate]) {
-        getModulePortsAndLocators.map { case (port, sourceInfo) => DefInvalid(sourceInfo, port.ref) }
-      } else {
-        Seq()
-      }
-    }
-    val component = DefModule(this, name, firrtlPorts, invalidateCommands ++: _commands.result())
+    val component = DefModule(this, name, firrtlPorts, _commands.result())
     _component = Some(component)
     _component
   }
 
-  private[chisel3] def initializeInParent(): Unit = {
-    implicit val sourceInfo = UnlocatableSourceInfo
-
-    if (Builder.currentModule.get.isInstanceOf[ImplicitInvalidate]) {
-      for ((port, sourceInfo) <- getModulePortsAndLocators) {
-        pushCommand(DefInvalid(sourceInfo, port.ref))
-      }
-    }
-  }
+  private[chisel3] def initializeInParent(): Unit = { }
 }
 
 trait RequireAsyncReset extends Module {
@@ -128,6 +113,3 @@ trait RequireAsyncReset extends Module {
 trait RequireSyncReset extends Module {
   override private[chisel3] def mkReset: Bool = Bool()
 }
-
-/** Mix with a [[RawModule]] to automatically connect DontCare to the module's ports, wires, and children instance IOs. */
-trait ImplicitInvalidate { self: RawModule => }


### PR DESCRIPTION
This API was added to help port off of `import Chisel`. Now that Chisel is removed, I want to remove this API as well.

### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [N/A] Did you add at least one test demonstrating the PR?
- [N/A] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- removal of feature/API


#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
Now, users must explicitly assign DontCare to a module, at instantiation site, rather than this happening automatically because the module extended ImplicitInvalidate.

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

Remove ImplicitInvalidate - now users must explicitly assign DontCare to a module, at instantiation site, rather than this happening automatically because the module extended ImplicitInvalidate.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
