### PR TITLE
Deprecate ChiselStage$.elaborate

### DIFF
--- a/integration-tests/src/test/scala/chiselTest/LFSRSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/LFSRSpec.scala
@@ -126,7 +126,7 @@ class LFSRSpec extends ChiselFlatSpec with Utils {
   it should "throw an exception if initialized to a seed of zero for XOR configuration" in {
     {
       the[IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
-        ChiselStage.elaborate(new FooLFSR(XOR, Some(0)))
+        ChiselStage.emitCHIRRTL(new FooLFSR(XOR, Some(0)))
       }
     }.getMessage should include("Seed cannot be zero")
   }
@@ -134,7 +134,7 @@ class LFSRSpec extends ChiselFlatSpec with Utils {
   it should "throw an exception if initialized to a seed of all ones for XNOR configuration" in {
     {
       the[IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
-        ChiselStage.elaborate(new FooLFSR(XNOR, Some(15)))
+        ChiselStage.emitCHIRRTL(new FooLFSR(XNOR, Some(15)))
       }
     }.getMessage should include("Seed cannot be all ones")
   }
@@ -152,7 +152,7 @@ class LFSRSpec extends ChiselFlatSpec with Utils {
   it should "throw an exception if no LFSR taps are known" in {
     {
       the[IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
-        ChiselStage.elaborate(new MaxPeriodGaloisLFSR(787))
+        ChiselStage.emitCHIRRTL(new MaxPeriodGaloisLFSR(787))
       }
     }.getMessage should include("No max period LFSR taps stored for requested width")
   }

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -211,6 +211,10 @@ object ChiselStage {
     *
     * @param gen a call-by-name Chisel module
     */
+  @deprecated(
+    "this exposes the internal Chisel circuit which was not supposed to be public---use either ChiselStage.convert or ChiselStage.emitCHIRRTL instead",
+    "Chisel 5.0"
+  )
   def elaborate(
     gen:  => RawModule,
     args: Array[String] = Array.empty

--- a/src/test/scala/chisel3/internal/NameCollisionSpec.scala
+++ b/src/test/scala/chisel3/internal/NameCollisionSpec.scala
@@ -10,7 +10,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
 
   it should "error on duplicated names with a correct message" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(
+      ChiselStage.emitCHIRRTL(
         new Module {
           val foo, bar = IO(Input(UInt(8.W)))
           val out = IO(Output(UInt(8.W)))
@@ -31,7 +31,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
   it should "error on sanitization resulting in duplicated names with a helpful message" in {
     // Case one: An unsanitary name that results in a collision with an existing name once sanitized
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(
+      ChiselStage.emitCHIRRTL(
         new Module {
           val foo, bar = IO(Input(UInt(8.W)))
           val out = IO(Output(UInt(8.W)))
@@ -50,7 +50,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
     )
 
     // Case two: An unsanitary name which does not collide with any names once sanitized. No error is raised
-    ChiselStage.elaborate(
+    ChiselStage.emitCHIRRTL(
       new Module {
         val foo, bar = IO(Input(UInt(8.W)))
         val out = IO(Output(UInt(8.W)))
@@ -66,7 +66,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
   it should "error on nameless ports being assigned default names" in {
 
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(
+      ChiselStage.emitCHIRRTL(
         new Module {
           // Write to an output port that isn't assigned to a val, and so doesn't get prefixed
           IO(Output(UInt(8.W))) := 123.U

--- a/src/test/scala/chisel3/testers/TestUtils.scala
+++ b/src/test/scala/chisel3/testers/TestUtils.scala
@@ -33,4 +33,5 @@ object TestUtils {
     }.get
     (circuit, processedAnnos ++ circuit.annotations)
   }
+
 }

--- a/src/test/scala/chiselTests/AnalogSpec.scala
+++ b/src/test/scala/chiselTests/AnalogSpec.scala
@@ -93,7 +93,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
 
   it should "NOT be bindable to registers" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})
           val reg = Reg(Analog(32.W))
@@ -104,7 +104,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
 
   it should "NOT be bindable to a direction" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
             val a = Input(Analog(32.W))
@@ -113,7 +113,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
       }
     }
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
             val a = Output(Analog(32.W))
@@ -124,7 +124,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "be flippable" in {
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       new Module {
         val io = IO(new Bundle {
           val a = Flipped(Analog(32.W))
@@ -137,7 +137,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
   // Should this be an error?
   ignore should "NOT be a legal type for Mem" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})
           val mem = Mem(16, Analog(32.W))
@@ -148,7 +148,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
 
   it should "NOT be bindable to Mem ports" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})
           val mem = Mem(16, Analog(32.W))
@@ -186,7 +186,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
 
   it should "error if any bulk connected more than once" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val wires = List.fill(3)(Wire(Analog(32.W)))
         wires(0) <> wires(1)
@@ -194,7 +194,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
       })
     }
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val wires = List.fill(2)(Wire(Analog(32.W)))
         wires(0) <> DontCare
@@ -204,13 +204,13 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "allow DontCare connection" in {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val a = Analog(1.W)
       })
       io.a := DontCare
     })
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val a = Analog(1.W)
       })
@@ -223,14 +223,14 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
       val x = Input(UInt(8.W))
       val y = Analog(8.W)
     }
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val a = new MyBundle
       })
       val w = Wire(new MyBundle)
       w <> io.a
     })
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val a = Vec(1, new MyBundle)
       })

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -157,18 +157,18 @@ class AssertSpec extends ChiselFlatSpec with Utils {
     assertTesterPasses { new AssertPrintablePortScope }
   }
   "Assert Printables" should "respect wire scoping" in {
-    a[ChiselException] should be thrownBy { ChiselStage.elaborate(new AssertPrintableWireScope) }
+    a[ChiselException] should be thrownBy { ChiselStage.emitCHIRRTL(new AssertPrintableWireScope) }
   }
   "Assume Printables" should "respect port scoping" in {
     assertTesterPasses { new AssumePrintablePortScope }
   }
 
   "Assume Printables" should "respect wire scoping" in {
-    a[ChiselException] should be thrownBy { ChiselStage.elaborate(new AssumePrintableWireScope) }
+    a[ChiselException] should be thrownBy { ChiselStage.emitCHIRRTL(new AssumePrintableWireScope) }
   }
 
   "Assert Printables" should "respect when scope" in {
-    a[ChiselException] should be thrownBy { ChiselStage.elaborate(new AssertPrintableFailingWhenScope) }
+    a[ChiselException] should be thrownBy { ChiselStage.emitCHIRRTL(new AssertPrintableFailingWhenScope) }
   }
 
   "Assertions" should "allow the modulo operator % in the message" in {
@@ -186,7 +186,7 @@ class AssertSpec extends ChiselFlatSpec with Utils {
   they should "not allow unescaped % in the message" in {
     a[java.util.UnknownFormatConversionException] should be thrownBy {
       extractCause[java.util.UnknownFormatConversionException] {
-        ChiselStage.elaborate { new BadUnescapedPercentAssertTester }
+        ChiselStage.emitCHIRRTL { new BadUnescapedPercentAssertTester }
       }
     }
   }
@@ -197,7 +197,7 @@ class AssertSpec extends ChiselFlatSpec with Utils {
   they should "not allow unescaped % in the printable message" in {
     a[java.util.UnknownFormatConversionException] should be thrownBy {
       extractCause[java.util.UnknownFormatConversionException] {
-        ChiselStage.elaborate { new BadUnescapedPercentAssertTester }
+        ChiselStage.emitCHIRRTL { new BadUnescapedPercentAssertTester }
       }
     }
   }

--- a/src/test/scala/chiselTests/AsyncResetSpec.scala
+++ b/src/test/scala/chiselTests/AsyncResetSpec.scala
@@ -142,11 +142,11 @@ class AsyncResetSpec extends ChiselFlatSpec with Utils {
   behavior.of("AsyncReset")
 
   it should "be able to be connected to DontCare" in {
-    ChiselStage.elaborate(new AsyncResetDontCareModule)
+    ChiselStage.emitCHIRRTL(new AsyncResetDontCareModule)
   }
 
   it should "be allowed with literal reset values" in {
-    ChiselStage.elaborate(new BasicTester {
+    ChiselStage.emitCHIRRTL(new BasicTester {
       withReset(reset.asAsyncReset)(RegInit(123.U))
     })
   }
@@ -164,7 +164,7 @@ class AsyncResetSpec extends ChiselFlatSpec with Utils {
 
   it should "NOT be allowed to connect directly to a Bool" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new BasicTester {
+      ChiselStage.emitCHIRRTL(new BasicTester {
         val bool = Wire(Bool())
         val areset = reset.asAsyncReset
         bool := areset
@@ -181,7 +181,7 @@ class AsyncResetSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "allow casting to and from Bool" in {
-    ChiselStage.elaborate(new BasicTester {
+    ChiselStage.emitCHIRRTL(new BasicTester {
       val r: Reset = reset
       val a: AsyncReset = WireInit(r.asAsyncReset)
       val b: Bool = a.asBool

--- a/src/test/scala/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala/chiselTests/AutoClonetypeSpec.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.util.QueueIO
-import circt.stage.ChiselStage.elaborate
+import circt.stage.ChiselStage.emitCHIRRTL
 
 import scala.collection.immutable.ListMap
 
@@ -93,7 +93,7 @@ class RecordWithVerbotenMethods(w: Int) extends Record {
 class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
 
   "Bundles with Scala args" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new Bundle {})
 
@@ -104,7 +104,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Bundles with Scala implicit args" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new Bundle {})
 
@@ -117,7 +117,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Bundles with Scala explicit and impicit args" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new Bundle {})
 
@@ -131,7 +131,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Subtyped Bundles" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new Bundle {})
 
@@ -141,7 +141,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
         assert(myWire.i2 == 4)
       }
     }
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new Bundle {})
 
@@ -158,7 +158,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Subtyped Bundles that don't clone well" should "be now be supported!" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new Bundle {})
         val myWire = Wire(new SubBundleInvalid(8, 4))
@@ -167,11 +167,11 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Inner bundles with Scala args" should "not need clonetype" in {
-    elaborate { new ModuleWithInner }
+    emitCHIRRTL { new ModuleWithInner }
   }
 
   "Bundles with arguments as fields" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(Output(new BundleWithArgumentField(UInt(8.W), UInt(8.W))))
         io.x := 1.U
@@ -181,7 +181,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "also work when giving directions to the fields" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new BundleWithArgumentField(Input(UInt(8.W)), Output(UInt(8.W))))
         io.y := io.x
@@ -190,7 +190,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Bundles inside companion objects" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(Output(new CompanionObjectWithBundle.Inner))
         io.data := 1.U
@@ -199,7 +199,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Parameterized bundles inside companion objects" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(Output(new CompanionObjectWithBundle.ParameterizedInner(8)))
         io.data := 1.U
@@ -208,7 +208,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Nested directioned anonymous Bundles" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val io = IO(new NestedAnonymousBundle)
         val a = WireDefault(io)
@@ -218,7 +218,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "3.0 null compatibility" should "not need clonetype" in {
-    elaborate {
+    emitCHIRRTL {
       new Module {
         class InnerClassThing {
           def createBundle: Bundle = new Bundle {
@@ -233,7 +233,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
 
   "Aliased fields" should "be caught" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      elaborate {
+      emitCHIRRTL {
         new Module {
           val bundleFieldType = UInt(8.W)
           val io = IO(Output(new Bundle {
@@ -251,7 +251,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
         val a = typeTuple._1
       }
 
-      elaborate {
+      emitCHIRRTL {
         new Module {
           // This needs to be constructed before the call to Output, otherwise it won't be cloned
           // thanks to lazy cloning
@@ -270,7 +270,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
         val x = Output(UInt(3.W))
       }))
     }
-    elaborate { new TestModule }
+    emitCHIRRTL { new TestModule }
   }
 
   "Wrapped IO construction with parent references" should "not fail for autoclonetype" in {
@@ -282,7 +282,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
         val x = Output(UInt(blah.W))
       }))
     }
-    elaborate { new TestModule(3) }
+    emitCHIRRTL { new TestModule(3) }
   }
 
   "Autoclonetype" should "support Bundles with if-blocks" in {
@@ -296,7 +296,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       })
       io.out := io.in
     }
-    elaborate(new MyModule(3))
+    emitCHIRRTL(new MyModule(3))
   }
 
   behavior.of("Compiler Plugin Autoclonetype")
@@ -308,14 +308,14 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       io.count := 0.U
       io.error := true.B
     }
-    elaborate(new MyModule)
+    emitCHIRRTL(new MyModule)
   }
 
   it should "support Bundles with non-val parameters" in {
     class MyBundle(i: Int) extends Bundle {
       val foo = UInt(i.W)
     }
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val in = IO(Input(new MyBundle(8)))
         val out = IO(Output(new MyBundle(8)))
@@ -328,7 +328,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
     class MyBundle[T <: Data](gen: T) extends Bundle {
       val foo = gen
     }
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val in = IO(Input(new MyBundle(UInt(8.W))))
         val out = IO(Output(new MyBundle(UInt(8.W))))
@@ -341,7 +341,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
     class MyBundle(implicit i: Int) extends Bundle {
       val foo = UInt(i.W)
     }
-    elaborate {
+    emitCHIRRTL {
       new Module {
         implicit val x = 8
         val in = IO(Input(new MyBundle))
@@ -355,7 +355,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
     class MyBundle(i: Int)(j: Int, jj: Int)(k: UInt) extends Bundle {
       val foo = UInt((i + j + jj + k.getWidth).W)
     }
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val in = IO(Input(new MyBundle(8)(8, 8)(UInt(8.W))))
         val out = IO(Output(new MyBundle(8)(8, 8)(UInt(8.W))))
@@ -368,7 +368,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
     class MyBundle(i: Int) extends Bundle {
       val foo = UInt(i.W)
     }
-    elaborate {
+    emitCHIRRTL {
       new Module {
         val in = IO(Input(new MyBundle(8)))
         val out = IO(Output(new MyBundle(8)))
@@ -386,7 +386,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(new MyBundle(4)))
       out := in
     }
-    elaborate(new MyModule(UInt(8.W)))
+    emitCHIRRTL(new MyModule(UInt(8.W)))
   }
 
   it should "work for higher-kinded types" in {
@@ -400,7 +400,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       val io = IO(Output(new MyBundle[UInt, DataGen[UInt]](new DataGen(UInt(3.W)))))
       io.foo := 0.U
     }
-    elaborate(new MyModule)
+    emitCHIRRTL(new MyModule)
   }
 
   it should "support Bundles with vararg arguments" in {
@@ -419,7 +419,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(new VarArgsBundle(1)(2, 3, 4)))
       out := in
     }
-    elaborate(new MyModule)
+    emitCHIRRTL(new MyModule)
   }
 
   it should "support Records that mixin AutoCloneType" in {
@@ -429,7 +429,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(gen))
       out := in
     }
-    elaborate(new MyModule)
+    emitCHIRRTL(new MyModule)
   }
 
   it should "support Records that don't mixin AutoCloneType and use forbidden methods" in {
@@ -439,7 +439,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(gen))
       out := in
     }
-    elaborate(new MyModule)
+    emitCHIRRTL(new MyModule)
   }
 
   it should "compile with package private default bundle constructors" in {
@@ -454,6 +454,6 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(PrivateDefaultConsBundle(8)))
       out := in
     }
-    elaborate(new MyModule)
+    emitCHIRRTL(new MyModule)
   }
 }

--- a/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
+++ b/src/test/scala/chiselTests/AutoNestedCloneSpec.scala
@@ -2,7 +2,7 @@
 
 package chiselTests
 import chisel3._
-import circt.stage.ChiselStage.elaborate
+import circt.stage.ChiselStage.emitCHIRRTL
 import org.scalatest.matchers.should.Matchers
 
 class BundleWithAnonymousInner(val w: Int) extends Bundle {
@@ -16,7 +16,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   behavior.of("autoCloneType of inner Bundle in Chisel3")
 
   it should "clone a doubly-nested inner bundle successfully" in {
-    elaborate {
+    emitCHIRRTL {
       class Outer(val w: Int) extends Module {
         class Middle(val w: Int) {
           class InnerIOType extends Bundle {
@@ -32,7 +32,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   }
 
   it should "clone an anonymous inner bundle successfully" in {
-    elaborate {
+    emitCHIRRTL {
       class TestTop(val w: Int) extends Module {
         val io = IO(new Bundle {})
         val myWire = Wire(new Bundle { val a = UInt(w.W) })
@@ -42,7 +42,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   }
 
   it should "pick the correct $outer instance for an anonymous inner bundle" in {
-    elaborate {
+    emitCHIRRTL {
       class Inner(val w: Int) extends Module {
         val io = IO(new Bundle {
           val in = Input(UInt(w.W))
@@ -64,7 +64,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   }
 
   it should "clone an anonymous, bound, inner bundle of another bundle successfully" in {
-    elaborate {
+    emitCHIRRTL {
       class TestModule(w: Int) extends Module {
         val io = IO(new BundleWithAnonymousInner(w))
         val w0 = WireDefault(io)
@@ -75,7 +75,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   }
 
   it should "clone an anonymous, inner bundle of a Module, bound to another bundle successfully" in {
-    elaborate {
+    emitCHIRRTL {
       class TestModule(w: Int) extends Module {
         val bun = new Bundle {
           val foo = UInt(w.W)
@@ -91,7 +91,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   }
 
   it should "clone a double-nested anonymous Bundle" in {
-    elaborate {
+    emitCHIRRTL {
       class TestModule() extends Module {
         val io = IO(new Bundle {
           val inner = Input(new Bundle {
@@ -104,7 +104,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   }
 
   it should "support an anonymous doubly-nested inner bundle" in {
-    elaborate {
+    emitCHIRRTL {
       class Outer(val w: Int) extends Module {
         class Middle(val w: Int) {
           def getIO: Bundle = new Bundle {
@@ -119,7 +119,7 @@ class AutoNestedCloneSpec extends ChiselFlatSpec with Matchers with Utils {
   }
 
   it should "support anonymous Inner bundles that capture type parameters from outer Bundles" in {
-    elaborate(new Module {
+    emitCHIRRTL(new Module {
       class MyBundle[T <: Data](n: Int, gen: T) extends Bundle {
         val foo = new Bundle {
           val x = Input(Vec(n, gen))

--- a/src/test/scala/chiselTests/BetterNamingTests.scala
+++ b/src/test/scala/chiselTests/BetterNamingTests.scala
@@ -75,19 +75,19 @@ class BetterNamingTests extends ChiselFlatSpec {
 
   it should "provide unique counters for each name" in {
     var module: PerNameIndexing = null
-    ChiselStage.elaborate { module = new PerNameIndexing(4); module }
+    ChiselStage.emitCHIRRTL { module = new PerNameIndexing(4); module }
     assert(module.getNameFailures() == Nil)
   }
 
   it should "provide names for things defined in Iterable[HasId] and Option[HasId]" in {
     var module: IterableNaming = null
-    ChiselStage.elaborate { module = new IterableNaming; module }
+    ChiselStage.emitCHIRRTL { module = new IterableNaming; module }
     assert(module.getNameFailures() == Nil)
   }
 
   it should "allow digits to be field names in Records" in {
     var module: DigitFieldNamesInRecord = null
-    ChiselStage.elaborate { module = new DigitFieldNamesInRecord; module }
+    ChiselStage.emitCHIRRTL { module = new DigitFieldNamesInRecord; module }
     assert(module.getNameFailures() == Nil)
   }
 

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -219,7 +219,7 @@ class BlackBoxSpec extends ChiselFlatSpec {
     assertTesterPasses({ new BlackBoxWithParamsTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
   }
   "DataMirror.modulePorts" should "work with BlackBox" in {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {})
       val m = Module(new BlackBoxPassthrough)
       assert(DataMirror.modulePorts(m) == Seq("in" -> m.io.in, "out" -> m.io.out))
@@ -231,7 +231,7 @@ class BlackBoxSpec extends ChiselFlatSpec {
 
   "A BlackBox with no 'val io'" should "give a reasonable error message" in {
     (the[ChiselException] thrownBy {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val inst = Module(new BlackBoxNoIO)
       })
     }).getMessage should include("must have a port named 'io' of type Record")
@@ -239,7 +239,7 @@ class BlackBoxSpec extends ChiselFlatSpec {
 
   "A BlackBox with non-Record 'val io'" should "give a reasonable error message" in {
     (the[ChiselException] thrownBy {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val inst = Module(new BlackBoxUIntIO)
       })
     }).getMessage should include("must have a port named 'io' of type Record")

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -263,7 +263,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   "bundle literals with bad field specifiers" should "fail" in {
     val exc = intercept[BundleLiteralException] {
       extractCause[BundleLiteralException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new RawModule {
             val bundle = new MyBundle
             bundle.Lit(x => bundle.a -> 0.U) // DONT DO THIS, this gets past a syntax error to exercise the failure
@@ -277,7 +277,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   "bundle literals with duplicate fields" should "fail" in {
     val exc = intercept[BundleLiteralException] {
       extractCause[BundleLiteralException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new RawModule {
             (new MyBundle).Lit(_.a -> 0.U, _.a -> 0.U)
           }
@@ -291,7 +291,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   "bundle literals with non-literal values" should "fail" in {
     val exc = intercept[BundleLiteralException] {
       extractCause[BundleLiteralException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new RawModule {
             (new MyBundle).Lit(_.a -> UInt())
           }
@@ -305,7 +305,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   "bundle literals with non-type-equivalent element fields" should "fail" in {
     val exc = intercept[BundleLiteralException] {
       extractCause[BundleLiteralException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new RawModule {
             (new MyBundle).Lit(_.a -> true.B)
           }
@@ -319,7 +319,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   "bundle literals with non-type-equivalent sub-bundles" should "fail" in {
     val exc = intercept[BundleLiteralException] {
       extractCause[BundleLiteralException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new RawModule {
             (new MyOuterBundle).Lit(_.b -> (new MyBundle).Lit(_.a -> 0.U))
           }
@@ -333,7 +333,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   "bundle literals with non-type-equivalent enum element fields" should "fail" in {
     val exc = intercept[BundleLiteralException] {
       extractCause[BundleLiteralException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new RawModule {
             (new MyBundle).Lit(_.c -> MyEnumB.sB)
           }
@@ -345,7 +345,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
   }
 
   "partial bundle literals" should "fail to pack" in {
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val bundleLit = (new MyBundle).Lit(_.a -> 42.U)
         bundleLit.litOption should equal(None)

--- a/src/test/scala/chiselTests/BundleSpec.scala
+++ b/src/test/scala/chiselTests/BundleSpec.scala
@@ -58,7 +58,7 @@ trait BundleSpecUtils {
 
 class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
   "Bundles with the same fields but in different orders" should "bulk connect" in {
-    ChiselStage.elaborate { new MyModule(new BundleFooBar, new BundleBarFoo) }
+    ChiselStage.emitCHIRRTL { new MyModule(new BundleFooBar, new BundleBarFoo) }
   }
 
   "Bundles" should "follow UInt serialization/deserialization API" in {
@@ -67,17 +67,17 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
 
   "Bulk connect on Bundles" should "check that the fields match" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate { new MyModule(new BundleFooBar, new BundleFoo) }
+      ChiselStage.emitCHIRRTL { new MyModule(new BundleFooBar, new BundleFoo) }
     }).getMessage should include("Right Record missing field")
 
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate { new MyModule(new BundleFoo, new BundleFooBar) }
+      ChiselStage.emitCHIRRTL { new MyModule(new BundleFoo, new BundleFooBar) }
     }).getMessage should include("Left Record missing field")
   }
 
   "Bundles" should "not be able to use Seq for constructing hardware" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
             val b = new BadSeqBundle
@@ -125,7 +125,7 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
     }
 
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(Output(new AliasedBundle))
           io.a := 0.U
@@ -137,7 +137,7 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
 
   "Bundles" should "not have bound hardware" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           class MyBundle(val foo: UInt) extends Bundle
           val in = IO(Input(new MyBundle(123.U))) // This should error: value passed in instead of type
@@ -150,7 +150,7 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
   }
   "Bundles" should "not recursively contain aggregates with bound hardware" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           class MyBundle(val foo: UInt) extends Bundle
           val out = IO(Output(Vec(2, UInt(8.W))))
@@ -161,7 +161,7 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
     }).getMessage should include("Bundle: MyBundle contains hardware fields: foo: BundleSpec_Anon.out")
   }
   "Unbound bundles sharing a field" should "not error" in {
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val foo = new Bundle {
           val x = UInt(8.W)
@@ -187,7 +187,7 @@ class BundleSpec extends ChiselFlatSpec with BundleSpecUtils with Utils {
     }
 
     val x = intercept[ChiselException] {
-      ChiselStage.elaborate(new Example, Array("--throw-on-first-error"))
+      ChiselStage.emitCHIRRTL(new Example, Array("--throw-on-first-error"))
     }
     x.getMessage should include(
       "Called litValue on aggregate MyBundle$1(a=UInt<8>(8), b=Bool(true), c=UInt<4>(DontCare)) contains DontCare"

--- a/src/test/scala/chiselTests/ChiselEnum.scala
+++ b/src/test/scala/chiselTests/ChiselEnum.scala
@@ -368,34 +368,34 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
 
   it should "fail to instantiate non-literal enums with the Value function" in {
     an[ExceptionInInitializerError] should be thrownBy extractCause[ExceptionInInitializerError] {
-      ChiselStage.elaborate(new SimpleConnector(NonLiteralEnumType(), NonLiteralEnumType()))
+      ChiselStage.emitCHIRRTL(new SimpleConnector(NonLiteralEnumType(), NonLiteralEnumType()))
     }
   }
 
   it should "fail to instantiate non-increasing enums with the Value function" in {
     an[ExceptionInInitializerError] should be thrownBy extractCause[ExceptionInInitializerError] {
-      ChiselStage.elaborate(new SimpleConnector(NonIncreasingEnum(), NonIncreasingEnum()))
+      ChiselStage.emitCHIRRTL(new SimpleConnector(NonIncreasingEnum(), NonIncreasingEnum()))
     }
   }
 
   it should "connect enums of the same type" in {
-    ChiselStage.elaborate(new SimpleConnector(EnumExample(), EnumExample()))
-    ChiselStage.elaborate(new SimpleConnector(EnumExample(), EnumExample.Type()))
+    ChiselStage.emitCHIRRTL(new SimpleConnector(EnumExample(), EnumExample()))
+    ChiselStage.emitCHIRRTL(new SimpleConnector(EnumExample(), EnumExample.Type()))
   }
 
   it should "fail to connect a strong enum to a UInt" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new SimpleConnector(EnumExample(), UInt()))
+      ChiselStage.emitCHIRRTL(new SimpleConnector(EnumExample(), UInt()))
     }
   }
 
   it should "fail to connect enums of different types" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new SimpleConnector(EnumExample(), OtherEnum()))
+      ChiselStage.emitCHIRRTL(new SimpleConnector(EnumExample(), OtherEnum()))
     }
 
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new SimpleConnector(EnumExample.Type(), OtherEnum.Type()))
+      ChiselStage.emitCHIRRTL(new SimpleConnector(EnumExample.Type(), OtherEnum.Type()))
     }
   }
 
@@ -417,21 +417,21 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
 
   it should "prevent illegal literal casts to enums" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new CastToInvalidEnumTester)
+      ChiselStage.emitCHIRRTL(new CastToInvalidEnumTester)
     }
   }
 
   it should "only allow non-literal casts to enums if the width is smaller than or equal to the enum width" in {
     for (w <- 0 to EnumExample.getWidth)
-      ChiselStage.elaborate(new CastFromNonLitWidth(Some(w)))
+      ChiselStage.emitCHIRRTL(new CastFromNonLitWidth(Some(w)))
 
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new CastFromNonLitWidth)
+      ChiselStage.emitCHIRRTL(new CastFromNonLitWidth)
     }
 
     for (w <- (EnumExample.getWidth + 1) to (EnumExample.getWidth + 100)) {
       a[ChiselException] should be thrownBy extractCause[ChiselException] {
-        ChiselStage.elaborate(new CastFromNonLitWidth(Some(w)))
+        ChiselStage.emitCHIRRTL(new CastFromNonLitWidth(Some(w)))
       }
     }
   }
@@ -442,7 +442,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
 
   it should "fail to compare enums of different types" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new InvalidEnumOpsTester)
+      ChiselStage.emitCHIRRTL(new InvalidEnumOpsTester)
     }
   }
 
@@ -483,7 +483,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(MyEnum()))
       out := MyEnum(in)
     }
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new MyModule))
     log should include("warn")
     log should include("Casting non-literal UInt")
   }
@@ -498,7 +498,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(TotalEnum()))
       out := TotalEnum(in)
     }
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new MyModule))
     (log should not).include("warn")
   }
 
@@ -515,7 +515,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
         out := res
       }
     }
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new MyModule))
     (log should not).include("warn")
   }
 
@@ -536,7 +536,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
       }
       out2 := TestEnum2(in)
     }
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new MyModule))
     log should include("warn")
     log should include("TestEnum2") // not suppressed
     (log should not).include("TestEnum1") // suppressed
@@ -552,7 +552,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
       val out = IO(Output(MyEnum()))
       out := MyEnum.safe(in)._1
     }
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new MyModule))
     (log should not).include("warn")
   }
 
@@ -568,7 +568,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
       assert(valid.litToBoolean, "It should be true.B")
       out := res
     }
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new MyModule))
     (log should not).include("warn")
   }
 

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -107,7 +107,7 @@ trait ChiselRunners extends Assertions {
 
   def elaborateAndGetModule[A <: RawModule](t: => A): A = {
     var res: Any = null
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       res = t
       res.asInstanceOf[A]
     }

--- a/src/test/scala/chiselTests/ConnectSpec.scala
+++ b/src/test/scala/chiselTests/ConnectSpec.scala
@@ -44,7 +44,7 @@ class ConnectSpec extends ChiselPropSpec with Utils {
   property("SInt := UInt should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(UInt(16.W), SInt(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(UInt(16.W), SInt(16.W)) }
       }
     }
   }
@@ -54,7 +54,7 @@ class ConnectSpec extends ChiselPropSpec with Utils {
   property("UInt := SInt should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(SInt(16.W), UInt(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(SInt(16.W), UInt(16.W)) }
       }
     }
   }
@@ -64,7 +64,7 @@ class ConnectSpec extends ChiselPropSpec with Utils {
   property("Clock := UInt should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(Clock(), UInt(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(Clock(), UInt(16.W)) }
       }
     }
   }
@@ -72,40 +72,40 @@ class ConnectSpec extends ChiselPropSpec with Utils {
   property("Analog := Analog should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(Analog(16.W), Analog(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), Analog(16.W)) }
       }
     }
   }
   property("Analog := UInt should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(Analog(16.W), UInt(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), UInt(16.W)) }
       }
     }
   }
   property("Analog := SInt should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(Analog(16.W), SInt(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), SInt(16.W)) }
       }
     }
   }
   property("UInt := Analog should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(UInt(16.W), Analog(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(UInt(16.W), Analog(16.W)) }
       }
     }
   }
   property("SInt := Analog should fail") {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new CrossConnectTester(SInt(16.W), Analog(16.W)) }
+        ChiselStage.emitCHIRRTL { new CrossConnectTester(SInt(16.W), Analog(16.W)) }
       }
     }
   }
   property("Pipe internal connections should succeed") {
-    ChiselStage.elaborate(new PipeInternalWires)
+    ChiselStage.emitCHIRRTL(new PipeInternalWires)
   }
 
   property("Connect error messages should have meaningful information") {
@@ -118,7 +118,7 @@ class ConnectSpec extends ChiselPropSpec with Utils {
       inner.myReg := false.B // ERROR
     }
 
-    val assignError = the[ChiselException] thrownBy { ChiselStage.elaborate { new OuterAssignExample } }
+    val assignError = the[ChiselException] thrownBy { ChiselStage.emitCHIRRTL { new OuterAssignExample } }
     val expectedAssignError = """.*@: myReg in InnerExample cannot be written from module OuterAssignExample."""
     (assignError.getMessage should fullyMatch).regex(expectedAssignError)
 
@@ -128,12 +128,12 @@ class ConnectSpec extends ChiselPropSpec with Utils {
       myReg := inner.myReg // ERROR
     }
 
-    val readError = the[ChiselException] thrownBy { ChiselStage.elaborate { new OuterReadExample } }
+    val readError = the[ChiselException] thrownBy { ChiselStage.emitCHIRRTL { new OuterReadExample } }
     val expectedReadError = """.*@: myReg in InnerExample cannot be read from module OuterReadExample."""
     (readError.getMessage should fullyMatch).regex(expectedReadError)
 
     val typeMismatchError = the[ChiselException] thrownBy {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new RawModule {
           val myUInt = Wire(UInt(4.W))
           val mySInt = Wire(SInt(4.W))

--- a/src/test/scala/chiselTests/DataPrint.scala
+++ b/src/test/scala/chiselTests/DataPrint.scala
@@ -27,7 +27,7 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
   }
 
   "Data types" should "have a meaningful string representation" in {
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         UInt().toString should be("UInt")
         UInt(8.W).toString should be("UInt<8>")
@@ -85,11 +85,11 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
   }
 
   "Bound data types" should "have a meaningful string representation" in {
-    ChiselStage.elaborate { new BoundDataModule }
+    ChiselStage.emitCHIRRTL { new BoundDataModule }
   }
 
   "Literals" should "have a meaningful string representation" in {
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         3.U.toString should be("UInt<2>(3)")
         3.U(5.W).toString should be("UInt<5>(3)")

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -8,7 +8,7 @@ import chisel3.util.Decoupled
 
 class DecoupledSpec extends ChiselFlatSpec {
   "Decoupled() and Decoupled.empty" should "give DecoupledIO with empty payloads" in {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val in = Flipped(Decoupled())
         val out = Decoupled.empty

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -49,36 +49,36 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
   //TODO: In Chisel3 these are actually FIRRTL errors. Remove from tests?
 
   property("Outputs should be assignable") {
-    ChiselStage.elaborate(new GoodDirection)
+    ChiselStage.emitCHIRRTL(new GoodDirection)
   }
 
   property("Inputs should not be assignable") {
     a[Exception] should be thrownBy extractCause[Exception] {
-      ChiselStage.elaborate(new BadDirection)
+      ChiselStage.emitCHIRRTL(new BadDirection)
     }
     a[Exception] should be thrownBy extractCause[Exception] {
-      ChiselStage.elaborate(new BadSubDirection)
+      ChiselStage.emitCHIRRTL(new BadSubDirection)
     }
   }
 
   property("Top-level forced outputs should be assignable") {
-    ChiselStage.elaborate(new TopDirectionOutput)
+    ChiselStage.emitCHIRRTL(new TopDirectionOutput)
   }
 
   property("Empty Vecs with directioned sample_element should not cause direction errors") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = Vec(0, Output(UInt(8.W)))
       })
     })
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = Flipped(Vec(0, Output(UInt(8.W))))
       })
     })
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = Output(Vec(0, UInt(8.W)))
@@ -89,7 +89,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
   property(
     "Empty Vecs with no direction on the sample_element should not cause direction errors, as Chisel and chisel3 directions are merged"
   ) {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = Vec(0, UInt(8.W))
@@ -98,19 +98,19 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
   }
 
   property("Empty Bundles should not cause direction errors") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = new Bundle {}
       })
     })
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = Flipped(new Bundle {})
       })
     })
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = Input(UInt(8.W))
         val x = new Bundle {
@@ -123,7 +123,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
   property(
     "Explicitly directioned but empty Bundles should not cause direction errors because Chisel and chisel3 directionality are merged"
   ) {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val foo = UInt(8.W)
         val x = Input(new Bundle {})
@@ -160,7 +160,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
   }
 
   property("Directions should be preserved through cloning and binding of Bundles") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       class MyBundle extends Bundle {
         val foo = Input(UInt(8.W))
         val bar = Output(UInt(8.W))
@@ -197,7 +197,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
   }
 
   property("Directions should be preserved through cloning and binding of Vecs") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val a = Vec(1, Input(UInt(8.W)))
       val b = Vec(1, a)
       val c = Vec(1, Flipped(a))

--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -52,7 +52,7 @@ class DontTouchSpec extends ChiselFlatSpec with Utils {
   }
   "Dont touch" should "only work on bound hardware" in {
     a[chisel3.BindingException] should be thrownBy extractCause[BindingException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         dontTouch(new Bundle { val a = UInt(32.W) })
       })

--- a/src/test/scala/chiselTests/EnableShiftRegister.scala
+++ b/src/test/scala/chiselTests/EnableShiftRegister.scala
@@ -46,7 +46,7 @@ class EnableShiftRegisterTester(c: EnableShiftRegister) extends Tester(c) {
 class EnableShiftRegisterSpec extends ChiselPropSpec {
 
   property("EnableShiftRegister should elaborate") {
-    ChiselStage.elaborate { new EnableShiftRegister }
+    ChiselStage.emitCHIRRTL { new EnableShiftRegister }
   }
 
   ignore("EnableShiftRegisterTester should return the correct result") {}

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -108,7 +108,7 @@ class ExtModuleSpec extends ChiselFlatSpec {
     assertTesterPasses({ new MultiExtModuleTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
   }
   "DataMirror.modulePorts" should "work with ExtModule" in {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {})
       val m = Module(new extmoduletests.BlackBoxPassthrough)
       assert(DataMirror.modulePorts(m) == Seq("in" -> m.in, "out" -> m.out))

--- a/src/test/scala/chiselTests/GCD.scala
+++ b/src/test/scala/chiselTests/GCD.scala
@@ -48,7 +48,7 @@ class GCDSpec extends ChiselPropSpec {
   )
 
   property("GCD should elaborate") {
-    ChiselStage.elaborate { new GCD }
+    ChiselStage.emitCHIRRTL { new GCD }
   }
 
   property("GCDTester should return the correct result") {

--- a/src/test/scala/chiselTests/IOCompatibility.scala
+++ b/src/test/scala/chiselTests/IOCompatibility.scala
@@ -38,11 +38,11 @@ class IOCModuleWire extends Module {
 class IOCompatibilitySpec extends ChiselPropSpec with Matchers with Utils {
 
   property("IOCModuleVec should elaborate") {
-    ChiselStage.elaborate { new IOCModuleVec(2) }
+    ChiselStage.emitCHIRRTL { new IOCModuleVec(2) }
   }
 
   property("IOCModuleWire should elaborate") {
-    ChiselStage.elaborate { new IOCModuleWire }
+    ChiselStage.emitCHIRRTL { new IOCModuleWire }
   }
 
   class IOUnwrapped extends Module {
@@ -52,7 +52,7 @@ class IOCompatibilitySpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Unwrapped IO should generate an exception") {
     a[BindingException] should be thrownBy extractCause[BindingException] {
-      ChiselStage.elaborate(new IOUnwrapped)
+      ChiselStage.emitCHIRRTL(new IOUnwrapped)
     }
   }
 }

--- a/src/test/scala/chiselTests/IllegalRefSpec.scala
+++ b/src/test/scala/chiselTests/IllegalRefSpec.scala
@@ -61,13 +61,13 @@ class IllegalRefSpec extends ChiselFlatSpec with Utils {
     case (k, v) =>
       s"Illegal cross-module references in ${k}" should "fail" in {
         a[ChiselException] should be thrownBy extractCause[ChiselException] {
-          ChiselStage.elaborate { new IllegalRefOuter(v) }
+          ChiselStage.emitCHIRRTL { new IllegalRefOuter(v) }
         }
       }
 
       s"Using a signal that has escaped its enclosing when scope in ${k}" should "fail" in {
         a[ChiselException] should be thrownBy extractCause[ChiselException] {
-          ChiselStage.elaborate { new CrossWhenConnect(v) }
+          ChiselStage.emitCHIRRTL { new CrossWhenConnect(v) }
         }
       }
   }

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -26,7 +26,7 @@ class InstanceNameSpec extends ChiselFlatSpec {
   behavior.of("instanceName")
   val moduleName = "InstanceNameModule"
   var m: InstanceNameModule = _
-  ChiselStage.elaborate { m = new InstanceNameModule; m }
+  ChiselStage.emitCHIRRTL { m = new InstanceNameModule; m }
 
   it should "work with module IO" in {
     val io = m.io.pathName

--- a/src/test/scala/chiselTests/InvalidateAPISpec.scala
+++ b/src/test/scala/chiselTests/InvalidateAPISpec.scala
@@ -88,7 +88,7 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
     }
     val exception = intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate(new ModuleWithDontCareSink)
+        ChiselStage.emitCHIRRTL(new ModuleWithDontCareSink)
       }
     }
     exception.getMessage should include("DontCare cannot be a connection sink")
@@ -101,7 +101,7 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
     }
     val exception = intercept[BiConnectException] {
       extractCause[BiConnectException] {
-        circt.stage.ChiselStage.elaborate(new ModuleWithDontCareSink)
+        circt.stage.ChiselStage.emitCHIRRTL(new ModuleWithDontCareSink)
       }
     }
     exception.getMessage should include("DontCare cannot be a connection sink (LHS)")

--- a/src/test/scala/chiselTests/LazyCloneSpec.scala
+++ b/src/test/scala/chiselTests/LazyCloneSpec.scala
@@ -43,7 +43,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
         val y = Input(new Foo)
       }))
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     Counter.count should be(2L)
   }
 
@@ -56,7 +56,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
         val y = Input(foo)
       }))
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     Counter.count should be(3L)
   }
 
