### PR TITLE
Make name not lazy for modules

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -406,7 +406,8 @@ package experimental {
     }
 
     /** Legalized name of this module. */
-    final val name =
+    final lazy val name: String = {
+      _parent.map(_.name) // Name parent before me!
       try {
         // PseudoModules are not "true modules" and thus should share
         // their original modules names without uniquification
@@ -422,6 +423,7 @@ package experimental {
           )
         case t: Throwable => throw t
       }
+    }
 
     /** Returns a FIRRTL ModuleName that references this object
       *

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -406,7 +406,7 @@ package experimental {
     }
 
     /** Legalized name of this module. */
-    final lazy val name =
+    final val name =
       try {
         // PseudoModules are not "true modules" and thus should share
         // their original modules names without uniquification

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -233,7 +233,9 @@ class ModuleSpec extends ChiselPropSpec with Utils {
   }
 
   property("A desiredName parameterized by a submodule should work") {
-    ChiselStage.elaborate(new ModuleWrapper(new ModuleWire)).name should be("ModuleWireWrapper")
+    (the[ChiselException] thrownBy extractCause[ChiselException](
+      ChiselStage.elaborate(new ModuleWrapper(new ModuleWire))
+    )).getMessage should include("desiredName of chiselTests.ModuleWrapper is null")
   }
   property("A name generating a null pointer exception should provide a good error message") {
     (the[ChiselException] thrownBy extractCause[ChiselException](


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following:
- bug fix
- performance improvement
- documentation
- code refactoring
- code cleanup
- backend code generation
- new feature/API
-->

#### API Impact

<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->

#### Backend Code Generation Impact

<!-- Does this change any generated Verilog?  -->
<!-- How does it change it or in what circumstances would it?  -->

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
<!-- Options are:
- Squash: The PR will be squashed and merged (choose this if you have no preference.
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.
-->

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
