### PR TITLE
Handle BoringUtils in Chisel, rather than in FIRRTL compiler

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -481,6 +481,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
       case OpBinding(_, _)           => "OpResult"
       case MemoryPortBinding(_, _)   => "MemPort"
       case PortBinding(_)            => "IO"
+      case SecretPortBinding(_)      => "IO"
       case RegBinding(_, _)          => "Reg"
       case WireBinding(_, _)         => "Wire"
       case DontCareBinding()         => "(DontCare)"

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -247,18 +247,23 @@ package internal {
 package experimental {
 
   import chisel3.experimental.hierarchy.core.{IsInstantiable, Proto}
+  import scala.annotation.nowarn
 
   object BaseModule {
-    implicit class BaseModuleExtensions[T <: BaseModule](b: T) {
+    implicit class BaseModuleExtensions[T <: BaseModule](b: T)(implicit si: SourceInfo) {
       import chisel3.experimental.hierarchy.core.{Definition, Instance}
-      def toInstance:   Instance[T] = new Instance(Proto(b))
-      def toDefinition: Definition[T] = new Definition(Proto(b))
+      def toInstance: Instance[T] = new Instance(Proto(b))
+      def toDefinition: Definition[T] = {
+        b.toDefinitionCalled = Some(si)
+        new Definition(Proto(b))
+      }
     }
   }
 
   /** Abstract base class for Modules, an instantiable organizational unit for RTL.
     */
   // TODO: seal this?
+  @nowarn("msg=class Port") // delete when Port becomes private
   abstract class BaseModule extends HasId with IsInstantiable {
     _parent.foreach(_.addId(this))
 
@@ -309,8 +314,22 @@ package experimental {
     //
     protected var _closed = false
 
-    /** Internal check if a Module is closed */
+    /** Internal check if a Module's constructor has finished executing */
     private[chisel3] def isClosed = _closed
+
+    private[chisel3] var toDefinitionCalled:  Option[SourceInfo] = None
+    private[chisel3] var modulePortsAskedFor: Option[SourceInfo] = None
+
+    /** Where a Module becomes fully closed (no secret ports drilled afterwards) */
+    private[chisel3] def fullyClosedLocation = toDefinitionCalled.orElse(modulePortsAskedFor)
+    private[chisel3] def fullyClosedErrorMessages: Iterable[(SourceInfo, String)] = {
+      toDefinitionCalled.map(si =>
+        (si, s"Calling .toDefinition fully closes ${name}, but it is later bored through!")
+      ) ++
+        modulePortsAskedFor.map(si =>
+          (si, s"Reflecting on all io's fully closes ${name}, but it is later bored through!")
+        )
+    }
 
     // Fresh Namespace because in Firrtl, Modules namespaces are disjoint with the global namespace
     private[chisel3] val _namespace = Namespace.empty
@@ -511,9 +530,10 @@ package experimental {
       *
       * TODO: Use SeqMap/VectorMap when those data structures become available.
       */
-    private[chisel3] def getChiselPorts: Seq[(String, Data)] = {
+    private[chisel3] def getChiselPorts(implicit si: SourceInfo): Seq[(String, Data)] = {
       require(_closed, "Can't get ports before module close")
-      _component.get.ports.map { port =>
+      modulePortsAskedFor = Some(si) // super-lock down the module
+      (_component.get.ports ++ _component.get.secretPorts).map { port =>
         (port.id.getRef.asInstanceOf[ModuleIO].name, port.id)
       }
     }
@@ -536,6 +556,35 @@ package experimental {
     )(
       implicit sourceInfo: SourceInfo
     ): Unit = _bindIoInPlace(iodef)
+
+    // Must have separate createSecretIO from addSecretIO to get plugin to name it
+    // data must be a fresh Chisel type
+    private[chisel3] def createSecretIO(data: => Data)(implicit sourceInfo: SourceInfo): Data = {
+      val iodef = data
+      // forcename
+      internal.requireIsChiselType(iodef, "io type")
+
+      if (toDefinitionCalled.nonEmpty)
+        Builder.error("can only create secret ports when a module has not been used as a Definition")
+      if (modulePortsAskedFor.nonEmpty)
+        Builder.error("can only create secret ports when a module has not been asked for all its IO")
+
+      iodef.bind(internal.SecretPortBinding(this))
+      iodef
+    }
+
+    // Must have separate createSecretIO from addSecretIO to get plugin to name it
+    private[chisel3] def addSecretIO(iodef: Data)(implicit sourceInfo: SourceInfo): Data = {
+      val name = iodef._computeName(None).getOrElse("secret")
+      iodef.setRef(ModuleIO(this, _namespace.name(name)))
+      val newPort = new Port(iodef, iodef.specifiedDirection, sourceInfo)
+      if (_closed) {
+        _component.get.secretPorts += newPort
+      } else secretPorts += newPort
+      iodef
+    }
+
+    private[chisel3] val secretPorts: ArrayBuffer[Port] = ArrayBuffer.empty
 
     /**
       * This must wrap the datatype used to set the io field of any Module.

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -5,7 +5,7 @@ package chisel3
 import scala.util.Try
 import scala.language.experimental.macros
 import scala.annotation.nowarn
-import chisel3.experimental.{BaseModule, UnlocatableSourceInfo}
+import chisel3.experimental.{BaseModule, SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal._
 import chisel3.experimental.hierarchy.{InstanceClone, ModuleClone}
 import chisel3.internal.Builder._
@@ -99,8 +99,20 @@ abstract class RawModule extends BaseModule {
     // Generate IO invalidation commands to initialize outputs as unused,
     //  unless the client wants explicit control over their generation.
     val component = DefModule(this, name, firrtlPorts, _commands.result())
+
+    // Secret connections can be staged if user bored into children modules
+    component.secretConnects ++= stagedSecretConnects
     _component = Some(component)
     _component
+  }
+  private[chisel3] val stagedSecretConnects = collection.mutable.ArrayBuffer[Connect]()
+
+  private[chisel3] def secretConnection(left: Data, right: Data)(implicit si: SourceInfo): Unit = {
+    if (_closed) {
+      _component.get.asInstanceOf[DefModule].secretConnects += Connect(si, left.lref, Node(right))
+    } else {
+      stagedSecretConnects += Connect(si, left.lref, Node(right))
+    }
   }
 
   private[chisel3] def initializeInParent(): Unit = {}

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -61,7 +61,7 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
     }
 
     targetTopBinding match {
-      case _: WireBinding | _: PortBinding  | _: SecretPortBinding | _: ViewBinding | _: AggregateViewBinding =>
+      case _: WireBinding | _: PortBinding | _: SecretPortBinding | _: ViewBinding | _: AggregateViewBinding =>
         direction = ActualDirection.Bidirectional(ActualDirection.Default)
       case x => throwException(s"Analog can only be Ports and Wires, not '$x'")
     }

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -61,7 +61,7 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
     }
 
     targetTopBinding match {
-      case _: WireBinding | _: PortBinding | _: ViewBinding | _: AggregateViewBinding =>
+      case _: WireBinding | _: PortBinding  | _: SecretPortBinding | _: ViewBinding | _: AggregateViewBinding =>
         direction = ActualDirection.Bidirectional(ActualDirection.Default)
       case x => throwException(s"Analog can only be Ports and Wires, not '$x'")
     }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
@@ -2,14 +2,16 @@
 
 package chisel3.experimental.hierarchy
 
-import chisel3.experimental.BaseModule
+import chisel3.experimental.{BaseModule, SourceInfo}
 import chisel3.internal.{HasId, PseudoModule}
 import chisel3.internal.firrtl.{Component, ModuleCloneIO, Ref}
 import chisel3.internal.{throwException, Namespace}
 import chisel3._
 
 // Private internal class to serve as a _parent for Data in cloned ports
-private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T) extends PseudoModule with core.IsClone[T] {
+private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si: SourceInfo)
+    extends PseudoModule
+    with core.IsClone[T] {
   override def toString = s"ModuleClone(${getProto})"
   // Do not call default addId function, which may modify a module that is already "closed"
   override def addId(d: HasId): Unit = ()

--- a/core/src/main/scala/chisel3/experimental/prefix.scala
+++ b/core/src/main/scala/chisel3/experimental/prefix.scala
@@ -84,3 +84,24 @@ object noPrefix {
     ret
   }
 }
+
+object skipPrefix {
+
+  /** Use to remove the latest prefix value (if one exists) so signals within the scope are prefixed with one less value
+    * outside the scope
+    *
+    * @param f a function for which any generated components are given the prefix
+    * @tparam T The return type of the provided function
+    * @return The return value of the provided function
+    */
+  def apply[T](f: => T): T = {
+    val prefix = Builder.getPrefix
+    val skipped = if (prefix.nonEmpty) prefix.tail else prefix
+    Builder.clearPrefix()
+    Builder.setPrefix(skipped)
+    val ret = f
+    Builder.clearPrefix()
+    Builder.setPrefix(prefix)
+    ret
+  }
+}

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -38,7 +38,7 @@ private[chisel3] object BindingDirection {
     */
   def from(binding: TopBinding, direction: ActualDirection): BindingDirection = {
     binding match {
-      case PortBinding(_) =>
+      case _: PortBinding | _: SecretPortBinding =>
         direction match {
           case ActualDirection.Output => Output
           case ActualDirection.Input  => Input

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -89,6 +89,9 @@ sealed trait ConditionalDeclarable extends TopBinding {
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 case class PortBinding(enclosure: BaseModule) extends ConstrainedBinding
 
+// Added to handle BoringUtils in Chisel
+private[chisel3] case class SecretPortBinding(enclosure: BaseModule) extends ConstrainedBinding
+
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 case class OpBinding(enclosure: RawModule, visibility: Option[WhenContext])
     extends ConstrainedBinding

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -354,12 +354,17 @@ private[chisel3] object Converter {
 
   def convert(component: Component): fir.DefModule = component match {
     case ctx @ DefModule(_, name, ports, cmds) =>
-      fir.Module(fir.NoInfo, name, ports.map(p => convert(p)), convert(cmds, ctx))
+      fir.Module(
+        fir.NoInfo,
+        name,
+        (ports ++ ctx.secretPorts).map(p => convert(p)),
+        convert(cmds ++ ctx.secretConnects, ctx)
+      )
     case ctx @ DefBlackBox(id, name, ports, topDir, params) =>
       fir.ExtModule(
         fir.NoInfo,
         name,
-        ports.map(p => convert(p, topDir)),
+        (ports ++ ctx.secretPorts).map(p => convert(p, topDir)),
         id.desiredName,
         params.keys.toList.sorted.map { name => convert(name, params(name)) }
       )
@@ -367,7 +372,7 @@ private[chisel3] object Converter {
       fir.IntModule(
         fir.NoInfo,
         name,
-        ports.map(p => convert(p, topDir)),
+        (ports ++ ctx.secretPorts).map(p => convert(p, topDir)),
         id.intrinsic,
         params.keys.toList.sorted.map { name => convert(name, params(name)) }
       )

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -13,6 +13,7 @@ import _root_.firrtl.annotations.Annotation
 import scala.collection.immutable.NumericRange
 import scala.math.BigDecimal.RoundingMode
 import scala.annotation.nowarn
+import scala.collection.mutable
 
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 case class PrimOp(name: String) {
@@ -361,11 +362,14 @@ abstract class Component extends Arg {
   def id:    BaseModule
   def name:  String
   def ports: Seq[Port]
+  val secretPorts: mutable.ArrayBuffer[Port] = id.secretPorts
 }
 
 @nowarn("msg=class Port") // delete when Port becomes private
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefModule(id: RawModule, name: String, ports: Seq[Port], commands: Seq[Command]) extends Component
+case class DefModule(id: RawModule, name: String, ports: Seq[Port], commands: Seq[Command]) extends Component {
+  val secretConnects: mutable.ArrayBuffer[Connect] = mutable.ArrayBuffer[Connect]()
+}
 
 @nowarn("msg=class Port") // delete when Port becomes private
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -5,7 +5,7 @@ package chisel3.reflect
 import chisel3._
 import chisel3.internal._
 import chisel3.internal.firrtl._
-import chisel3.experimental.BaseModule
+import chisel3.experimental.{BaseModule, SourceInfo}
 import scala.reflect.ClassTag
 
 object DataMirror {
@@ -14,6 +14,15 @@ object DataMirror {
   def directionOf(target: Data): ActualDirection = {
     requireIsHardware(target, "node requested directionality on")
     target.direction
+  }
+
+  /** Returns true if target has been `Flipped` or `Input` directly */
+  def hasOuterFlip(target: Data): Boolean = {
+    import chisel3.SpecifiedDirection.{Flip, Input}
+    target.specifiedDirection match {
+      case Flip | Input => true
+      case _            => false
+    }
   }
 
   private def hasBinding[B <: ConstrainedBinding: ClassTag](target: Data) = {
@@ -114,7 +123,7 @@ object DataMirror {
     * // )
     * }}}
     */
-  def modulePorts(target: BaseModule): Seq[(String, Data)] = target.getChiselPorts
+  def modulePorts(target: BaseModule)(implicit si: SourceInfo): Seq[(String, Data)] = target.getChiselPorts
 
   /** Returns a recursive representation of a module's ports with underscore-qualified names
     * {{{
@@ -145,7 +154,7 @@ object DataMirror {
     *       of its children.
     * @see [[DataMirror.modulePorts]] for a non-recursive representation of the ports.
     */
-  def fullModulePorts(target: BaseModule): Seq[(String, Data)] = {
+  def fullModulePorts(target: BaseModule)(implicit si: SourceInfo): Seq[(String, Data)] = {
     def getPortNames(name: String, data: Data): Seq[(String, Data)] = Seq(name -> data) ++ (data match {
       case _: Element => Seq()
       case r: Record =>
@@ -345,5 +354,31 @@ object DataMirror {
       case (l, r) => collectMembersOverAllForAnyFunction(l, r)(collector)
     }
     myItems ++ childItems
+  }
+
+  // Function to path upwards, stopping if reaching including
+  private[chisel3] def modulePath(h: HasId, until: Option[BaseModule]): Seq[BaseModule] = {
+    val me = h match {
+      case m: BaseModule => Seq(m)
+      case d: Data       => d.topBinding.location.toSeq
+      case m: MemBase[_] => m._parent.toSeq
+    }
+    if (me == until.toSeq) Nil
+    else {
+      me ++ me.flatMap(x => x._parent.toSeq.flatMap(p => modulePath(p, until)))
+    }
+  }
+  // Function to find the least common ancestor of two nodes
+  private[chisel3] def leastCommonAncestorModule(left: HasId, right: HasId): Option[BaseModule] = {
+    val leftPath = modulePath(left, None)
+    val leftPathSet = leftPath.toSet
+    val rightPath = modulePath(right, None)
+    rightPath.collectFirst { case p if leftPathSet.contains(p) => p }
+  }
+  // Returns LCA paths if a common ancestor exists
+  private[chisel3] def findLCAPaths(left: HasId, right: HasId): Option[(Seq[BaseModule], Seq[BaseModule])] = {
+    leastCommonAncestorModule(left, right).map { lca =>
+      (modulePath(left, Some(lca)), modulePath(right, Some(lca)))
+    }
   }
 }

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -37,7 +37,7 @@ object DataMirror {
     * @param x the `Data` to check
     * @return `true` if x is an IO port, `false` otherwise
     */
-  def isIO(x: Data): Boolean = hasBinding[PortBinding](x)
+  def isIO(x: Data): Boolean = hasBinding[PortBinding](x) || hasBinding[SecretPortBinding](x)
 
   /** Check if a given `Data` is a Wire
     * @param x the `Data` to check

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -220,7 +220,7 @@ object BoringUtils {
     }
     def drill(source: Data, path: Seq[BaseModule], up: Boolean): Data = {
       path.foldLeft(source) {
-        case (rhs, module) if (module.fullyClosedLocation.nonEmpty) => boringError(module); DontCare
+        case (rhs, module) if (module.isFullyClosed) => boringError(module); DontCare
         case (rhs, module) =>
           skipPrefix { // so `lcaSource` isn't in the name of the secret port
             /** create a port, and drill up. */

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -3,13 +3,11 @@
 package chisel3.util.experimental
 
 import chisel3._
-import chisel3.experimental.{annotate, ChiselAnnotation}
+import chisel3.experimental.{annotate, requireIsHardware, skipPrefix, BaseModule, ChiselAnnotation, SourceInfo}
 import chisel3.internal.{Builder, BuilderContextCache, NamedComponent, Namespace}
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
 import firrtl.passes.wiring.{SinkAnnotation, SourceAnnotation}
 import firrtl.annotations.{ComponentName, ModuleName}
-
-import scala.concurrent.SyncVar
 
 /** An exception related to BoringUtils
   * @param message the exception message
@@ -39,14 +37,14 @@ class BoringUtilsException(message: String) extends Exception(message)
   * We can then connect `x` to `y` using [[BoringUtils]] without modifiying the Chisel IO of `Constant`, `Expect`, or
   * modules that may instantiate them. There are two approaches to do this:
   *
-  * 1. Hierarchical boring using [[BoringUtils.bore]]
+  * 1. Hierarchical boring using BoringUtils.bore
   *
   * 2. Non-hierarchical boring using [[BoringUtils.addSink]]/[[BoringUtils.addSource]]
   *
   * ===Hierarchical Boring===
   *
   * Hierarchical boring involves connecting one sink instance to another source instance in a parent module. Below,
-  * module `Top` contains an instance of `Constant` and `Expect`. Using [[BoringUtils.bore]], we can connect
+  * module `Top` contains an instance of `Constant` and `Expect`. Using BoringUtils.bore, we can connect
   * `constant.x` to `expect.y`.
   *
   * {{{
@@ -55,6 +53,17 @@ class BoringUtilsException(message: String) extends Exception(message)
   *   val constant = Module(new Constant)
   *   val expect = Module(new Expect)
   *   BoringUtils.bore(constant.x, Seq(expect.y))
+  * }
+  * }}}
+  *
+  * Bottom-up boring involves boring a sink in a child instance to the current module, where it can be assigned from.
+  * Using BoringUtils.bore, we can connect from `constant.x` to `mywire`.
+  *
+  * {{{
+  * class Top extends Module {
+  *   val io = IO(new Bundle { val foo = UInt(3.W) })
+  *   val constant = Module(new Constant)
+  *   io.foo := BoringUtils.bore(constant.x)
   * }
   * }}}
   *
@@ -192,5 +201,70 @@ object BoringUtils {
     val genName = addSource(source, boringName, true, true)
     sinks.foreach(addSink(_, genName, true, true))
     genName
+  }
+
+  /** Access a source [[Data]] that may or may not be in the current module.  If
+    * this is in a child module, then create ports to allow access the
+    * requrested source.
+    */
+  def bore(source: Data)(implicit si: SourceInfo): Data = {
+    import reflect.DataMirror
+    def parent(d: Data): BaseModule = d.topBinding.location.get
+    def purePortType = if (DataMirror.hasOuterFlip(source)) Flipped(chiselTypeOf(source)) else chiselTypeOf(source)
+    def boringError(module: BaseModule): Unit = {
+      (module.fullyClosedErrorMessages ++ Seq(
+        (si, s"Can only bore into modules that are not fully closed: ${module.name} was fully closed")
+      )).foreach {
+        case (sourceInfo, msg) => Builder.error(msg)(sourceInfo)
+      }
+    }
+    def drill(source: Data, path: Seq[BaseModule], up: Boolean): Data = {
+      path.foldLeft(source) {
+        case (rhs, module) if (module.fullyClosedLocation.nonEmpty) => boringError(module); DontCare
+        case (rhs, module) =>
+          skipPrefix { // so `lcaSource` isn't in the name of the secret port
+            /** create a port, and drill up. */
+            val bore = if (up) module.createSecretIO(purePortType) else module.createSecretIO(Flipped(purePortType))
+            module.addSecretIO(bore)
+            if (up) {
+              module.asInstanceOf[RawModule].secretConnection(bore, rhs)
+            } else parent(rhs).asInstanceOf[RawModule].secretConnection(bore, rhs)
+            bore
+          }
+      }
+    }
+
+    requireIsHardware(source)
+    val thisModule = Builder.currentModule.get
+    source.topBindingOpt match {
+      case None =>
+        Builder.error(s"Cannot bore from ${source._errorContext}")
+        return DontCare
+      case Some(internal.CrossModuleBinding) =>
+        Builder.error(
+          s"Cannot bore across a Definition/Instance boundary:${thisModule._errorContext} cannot access ${source}"
+        )
+        return DontCare
+      case _ => // Actually bore
+    }
+    if (parent(source) == thisModule) {
+
+      /** No boring to do */
+      return source
+    }
+
+    val lcaResult = DataMirror.findLCAPaths(source, thisModule)
+    if (lcaResult.isEmpty) {
+      Builder.error(s"Cannot bore from $source to ${thisModule.name}, as they do not share a least common ancestor")
+      return DontCare
+    }
+    val (upPath, downPath) = lcaResult.get
+    val lcaSource = drill(source, upPath, true)
+    val sink = drill(lcaSource, downPath.reverse, false)
+
+    /** Creating an intermediate wire so secret stuff never escapes */
+    val bore = Wire(purePortType)
+    thisModule.asInstanceOf[RawModule].secretConnection(bore, sink)
+    bore
   }
 }

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -17,7 +17,7 @@ abstract class ShouldntAssertTester(cyclesToWait: BigInt = 4) extends BasicTeste
   when(done) { stop() }
 }
 
-class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with MatchesOrOmits {
+class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with MatchesAndOmits {
   val args = Array("--throw-on-first-error", "--full-stacktrace")
 
   class BoringInverter extends Module {
@@ -151,7 +151,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       b := BoringUtils.bore(bar.b_wire)
       c := BoringUtils.bore(c_wire)
     }
-    matchesOrOmits(circt.stage.ChiselStage.emitCHIRRTL(new Foo))(
+    matchesAndOmits(circt.stage.ChiselStage.emitCHIRRTL(new Foo))(
       "module Baz :",
       "output a_bore : UInt<1>",
       "a_bore <= a_wire",
@@ -194,7 +194,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       val a = IO(Input(UInt(1.W)))
       val bar = Module(new Bar(a))
     }
-    matchesOrOmits(circt.stage.ChiselStage.emitCHIRRTL(new Foo))(
+    matchesAndOmits(circt.stage.ChiselStage.emitCHIRRTL(new Foo))(
       "module Bar :",
       "input q_bore : UInt<1>",
       "q <= q_bore_1", // Do normal connection before secret ones

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -362,12 +362,12 @@ trait Utils {
 }
 
 /** Contains helpful function to assert both statements to match, and statements to omit */
-trait MatchesOrOmits {
+trait MatchesAndOmits {
   private def matches(lines: List[String], matchh: String): Option[String] = lines.filter(_.contains(matchh)).lastOption
   private def omits(line:    String, omit:         String): Option[(String, String)] =
     if (line.contains(omit)) Some((omit, line)) else None
   private def omits(lines: List[String], omit: String): Seq[(String, String)] = lines.flatMap { omits(_, omit) }
-  def matchesOrOmits(output: String)(matchList: String*)(omitList: String*): Unit = {
+  def matchesAndOmits(output: String)(matchList: String*)(omitList: String*): Unit = {
     val lines = output.split("\n").toList
     val unmatched = matchList.flatMap { m =>
       if (matches(lines, m).nonEmpty) None else Some(m)

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -360,3 +360,22 @@ trait Utils {
 
   }
 }
+
+/** Contains helpful function to assert both statements to match, and statements to omit */
+trait MatchesOrOmits {
+  private def matches(lines: List[String], matchh: String): Option[String] = lines.filter(_.contains(matchh)).lastOption
+  private def omits(line:    String, omit:         String): Option[(String, String)] =
+    if (line.contains(omit)) Some((omit, line)) else None
+  private def omits(lines: List[String], omit: String): Seq[(String, String)] = lines.flatMap { omits(_, omit) }
+  def matchesOrOmits(output: String)(matchList: String*)(omitList: String*): Unit = {
+    val lines = output.split("\n").toList
+    val unmatched = matchList.flatMap { m =>
+      if (matches(lines, m).nonEmpty) None else Some(m)
+    }.map(x => s"  > $x was unmatched")
+    val unomitted = omitList.flatMap { o => omits(lines, o) }.map {
+      case (o, l) => s"  > $o was not omitted in ($l)"
+    }
+    val results = unmatched ++ unomitted
+    assert(results.isEmpty, results.mkString("\n"))
+  }
+}


### PR DESCRIPTION
This is a more complete implementation of #3167 , but rather than delaying closing of a module, adds a special area where ports and connections can be added to a module, post-closing. This second phase is closed when calling `.toDefinition` or reflecting on the ports (e.g. with `DataMirror`). 

A longer term plan is to fix some internals (e.g. when closing happens) so that we can unify these phases more gracefully.

For handling the D/I case, we can consider https://github.com/chipsalliance/chisel/pull/3173 as one approach.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.)


#### Release Notes

Added a new BoringUtils.bore that is performed during Chisel elaboration, not via Annotations+CIRCT. Punched ports are accessible to the user via DataMirror. However, using these reflection APIs or calling .toDefinition will fully close a module, to ensure that subsequent boring fails (and thus getting all ports is never stale).

Added a `skipPrefix` to enable ignoring the last prefix value in the prefix name stack.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