@@ -68,7 +68,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
         val bar = Input(new Bar(UInt(8.W)))
       }))
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     Counter.count should be(2L)
   }
 
@@ -80,7 +80,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
       val out = IO(Output(new GenRecord(gen)))
       out := in
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     Counter.count should be(4L)
   }
 
@@ -91,7 +91,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
       val out = IO(Output(new GenRecord(UInt(8.W))))
       out := in
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     Counter.count should be(2L)
   }
 
@@ -103,7 +103,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
       val out = IO(Output(new NestedGenBundle(gen)))
       out := in
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     Counter.count should be(4L)
   }
 
@@ -114,7 +114,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
       val out = IO(Output(new NestedGenBundle(UInt(8.W))))
       out := in
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     Counter.count should be(2L)
   }
 
@@ -125,7 +125,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
       val out = IO(Output(Vec(2, new Foo)))
       out := in
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     // Each Vec has 3 clones of Foo + the original Foo, then the Vec isn't cloned
     Counter.count should be(8L)
   }
@@ -138,7 +138,7 @@ class LazyCloneSpec extends ChiselFlatSpec {
       val out = IO(Output(Vec(2, gen)))
       out := in
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
     // Each Vec has 3 clones of Foo + the original Foo, then the Vec isn't cloned
     Counter.count should be(7L)
   }

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -34,7 +34,7 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
   }
 
   "litOption" should "return None for non-literal hardware" in {
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = Wire(UInt())
         assert(a.litOption == None)

--- a/src/test/scala/chiselTests/LiteralToTargetSpec.scala
+++ b/src/test/scala/chiselTests/LiteralToTargetSpec.scala
@@ -22,7 +22,7 @@ class LiteralToTargetSpec extends AnyFreeSpec with Matchers {
         bar.a.toTarget
       }
 
-      ChiselStage.elaborate(new Foo)
+      ChiselStage.emitCHIRRTL(new Foo)
     } should have).message("Illegal component name: UInt<1>(\"h01\") (note: literals are illegal)")
   }
 }

