### PR TITLE
Make return value of Serializer.lazily lazy

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -65,7 +65,7 @@ object Serializer {
       case n: Circuit   => sIt(n)(indent)
       case other => Iterator(serialize(other, indent))
     }
-  }
+  }.view // TODO replace .view with constructing a view directly above, but must drop 2.12 first.
 
   private def flattenInfo(infos: Seq[Info]): Seq[FileInfo] = infos.flatMap {
     case NoInfo => Seq()

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -176,4 +176,38 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
     SMemTestCircuit.circuit(ReadUnderWrite.New).serialize should include("new")
     SMemTestCircuit.circuit(ReadUnderWrite.Old).serialize should include("old")
   }
+
+  it should "support lazy serialization" in {
+    var stmtSerialized = false
+    case class HackStmt(stmt: Statement) extends Statement {
+      def serialize: String = {
+        stmtSerialized = true
+        stmt.serialize
+      }
+    }
+
+    val stmt = HackStmt(DefNode(NoInfo, "foo", Reference("bar")))
+    val it: Iterable[String] = Serializer.lazily(stmt)
+    assert(!stmtSerialized, "We should be able to construct the serializer lazily")
+
+    var mapExecuted = false
+    val it2: Iterable[String] = it.map { x =>
+      mapExecuted = true
+      x + ","
+    }
+    assert(!stmtSerialized && !mapExecuted, "We should be able to map the serializer lazily")
+
+    var appendExecuted = false
+    val it3: Iterable[String] = it2 ++ Seq("hi").view.map { x =>
+      appendExecuted = true
+      x
+    }
+    assert(!stmtSerialized && !mapExecuted && !appendExecuted, "We should be able to append to the serializer lazily")
+
+    val result = it3.mkString
+    assert(
+      stmtSerialized && mapExecuted && appendExecuted,
+      "Once we traverse the serializer, everything should execute"
+    )
+  }
 }


### PR DESCRIPTION
Directly subclassing Iterable is lazy-ish, but if you call any operation on the resulting value (eg. map or ++) it will evaluate the Iterable and return a List.

Forward port of https://github.com/chipsalliance/firrtl/pull/2627, no need to backport because the fix is on the firrtl repo for 3.6.x and before.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


- performance improvement


#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy


- Squash

#### Release Notes

Reduce peak memory usage during .fir serialization by using lazy intermediate data structures.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
