### PR TITLE
Deprecate Scala 2.12 in Chisel 3.6 through the compiler plugin

### DIFF
--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
@@ -21,6 +21,14 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
   class ChiselComponentPhase(prev: Phase) extends StdPhase(prev) {
     override def name: String = phaseName
     def apply(unit: CompilationUnit): Unit = {
+      // Issue a deprecation warning for Scala 2.12
+      val scalaVersion = scala.util.Properties.versionNumberString.split('.')
+      if (scalaVersion(0).toInt == 2 && scalaVersion(1).toInt == 12) {
+        val msg = s"Chisel 3.6 is the last version that will support Scala 2.12. Please upgrade to Scala 2.13."
+
+        global.reporter.warning(unit.body.pos, msg)
+      }
+
       if (ChiselPlugin.runComponent(global, arguments)(unit)) {
         unit.body = new MyTypingTransformer(unit).transform(unit.body)
       }


### PR DESCRIPTION
This introduces a new check to the compiler plugin for Scala 2.12 which will issue a warning for the planned 2.12 deprecation. I was unable to create a test within the plugin module to check for this behavior, but validated the changes by creating a sbt project pulling in this change as a local dependency, then compiled Chisel code with Scala 2.12.17 and 2.13.10. The former prints the warning for every compiled source file while the latter does not, as was expected.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you state the API impact?
- [ ] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- code cleanup / technical debt

#### API Impact

No change

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

Squash and merge

#### Release Notes
Deprecate Scala 2.12 for Chisel 3.6 and later versions

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels?
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