--- a/src/test/scala/chiselTests/MemorySearch.scala
+++ b/src/test/scala/chiselTests/MemorySearch.scala
@@ -51,7 +51,7 @@ class MemorySearchTester(c: MemorySearch) extends Tester(c) {
 class MemorySearchSpec extends ChiselPropSpec {
 
   property("MemorySearch should elaborate") {
-    ChiselStage.elaborate { new EnableShiftRegister }
+    ChiselStage.emitCHIRRTL { new EnableShiftRegister }
   }
 
   ignore("MemorySearch should return the correct result") {}

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -207,21 +207,21 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
 
   property("MixedVecs should not be able to take hardware types") {
     a[ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val hw = Wire(MixedVec(Seq(UInt(8.W), Bool())))
         val illegal = MixedVec(hw)
       })
     }
     a[ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val hw = Reg(MixedVec(Seq(UInt(8.W), Bool())))
         val illegal = MixedVec(hw)
       })
     }
     a[ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val v = Input(MixedVec(Seq(UInt(8.W), Bool())))
         })
@@ -256,7 +256,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
 
   property("Connecting a MixedVec and something of different size should report a ChiselException") {
     an[IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val out = Output(MixedVec(Seq(UInt(8.W), Bool())))
         })
@@ -265,7 +265,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
       })
     }
     an[IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val out = Output(MixedVec(Seq(UInt(8.W), Bool())))
         })

