### PR TITLE
Use %[[]] format for ChsielAnnotations

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -366,11 +366,11 @@ private[chisel3] object Converter {
   }
 
   def convert(circuit: Circuit): fir.Circuit =
-    fir.Circuit(fir.NoInfo, circuit.components.map(convert), circuit.name)
+    fir.Circuit(fir.NoInfo, circuit.components.map(convert), circuit.name, circuit.firrtlAnnotations.toSeq)
 
   // TODO Unclear if this should just be the default
   def convertLazily(circuit: Circuit): fir.Circuit = {
     val lazyModules = LazyList() ++ circuit.components
-    fir.Circuit(fir.NoInfo, lazyModules.map(convert), circuit.name)
+    fir.Circuit(fir.NoInfo, lazyModules.map(convert), circuit.name, circuit.firrtlAnnotations.toSeq)
   }
 }

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -529,4 +529,7 @@ case class ExtModule(
     extends DefModule
     with UseSerializer
 
-case class Circuit(info: Info, modules: Seq[DefModule], main: String) extends FirrtlNode with HasInfo with UseSerializer
+case class Circuit(info: Info, modules: Seq[DefModule], main: String, annotations: AnnotationSeq)
+    extends FirrtlNode
+    with HasInfo
+    with UseSerializer

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -2,6 +2,8 @@
 
 package firrtl.ir
 
+import firrtl.annotations.JsonProtocol
+
 case class Version(major: Int, minor: Int, patch: Int) {
   def serialize: String = s"$major.$minor.$patch"
   def incompatible(that: Version): Boolean =
@@ -365,11 +367,15 @@ object Serializer {
   }
 
   private def sIt(node: Circuit)(implicit indent: Int): Iterator[String] = node match {
-    case Circuit(info, modules, main) =>
+    case Circuit(info, modules, main, annotations) =>
       val prelude = {
         implicit val b = new StringBuilder // Scope this so we don't accidentally pass it anywhere
         b ++= s"FIRRTL version ${version.serialize}\n"
-        b ++= "circuit "; b ++= main; b ++= " :"; s(info)
+        b ++= "circuit "; b ++= main; b ++= " :";
+        if (annotations.nonEmpty) {
+          b ++= "%["; b ++= JsonProtocol.serialize(annotations); b ++= "]";
+        }
+        s(info)
         b.toString
       }
       Iterator(prelude) ++

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -38,7 +38,8 @@ class ExtModuleTests extends FirrtlFlatSpec {
           )
         )
       ),
-      "Top"
+      "Top",
+      Seq.empty
     )
 
     circuit.serialize should be(input)

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -79,7 +79,8 @@ object SerializerSpec {
         childModuleIR,
         testModuleIR
       ),
-      "test"
+      "test",
+      Seq.empty
     )
 
 }
@@ -112,7 +113,8 @@ object SMemTestCircuit {
           )
         )
       ),
-      "Example"
+      "Example",
+      Seq.empty
     )
 
   def findRuw(c: Circuit): ReadUnderWrite.Value = {

--- a/firrtl/src/test/scala/firrtlTests/stage/FirrtlOptionsViewSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/stage/FirrtlOptionsViewSpec.scala
@@ -30,7 +30,8 @@ class FirrtlOptionsViewSpec extends AnyFlatSpec with Matchers {
         )
       )
     ),
-    main
+    main,
+    Seq.empty
   )
 
   val grault: ir.Circuit = circuitIR("grault")

