### PR TITLE
Fix svsim to publish as part of unipublish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,6 +175,8 @@ lazy val testAssemblySettings = Seq(
 lazy val svsim = (project in file("svsim"))
   .settings(minimalSettings)
   .settings(
+    // Published as part of unipublish
+    publish / skip := true,
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
       "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % "test"
@@ -374,6 +376,7 @@ def addUnipublishDeps(proj: Project)(deps: Project*): Project = {
 lazy val unipublish =
   addUnipublishDeps(project in file("unipublish"))(
     firrtl,
+    svsim,
     macros,
     core,
     chisel


### PR DESCRIPTION
I missed this is review of https://github.com/chipsalliance/chisel/pull/3121

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [NA] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement


- bug fix

#### API Impact

svsim will now be in the published jars

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