--- a/src/test/scala/chiselTests/Module.scala
+++ b/src/test/scala/chiselTests/Module.scala
@@ -87,43 +87,43 @@ class NullModuleWrapper extends Module {
 class ModuleSpec extends ChiselPropSpec with Utils {
 
   property("ModuleVec should elaborate") {
-    ChiselStage.elaborate { new ModuleVec(2) }
+    ChiselStage.emitCHIRRTL { new ModuleVec(2) }
   }
 
   ignore("ModuleVecTester should return the correct result") {}
 
   property("ModuleWire should elaborate") {
-    ChiselStage.elaborate { new ModuleWire }
+    ChiselStage.emitCHIRRTL { new ModuleWire }
   }
 
   ignore("ModuleWireTester should return the correct result") {}
 
   property("ModuleWhen should elaborate") {
-    ChiselStage.elaborate { new ModuleWhen }
+    ChiselStage.emitCHIRRTL { new ModuleWhen }
   }
 
   ignore("ModuleWhenTester should return the correct result") {}
 
   property("Forgetting a Module() wrapper should result in an error") {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate { new ModuleForgetWrapper }
+      ChiselStage.emitCHIRRTL { new ModuleForgetWrapper }
     }).getMessage should include("attempted to instantiate a Module without wrapping it")
   }
 
   property("Double wrapping a Module should result in an error") {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate { new ModuleDoubleWrap }
+      ChiselStage.emitCHIRRTL { new ModuleDoubleWrap }
     }).getMessage should include("Called Module() twice without instantiating a Module")
   }
 
   property("Rewrapping an already instantiated Module should result in an error") {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate { new ModuleRewrap }
+      ChiselStage.emitCHIRRTL { new ModuleRewrap }
     }).getMessage should include("This is probably due to rewrapping a Module instance")
   }
 
   property("object Module.clock should return a reference to the currently in scope clock") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val clock2 = Input(Clock())
       })
