### PR TITLE
Remove deprecated CIRCT Options

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -140,7 +140,6 @@ class CIRCT extends Phase {
     val firrtlOptions = view[FirrtlOptions](annotations)
     val stageOptions = view[StageOptions](annotations)
 
-    var imcp = true
     var logLevel = _root_.logger.LogLevel.None
     var split = circtOptions.splitVerilog
     val includeDirs = mutable.ArrayBuffer.empty[String]
@@ -159,10 +158,7 @@ class CIRCT extends Phase {
         val filename = a.filename(annotations)
         a.replacements(filename)
       }
-      case _: ImportDefinitionAnnotation[_] => Nil
-      case firrtl.transforms.NoConstantPropagationAnnotation =>
-        imcp = false
-        Nil
+      case _:    ImportDefinitionAnnotation[_] => Nil
       case anno: _root_.logger.LogLevelAnnotation =>
         logLevel = anno.globalLogLevel
         Nil
@@ -203,7 +199,6 @@ class CIRCT extends Phase {
           case None                              => None
         }) ++
         circtOptions.preserveAggregate.map(_ => "-preserve-public-types=0") ++
-        (!imcp).option("-disable-imcp") ++
         /* Communicate the annotation file through a file. */
         (chiselAnnotationFilename.map(a => Seq("-annotation-file", a))).getOrElse(Seq.empty) ++
         includeDirs.flatMap(d => Seq("--include-dir", d.toString)) ++

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -140,7 +140,6 @@ class CIRCT extends Phase {
     val firrtlOptions = view[FirrtlOptions](annotations)
     val stageOptions = view[StageOptions](annotations)
 
-    var inferReadWrite = false
     var imcp = true
     var logLevel = _root_.logger.LogLevel.None
     var split = circtOptions.splitVerilog
@@ -161,9 +160,6 @@ class CIRCT extends Phase {
         a.replacements(filename)
       }
       case _: ImportDefinitionAnnotation[_] => Nil
-      case firrtl.passes.memlib.InferReadWriteAnnotation =>
-        inferReadWrite = true
-        Nil
       case firrtl.transforms.NoConstantPropagationAnnotation =>
         imcp = false
         Nil
@@ -207,7 +203,6 @@ class CIRCT extends Phase {
           case None                              => None
         }) ++
         circtOptions.preserveAggregate.map(_ => "-preserve-public-types=0") ++
-        (!inferReadWrite).option("-disable-infer-rw") ++
         (!imcp).option("-disable-imcp") ++
         /* Communicate the annotation file through a file. */
         (chiselAnnotationFilename.map(a => Seq("-annotation-file", a))).getOrElse(Seq.empty) ++


### PR DESCRIPTION
 Change CIRCT to turn on read-write inference by default. Re
move the ability to disable inter-module constant propagation (IMCP) when
running with CIRCT.  These options were removed in:

  https://github.com/llvm/circt/commit/9620d656f8a59998cc38472a60f83bfdcb6a8549