### PR TITLE
Add EphemeralSimulator API

### DIFF
--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -1,6 +1,7 @@
 package chisel3.simulator
 
 import svsim._
+import java.lang.ProcessHandle
 import chisel3.RawModule
 
 /**

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -1,0 +1,38 @@
+package chisel3.simulator
+
+import svsim._
+import chisel3.RawModule
+
+/**
+  * `EphemeralSimulator` provides a simple API for ephemeral invocations (such as `scala-cli` scripts) to simulate Chisel modules. To keep things really simple, it only provides the peek/poke API provides enough control while hiding some of the lower-level svsim complexity.
+  * The recommended way to use `EphemeralSimulator` is simply to `import chisel3.simulator.EphemeralSimulator._` and then call `simulate(new MyChiselModule()) { module => ... }`.
+  */
+object EphemeralSimulator extends PeekPokeAPI {
+
+  def simulate[T <: RawModule](
+    module: => T
+  )(body:   (T) => Unit
+  ): Unit = {
+    synchronized {
+      simulator.simulate(module)({ (_, dut) => body(dut) }).result
+    }
+  }
+
+  private class DefaultSimulator(val workspacePath: String) extends SingleBackendSimulator[verilator.Backend] {
+    val backend = verilator.Backend.initializeFromProcessEnvironment()
+    val tag = "default"
+    val commonCompilationSettings = CommonCompilationSettings()
+    val backendSpecificCompilationSettings = verilator.Backend.CompilationSettings()
+
+    // Try to clean up temporary workspace if possible
+    sys.addShutdownHook {
+      Runtime.getRuntime().exec(Array("rm", "-rf", workspacePath)).waitFor()
+    }
+  }
+  private lazy val simulator: DefaultSimulator = {
+    val temporaryDirectory = System.getProperty("java.io.tmpdir")
+    val id = ProcessHandle.current().pid().toString()
+    val className = getClass().getName().stripSuffix("$")
+    new DefaultSimulator(Seq(temporaryDirectory, className, id).mkString("/"))
+  }
+}

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -5,7 +5,7 @@ import chisel3.RawModule
 
 /** Provides a simple API for "ephemeral" invocations (where you don't care about the artifacts after the invocation completes) to
   * simulate Chisel modules. To keep things really simple, it only provides the
-  * peek/poke API provides enough control while hiding some of the lower-level svsim
+  * peek/poke API, which provides enough control while hiding some of the lower-level svsim
   * complexity.
   * @example
   * ```

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -3,9 +3,9 @@ package chisel3.simulator
 import svsim._
 import chisel3.RawModule
 
-/** Provides a simple API for ephemeral invocations (such as `scala-cli` scripts) to 
-  * simulate Chisel modules. To keep things really simple, it only provides the 
-  * peek/poke API provides enough control while hiding some of the lower-level svsim 
+/** Provides a simple API for "ephemeral" invocations (where you don't care about the artifacts after the invocation completes) to
+  * simulate Chisel modules. To keep things really simple, it only provides the
+  * peek/poke API provides enough control while hiding some of the lower-level svsim
   * complexity.
   * @example
   * ```

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -1,7 +1,6 @@
 package chisel3.simulator
 
 import svsim._
-import java.lang.ProcessHandle
 import chisel3.RawModule
 
 /**
@@ -25,6 +24,8 @@ object EphemeralSimulator extends PeekPokeAPI {
     val commonCompilationSettings = CommonCompilationSettings()
     val backendSpecificCompilationSettings = verilator.Backend.CompilationSettings()
 
+    println(s"GEORGE: $workspacePath")
+
     // Try to clean up temporary workspace if possible
     sys.addShutdownHook {
       Runtime.getRuntime().exec(Array("rm", "-rf", workspacePath)).waitFor()
@@ -32,7 +33,9 @@ object EphemeralSimulator extends PeekPokeAPI {
   }
   private lazy val simulator: DefaultSimulator = {
     val temporaryDirectory = System.getProperty("java.io.tmpdir")
-    val id = ProcessHandle.current().pid().toString()
+    // TODO: Use ProcessHandle when we can drop Java 8 support
+    // val id = ProcessHandle.current().pid().toString()
+    val id = java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
     val className = getClass().getName().stripSuffix("$")
     new DefaultSimulator(Seq(temporaryDirectory, className, id).mkString("/"))
   }

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -4,9 +4,8 @@ import svsim._
 import chisel3.RawModule
 
 /** Provides a simple API for "ephemeral" invocations (where you don't care about the artifacts after the invocation completes) to
-  * simulate Chisel modules. To keep things really simple, it only provides the
-  * peek/poke API, which provides enough control while hiding some of the lower-level svsim
-  * complexity.
+  * simulate Chisel modules. To keep things really simple, `EphemeralSimulator` simulations can only be controlled using the
+  * peek/poke API, which provides enough control while hiding some of the lower-level svsim complexity.
   * @example
   * ```
   * import chisel3.simulator.EphemeralSimulator._

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -3,9 +3,16 @@ package chisel3.simulator
 import svsim._
 import chisel3.RawModule
 
-/**
-  * `EphemeralSimulator` provides a simple API for ephemeral invocations (such as `scala-cli` scripts) to simulate Chisel modules. To keep things really simple, it only provides the peek/poke API provides enough control while hiding some of the lower-level svsim complexity.
-  * The recommended way to use `EphemeralSimulator` is simply to `import chisel3.simulator.EphemeralSimulator._` and then call `simulate(new MyChiselModule()) { module => ... }`.
+/** Provides a simple API for ephemeral invocations (such as `scala-cli` scripts) to 
+  * simulate Chisel modules. To keep things really simple, it only provides the 
+  * peek/poke API provides enough control while hiding some of the lower-level svsim 
+  * complexity.
+  * @example
+  * ```
+  * import chisel3.simulator.EphemeralSimulator._
+  * ...
+  * simulate(new MyChiselModule()) { module => ... }
+  * ```
   */
 object EphemeralSimulator extends PeekPokeAPI {
 

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -31,8 +31,6 @@ object EphemeralSimulator extends PeekPokeAPI {
     val commonCompilationSettings = CommonCompilationSettings()
     val backendSpecificCompilationSettings = verilator.Backend.CompilationSettings()
 
-    println(s"GEORGE: $workspacePath")
-
     // Try to clean up temporary workspace if possible
     sys.addShutdownHook {
       Runtime.getRuntime().exec(Array("rm", "-rf", workspacePath)).waitFor()

--- a/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
+++ b/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
@@ -3,7 +3,8 @@ package chisel3.simulator
 import svsim._
 import chisel3._
 
-object PeekPokeAPI extends PeekPokeAPI {}
+object PeekPokeAPI extends PeekPokeAPI
+
 trait PeekPokeAPI {
   case class FailedExpectationException[T](observed: T, expected: T, message: String)
       extends Exception(s"Failed Expectation: Observed value '$observed' != $expected. $message")

--- a/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
+++ b/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
@@ -14,14 +14,18 @@ trait PeekPokeAPI {
     def step(cycles: Int = 1): Unit = {
       val context = currentContext()
       context.willEvaluate()
-      val simulationPort = context.simulationPorts(clock)
-      simulationPort.tick(
-        timestepsPerPhase = 1,
-        maxCycles = cycles,
-        inPhaseValue = 0,
-        outOfPhaseValue = 1,
-        sentinel = None
-      )
+      if (cycles == 0) {
+        context.controller.run(0)
+      } else {
+        val simulationPort = context.simulationPorts(clock)
+        simulationPort.tick(
+          timestepsPerPhase = 1,
+          maxCycles = cycles,
+          inPhaseValue = 0,
+          outOfPhaseValue = 1,
+          sentinel = None
+        )
+      }
     }
 
     /**

--- a/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
+++ b/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
@@ -29,8 +29,9 @@ trait PeekPokeAPI {
       }
     }
 
-    /**
-      * Ticks this clock up to `maxCycles`, stops early if the specified port is equal to the specified value.
+    /** Ticks this clock up to `maxCycles`.
+      *
+      * Stops early if the `sentinelPort` is equal to the `sentinelValue`.
       */
     def stepUntil(sentinelPort: Data, sentinelValue: BigInt, maxCycles: Int): Unit = {
       val context = currentContext()

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -78,7 +78,8 @@ package object simulator {
             }
             case element: Element =>
               DataMirror.directionOf(element) match {
-                case ActualDirection.Input  => Seq((element, ModuleInfo.Port(name, isSettable = true)))
+                case ActualDirection.Input =>
+                  Seq((element, ModuleInfo.Port(name, isGettable = true, isSettable = true)))
                 case ActualDirection.Output => Seq((element, ModuleInfo.Port(name, isGettable = true)))
                 case _                      => Seq()
               }

--- a/src/test/scala/chiselTests/simulator/EphemeraSimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/EphemeraSimulatorSpec.scala
@@ -1,0 +1,24 @@
+package chiselTests.simulator
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
+
+import chisel3._
+import chisel3.simulator.EphemeralSimulator._
+
+class EphemeralSimulatorSpec extends AnyFunSpec with Matchers {
+  describe("EphemeralSimulator") {
+    it("runs GCD correctly") {
+      simulate(new GCD()) { gcd =>
+        gcd.io.a.poke(24.U)
+        gcd.io.b.poke(36.U)
+        gcd.io.loadValues.poke(1.B)
+        gcd.clock.step()
+        gcd.io.loadValues.poke(0.B)
+        gcd.clock.stepUntil(sentinelPort = gcd.io.resultIsValid, sentinelValue = 1, maxCycles = 10)
+        gcd.io.resultIsValid.expect(true.B)
+        gcd.io.result.expect(12)
+      }
+    }
+  }
+}

--- a/src/test/scala/chiselTests/simulator/GCD.scala
+++ b/src/test/scala/chiselTests/simulator/GCD.scala
@@ -2,6 +2,7 @@ package chiselTests.simulator
 
 import chisel3._
 
+/** A simple module useful for testing Chisel generation and testing */
 class GCD extends Module {
   val io = IO(new Bundle {
     val a = Input(UInt(32.W))

--- a/src/test/scala/chiselTests/simulator/GCD.scala
+++ b/src/test/scala/chiselTests/simulator/GCD.scala
@@ -1,0 +1,19 @@
+package chiselTests.simulator
+
+import chisel3._
+
+class GCD extends Module {
+  val io = IO(new Bundle {
+    val a = Input(UInt(32.W))
+    val b = Input(UInt(32.W))
+    val loadValues = Input(Bool())
+    val result = Output(UInt(32.W))
+    val resultIsValid = Output(Bool())
+  })
+  val x = Reg(UInt(32.W))
+  val y = Reg(UInt(32.W))
+  when(x > y) { x := x -% y }.otherwise { y := y -% x }
+  when(io.loadValues) { x := io.a; y := io.b }
+  io.result := x
+  io.resultIsValid := y === 0.U
+}

--- a/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
@@ -6,22 +6,6 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import svsim._
 
-class GCD extends Module {
-  val io = IO(new Bundle {
-    val a = Input(UInt(32.W))
-    val b = Input(UInt(32.W))
-    val loadValues = Input(Bool())
-    val result = Output(UInt(32.W))
-    val resultIsValid = Output(Bool())
-  })
-  val x = Reg(UInt(32.W))
-  val y = Reg(UInt(32.W))
-  when(x > y) { x := x -% y }.otherwise { y := y -% x }
-  when(io.loadValues) { x := io.a; y := io.b }
-  io.result := x
-  io.resultIsValid := y === 0.U
-}
-
 class VerilatorSimulator(val workspacePath: String) extends SingleBackendSimulator[verilator.Backend] {
   val backend = verilator.Backend.initializeFromProcessEnvironment()
   val tag = "verilator"

--- a/svsim/src/main/resources/simulation-driver.cpp
+++ b/svsim/src/main/resources/simulation-driver.cpp
@@ -546,7 +546,7 @@ static void resolveSettablePort(int id, SettablePort *out,
   out->bitWidth = 0;
   out->setter = NULL;
   if (port_setter(id, &out->bitWidth, &out->setter)) {
-    failWithError("Invalid port ID '%d'.", id);
+    failWithError("Encountered invalid port ID '%d' when %s.", id, description);
   }
   if (out->bitWidth <= 0) {
     failWithError("Encountered port with invalid bit width when %s.",
@@ -559,7 +559,7 @@ static void resolveGettablePort(int id, GettablePort *out,
   out->bitWidth = 0;
   out->getter = NULL;
   if (port_getter(id, &out->bitWidth, &out->getter)) {
-    failWithError("Invalid port ID '%d'.", id);
+    failWithError("Encountered invalid port ID '%d' when %s.", id, description);
   }
   if (out->bitWidth <= 0) {
     failWithError("Encountered port with invalid bit width when %s.",


### PR DESCRIPTION
Introduce `chisel3.simulator.EphemeralSimulator` for ephemeral scenarios (such as scala-cli).

This PR also adds `stepUntil` to PeekPokeAPI. This is effectively just svsim's `TICK` but is generally useful (for example in the GCD module used in the tests).

#### Type of Improvement

New feature/API

#### Release Notes

- Introduce `chisel3.simulator.EphemeralSimulator` for ephemeral scenarios (such as scala-cli)

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