@@ -132,7 +132,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
     })
   }
   property("object Module.reset should return a reference to the currently in scope reset") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val reset2 = Input(Bool())
       })
@@ -142,7 +142,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
   }
   property("object Module.currentModule should return an Option reference to the current Module") {
     def checkModule(mod: Module): Boolean = Module.currentModule.map(_ eq mod).getOrElse(false)
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {})
       assert(Module.currentModule.get eq this)
       assert(checkModule(this))
@@ -166,7 +166,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
   }
 
   property("DataMirror.modulePorts should work") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {})
       val m = Module(new chisel3.Module {
         val a = IO(UInt(8.W))
@@ -188,7 +188,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
       io.out(1) := delay + extra
     }
     var mod: MyModule = null
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       mod = new MyModule
       mod
     }
@@ -215,7 +215,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
       io.out(1) := delay + extra
     }
     var mod: MyModule = null
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       mod = new MyModule
       mod
     }
@@ -233,11 +233,11 @@ class ModuleSpec extends ChiselPropSpec with Utils {
   }
 
   property("A desiredName parameterized by a submodule should work") {
-    ChiselStage.elaborate(new ModuleWrapper(new ModuleWire)).name should be("ModuleWireWrapper")
+    ChiselStage.emitCHIRRTL(new ModuleWrapper(new ModuleWire)) should include("module ModuleWireWrapper")
   }
   property("A name generating a null pointer exception should provide a good error message") {
     (the[ChiselException] thrownBy extractCause[ChiselException](
-      ChiselStage.elaborate(new NullModuleWrapper)
+      ChiselStage.emitCHIRRTL(new NullModuleWrapper)
     )).getMessage should include("desiredName of chiselTests.NullModuleWrapper is null")
   }
   property("The name of a module in a function should be sane") {
@@ -247,13 +247,13 @@ class ModuleSpec extends ChiselPropSpec with Utils {
       }
       new Foo1
     }
-    ChiselStage.elaborate(foo)
+    ChiselStage.emitCHIRRTL(foo)
   }
   property("The name of an anonymous module should include '_Anon'") {
     trait Foo { this: RawModule =>
       assert(name.contains("_Anon"))
     }
-    ChiselStage.elaborate(new RawModule with Foo)
+    ChiselStage.emitCHIRRTL(new RawModule with Foo)
   }
 
   property("getVerilogString(new PlusOne() should produce a valid Verilog string") {

--- a/src/test/scala/chiselTests/MultiAssign.scala
+++ b/src/test/scala/chiselTests/MultiAssign.scala
@@ -35,7 +35,7 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   "Reassignments to literals" should "be disallowed" in {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new BasicTester {
             15.U := 7.U
           }
@@ -47,7 +47,7 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   "Reassignments to ops" should "be disallowed" in {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new BasicTester {
             (15.U + 1.U) := 7.U
           }
@@ -59,7 +59,7 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   "Reassignments to bit slices" should "be disallowed" in {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new BasicTester {
             (15.U)(1, 0) := 7.U
           }
@@ -71,7 +71,7 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
   "Bulk-connecting two read-only nodes" should "be disallowed" in {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new BasicTester {
             (15.U + 1.U) <> 7.U
           }

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -124,7 +124,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "return like a normal Scala block" in {
-    ChiselStage.elaborate(new BasicTester {
+    ChiselStage.emitCHIRRTL(new BasicTester {
       assert(withClock(this.clock) { 5 } == 5)
     })
   }
@@ -135,7 +135,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
       val port0 = mem(0.U)
     }
-    val (logMemDifferingClock, _) = grabLog(ChiselStage.elaborate(new modMemDifferingClock))
+    val (logMemDifferingClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modMemDifferingClock))
     logMemDifferingClock should include("memory is different")
 
     class modSyncReadMemDifferingClock extends Module {
@@ -143,7 +143,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
       val port0 = mem(0.U)
     }
-    val (logSyncReadMemDifferingClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemDifferingClock))
+    val (logSyncReadMemDifferingClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modSyncReadMemDifferingClock))
     logSyncReadMemDifferingClock should include("memory is different")
   }
 
@@ -153,7 +153,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = withClock(myClock) { Mem(4, UInt(8.W)) }
       mem(1.U) := 1.U
     }
-    val (logMemWriteDifferingClock, _) = grabLog(ChiselStage.elaborate(new modMemWriteDifferingClock))
+    val (logMemWriteDifferingClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modMemWriteDifferingClock))
     logMemWriteDifferingClock should include("memory is different")
 
     class modSyncReadMemWriteDifferingClock extends Module {
@@ -161,7 +161,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
       mem.write(1.U, 1.U)
     }
-    val (logSyncReadMemWriteDifferingClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemWriteDifferingClock))
+    val (logSyncReadMemWriteDifferingClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modSyncReadMemWriteDifferingClock))
     logSyncReadMemWriteDifferingClock should include("memory is different")
   }
 
@@ -171,7 +171,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = withClock(myClock) { SyncReadMem(4, UInt(8.W)) }
       val readVal = mem.read(0.U)
     }
-    val (logSyncReadMemReadDifferingClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemReadDifferingClock))
+    val (logSyncReadMemReadDifferingClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modSyncReadMemReadDifferingClock))
     logSyncReadMemReadDifferingClock should include("memory is different")
   }
 
@@ -181,7 +181,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = Mem(4, UInt(8.W))
       val port0 = mem(0.U, myClock)
     }
-    val (logMemPortClock, _) = grabLog(ChiselStage.elaborate(new modMemPortClock))
+    val (logMemPortClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modMemPortClock))
     (logMemPortClock should not).include("memory is different")
 
     class modSyncReadMemPortClock extends Module {
@@ -189,7 +189,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = SyncReadMem(4, UInt(8.W))
       val port0 = mem(0.U, myClock)
     }
-    val (logSyncReadMemPortClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemPortClock))
+    val (logSyncReadMemPortClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modSyncReadMemPortClock))
     (logSyncReadMemPortClock should not).include("memory is different")
   }
 
@@ -199,7 +199,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = Mem(4, UInt(8.W))
       mem.write(0.U, 0.U, myClock)
     }
-    val (logMemWriteClock, _) = grabLog(ChiselStage.elaborate(new modMemWriteClock))
+    val (logMemWriteClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modMemWriteClock))
     (logMemWriteClock should not).include("memory is different")
 
     class modSyncReadMemWriteClock extends Module {
@@ -207,7 +207,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = SyncReadMem(4, UInt(8.W))
       mem.write(0.U, 0.U, myClock)
     }
-    val (logSyncReadMemWriteClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemWriteClock))
+    val (logSyncReadMemWriteClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modSyncReadMemWriteClock))
     (logSyncReadMemWriteClock should not).include("memory is different")
   }
 
@@ -217,7 +217,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = Mem(4, UInt(8.W))
       val readVal = mem.read(0.U, myClock)
     }
-    val (logMemReadClock, _) = grabLog(ChiselStage.elaborate(new modMemReadClock))
+    val (logMemReadClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modMemReadClock))
     (logMemReadClock should not).include("memory is different")
 
     class modSyncReadMemReadClock extends Module {
@@ -225,7 +225,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       val mem = SyncReadMem(4, UInt(8.W))
       val readVal = mem.read(0.U, myClock)
     }
-    val (logSyncReadMemReadClock, _) = grabLog(ChiselStage.elaborate(new modSyncReadMemReadClock))
+    val (logSyncReadMemReadClock, _) = grabLog(ChiselStage.emitCHIRRTL(new modSyncReadMemReadClock))
     (logSyncReadMemReadClock should not).include("memory is different")
   }
 
