### PR TITLE
Fix MuxLookup old API deprecation

### DIFF
--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -97,11 +97,6 @@ class MuxTransform(val c: Context) extends SourceInfoTransformMacro {
 
 class MuxLookupTransform(val c: Context) extends SourceInfoTransformMacro {
   import c.universe._
-  def apply[S: c.WeakTypeTag, T: c.WeakTypeTag](key: c.Tree, default: c.Tree, mapping: c.Tree): c.Tree = {
-    val sType = weakTypeOf[S]
-    val tType = weakTypeOf[T]
-    q"$thisObj.do_apply[$sType, $tType]($key, $default, $mapping)($implicitSourceInfo)"
-  }
 
   def applyCurried[S: c.WeakTypeTag, T: c.WeakTypeTag](key: c.Tree, default: c.Tree)(mapping: c.Tree): c.Tree = {
     val sType = weakTypeOf[S]

--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -74,7 +74,7 @@ object MuxLookup extends SourceInfoDoc {
     */
   @deprecated("Use MuxLookup(key, default)(mapping) instead", "Chisel 3.6")
   def apply[S <: UInt, T <: Data](key: S, default: T, mapping: Seq[(S, T)]): T =
-    macro MuxLookupTransform.apply[S, T]
+    do_apply(key, default, mapping)
 
   /** @param key a key to search for
     * @param default a default value if nothing is found


### PR DESCRIPTION
It seems that deprecations on methods that are macro expanded away do not actually trigger a deprecation warning. Instead, we will just accept no source locator on the deprecated API (no released version of Chisel has the source locator).

This is needed before we can crack another 3.6 release.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- bug fix


#### API Impact

Removes a macro definition that has never been released and should not be used by users anyway.

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy


- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