--- a/firrtl/src/test/scala/firrtlTests/stage/phases/ChecksSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/stage/phases/ChecksSpec.scala
@@ -14,7 +14,7 @@ class ChecksSpec extends AnyFlatSpec with Matchers {
 
   class Fixture { val phase: Phase = new Checks }
 
-  val inputCircuit = FirrtlCircuitAnnotation(firrtl.ir.Circuit(firrtl.ir.NoInfo, Seq.empty, "Foo"))
+  val inputCircuit = FirrtlCircuitAnnotation(firrtl.ir.Circuit(firrtl.ir.NoInfo, Seq.empty, "Foo", Seq.empty))
   val outputFile = OutputFileAnnotation("bar")
   val outputAnnotationFile = OutputAnnotationFileAnnotation("baz")
   val infoMode = InfoModeAnnotation("ignore")

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -26,11 +26,9 @@ class Convert extends Phase {
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselCircuitAnnotation =>
       Some(a) ++
-        /* Convert this Chisel Circuit to a FIRRTL Circuit */
-        Some(FirrtlCircuitAnnotation(Converter.convert(a.circuit))) ++
-        /* Convert all Chisel Annotations to FIRRTL Annotations */
-        //TODO: clean up this code when firrtl is merged
-        a.circuit.firrtlAnnotations
+        /* Convert this Chisel Circuit to a FIRRTL Circuit.  ChiselAnnotations will be
+         * converted to FIRRTL Annotations and inserted inside the Circuit. */
+        Some(FirrtlCircuitAnnotation(Converter.convert(a.circuit)))
     case a => Some(a)
   }
 

--- a/src/test/scala/chisel3/testers/TestUtils.scala
+++ b/src/test/scala/chisel3/testers/TestUtils.scala
@@ -31,6 +31,6 @@ object TestUtils {
     val circuit = processedAnnos.collectFirst {
       case FirrtlCircuitAnnotation(a) => a
     }.get
-    (circuit, processedAnnos)
+    (circuit, processedAnnos ++ circuit.annotations)
   }
 }

--- a/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala
@@ -8,6 +8,7 @@ import chisel3.stage.{ChiselGeneratorAnnotation}
 import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 import firrtl.annotations.{CircuitTarget, SingleTargetAnnotation, Target}
+import firrtl.stage.FirrtlCircuitAnnotation
 import org.scalatest._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -127,6 +128,10 @@ class AnnotatingDiamondSpec extends AnyFreeSpec with Matchers {
           Array("--target-dir", "test_run_dir", "--target", "chirrtl"),
           Seq(ChiselGeneratorAnnotation(() => new TopOfDiamond))
         )
+        .flatMap {
+          case FirrtlCircuitAnnotation(circuit) => circuit.annotations
+          case _                                => None
+        }
         .filter {
           case _: IdentityAnnotation => true
           case _ => false

--- a/src/test/scala/chiselTests/ChiselEnum.scala
+++ b/src/test/scala/chiselTests/ChiselEnum.scala
@@ -9,6 +9,7 @@ import chisel3.stage.ChiselGeneratorAnnotation
 import circt.stage.ChiselStage
 import chisel3.util._
 import chisel3.testers.BasicTester
+import firrtl.stage.FirrtlCircuitAnnotation
 import org.scalatest.Assertion
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -802,10 +803,15 @@ class ChiselEnumAnnotationSpec extends AnyFreeSpec with Matchers {
     corrects.forall(c => annos.exists(isCorrect(_, c)))
 
   def test(strongEnumAnnotatorGen: () => Module): Unit = {
-    val annos = (new ChiselStage).execute(
-      Array("--target-dir", "test_run_dir", "--target", "chirrtl"),
-      Seq(ChiselGeneratorAnnotation(strongEnumAnnotatorGen))
-    )
+    val annos = (new ChiselStage)
+      .execute(
+        Array("--target-dir", "test_run_dir", "--target", "chirrtl"),
+        Seq(ChiselGeneratorAnnotation(strongEnumAnnotatorGen))
+      )
+      .flatMap {
+        case FirrtlCircuitAnnotation(circuit) => circuit.annotations
+        case _                                => None
+      }
 
     val enumDefAnnos = annos.collect { case a: EnumDefAnnotation => a }
     val enumCompAnnos = annos.collect { case a: EnumComponentAnnotation => a }

--- a/src/test/scala/chiselTests/NewAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/NewAnnotationsSpec.scala
@@ -55,6 +55,10 @@ class NewAnnotationsSpec extends AnyFreeSpec with Matchers {
           Array("--target", "chirrtl", "--target-dir", "test_run_dir"),
           Seq(ChiselGeneratorAnnotation(() => new UsesMuchUsedModule))
         )
+        .flatMap {
+          case FirrtlCircuitAnnotation(circuit) => circuit.annotations
+          case _                                => None
+        }
 
       val dontTouchAnnos = dutAnnos.collect { case DontTouchAnnotation(target) => target.serialize }
       val noDedupAnnos = dutAnnos.collect { case NoDedupAnnotation(target) => target.serialize }

--- a/src/test/scala/chiselTests/stage/phases/ConvertSpec.scala
+++ b/src/test/scala/chiselTests/stage/phases/ConvertSpec.scala
@@ -42,10 +42,11 @@ class ConvertSpec extends AnyFlatSpec with Matchers {
       .foldLeft(annos)((a, p) => p.transform(a))
 
     info("FIRRTL circuit generated")
-    annosx.collect { case a: FirrtlCircuitAnnotation => a.circuit.main }.toSeq should be(Seq("foo"))
+    val circuit = annosx.collectFirst { case a: FirrtlCircuitAnnotation => a.circuit }.get
+    circuit.main should be("foo")
 
     info("FIRRTL annotations generated")
-    annosx.collect { case a: ConvertSpecFirrtlAnnotation => a.name }.toSeq should be(Seq("bar"))
+    circuit.annotations.collect { case a: ConvertSpecFirrtlAnnotation => a.name }.toSeq should be(Seq("bar"))
 
   }
 

--- a/src/test/scala/chiselTests/util/SizeOfSpec.scala
+++ b/src/test/scala/chiselTests/util/SizeOfSpec.scala
@@ -7,6 +7,8 @@ import chisel3.util.circt.SizeOf
 
 import circt.stage.ChiselStage
 
+import firrtl.stage.FirrtlCircuitAnnotation
+
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -53,6 +55,10 @@ class SizeOfSpec extends AnyFlatSpec with Matchers {
         args = Array("--target", "chirrtl"),
         annotations = Seq(chisel3.stage.ChiselGeneratorAnnotation(() => new SizeOfTop))
       )
+      .flatMap {
+        case FirrtlCircuitAnnotation(circuit) => circuit.annotations
+        case _                                => None
+      }
       .mkString("\n") should include).regex(c)
   }
 }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -24,9 +24,12 @@ object ChiselStageSpec {
     val b = Output(Bool())
   }
 