@@ -238,7 +238,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "return like a normal Scala block" in {
-    ChiselStage.elaborate(new BasicTester {
+    ChiselStage.emitCHIRRTL(new BasicTester {
       assert(withReset(this.reset) { 5 } == 5)
     })
   }
@@ -256,7 +256,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
   }
 
   "withClockAndReset" should "return like a normal Scala block" in {
-    ChiselStage.elaborate(new BasicTester {
+    ChiselStage.emitCHIRRTL(new BasicTester {
       assert(withClockAndReset(this.clock, this.reset) { 5 } == 5)
     })
   }

--- a/src/test/scala/chiselTests/OptionBundle.scala
+++ b/src/test/scala/chiselTests/OptionBundle.scala
@@ -56,7 +56,7 @@ class OptionBundleSpec extends ChiselFlatSpec with Utils {
 
   "A Bundle with an Option field" should "assert out accessing a None Option field" in {
     a[Exception] should be thrownBy extractCause[Exception] {
-      ChiselStage.elaborate { new InvalidOptionBundleTester() }
+      ChiselStage.emitCHIRRTL { new InvalidOptionBundleTester() }
     }
   }
 }

--- a/src/test/scala/chiselTests/Padding.scala
+++ b/src/test/scala/chiselTests/Padding.scala
@@ -36,7 +36,7 @@ class PadsTester(c: Pads) extends Tester(c) {
 class PadderSpec extends ChiselPropSpec {
 
   property("Padder should elaborate") {
-    ChiselStage.elaborate { new Padder }
+    ChiselStage.emitCHIRRTL { new Padder }
   }
 
   ignore("PadderTester should return the correct result") {}

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -270,7 +270,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers with Utils {
     }
     a[java.util.UnknownFormatConversionException] should be thrownBy {
       extractCause[java.util.UnknownFormatConversionException] {
-        ChiselStage.elaborate { new MyModule }
+        ChiselStage.emitCHIRRTL { new MyModule }
       }
     }
   }
@@ -295,7 +295,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers with Utils {
     }
     a[java.util.UnknownFormatConversionException] should be thrownBy {
       extractCause[java.util.UnknownFormatConversionException] {
-        ChiselStage.elaborate { new MyModule }
+        ChiselStage.emitCHIRRTL { new MyModule }
       }
     }
   }

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -42,19 +42,19 @@ class ScopeTesterModule extends Module {
 
 class PrintfSpec extends ChiselFlatSpec {
   "A printf with a single argument" should "elaborate" in {
-    ChiselStage.elaborate(new SinglePrintfTester)
+    ChiselStage.emitCHIRRTL(new SinglePrintfTester)
   }
   "A printf with multiple arguments" should "elaborate" in {
-    ChiselStage.elaborate(new MultiPrintfTester)
+    ChiselStage.emitCHIRRTL(new MultiPrintfTester)
   }
   "A printf with ASCII characters 1-127" should "elaborate" in {
-    ChiselStage.elaborate(new ASCIIPrintfTester)
+    ChiselStage.emitCHIRRTL(new ASCIIPrintfTester)
   }
   "A printf with Printable ASCII characters 1-127" should "elaborate" in {
-    ChiselStage.elaborate(new ASCIIPrintableTester)
+    ChiselStage.emitCHIRRTL(new ASCIIPrintableTester)
   }
   "A printf with Printable targeting a format string using a port in another module" should "elaborate" in {
-    ChiselStage.elaborate {
+    ChiselStage.emitCHIRRTL {
       new Module {
         val mod = Module(new ScopeTesterModule)
         printf(mod.p)
@@ -63,7 +63,7 @@ class PrintfSpec extends ChiselFlatSpec {
   }
   "A printf with Printable targeting a format string using a wire inside another module" should "error" in {
     a[ChiselException] should be thrownBy {
-      circt.stage.ChiselStage.elaborate {
+      circt.stage.ChiselStage.emitCHIRRTL {
         new Module {
           val mod = Module(new ScopeTesterModule)
           printf(mod.wp)

--- a/src/test/scala/chiselTests/RawModuleSpec.scala
+++ b/src/test/scala/chiselTests/RawModuleSpec.scala
@@ -61,7 +61,7 @@ class ImplicitModuleDirectlyInRawModuleTester extends BasicTester {
 
 class RawModuleSpec extends ChiselFlatSpec with Utils {
   "RawModule" should "elaborate" in {
-    ChiselStage.elaborate { new RawModuleWithImplicitModule }
+    ChiselStage.emitCHIRRTL { new RawModuleWithImplicitModule }
   }
 
   "RawModule" should "work" in {
@@ -75,7 +75,7 @@ class RawModuleSpec extends ChiselFlatSpec with Utils {
   "ImplicitModule directly in a RawModule" should "fail" in {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new RawModuleWithDirectImplicitModule }
+        ChiselStage.emitCHIRRTL { new RawModuleWithDirectImplicitModule }
       }
     }
   }
@@ -83,7 +83,7 @@ class RawModuleSpec extends ChiselFlatSpec with Utils {
   "ImplicitModule directly in a RawModule in an ImplicitModule" should "fail" in {
     intercept[ChiselException] {
       extractCause[ChiselException] {
-        ChiselStage.elaborate { new ImplicitModuleDirectlyInRawModuleTester }
+        ChiselStage.emitCHIRRTL { new ImplicitModuleDirectlyInRawModuleTester }
       }
     }
   }

--- a/src/test/scala/chiselTests/RebindingSpec.scala
+++ b/src/test/scala/chiselTests/RebindingSpec.scala
@@ -8,7 +8,7 @@ import circt.stage.ChiselStage
 class RebindingSpec extends ChiselFlatSpec with Utils {
   "Rebinding a literal" should "fail" in {
     a[BindingException] should be thrownBy extractCause[BindingException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
             val a = 4.U
@@ -20,7 +20,7 @@ class RebindingSpec extends ChiselFlatSpec with Utils {
 
   "Rebinding a hardware type" should "fail" in {
     a[BindingException] should be thrownBy extractCause[BindingException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
             val a = Reg(UInt(32.W))

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -226,11 +226,11 @@ class RecordSpec extends ChiselFlatSpec with Utils {
   behavior.of("Records")
 
   they should "bulk connect similarly to Bundles" in {
-    ChiselStage.elaborate { new MyModule(fooBarType, fooBarType) }
+    ChiselStage.emitCHIRRTL { new MyModule(fooBarType, fooBarType) }
   }
 
   they should "bulk connect to Bundles" in {
-    ChiselStage.elaborate { new MyModule(new MyBundle, fooBarType) }
+    ChiselStage.emitCHIRRTL { new MyModule(new MyBundle, fooBarType) }
   }
 
   they should "emit FIRRTL bulk connects when possible" in {
@@ -248,7 +248,7 @@ class RecordSpec extends ChiselFlatSpec with Utils {
     }
 
     val e = intercept[AliasedAggregateFieldException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new AliasedFieldRecord)
         }
@@ -266,7 +266,7 @@ class RecordSpec extends ChiselFlatSpec with Utils {
 
   they should "work correctly for toTarget in nested OpaqueType Records" in {
     var mod: NestedRecordModule = null
-    ChiselStage.elaborate { mod = new NestedRecordModule; mod }
+    ChiselStage.emitCHIRRTL { mod = new NestedRecordModule; mod }
     val testStrings = Seq(
       mod.inst.io.foo.toTarget.serialize,
       mod.inst.io.foo.k.toTarget.serialize,
@@ -280,7 +280,7 @@ class RecordSpec extends ChiselFlatSpec with Utils {
 
   they should "work correctly with DataMirror in nested OpaqueType Records" in {
     var mod: NestedRecordModule = null
-    ChiselStage.elaborate { mod = new NestedRecordModule; mod }
+    ChiselStage.emitCHIRRTL { mod = new NestedRecordModule; mod }
     val ports = DataMirror.fullModulePorts(mod.inst)
     val expectedPorts = Seq(
       ("clock", mod.inst.clock),
@@ -310,13 +310,13 @@ class RecordSpec extends ChiselFlatSpec with Utils {
 
   they should "throw an error when map contains a named element and OpaqueType is mixed in" in {
     (the[Exception] thrownBy extractCause[Exception] {
-      ChiselStage.elaborate { new NamedSingleElementModule }
+      ChiselStage.emitCHIRRTL { new NamedSingleElementModule }
     }).getMessage should include("Opaque types must have exactly one element with an empty name")
   }
 
   they should "throw an error when map contains more than one element and OpaqueType is mixed in" in {
     (the[Exception] thrownBy extractCause[Exception] {
-      ChiselStage.elaborate { new ErroneousOverrideModule }
+      ChiselStage.emitCHIRRTL { new ErroneousOverrideModule }
     }).getMessage should include("Opaque types must have exactly one element with an empty name")
   }
 
@@ -343,14 +343,14 @@ class RecordSpec extends ChiselFlatSpec with Utils {
 
   they should "work with .toTarget" in {
     var m: SingleElementRecordModule = null
-    ChiselStage.elaborate { m = new SingleElementRecordModule; m }
+    ChiselStage.emitCHIRRTL { m = new SingleElementRecordModule; m }
     val q = m.in1.toTarget.toString
     assert(q == "~SingleElementRecordModule|SingleElementRecordModule>in1")
   }
 
   they should "NOT work with .toTarget on non-data OpaqueType Record" in {
     var m: SingleElementRecordModule = null
-    ChiselStage.elaborate { m = new SingleElementRecordModule; m }
+    ChiselStage.emitCHIRRTL { m = new SingleElementRecordModule; m }
     a[ChiselException] shouldBe thrownBy { m.r.toTarget }
   }
 
@@ -372,16 +372,16 @@ class RecordSpec extends ChiselFlatSpec with Utils {
 
   "Bulk connect on Record" should "check that the fields match" in {
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate { new MyModule(fooBarType, new CustomBundle("bar" -> UInt(32.W))) }
+      ChiselStage.emitCHIRRTL { new MyModule(fooBarType, new CustomBundle("bar" -> UInt(32.W))) }
     }).getMessage should include("Right Record missing field")
 
     (the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate { new MyModule(new CustomBundle("bar" -> UInt(32.W)), fooBarType) }
+      ChiselStage.emitCHIRRTL { new MyModule(new CustomBundle("bar" -> UInt(32.W)), fooBarType) }
     }).getMessage should include("Left Record missing field")
   }
 
   "CustomBundle" should "work like built-in aggregates" in {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val gen = new CustomBundle("foo" -> UInt(32.W))
       val io = IO(Output(gen))
       val wire = Wire(gen)
@@ -390,7 +390,7 @@ class RecordSpec extends ChiselFlatSpec with Utils {
   }
 
   "CustomBundle" should "check the types" in {
-    ChiselStage.elaborate { new RecordTypeTester }
+    ChiselStage.emitCHIRRTL { new RecordTypeTester }
   }
 
   "Record with unstable elements" should "error" in {
@@ -398,7 +398,7 @@ class RecordSpec extends ChiselFlatSpec with Utils {
       def elements = SeqMap("a" -> UInt(8.W))
     }
     val e = the[ChiselException] thrownBy {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(Input(new MyRecord))
       })
     }
@@ -438,7 +438,7 @@ class RecordSpec extends ChiselFlatSpec with Utils {
     }
 
     val e = the[ChiselException] thrownBy {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val myReg = RegInit(0.U(8.W))
         val io = IO(Input(new MyRecord(myReg)))
       })

--- a/src/test/scala/chiselTests/Reg.scala
+++ b/src/test/scala/chiselTests/Reg.scala
@@ -15,7 +15,7 @@ class RegSpec extends ChiselFlatSpec {
       val reg = Reg(UInt(2.W))
       DataMirror.widthOf(reg) should be(2.W)
     }
-    ChiselStage.elaborate { new RegOutTypeWidthTester }
+    ChiselStage.emitCHIRRTL { new RegOutTypeWidthTester }
   }
 
   "RegNext" should "be of unknown width" in {
@@ -27,7 +27,7 @@ class RegSpec extends ChiselFlatSpec {
       val reg3 = RegNext(2.U(3.W), 4.U(5.W))
       DataMirror.widthOf(reg3).known should be(false)
     }
-    ChiselStage.elaborate { new RegUnknownWidthTester }
+    ChiselStage.emitCHIRRTL { new RegUnknownWidthTester }
   }
 
   "RegInit" should "have width only if specified in the literal" in {
@@ -37,7 +37,7 @@ class RegSpec extends ChiselFlatSpec {
       val reg2 = RegInit(20.U(7.W))
       DataMirror.widthOf(reg2) should be(7.W)
     }
-    ChiselStage.elaborate { new RegForcedWidthTester }
+    ChiselStage.emitCHIRRTL { new RegForcedWidthTester }
   }
 }
 

--- a/src/test/scala/chiselTests/ResetSpec.scala
+++ b/src/test/scala/chiselTests/ResetSpec.scala
@@ -38,7 +38,7 @@ class ResetSpec extends ChiselFlatSpec with Utils {
   behavior.of("Reset")
 
   it should "be able to be connected to DontCare" in {
-    ChiselStage.elaborate(new AbstractResetDontCareModule)
+    ChiselStage.emitCHIRRTL(new AbstractResetDontCareModule)
   }
 
   it should "be able to drive Bool" in {
@@ -105,7 +105,7 @@ class ResetSpec extends ChiselFlatSpec with Utils {
 
   "Chisel" should "error if sync and async modules are nested" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new Module with RequireAsyncReset {
+      ChiselStage.emitCHIRRTL(new Module with RequireAsyncReset {
         val mod = Module(new Module with RequireSyncReset)
       })
     }

--- a/src/test/scala/chiselTests/Risc.scala
+++ b/src/test/scala/chiselTests/Risc.scala
@@ -116,7 +116,7 @@ class RiscTester(c: Risc) extends Tester(c) {
 class RiscSpec extends ChiselPropSpec {
 
   property("Risc should elaborate") {
-    ChiselStage.elaborate { new Risc }
+    ChiselStage.emitCHIRRTL { new Risc }
   }
 
   ignore("RiscTester should return the correct result") {}

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -114,12 +114,12 @@ class SIntLitZeroWidthTester extends BasicTester {
 class SIntOpsSpec extends ChiselPropSpec with Utils {
 
   property("SIntOps should elaborate") {
-    ChiselStage.elaborate { new SIntOps }
+    ChiselStage.emitCHIRRTL { new SIntOps }
   }
 
   property("Negative shift amounts are invalid") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new NegativeShift(SInt()))
+      ChiselStage.emitCHIRRTL(new NegativeShift(SInt()))
     }
   }
 

--- a/src/test/scala/chiselTests/Stack.scala
+++ b/src/test/scala/chiselTests/Stack.scala
@@ -70,7 +70,7 @@ class StackTester(c: Stack) extends Tester(c) {
 class StackSpec extends ChiselPropSpec {
 
   property("Stack should elaborate") {
-    ChiselStage.elaborate { new ChiselStack(2) }
+    ChiselStage.emitCHIRRTL { new ChiselStack(2) }
   }
 
   ignore("StackTester should return the correct result") {}

--- a/src/test/scala/chiselTests/SwitchSpec.scala
+++ b/src/test/scala/chiselTests/SwitchSpec.scala
@@ -9,7 +9,7 @@ import circt.stage.ChiselStage
 class SwitchSpec extends ChiselFlatSpec with Utils {
   "switch" should "require literal conditions" in {
     a[java.lang.IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val state = RegInit(0.U)
         val wire = WireDefault(0.U)
@@ -21,7 +21,7 @@ class SwitchSpec extends ChiselFlatSpec with Utils {
   }
   it should "require mutually exclusive conditions" in {
     a[java.lang.IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val state = RegInit(0.U)
         switch(state) {

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -8,7 +8,7 @@ import circt.stage.ChiselStage
 class ToTargetSpec extends ChiselFlatSpec with Utils {
 
   var m: InstanceNameModule = _
-  ChiselStage.elaborate { m = new InstanceNameModule; m }
+  ChiselStage.emitCHIRRTL { m = new InstanceNameModule; m }
 
   val mn = "InstanceNameModule"
   val top = s"~$mn|$mn"
@@ -53,7 +53,7 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
 
     val e = the[ChiselException] thrownBy extractCause[ChiselException] {
       var e: Example = null
-      circt.stage.ChiselStage.elaborate { e = new Example; e }
+      circt.stage.ChiselStage.emitCHIRRTL { e = new Example; e }
       e.tpe.toTarget
     }
     e.getMessage should include(

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -208,20 +208,20 @@ class UIntLitZeroWidthTester extends BasicTester {
 class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Bools can be created from 1 bit UInts") {
-    ChiselStage.elaborate(new GoodBoolConversion)
+    ChiselStage.emitCHIRRTL(new GoodBoolConversion)
   }
 
   property("Bools cannot be created from 0 bit UInts") {
-    a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.elaborate(new ZeroWidthBoolConversion) }
+    a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.emitCHIRRTL(new ZeroWidthBoolConversion) }
   }
 
   property("Bools cannot be created from >1 bit UInts") {
-    a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.elaborate(new BadBoolConversion) }
+    a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.emitCHIRRTL(new BadBoolConversion) }
   }
 
   property("Out-of-bounds extraction from known-width UInts") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new RawModule {
+      ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(2.W)))
         u(2, 1)
       })
@@ -230,7 +230,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Out-of-bounds single-bit extraction from known-width UInts") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new RawModule {
+      ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(2.W)))
         u(2)
       })
@@ -239,7 +239,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Out-of-bounds extraction from known-zero-width UInts") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new RawModule {
+      ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(0.W)))
         u(0, 0)
       })
@@ -248,7 +248,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Out-of-bounds single-bit extraction from known-zero-width UInts") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new RawModule {
+      ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(0.W)))
         u(0)
       })
@@ -256,7 +256,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
   }
 
   property("UIntOps should elaborate") {
-    ChiselStage.elaborate { new UIntOps }
+    ChiselStage.emitCHIRRTL { new UIntOps }
   }
 
   property("UIntOpsTester should return the correct result") {
@@ -265,7 +265,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Negative shift amounts are invalid") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new NegativeShift(UInt()))
+      ChiselStage.emitCHIRRTL(new NegativeShift(UInt()))
     }
   }
 
@@ -288,7 +288,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
   }
 
   property("asBools should support chained apply") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val in = Input(UInt(8.W))
         val out = Output(Bool())
@@ -397,15 +397,15 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
     }
 
     Seq(
-      grabLog(ChiselStage.elaborate(new TooWide)),
-      grabLog(ChiselStage.elaborate(new TooNarrow))
+      grabLog(ChiselStage.emitCHIRRTL(new TooWide)),
+      grabLog(ChiselStage.emitCHIRRTL(new TooNarrow))
     ).foreach {
       case (log, _) =>
         log should include("warn")
     }
 
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new RawModule {
+      ChiselStage.emitCHIRRTL(new RawModule {
         val in = IO(Input(UInt(0.W)))
         val index = IO(Input(UInt(1.W)))
         val out = IO(Output(Bool()))
@@ -431,7 +431,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
     }
 
     Seq(
-      grabLog(ChiselStage.elaborate(new Ok))
+      grabLog(ChiselStage.emitCHIRRTL(new Ok))
     ).foreach {
       case (log, _) =>
         log should be("")

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -86,7 +86,7 @@ class VecSpec extends ChiselPropSpec with Utils {
 
   property("Vec.fill with a pure type should generate an exception") {
     a[BindingException] should be thrownBy extractCause[BindingException] {
-      ChiselStage.elaborate(new IOTesterModFill(8))
+      ChiselStage.emitCHIRRTL(new IOTesterModFill(8))
     }
   }
 
@@ -318,7 +318,7 @@ class VecSpec extends ChiselPropSpec with Utils {
   }
 
   property("It should be possible to bulk connect a Vec and a Seq") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val out = Output(Vec(4, UInt(8.W)))
       })
@@ -329,7 +329,7 @@ class VecSpec extends ChiselPropSpec with Utils {
 
   property("Bulk connecting a Vec and Seq of different sizes should report a ChiselException") {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val out = Output(Vec(4, UInt(8.W)))
         })
@@ -340,7 +340,7 @@ class VecSpec extends ChiselPropSpec with Utils {
   }
 
   property("It should be possible to initialize a Vec with DontCare") {
-    ChiselStage.elaborate(new Module {
+    ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val out = Output(Vec(4, UInt(8.W)))
       })
@@ -350,7 +350,7 @@ class VecSpec extends ChiselPropSpec with Utils {
 
   property("Indexing a Chisel type Vec by a hardware type should give a sane error message") {
     a[ExpectedHardwareException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate {
+      ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})
           val foo = Vec(2, Bool())
@@ -361,7 +361,7 @@ class VecSpec extends ChiselPropSpec with Utils {
   }
 
   property("reduceTree should preserve input/output type") {
-    ChiselStage.elaborate(new ReduceTreeTester)
+    ChiselStage.emitCHIRRTL(new ReduceTreeTester)
   }
 
   property("Vecs of empty Bundles and empty Records should work") {

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -405,7 +405,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
   "vec literals with non-literal values should fail" in {
     val exc = intercept[VecLiteralException] {
       extractCause[VecLiteralException] {
-        ChiselStage.elaborate {
+        ChiselStage.emitCHIRRTL {
           new RawModule {
             (Vec(3, UInt(11.W)).Lit(0 -> UInt()))
           }

--- a/src/test/scala/chiselTests/VecToTargetSpec.scala
+++ b/src/test/scala/chiselTests/VecToTargetSpec.scala
@@ -65,7 +65,7 @@ trait VecToTargetSpecUtils extends Utils {
 class VecToTargetSpec extends ChiselFunSpec with VecToTargetSpecUtils {
   describe("Vec subaccess") {
     var foo: Foo = null
-    ChiselStage.elaborate { foo = new Foo; foo }
+    ChiselStage.emitCHIRRTL { foo = new Foo; foo }
 
     describe("with a Scala literal") {
       (it should behave).like(conversionSucceeds(foo.vecSubaccessScalaLit))

--- a/src/test/scala/chiselTests/WarningSpec.scala
+++ b/src/test/scala/chiselTests/WarningSpec.scala
@@ -25,7 +25,7 @@ class WarningSpec extends ChiselFlatSpec with Utils {
   }
 
   "Warnings" should "be de-duplicated" in {
-    val (log, _) = grabLog(ChiselStage.elaborate(new MyModule))
+    val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new MyModule))
     def countSubstring(s: String, sub: String) =
       s.sliding(sub.length).count(_ == sub)
     countSubstring(log, "Casting non-literal UInt") should be(1)

--- a/src/test/scala/chiselTests/When.scala
+++ b/src/test/scala/chiselTests/When.scala
@@ -146,7 +146,7 @@ class WhenSpec extends ChiselFlatSpec with Utils {
 
   "Returning in a when scope" should "give a reasonable error message" in {
     val e = the[ChiselException] thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val foo = Input(UInt(8.W))
           val bar = Input(UInt(8.W))

--- a/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
+++ b/src/test/scala/chiselTests/experimental/ProgrammaticPortsSpec.scala
@@ -35,7 +35,7 @@ class ProgrammaticPortsSpec extends ChiselFlatSpec with Utils {
 
   private def doTest(testMod: => NamedModuleTester): Unit = {
     var module: NamedModuleTester = null
-    ChiselStage.elaborate { module = testMod; module }
+    ChiselStage.emitCHIRRTL { module = testMod; module }
     assert(module.getNameFailures() == Nil)
   }
 
@@ -65,7 +65,7 @@ class ProgrammaticPortsSpec extends ChiselFlatSpec with Utils {
 
   "SuggestName collisions on ports" should "be illegal" in {
     a[ChiselException] should be thrownBy extractCause[ChiselException] {
-      ChiselStage.elaborate(new Module {
+      ChiselStage.emitCHIRRTL(new Module {
         val foo = IO(UInt(8.W)).suggestName("apple")
         val bar = IO(UInt(8.W)).suggestName("apple")
       })

--- a/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
@@ -71,11 +71,11 @@ class DataMirrorSpec extends ChiselFlatSpec {
       assertNone(typ)
       assertNone(vectyp)
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
   }
 
   it should "support getParent for normal modules" in {
-    ChiselStage.elaborate(new Parent)
+    ChiselStage.emitCHIRRTL(new Parent)
   }
 
   it should "support getParent for normal modules even when used in a D/I context" in {
@@ -85,7 +85,7 @@ class DataMirrorSpec extends ChiselFlatSpec {
       val inst = Instance(defn)
       DataMirror.getParent(this) should be(None)
     }
-    ChiselStage.elaborate(new Top)
+    ChiselStage.emitCHIRRTL(new Top)
   }
 
   it should "support getting name guesses even though they may change" in {
@@ -105,7 +105,7 @@ class DataMirrorSpec extends ChiselFlatSpec {
       queryNameGuess(io) should be("potato")
       queryNameGuess(io.foo) should be("potato.foo")
     }
-    ChiselStage.elaborate(new MyModule)
+    ChiselStage.emitCHIRRTL(new MyModule)
   }
 
   it should "not support name guesses for non-hardware" in {

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -27,7 +27,7 @@ class CatSpec extends ChiselFlatSpec {
 
   it should "not fail to elaborate a zero-element Vec" in {
 
-    ChiselStage.elaborate(new JackIsATypeSystemGod)
+    ChiselStage.emitCHIRRTL(new JackIsATypeSystemGod)
 
   }
 

--- a/src/test/scala/chiselTests/util/random/PRNGSpec.scala
+++ b/src/test/scala/chiselTests/util/random/PRNGSpec.scala
@@ -69,7 +69,7 @@ class PRNGSpec extends ChiselFlatSpec with Utils {
   it should "throw an exception if the step size is < 1" in {
     {
       the[IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
-        ChiselStage.elaborate(new CyclePRNG(0, Some(1), 1, true))
+        ChiselStage.emitCHIRRTL(new CyclePRNG(0, Some(1), 1, true))
       }
     }.getMessage should include("Width must be greater than zero!")
   }
@@ -77,7 +77,7 @@ class PRNGSpec extends ChiselFlatSpec with Utils {
   it should "throw an exception if the step size is <= 0" in {
     {
       the[IllegalArgumentException] thrownBy extractCause[IllegalArgumentException] {
-        ChiselStage.elaborate(new CyclePRNG(1, Some(1), 0, true))
+        ChiselStage.emitCHIRRTL(new CyclePRNG(1, Some(1), 0, true))
       }
     }.getMessage should include("Step size must be greater than one!")
   }


### PR DESCRIPTION
Deprecate ChiselStage$.elaborate as this exposes internal Chisel APIs, namely "chisel3.internal.firrtl.Circuit".  Replace usages of this in tests with emitCHIRRTL.