### PR TITLE
Undo move of Cat from chisel3.util to chisel3

### DIFF
--- a/docs/src/cookbooks/verilog-vs-chisel.md
+++ b/docs/src/cookbooks/verilog-vs-chisel.md
@@ -15,7 +15,7 @@ This page serves as a quick introduction to Chisel for those familiar with Veril
 import chisel3._
 import chisel3.util.{switch, is}
 import circt.stage.ChiselStage
-import chisel3.util.{Fill, DecoupledIO}
+import chisel3.util.{Cat, Fill, DecoupledIO}
 ```
 
 <body>

--- a/integration-tests/src/test/scala/chiselTest/LFSRSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/LFSRSpec.scala
@@ -4,7 +4,7 @@ package chiselTests.util.random
 
 import chisel3._
 import circt.stage.ChiselStage
-import chisel3.util.Counter
+import chisel3.util.{Cat, Counter}
 import chisel3.util.random._
 import chisel3.testers.{BasicTester, TesterDriver}
 import chiselTests.{ChiselFlatSpec, Utils}

--- a/src/main/scala/chisel3/util/Cat.scala
+++ b/src/main/scala/chisel3/util/Cat.scala
@@ -1,4 +1,7 @@
-package chisel3
+// SPDX-License-Identifier: Apache-2.0
+package chisel3.util
+
+import chisel3._
 
 import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.SourceInfoTransform

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests
+package chiselTests.util
 
 import chisel3._
+import chisel3.util.Cat
 import chisel3.experimental.noPrefix
+import chiselTests.ChiselFlatSpec
 import circt.stage.ChiselStage
 
 object CatSpec {
@@ -21,7 +23,7 @@ class CatSpec extends ChiselFlatSpec {
 
   import CatSpec._
 
-  behavior.of("chisel3.Cat")
+  behavior.of("chisel3.util.Cat")
 
   it should "not fail to elaborate a zero-element Vec" in {
 


### PR DESCRIPTION
It is a very painful change for users with marginal benefit. We plan to change the package to chisel in the not-so-distant future--that's a much better opportunity to make this change.

FYI @sequencer @chick 

See https://github.com/chipsalliance/chisel/pull/3075 for relevant discussion about the original change, this is a manual revert of https://github.com/chipsalliance/chisel/pull/3062

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


- code refactoring


#### API Impact

Restore the Chisel 3.6.0-RC2 API

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy


- Squash


#### Release Notes

Restore `Cat` to package `chisel3.util`, remove it from package `chisel3`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