-  class Foo extends RawModule {
+  class Foo(hasDontTouch: Boolean = false) extends RawModule {
     val a = IO(new FooBundle)
     val b = IO(Flipped(new FooBundle))
+    if (hasDontTouch) {
+      dontTouch(a)
+    }
     b <> a
   }
 
@@ -277,6 +280,26 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
         file should exist
       }
     }
+
+    it("should emit Annotations inline in emitted CHIRRTL") {
+      val targetDir = os.pwd / "ChiselStageSpec" / "should-inline-Annotations-in-emitted-CHIRRTL"
+
+      val args: Array[String] = Array(
+        "--target",
+        "chirrtl",
+        "--target-dir",
+        targetDir.toString
+      )
+
+      (new ChiselStage)
+        .execute(
+          args,
+          Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.Foo(hasDontTouch = true)))
+        )
+
+      info("output file included an Annotation")
+      os.read(targetDir / "Foo.fir") should include("firrtl.transforms.DontTouchAnnotation")
+    }
   }
 
   describe("ChiselStage exception handling") {
@@ -404,7 +427,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val lines = stdout.split("\n")
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:74:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:77:9: Negative shift amounts are illegal (got -1)"
       )
       lines(1) should include("    3.U >> -1")
       lines(2) should include("        ^")
@@ -425,7 +448,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines.size should equal(2)
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:74:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:77:9: Negative shift amounts are illegal (got -1)"
       )
       (lines(1) should not).include("3.U >> -1")
     }
@@ -869,8 +892,12 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
     it("should emit specification FIRRTL (CHIRRTL) with the correct FIRRTL spec version") {
 
-      val text = ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo)
+      val text = ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo(hasDontTouch = true))
+      info("found a version string")
       text should include("FIRRTL version 1.2.0")
+      info("found an Annotation")
+      text should include("firrtl.transforms.DontTouchAnnotation")
+      info("found a circuit")
       text should include("circuit Foo")
 
     }

--- a/src/test/scala/circtTests/stage/phases/AddImplicitOutputFileSpec.scala
+++ b/src/test/scala/circtTests/stage/phases/AddImplicitOutputFileSpec.scala
@@ -29,7 +29,8 @@ class AddImplicitOutputFileSpec extends AnyFlatSpec with Matchers {
         )
       )
     ),
-    "foo"
+    "foo",
+    Seq.empty
   )
 
   behavior.of(classOf[AddImplicitOutputFile].toString)


### PR DESCRIPTION
Change FIRRTL Circuit conversion/serialization to place ChiselAnnotations (converted to FIRRTL Annotations) inside the FIRRTL Circuit and to serialize this using the "%[[]]" inline JSON format that is present in the FIRRTL spec.  This does not remove _all_ annotations passed via the annotation file, but it is the first step towards that.