### PR TITLE
Remove unnecessary sonatype resolvers for firrtl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -161,11 +161,7 @@ lazy val firrtlSettings = Seq(
       case Some((2, major)) if major <= 12 => Seq()
       case _                               => Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4")
     }
-  },
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases")
-  )
+  }
 )
 
 lazy val mimaSettings = Seq(


### PR DESCRIPTION
Remove deprecated "sonatypeRepo" from firrtl compilation unit.  This is unnecessary given that the firrtl compilation unit uses "commonSettings" which already include the non-deprecated versions of the Sonatype Repositories.