### PR TITLE
[CI] Add Release Notes Automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,31 +5,27 @@
 - [ ] Did you delete any extraneous printlns/debugging code?
 - [ ] Did you specify the type of improvement?
 - [ ] Did you add appropriate documentation in `docs/src`?
-- [ ] Did you state the API impact?
-- [ ] Did you specify the code generation impact?
 - [ ] Did you request a desired merge strategy?
 - [ ] Did you add text to be included in the Release Notes for this change?
+
+<!--
+If you PR has any impact on the user API or affects backend code generation,
+please describe the change in the "Release Notes" section below.
+-->
 
 #### Type of Improvement
 
 <!-- Choose one or more from the following:
-- bug fix
-- performance improvement
-- documentation
-- code refactoring
-- code cleanup
-- backend code generation
-- new feature/API
+- Feature (or new API)
+- API modification
+- API deprecation
+- Backend code generation
+- Performance improvement
+- Bugfix
+- Documentation or website-related
+- Dependency update
+- Internal or build-related (includes code refactoring/cleanup)
 -->
-
-#### API Impact
-
-<!-- How would this affect the current API? Does this add, extend, deprecate, remove, or break any existing API? -->
-
-#### Backend Code Generation Impact
-
-<!-- Does this change any generated Verilog?  -->
-<!-- How does it change it or in what circumstances would it?  -->
 
 #### Desired Merge Strategy
 
@@ -41,11 +37,12 @@
 
 #### Release Notes
 <!--
-Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
+The title of your PR will be included in the release notes in addition to any text in this section.
+Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
 -->
 
 ### Reviewer Checklist (only modified by reviewer)
-- [ ] Did you add the appropriate labels?
+- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
 - [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
 - [ ] Did you review?
 - [ ] Did you check whether all relevant Contributor checkboxes have been checked?

--- a/.github/workflows/config/release-notes.json
+++ b/.github/workflows/config/release-notes.json
@@ -1,0 +1,76 @@
+{
+    "categories": [
+      {
+        "title": "## Features",
+        "labels": ["Feature"]
+      },
+      {
+        "title": "## API Modification",
+        "labels": ["API Modification"]
+      },
+      {
+        "title": "## API Deprecation",
+        "labels": ["Deprecation"]
+      },
+      {
+        "title": "## Backend Code Generation",
+        "labels": ["Backend Code Generation"]
+      },
+      {
+        "title": "## Performance",
+        "labels": ["Performance"]
+      },
+      {
+        "title": "## Fixes",
+        "labels": ["Bugfix"]
+      },
+      {
+        "title": "## Documentation",
+        "labels": ["Documentation"]
+      },
+      {
+        "title": "## Dependency Updates",
+        "labels": ["Dependency Update"]
+      },
+      {
+        "title": "## Build and Internal Changes",
+        "labels": ["Internal"]
+      },
+      {
+        "title": "## Uncategorized",
+        "labels": []
+      }
+    ],
+    "ignore_labels": [
+      "No Release Notes"
+    ],
+    "sort": {
+      "order": "ASC",
+      "on_property": "mergedAt"
+    },
+    "template": "${{CHANGELOG}}\n\n**Full Changelog:** ${{RELEASE_DIFF}}\n",
+    "pr_template": "- ${{TITLE}} (by @${{AUTHOR}} in ${{URL}})${{RELEASE_NOTES}}",
+    "empty_template": "- no changes",
+    "transformers": [
+      {
+        "pattern": "<!--.*-->",
+        "flags": "gus",
+        "target": ""
+      }
+    ],
+    "custom_placeholders": [
+      {
+        "name": "RELEASE_NOTES",
+        "source": "BODY",
+        "transformer": {
+          "pattern": ".*#### Release Notes(?:[\n\\s]|(?:<!--.*?-->))*((?:\\S(?!!--)).*?)[\n\\s]*\n#.*",
+          "flags": "gus",
+          "target": "\n  $1"
+        }
+      }
+    ],
+    "trim_values": false,
+    "max_tags_to_fetch": 200,
+    "max_pull_requests": 500,
+    "max_back_track_time_days": 365
+}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,47 @@
+name: Generate Release Notes
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      toTag:
+        description: 'Tag or ref for which to generate release notes'
+        required: true
+      fromTag:
+        # If you leave this blank, it'll select previous SemVer version
+        # WARNING: Cannot use anything older than a005498 because of the git tree merge
+        description: 'Tag or ref from which to start generating release notes'
+        required: false
+
+
+jobs:
+  generate_release_notes:
+    name: Generate Release Notes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build Release Notes
+        id: release-notes
+        uses: mikepenz/release-changelog-builder-action@v3.7.0
+        with:
+          configuration: .github/workflows/config/release-notes.json
+          failOnError: true
+          # Amazingly, on release where the inputs are empty, this just does the right thing
+          # The "toTag" is the released tag, and the "fromTag" is the previous tag according to SemVer
+          fromTag: ${{ github.event.inputs.fromTag }}
+          toTag: ${{ github.event.inputs.toTag }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Report Release Notes
+        run: echo '${{steps.release-notes.outputs.changelog}}' >> $GITHUB_STEP_SUMMARY
+      - name: Upload Release Notes (on release)
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          body: ${{ steps.release-notes.outputs.changelog }}
+      - name: Error on uncategorized PRs
+        if: steps.release-notes.outputs.uncategorized_prs != 0
+        run: exit 1
+

--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -18,5 +18,5 @@ jobs:
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:v1.4.25
         with:
-          one_of: Feature,Performance,API Modification,Deprecation,Bugfix,Documentation,Dependency Update,Internal,No Release Notes
+          one_of: Feature,Performance,API Modification,Deprecation,Backend Code Generation,Bugfix,Documentation,Dependency Update,Internal,No Release Notes
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,9 @@
 
 6. Please make your PRs against the `master` branch. The project admins, when reviewing your PR, will decide which stable version (if any) your change should be backported to. The backports will be opened automatically on your behalf once your `master` PR is merged.
 
-7. If your backport PR(s) get labeled with `bp-conflict`, it means they cannot be automatically be merged. You can help get them merged by openening a PR against the already-existing backport branch (will be named something like `mergify/bp/3.5.x/pr-2512`) with the necessary cleanup changes. The admins will merge your cleanup PR and remove the `bp-conflict` label if appropriate.
+7. The PR template will require you to select "Type of Improvement." A reviewer or someone with write access will add the appropriate label to your PR based on this type of improvement which will include your PR in the correct category in the release notes.
+
+8. If your backport PR(s) get labeled with `bp-conflict`, it means they cannot be automatically be merged. You can help get them merged by openening a PR against the already-existing backport branch (will be named something like `mergify/bp/3.5.x/pr-2512`) with the necessary cleanup changes. The admins will merge your cleanup PR and remove the `bp-conflict` label if appropriate.
 
  
 ### Frequently Asked Questions


### PR DESCRIPTION
Add new workflow to generate release notes. This workflow can be run manually via workflow dispatch, but will also run automatically upon creating a release. The workflow dispatch can be used for testing, previewing release notes for a potential release, or for generating release notes for past releases for when the automation has a bug or didn't exist.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you state the API impact?
- [x] Did you specify the code generation impact?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)

#### API Impact

No impact

#### Backend Code Generation Impact

No impact

#### Desired Merge Strategy

- Squash

#### Release Notes
<!--
Text from here to the end of the body will be considered for inclusion in the release notes for the version containing this pull request.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
