### PR TITLE
Add `Simulator` class for simulating Chisel modules with `svsim`

### DIFF
--- a/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
+++ b/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
@@ -28,8 +28,7 @@ object PeekPokeAPI {
     }
   }
 
-  sealed trait SimulationData {
-    type T <: Data
+  sealed trait SimulationData[T <: Data] {
     val data: T
 
     private def isSigned = data.isInstanceOf[SInt]
@@ -63,18 +62,15 @@ object PeekPokeAPI {
 
   }
 
-  implicit final class testableSInt(val data: SInt) extends SimulationData {
-    type T = SInt
+  implicit final class testableSInt(val data: SInt) extends SimulationData[SInt] {
     override def encode(width: Int, value: BigInt) = value.asSInt(width.W)
   }
 
-  implicit final class testableUInt(val data: UInt) extends SimulationData {
-    type T = UInt
+  implicit final class testableUInt(val data: UInt) extends SimulationData[UInt] {
     override def encode(width: Int, value: BigInt) = value.asUInt(width.W)
   }
 
-  implicit final class testableBool(val data: Bool) extends SimulationData {
-    type T = Bool
+  implicit final class testableBool(val data: Bool) extends SimulationData[Bool] {
     override def encode(width: Int, value: BigInt): Bool = {
       if (value.isValidByte) {
         value.byteValue match {

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -1,0 +1,181 @@
+package chisel3.simulator
+
+import chisel3.{Data, RawModule}
+import scala.util.Try
+import svsim._
+
+final object Simulator {
+  trait BackendProcessor {
+    def process[T <: Backend](
+      backend:                            T
+    )(tag:                                String,
+      commonCompilationSettings:          CommonCompilationSettings,
+      backendSpecificCompilationSettings: backend.CompilationSettings
+    ): Unit
+  }
+
+  final case class BackendInvocationDigest[T](
+    compilationStartTime: Long,
+    compilationEndTime:   Long,
+    outcome:              BackendInvocationOutcome[T]) {
+    def result = outcome match {
+      case SimulationDigest(_, _, outcome) => outcome.get
+      case CompilationFailed(error)        => throw error
+    }
+  }
+  sealed trait BackendInvocationOutcome[T]
+  final case class CompilationFailed[T](error: Throwable) extends BackendInvocationOutcome[T]
+
+  final case class SimulationDigest[T](
+    simulationStartTime: Long,
+    simulationEndTime:   Long,
+    outcome:             Try[T])
+      extends BackendInvocationOutcome[T]
+
+  private[simulator] final class WorkspaceCompiler[T <: RawModule, U](
+    workspace:                        Workspace,
+    customSimulationWorkingDirectory: Option[String],
+    verbose:                          Boolean,
+    body:                             (Simulation.Controller) => U)
+      extends BackendProcessor {
+    val results = scala.collection.mutable.Stack[BackendInvocationDigest[U]]()
+
+    def process[T <: Backend](
+      backend:                            T
+    )(tag:                                String,
+      commonCompilationSettings:          CommonCompilationSettings,
+      backendSpecificCompilationSettings: backend.CompilationSettings
+    ): Unit = {
+
+      results.push({
+        val compilationStartTime = System.nanoTime()
+        try {
+          val simulation = workspace
+            .compile(backend)(
+              tag,
+              commonCompilationSettings,
+              backendSpecificCompilationSettings,
+              customSimulationWorkingDirectory,
+              verbose
+            )
+          val compilationEndTime = System.nanoTime()
+          val simulationOutcome = Try {
+            simulation.run(body)
+          }
+          val simulationEndTime = System.nanoTime()
+          BackendInvocationDigest(
+            compilationStartTime = compilationStartTime,
+            compilationEndTime = compilationEndTime,
+            outcome = SimulationDigest(
+              simulationStartTime = compilationEndTime,
+              simulationEndTime = simulationEndTime,
+              outcome = simulationOutcome
+            )
+          )
+        } catch {
+          case error: Throwable =>
+            BackendInvocationDigest(
+              compilationStartTime = compilationStartTime,
+              compilationEndTime = System.nanoTime(),
+              outcome = CompilationFailed(error)
+            )
+        }
+      })
+    }
+  }
+
+  private[simulator] final case class SimulationContext(
+    ports:      Seq[(Data, ModuleInfo.Port)],
+    controller: Simulation.Controller) {
+    val simulationPorts = ports.map { case (data, port) => data -> controller.port(port.name) }.toMap
+
+    // When using the low-level API, the user must explicitly call `controller.completeInFlightCommands()` to ensure that all commands are executed. When using a higher-level API like peek/poke, we handle this automatically.
+    private var shouldCompleteInFlightCommands: Boolean = false
+    def completeSimulation() = {
+      if (shouldCompleteInFlightCommands) {
+        shouldCompleteInFlightCommands = false
+        controller.completeInFlightCommands()
+      }
+    }
+
+    // The peek/poke API implicitly evaluates on the first peek after one or more pokes. This is _only_ for peek/poke and using `controller` directly will not provide this behavior.
+    private var evaluateBeforeNextPeek: Boolean = false
+    def willPoke() = {
+      shouldCompleteInFlightCommands = true
+      evaluateBeforeNextPeek = true
+    }
+    def willPeek() = {
+      shouldCompleteInFlightCommands = true
+      if (evaluateBeforeNextPeek) {
+        evaluateBeforeNextPeek = false
+        controller.run(0)
+      }
+    }
+  }
+  private[simulator] val dynamicSimulationContext = new scala.util.DynamicVariable[Option[SimulationContext]](None)
+}
+
+trait Simulator {
+
+  def workspacePath: String
+  def workingDirectoryPrefix = "workdir"
+  def customSimulationWorkingDirectory: Option[String] = None
+  def verbose:                          Boolean = false
+
+  private[simulator] def processBackends(processor: Simulator.BackendProcessor): Unit
+  private[simulator] def _simulate[T <: RawModule, U](
+    module: => T
+  )(body:   (Simulation.Controller, T) => U
+  ): Seq[Simulator.BackendInvocationDigest[U]] = {
+    val workspace = new Workspace(path = workspacePath, workingDirectoryPrefix = workingDirectoryPrefix)
+    workspace.reset()
+    val (dut, ports) = workspace.elaborateGeneratedModuleInternal({ () => module })
+    workspace.generateAdditionalSources()
+    val compiler = new Simulator.WorkspaceCompiler(
+      workspace,
+      customSimulationWorkingDirectory,
+      verbose,
+      { controller =>
+        require(Simulator.dynamicSimulationContext.value.isEmpty, "Nested simulations are not supported.")
+        val context = Simulator.SimulationContext(ports, controller)
+        Simulator.dynamicSimulationContext.withValue(Some(context)) {
+          val outcome = body(controller, dut)
+          context.completeSimulation()
+          outcome
+        }
+      }
+    )
+    processBackends(compiler)
+    compiler.results.toSeq
+  }
+}
+
+trait MultiBackendSimulator extends Simulator {
+  def processBackends(processor: Simulator.BackendProcessor): Unit
+
+  def simulate[T <: RawModule, U](
+    module: => T
+  )(body:   (Simulation.Controller, T) => U
+  ): Seq[Simulator.BackendInvocationDigest[U]] = {
+    _simulate(module)(body)
+  }
+}
+
+trait SingleBackendSimulator[T <: Backend] extends Simulator {
+  val backend: T
+  def tag:                                String
+  def commonCompilationSettings:          CommonCompilationSettings
+  def backendSpecificCompilationSettings: backend.CompilationSettings
+
+  final def processBackends(processor: Simulator.BackendProcessor): Unit = {
+    processor.process(backend)(tag, commonCompilationSettings, backendSpecificCompilationSettings)
+  }
+
+  def simulate[T <: RawModule, U](
+    module: => T
+  )(body:   (Simulation.Controller, T) => U
+  ): Simulator.BackendInvocationDigest[U] = {
+    _simulate(module)(body).head
+  }
+
+}

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -100,6 +100,9 @@ final object Simulator {
 
     // The peek/poke API implicitly evaluates on the first peek after one or more pokes. This is _only_ for peek/poke and using `controller` directly will not provide this behavior.
     private var evaluateBeforeNextPeek: Boolean = false
+    def willEvaluate() = {
+      evaluateBeforeNextPeek = false
+    }
     def willPoke() = {
       shouldCompleteInFlightCommands = true
       evaluateBeforeNextPeek = true
@@ -107,7 +110,7 @@ final object Simulator {
     def willPeek() = {
       shouldCompleteInFlightCommands = true
       if (evaluateBeforeNextPeek) {
-        evaluateBeforeNextPeek = false
+        willEvaluate()
         controller.run(0)
       }
     }

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -1,0 +1,96 @@
+package chisel3
+
+import svsim._
+import chisel3.reflect.DataMirror
+
+package object simulator {
+  implicit class SimulationController(controller: Simulation.Controller) {
+    def port(data: Data): Simulation.Port = {
+      val context = Simulator.dynamicSimulationContext.value.get
+      assert(context.controller == controller)
+      context.simulationPorts(data)
+    }
+  }
+
+  implicit class ChiselWorkspace(workspace: Workspace) {
+    def elaborateGeneratedModule[T <: RawModule](
+      generateModule: () => T
+    ): T = {
+      elaborateGeneratedModuleInternal(generateModule)._1
+    }
+    private[simulator] def elaborateGeneratedModuleInternal[T <: RawModule](
+      generateModule: () => T
+    ): (T, Seq[(Data, ModuleInfo.Port)]) = {
+      // Use CIRCT to generate SystemVerilog sources, and potentially additional artifacts
+      var someDut: Option[T] = None
+      val outputAnnotations = (new circt.stage.ChiselStage).execute(
+        Array("--target", "systemverilog", "--split-verilog"),
+        Seq(
+          chisel3.stage.ChiselGeneratorAnnotation { () =>
+            val dut = generateModule()
+            someDut = Some(dut)
+            dut
+          },
+          circt.stage.FirtoolOption("-disable-annotation-unknown"),
+          firrtl.options.TargetDirAnnotation(workspace.supportArtifactsPath)
+        )
+      )
+
+      // Move the relevant files over to primary-sources
+      val filelist =
+        new java.io.BufferedReader(new java.io.FileReader(s"${workspace.supportArtifactsPath}/filelist.f"))
+      try {
+        filelist.lines().forEach { immutableFilename =>
+          var filename = immutableFilename
+          /// Some files are provided as absolute paths
+          if (filename.startsWith(workspace.supportArtifactsPath)) {
+            filename = filename.substring(workspace.supportArtifactsPath.length + 1)
+          }
+          java.nio.file.Files.move(
+            java.nio.file.Paths.get(s"${workspace.supportArtifactsPath}/$filename"),
+            java.nio.file.Paths.get(s"${workspace.primarySourcesPath}/$filename")
+          )
+        }
+      } finally {
+        filelist.close()
+      }
+
+      // Initialize Module Info
+      val dut = someDut.get
+      val ports = {
+        def leafPorts(node: Data, name: String): Seq[(Data, ModuleInfo.Port)] = {
+          node match {
+            case record: Record => {
+              record.elements.toSeq.flatMap {
+                case (fieldName, field) =>
+                  leafPorts(field, s"${name}_${fieldName}")
+              }
+            }
+            case vec: Vec[_] => {
+              vec.zipWithIndex.flatMap {
+                case (element, index) =>
+                  leafPorts(element, s"${name}_${index}")
+              }
+            }
+            case element: Element =>
+              DataMirror.directionOf(element) match {
+                case ActualDirection.Input  => Seq((element, ModuleInfo.Port(name, isSettable = true)))
+                case ActualDirection.Output => Seq((element, ModuleInfo.Port(name, isGettable = true)))
+                case _                      => Seq()
+              }
+          }
+        }
+        DataMirror.modulePorts(dut).flatMap {
+          case (name, data) => leafPorts(data, name)
+        }
+      }
+      workspace.elaborate(
+        ModuleInfo(
+          name = dut.name,
+          ports = ports.map(_._2)
+        )
+      )
+      (dut, ports)
+    }
+  }
+}

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -58,6 +58,10 @@ package object simulator {
       // Initialize Module Info
       val dut = someDut.get
       val ports = {
+
+        /**
+          * We infer the names of various ports since we don't currently have a good alternative when using MFC. We hope to replace this once we get better support from CIRCT.
+          */
         def leafPorts(node: Data, name: String): Seq[(Data, ModuleInfo.Port)] = {
           node match {
             case record: Record => {

--- a/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
@@ -1,0 +1,69 @@
+package chiselTests.simulator
+
+import chisel3._
+import chisel3.simulator._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
+import svsim._
+import chisel3.simulator.Simulator.CompilationFailed
+import chisel3.simulator.Simulator.SimulationDigest
+
+class GCD extends Module {
+  val io = IO(new Bundle {
+    val a = Input(UInt(32.W))
+    val b = Input(UInt(32.W))
+    val loadValues = Input(Bool())
+    val result = Output(UInt(32.W))
+    val resultIsValid = Output(Bool())
+  })
+  val x = Reg(UInt(32.W))
+  val y = Reg(UInt(32.W))
+  when(x > y) { x := x -% y }.otherwise { y := y -% x }
+  when(io.loadValues) { x := io.a; y := io.b }
+  io.result := x
+  io.resultIsValid := y === 0.U
+}
+
+final class VerilatorSimulator(val workspacePath: String) extends SingleBackendSimulator[verilator.Backend] {
+  val backend = verilator.Backend.initializeFromProcessEnvironment()
+  val tag = "verilator"
+  val commonCompilationSettings = CommonCompilationSettings()
+  val backendSpecificCompilationSettings = verilator.Backend.CompilationSettings()
+}
+
+class SimulatorSpec extends AnyFunSpec with Matchers {
+  describe("Chisel Simulator") {
+    it("runs GCD correctly") {
+      val simulator = new VerilatorSimulator("test_run_dir/simulator/GCDSimulator")
+      val result = simulator
+        .simulate(new GCD()) { (controller, gcd) =>
+          val a = controller.port(gcd.io.a)
+          val b = controller.port(gcd.io.b)
+          val loadValues = controller.port(gcd.io.loadValues)
+          val result = controller.port(gcd.io.result)
+          val resultIsValid = controller.port(gcd.io.resultIsValid)
+          val clock = controller.port(gcd.clock)
+          a.set(24)
+          b.set(36)
+          loadValues.set(1)
+          clock.tick(
+            inPhaseValue = 0,
+            outOfPhaseValue = 1,
+            timestepsPerPhase = 1,
+            cycles = 1
+          )
+          loadValues.set(0)
+          clock.tick(
+            inPhaseValue = 0,
+            outOfPhaseValue = 1,
+            timestepsPerPhase = 1,
+            maxCycles = 10,
+            sentinel = Some(resultIsValid, 1)
+          )
+          result.get().asBigInt
+        }
+        .result
+      assert(result === 12)
+    }
+  }
+}

--- a/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
@@ -5,8 +5,6 @@ import chisel3.simulator._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import svsim._
-import chisel3.simulator.Simulator.CompilationFailed
-import chisel3.simulator.Simulator.SimulationDigest
 
 class GCD extends Module {
   val io = IO(new Bundle {

--- a/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
@@ -75,6 +75,7 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
           gcd.clock.step()
           gcd.io.loadValues.poke(0.B)
           gcd.clock.step(10)
+          gcd.io.result.expect(12)
           gcd.io.result.peek().litValue
         }
         .result

--- a/svsim/README.md
+++ b/svsim/README.md
@@ -88,7 +88,7 @@ building blocks in a higher-level framework.
 
 `svsim` currently provides two `Backend`s: `verilator.Backend` and
 `vcs.Backend`. Settings which **all** `svsim` `Backend`s must support (like
-SystemVerilog preprocessor defines) live in `SvsimCompilationSettings`, and each
+SystemVerilog preprocessor defines) live in `CommonCompilationSettings`, and each
 backend has its own backend-specific `CompilationSettings`.
 
 ## Advanced Usage

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -4,15 +4,15 @@ package svsim
 
 /** Settings supported by all svsim backends.
   */
-case class SvsimCompilationSettings(
-  verilogPreprocessorDefines: Seq[SvsimCompilationSettings.VerilogPreprocessorDefine] = Seq(),
-  optimizationStyle:          SvsimCompilationSettings.OptimizationStyle = SvsimCompilationSettings.OptimizationStyle.Default,
-  availableParallelism: SvsimCompilationSettings.AvailableParallelism =
-    SvsimCompilationSettings.AvailableParallelism.Default,
-  defaultTimescale:  Option[SvsimCompilationSettings.Timescale] = None,
+case class CommonCompilationSettings(
+  verilogPreprocessorDefines: Seq[CommonCompilationSettings.VerilogPreprocessorDefine] = Seq(),
+  optimizationStyle:          CommonCompilationSettings.OptimizationStyle = CommonCompilationSettings.OptimizationStyle.Default,
+  availableParallelism: CommonCompilationSettings.AvailableParallelism =
+    CommonCompilationSettings.AvailableParallelism.Default,
+  defaultTimescale:  Option[CommonCompilationSettings.Timescale] = None,
   libraryExtensions: Option[Seq[String]] = None,
   libraryPaths:      Option[Seq[String]] = None)
-object SvsimCompilationSettings {
+object CommonCompilationSettings {
   object VerilogPreprocessorDefine {
     def apply(name: String, value: String) = new VerilogPreprocessorDefine(name, Some(value))
     def apply(name: String) = new VerilogPreprocessorDefine(name, None)
@@ -50,7 +50,7 @@ object SvsimCompilationSettings {
     case class UpTo(value: Int) extends AvailableParallelism
   }
 
-  val default = SvsimCompilationSettings()
+  val default = CommonCompilationSettings()
 
   sealed trait Timescale
   object Timescale {
@@ -64,7 +64,7 @@ trait Backend {
     outputBinaryName:        String,
     topModuleName:           String,
     additionalHeaderPaths:   Seq[String],
-    commonSettings:          SvsimCompilationSettings,
+    commonSettings:          CommonCompilationSettings,
     backendSpecificSettings: CompilationSettings
   ): Backend.InvocationSettings
 }

--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -255,7 +255,7 @@ final class Workspace(
   def compile[T <: Backend](
     backend:                          T
   )(workingDirectoryTag:              String,
-    commonSettings:                   SvsimCompilationSettings,
+    commonSettings:                   CommonCompilationSettings,
     backendSpecificSettings:          backend.CompilationSettings,
     customSimulationWorkingDirectory: Option[String],
     verbose:                          Boolean

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -42,7 +42,7 @@ object Backend {
         (fsdbEnabled, svsim.Backend.enableFsdbTracingFlag)
       ).collect {
         case (true, value) =>
-          svsim.SvsimCompilationSettings.VerilogPreprocessorDefine(value)
+          svsim.CommonCompilationSettings.VerilogPreprocessorDefine(value)
       }
       private[vcs] def environment = fsdbSettings match {
         case None                                        => Seq()
@@ -93,7 +93,7 @@ final class Backend(
     outputBinaryName:        String,
     topModuleName:           String,
     additionalHeaderPaths:   Seq[String],
-    commonSettings:          SvsimCompilationSettings,
+    commonSettings:          CommonCompilationSettings,
     backendSpecificSettings: CompilationSettings
   ): svsim.Backend.InvocationSettings = {
     // These environment variables apply to both compilation and simulation
@@ -107,7 +107,7 @@ final class Backend(
     ).flatten
 
     //format: off
-    import SvsimCompilationSettings._
+    import CommonCompilationSettings._
     import Backend.CompilationSettings._
     svsim.Backend.InvocationSettings(
       compilerPath = s"$vcsHome/bin/vcs",

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -37,10 +37,10 @@ final class Backend(
     outputBinaryName:        String,
     topModuleName:           String,
     additionalHeaderPaths:   Seq[String],
-    commonSettings:          SvsimCompilationSettings,
+    commonSettings:          CommonCompilationSettings,
     backendSpecificSettings: CompilationSettings
   ): svsim.Backend.InvocationSettings = {
-    import SvsimCompilationSettings._
+    import CommonCompilationSettings._
     import Backend.CompilationSettings._
     //format: off
     svsim.Backend.InvocationSettings(

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -51,7 +51,7 @@ trait BackendSpec extends AnyFunSpec with Matchers {
             backend
           )(
             workingDirectoryTag = name,
-            commonSettings = SvsimCompilationSettings(),
+            commonSettings = CommonCompilationSettings(),
             backendSpecificSettings = compilationSettings,
             customSimulationWorkingDirectory = None,
             verbose = false
@@ -68,7 +68,7 @@ trait BackendSpec extends AnyFunSpec with Matchers {
           backend
         )(
           workingDirectoryTag = name,
-          commonSettings = SvsimCompilationSettings(),
+          commonSettings = CommonCompilationSettings(),
           backendSpecificSettings = compilationSettings,
           customSimulationWorkingDirectory = None,
           verbose = false


### PR DESCRIPTION
#### Type of Improvement

New feature/API

Added a `Simulator` class which provides the glue code to use Chisel modules with `svsim`.

Next steps: Create an interface designed for unit tests and port `ChiselRunner` to use that interface.

#### API Impact

This is all new API, though I have renamed `SvsimCompilationSettings` to `svsim.CommonCompilationSettings` which I think is clearer.

#### Backend Code Generation Impact

None

#### Release Notes

- Added `chisel3.simulator.Simulator` for simulating Chisel modules with `svsim`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
