### PR TITLE
Allow DataView of Reset <=> [UInt<1>, AsyncReset]

### DIFF
--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -117,7 +117,6 @@ package object dataview {
           val fieldName = viewFieldName(vex)
           throw InvalidViewException(s"Field $fieldName specified as view of non-type-equivalent value $tex")
       }
-
       // View width must be unknown or match target width
       if (vex.widthKnown && vex.width != tex.width) {
         def widthAsString(x: Element) = x.widthOption.map("<" + _ + ">").getOrElse("<unknown>")

--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -106,12 +106,12 @@ package object dataview {
       (tex, vex) match {
         /* Allow views where the types are equal. */
         case (a, b) if a.getClass == b.getClass =>
-        /* Allow UInt <=> Reset views. */
-        case (a: UInt, _: Reset) if a.isWidthKnown && a.getWidth == 1 => true
-        case (_: Reset, a: UInt) if a.isWidthKnown && a.getWidth == 1 => true
+        /* allow bool <=> reset views. */
+        case (a: Bool, _: Reset) =>
+        case (_: Reset, a: Bool) =>
         /* Allow AsyncReset <=> Reset views. */
-        case (a: AsyncReset, _: Reset) => true
-        case (_: Reset, a: AsyncReset) => true
+        case (a: AsyncReset, _: Reset) =>
+        case (_: Reset, a: AsyncReset) =>
         /* All other views produce a runtime error. */
         case _ =>
           val fieldName = viewFieldName(vex)

--- a/src/test/scala/chiselTests/experimental/DataView.scala
+++ b/src/test/scala/chiselTests/experimental/DataView.scala
@@ -548,7 +548,7 @@ class DataViewSpec extends ChiselFlatSpec {
 
   it should "allow views between reset types" in {
     class A extends Bundle {
-      val uint = AsyncReset()
+      val bool = Bool()
       val asyncreset = AsyncReset()
     }
 
@@ -563,7 +563,7 @@ class DataViewSpec extends ChiselFlatSpec {
 
       implicit val view = DataView[A, B](
         _ => new B,
-        _.uint -> _.reset_0,
+        _.bool -> _.reset_0,
         _.asyncreset -> _.reset_1
       )
 
@@ -575,7 +575,7 @@ class DataViewSpec extends ChiselFlatSpec {
       .split('\n')
       .map(_.takeWhile(_ != '@'))
       .map(_.trim) should contain).allOf(
-      "a.uint <= b.reset_0",
+      "a.bool <= b.reset_0",
       "a.asyncreset <= b.reset_1"
     )
   }

--- a/src/test/scala/chiselTests/experimental/DataView.scala
+++ b/src/test/scala/chiselTests/experimental/DataView.scala
@@ -546,6 +546,40 @@ class DataViewSpec extends ChiselFlatSpec {
     chirrtl should include("dataOut <= vec[addrReg]")
   }
 
+  it should "allow views between reset types" in {
+    class A extends Bundle {
+      val uint = AsyncReset()
+      val asyncreset = AsyncReset()
+    }
+
+    class B extends Bundle {
+      val reset_0 = Reset()
+      val reset_1 = Reset()
+    }
+
+    class Foo extends RawModule {
+      val a = Wire(new A)
+      val b = Wire(new B)
+
+      implicit val view = DataView[A, B](
+        _ => new B,
+        _.uint -> _.reset_0,
+        _.asyncreset -> _.reset_1
+      )
+
+      a.viewAs[B] := b
+    }
+
+    (ChiselStage
+      .emitCHIRRTL(new Foo, Array("--full-stacktrace"))
+      .split('\n')
+      .map(_.takeWhile(_ != '@'))
+      .map(_.trim) should contain).allOf(
+      "a.uint <= b.reset_0",
+      "a.asyncreset <= b.reset_1"
+    )
+  }
+
   it should "error if you try to dynamically index a Vec view that does not correspond to a Vec target" in {
     class MyModule extends Module {
       val inA, inB = IO(Input(UInt(8.W)))


### PR DESCRIPTION
Change what DataView allows in its type checking to enable Reset to be viewed as either a UInt<1> or an AsyncReset.  This enables more flexible DataViews which match already allowable Chisel and FIRRTL connection semantics.

#### Release Notes

Change what DataView allows in its type checking to enable Reset to be viewed as either a UInt<1> or an AsyncReset.  This enables more flexible DataViews which match already allowable Chisel and FIRRTL connection semantics.