### PR TITLE
[codegen] Use FIRRTL 3.0.0 syntax (connect, invalidate, regreset, radix-encoded integer literals)

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -145,7 +145,7 @@ case class ILit(n: BigInt) extends Arg {
 
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 case class ULit(n: BigInt, w: Width) extends LitArg(n, w) {
-  def name:     String = "UInt" + width + "(\"h0" + num.toString(16) + "\")"
+  def name:     String = "UInt" + width + "(0h0" + num.toString(16) + ")"
   def minWidth: Int = (if (w.known) 0 else 1).max(n.bitLength)
 
   def cloneWithWidth(newWidth: Width): this.type = {

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -8,7 +8,7 @@ import firrtl.testutils._
 class ExtModuleTests extends FirrtlFlatSpec {
   "extmodule" should "serialize and re-parse equivalently" in {
     val input =
-      """|FIRRTL version 2.0.0
+      """|FIRRTL version 3.0.0
          |circuit Top :
          |  extmodule Top :
          |    input y : UInt<0>

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -34,8 +34,8 @@ object SerializerSpec {
       |  output out : UInt<8>
       |
       |  inst c of child
-      |  c.in <= in
-      |  out <= c.out""".stripMargin
+      |  connect c.in, in
+      |  connect out, c.out""".stripMargin
 
   val testModuleTabbed: String = tab(testModule)
 
@@ -234,10 +234,10 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
     Serializer.serialize(rwProbeDefine) should be("define c.in = rwprobe(in)")
 
     val probeRead = Connect(NoInfo, Reference("out"), ProbeRead(Reference("c.out")))
-    Serializer.serialize(probeRead) should be("out <= read(c.out)")
+    Serializer.serialize(probeRead) should be("connect out, read(c.out)")
 
     val probeForceInitial = ProbeForceInitial(NoInfo, Reference("outProbe"), UIntLiteral(100, IntWidth(8)))
-    Serializer.serialize(probeForceInitial) should be("force_initial(outProbe, UInt<8>(\"h64\"))")
+    Serializer.serialize(probeForceInitial) should be("force_initial(outProbe, UInt<8>(0h64))")
 
     val probeReleaseInitial = ProbeReleaseInitial(NoInfo, Reference("outProbe"))
     Serializer.serialize(probeReleaseInitial) should be("release_initial(outProbe)")

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -155,17 +155,17 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
     matchesAndOmits(circt.stage.ChiselStage.emitCHIRRTL(new Foo))(
       "module Baz :",
       "output a_bore : UInt<1>",
-      "a_bore <= a_wire",
+      "connect a_bore, a_wire",
       "module Bar :",
       "output b_bore : UInt<2>",
-      "a_bore <= baz.a_bore",
-      "b_bore <= b_wire",
+      "connect a_bore, baz.a_bore",
+      "connect b_bore, b_wire",
       "module Foo :",
-      "a <= a_bore",
-      "b <= b_bore",
-      "c <= c_wire",
-      "a_bore <= bar.a_bore",
-      "b_bore <= bar.b_bore"
+      "connect a, a_bore",
+      "connect b, b_bore",
+      "connect c, c_wire",
+      "connect a_bore, bar.a_bore",
+      "connect b_bore, bar.b_bore"
     )()
   }
 
@@ -186,14 +186,14 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
     matchesAndOmits(circt.stage.ChiselStage.emitCHIRRTL(new Foo))(
       "module Bar :",
       "output b_bore : UInt<1>",
-      "b_bore <= a",
+      "connect b_bore, a",
       "module Baz :",
       "input b_bore : UInt<1>",
       "wire b_bore_1 : UInt<1>",
-      "b_bore_1 <= b_bore",
-      "b <= b_bore_1",
+      "connect b_bore_1, b_bore",
+      "connect b, b_bore_1",
       "module Foo",
-      "baz.b_bore <= bar.b_bore"
+      "connect baz.b_bore, bar.b_bore"
     )()
   }
 
@@ -226,11 +226,11 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
     matchesAndOmits(circt.stage.ChiselStage.emitCHIRRTL(new Foo))(
       "module Bar :",
       "input q_bore : UInt<1>",
-      "q <= q_bore_1", // Do normal connection before secret ones
-      "q_bore_1 <= q_bore",
+      "connect q, q_bore_1", // Do normal connection before secret ones
+      "connect q_bore_1, q_bore",
       "module Foo :",
       "input a : UInt<1>",
-      "bar.q_bore <= a"
+      "connect bar.q_bore, a"
     )()
   }
 
@@ -324,7 +324,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "define out_bore = probe(internalWire)",
       "module Top :",
       "define outProbe = foo.bore",
-      "out <= read(foo.out_bore)"
+      "connect out, read(foo.out_bore)"
     )()
   }
 
@@ -349,7 +349,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "output out_bore : Probe<UInt<1>>",
       "define out_bore = bar.out_bore",
       "module Top :",
-      "out <= read(foo.out_bore)"
+      "connect out, read(foo.out_bore)"
     )()
   }
 
@@ -370,10 +370,10 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "input bore : UInt<1>",
       "input out_bore : UInt<1>",
       "define outProbe = probe(tapIntermediate)",
-      "out <= out_tapIntermediate",
+      "connect out, out_tapIntermediate",
       "module Top :",
-      "foo.bore <= parentWire",
-      "foo.out_bore <= parentWire"
+      "connect foo.bore, parentWire",
+      "connect foo.out_bore, parentWire"
     )()
   }
 
@@ -393,12 +393,12 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
     matchesAndOmits(chirrtl)(
       "module Bar :",
       "input out_bore : UInt<1>",
-      "out <= out_tapIntermediate",
+      "connect out, out_tapIntermediate",
       "module Foo :",
-      "bar.out_bore <= out_bore",
+      "connect bar.out_bore, out_bore",
       "input out_bore : UInt<1>",
       "module Top :",
-      "foo.out_bore <= parentWire"
+      "connect foo.out_bore, parentWire"
     )()
   }
 
@@ -421,9 +421,9 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "define b_bore = probe(a)",
       "module Baz :",
       "input b_bore : UInt<1>",
-      "b_tapIntermediate <= b_bore",
+      "connect b_tapIntermediate, b_bore",
       "module Top :",
-      "baz.b_bore <= read(bar.b_bore)"
+      "connect baz.b_bore, read(bar.b_bore)"
     )()
   }
 
@@ -449,12 +449,12 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "define b_bore = probe(a)",
       "module Baz :",
       "input b_bore : UInt<1>",
-      "b_tapIntermediate <= b_bore",
+      "connect b_tapIntermediate, b_bore",
       "module Foo :",
       "input b_bore : UInt<1>",
-      "baz.b_bore <= b_bore",
+      "connect baz.b_bore, b_bore",
       "module Top :",
-      "foo.b_bore <= read(bar.b_bore)"
+      "connect foo.b_bore, read(bar.b_bore)"
     )()
   }
 
@@ -481,8 +481,8 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "output out_bore : RWProbe<UInt<1>>",
       "define out_bore = bar.out_bore",
       "module Top :",
-      "out <= read(foo.out_bore)",
-      "force_initial(foo.bore, UInt<1>(\"h0\"))"
+      "connect out, read(foo.out_bore)",
+      "force_initial(foo.bore, UInt<1>(0h0))"
     )()
   }
 

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -19,8 +19,8 @@ class BulkConnectSpec extends ChiselPropSpec {
       io.outMono := io.inMono
       io.outBi <> io.inBi
     })
-    chirrtl should include("io.outMono <= io.inMono")
-    chirrtl should include("io.outBi <= io.inBi")
+    chirrtl should include("connect io.outMono, io.inMono")
+    chirrtl should include("connect io.outBi, io.inBi")
   }
 
   property("Chisel connects should not emit FIRRTL bulk connects between differing FIRRTL types") {
@@ -40,8 +40,8 @@ class BulkConnectSpec extends ChiselPropSpec {
       out <> in
     })
     // out <- in is illegal FIRRTL
-    exactly(2, chirrtl.split('\n')) should include("out.foo.bar <= in.foo.bar")
-    chirrtl shouldNot include("out <= in")
+    exactly(2, chirrtl.split('\n')) should include("connect out.foo.bar, in.foo.bar")
+    chirrtl shouldNot include("connect out, in")
     chirrtl shouldNot include("out <- in")
   }
 
@@ -58,11 +58,11 @@ class BulkConnectSpec extends ChiselPropSpec {
       deq <> enq
     })
 
-    chirrtl shouldNot include("wire <= enq")
-    chirrtl should include("wire.bits <= enq.bits")
-    chirrtl should include("wire.valid <= enq.valid")
-    chirrtl should include("wire.ready <= enq.ready")
-    chirrtl should include("deq <= enq")
+    chirrtl shouldNot include("connect wire, enq")
+    chirrtl should include("connect wire.bits, enq.bits")
+    chirrtl should include("connect wire.valid, enq.valid")
+    chirrtl should include("connect wire.ready, enq.ready")
+    chirrtl should include("connect deq, enq")
   }
 
   property("Chisel connects should not emit a FIRRTL bulk connect for BlackBox IO Bundles") {
@@ -81,8 +81,8 @@ class BulkConnectSpec extends ChiselPropSpec {
       io <> bb.io
     })
     // There won't be a bb.io Bundle in FIRRTL, so connections have to be done element-wise
-    chirrtl should include("bb.O <= io.O")
-    chirrtl should include("io.I <= bb.I")
+    chirrtl should include("connect bb.O, io.O")
+    chirrtl should include("connect io.I, bb.I")
   }
 
   property("MonoConnect should bulk connect undirectioned internal wires") {
@@ -92,6 +92,6 @@ class BulkConnectSpec extends ChiselPropSpec {
       val w2 = Wire(Vec(2, UInt(8.W)))
       w2 := w1
     })
-    chirrtl should include("w2 <= w1")
+    chirrtl should include("connect w2, w1")
   }
 }

--- a/src/test/scala/chiselTests/ChiselEnum.scala
+++ b/src/test/scala/chiselTests/ChiselEnum.scala
@@ -577,7 +577,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
 
   it should "work with Printables" in {
     ChiselStage.emitCHIRRTL(new LoadStoreExample) should include(
-      """printf(clock, UInt<1>("h1"), "%c%c%c%c%c", _chiselTestsOpcodePrintable[0], _chiselTestsOpcodePrintable[1], _chiselTestsOpcodePrintable[2], _chiselTestsOpcodePrintable[3], _chiselTestsOpcodePrintable[4])"""
+      """printf(clock, UInt<1>(0h1), "%c%c%c%c%c", _chiselTestsOpcodePrintable[0], _chiselTestsOpcodePrintable[1], _chiselTestsOpcodePrintable[2], _chiselTestsOpcodePrintable[3], _chiselTestsOpcodePrintable[4])"""
     )
   }
 }

--- a/src/test/scala/chiselTests/DecoupledSpec.scala
+++ b/src/test/scala/chiselTests/DecoupledSpec.scala
@@ -27,13 +27,13 @@ class DecoupledSpec extends ChiselFlatSpec {
       })
 
     // Check for data assignment
-    chirrtl should include("""node _deq_map_bits_T = add(enq.bits, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_map_bits_T = add(enq.bits, UInt<1>(0h1)""")
     chirrtl should include("""node _deq_map_bits = tail(_deq_map_bits_T, 1)""")
-    chirrtl should include("""_deq_map.bits <= _deq_map_bits""")
-    chirrtl should include("""deq <= _deq_map""")
+    chirrtl should include("""connect _deq_map.bits, _deq_map_bits""")
+    chirrtl should include("""connect deq, _deq_map""")
 
     // Check for back-pressure (ready signal is driven in the opposite direction of bits + valid)
-    chirrtl should include("""enq.ready <= _deq_map.ready""")
+    chirrtl should include("""connect enq.ready, _deq_map.ready""")
   }
 
   "Decoupled.map" should "apply a function to a wrapped Bundle" in {
@@ -66,22 +66,22 @@ class DecoupledSpec extends ChiselFlatSpec {
     // Check for data assignment
     chirrtl should include("""wire _deq_map_bits : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")
 
-    chirrtl should include("""node _deq_map_bits_res_foo_T = add(enq.bits.foo, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_map_bits_res_foo_T = add(enq.bits.foo, UInt<1>(0h1)""")
     chirrtl should include("""node _deq_map_bits_res_foo_T_1 = tail(_deq_map_bits_res_foo_T, 1)""")
-    chirrtl should include("""_deq_map_bits.foo <= _deq_map_bits_res_foo_T_1""")
+    chirrtl should include("""connect _deq_map_bits.foo, _deq_map_bits_res_foo_T_1""")
 
-    chirrtl should include("""node _deq_map_bits_res_bar_T = sub(enq.bits.bar, UInt<1>("h1")""")
+    chirrtl should include("""node _deq_map_bits_res_bar_T = sub(enq.bits.bar, UInt<1>(0h1)""")
     chirrtl should include("""node _deq_map_bits_res_bar_T_1 = tail(_deq_map_bits_res_bar_T, 1)""")
-    chirrtl should include("""_deq_map_bits.bar <= _deq_map_bits_res_bar_T_1""")
+    chirrtl should include("""connect _deq_map_bits.bar, _deq_map_bits_res_bar_T_1""")
 
-    chirrtl should include("""_deq_map_bits.fizz <= UInt<1>("h0")""")
-    chirrtl should include("""_deq_map_bits.buzz <= UInt<1>("h1")""")
+    chirrtl should include("""connect _deq_map_bits.fizz, UInt<1>(0h0)""")
+    chirrtl should include("""connect _deq_map_bits.buzz, UInt<1>(0h1)""")
 
-    chirrtl should include("""_deq_map.bits <= _deq_map_bits""")
-    chirrtl should include("""deq <= _deq_map""")
+    chirrtl should include("""connect _deq_map.bits, _deq_map_bits""")
+    chirrtl should include("""connect deq, _deq_map""")
 
     // Check for back-pressure (ready signal is driven in the opposite direction of bits + valid)
-    chirrtl should include("""enq.ready <= _deq_map.ready""")
+    chirrtl should include("""connect enq.ready, _deq_map.ready""")
   }
 
   "Decoupled.map" should "apply a function to a wrapped Bundle and return a different typed DecoupledIO" in {
@@ -102,10 +102,10 @@ class DecoupledSpec extends ChiselFlatSpec {
 
     // Check for data assignment
     chirrtl should include("""node _deq_map_bits = and(enq.bits.foo, enq.bits.bar)""")
-    chirrtl should include("""_deq_map.bits <= _deq_map_bits""")
-    chirrtl should include("""deq <= _deq_map""")
+    chirrtl should include("""connect _deq_map.bits, _deq_map_bits""")
+    chirrtl should include("""connect deq, _deq_map""")
 
     // Check for back-pressure (ready signal is driven in the opposite direction of bits + valid)
-    chirrtl should include("""enq.ready <= _deq_map.ready""")
+    chirrtl should include("""connect enq.ready, _deq_map.ready""")
   }
 }

--- a/src/test/scala/chiselTests/Direction.scala
+++ b/src/test/scala/chiselTests/Direction.scala
@@ -459,7 +459,7 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
     // Check that emitted directions are correct.
     assert(emitted.contains("input incoming : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"))
     assert(emitted.contains("output outgoing : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}"))
-    assert(emitted.contains("outgoing <= incoming"))
+    assert(emitted.contains("connect outgoing, incoming"))
   }
   property("Can now mix Input/Output and Flipped within the same bundle") {
     class Decoupled extends Bundle {
@@ -488,10 +488,10 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
         "input io : { producer : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}, flip consumer : { bits : UInt<3>, valid : UInt<1>, flip ready : UInt<1>}, flip monitor : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}, driver : { bits : UInt<3>, valid : UInt<1>, ready : UInt<1>}}"
       )
     )
-    assert(emitted.contains("io.consumer <= io.producer"))
-    assert(emitted.contains("io.monitor.bits <= io.driver.bits"))
-    assert(emitted.contains("io.monitor.valid <= io.driver.valid"))
-    assert(emitted.contains("io.monitor.ready <= io.driver.ready"))
+    assert(emitted.contains("connect io.consumer, io.producer"))
+    assert(emitted.contains("connect io.monitor.bits, io.driver.bits"))
+    assert(emitted.contains("connect io.monitor.valid, io.driver.valid"))
+    assert(emitted.contains("connect io.monitor.ready, io.driver.ready"))
   }
   property("Bugfix: marking Vec fields with mixed directionality as Output/Input clears inner directions") {
     class Decoupled extends Bundle {

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -120,19 +120,19 @@ class ExtModuleSpec extends ChiselFlatSpec {
   it should "work with .suggestName (aka it should not require reflection for naming)" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new ExtModuleWithSuggestNameTester)
     chirrtl should include("input foo : UInt<8>")
-    chirrtl should include("inst.foo <= in")
+    chirrtl should include("connect inst.foo, in")
   }
 
   it should "work with FlatIO" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new ExtModuleWithFlatIOTester)
-    chirrtl should include("io.out <= inst.out")
-    chirrtl should include("inst.in <= io.in")
+    chirrtl should include("connect io.out, inst.out")
+    chirrtl should include("connect inst.in, io.in")
     chirrtl shouldNot include("badIO")
   }
 
   it should "not have invalidated ports in a chisel3._ context" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new ExtModuleInvalidatedTester)
-    chirrtl shouldNot include("inst.in is invalid")
-    chirrtl shouldNot include("inst.out is invalid")
+    chirrtl shouldNot include("invalidater inst.in")
+    chirrtl shouldNot include("invalidate inst.out")
   }
 }

--- a/src/test/scala/chiselTests/InstanceNameSpec.scala
+++ b/src/test/scala/chiselTests/InstanceNameSpec.scala
@@ -35,7 +35,7 @@ class InstanceNameSpec extends ChiselFlatSpec {
 
   it should "work for literals" in {
     val x = m.x.pathName
-    assert(x == moduleName + ".UInt<2>(\"h03\")")
+    assert(x == moduleName + ".UInt<2>(0h03)")
   }
 
   it should "NOT work for non-hardware values" in {

--- a/src/test/scala/chiselTests/InvalidateAPISpec.scala
+++ b/src/test/scala/chiselTests/InvalidateAPISpec.scala
@@ -26,36 +26,36 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
     val out = Output(Bool())
   }
 
-  property("an output connected to DontCare should emit a Firrtl \"is invalid\"") {
+  property("an output connected to DontCare should emit a Firrtl \"invalidate\"") {
     class ModuleWithDontCare extends Module {
       val io = IO(new TrivialInterface)
       io.out := DontCare
       io.out := io.in
     }
     val firrtlOutput = myGenerateFirrtl(new ModuleWithDontCare)
-    firrtlOutput should include("io.out is invalid")
+    firrtlOutput should include("invalidate io.out")
   }
 
-  property("an output without a DontCare should NOT emit a Firrtl \"is invalid\"") {
+  property("an output without a DontCare should NOT emit a Firrtl \"invalidate\"") {
     class ModuleWithoutDontCare extends Module {
       val io = IO(new TrivialInterface)
       io.out := io.in
     }
     val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
-    (firrtlOutput should not).include("is invalid")
+    (firrtlOutput should not).include("invalidate")
   }
 
-  property("a bundle with a DontCare should emit a Firrtl \"is invalid\"") {
+  property("a bundle with a DontCare should emit a Firrtl \"invalidate\"") {
     class ModuleWithoutDontCare extends Module {
       val io = IO(new TrivialInterface)
       io <> DontCare
     }
     val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
-    firrtlOutput should include("io.out is invalid")
-    firrtlOutput should include("io.in is invalid")
+    firrtlOutput should include("invalidate io.out")
+    firrtlOutput should include("invalidate io.in")
   }
 
-  property("a Vec with a DontCare should emit a Firrtl \"is invalid\" with bulk connect") {
+  property("a Vec with a DontCare should emit a Firrtl \"invalidate\" with bulk connect") {
     val nElements = 5
     class ModuleWithoutDontCare extends Module {
       val io = IO(new Bundle {
@@ -65,10 +65,10 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
     }
     val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
     for (i <- 0 until nElements)
-      firrtlOutput should include(s"io.outs[$i] is invalid")
+      firrtlOutput should include(s"invalidate io.outs[$i]")
   }
 
-  property("a Vec with a DontCare should emit a Firrtl \"is invalid\" with mono connect") {
+  property("a Vec with a DontCare should emit a Firrtl \"invalidate\" with mono connect") {
     val nElements = 5
     class ModuleWithoutDontCare extends Module {
       val io = IO(new Bundle {
@@ -78,7 +78,7 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
     }
     val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
     for (i <- 0 until nElements)
-      firrtlOutput should include(s"io.ins[$i] is invalid")
+      firrtlOutput should include(s"invalidate io.ins[$i]")
   }
 
   property("a DontCare cannot be a connection sink (LHS) for := ") {
@@ -162,6 +162,6 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
       val foo = IO(Output(Clock()))
       foo := DontCare
     }
-    myGenerateFirrtl(new ClockConnectedToDontCare) should include("foo is invalid")
+    myGenerateFirrtl(new ClockConnectedToDontCare) should include("invalidate foo")
   }
 }

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -27,7 +27,7 @@ class LTLSpec extends AnyFlatSpec with Matchers {
 
     chirrtl should include("inst ltl_delay of LTLDelayIntrinsic_42_0")
     chirrtl should include("input a : UInt<1>")
-    chirrtl should include("ltl_delay.in <= a")
+    chirrtl should include("connect ltl_delay.in, a")
   }
 
   it should "allow booleans to be used as properties" in {
@@ -42,7 +42,7 @@ class LTLSpec extends AnyFlatSpec with Matchers {
 
     chirrtl should include("inst ltl_eventually of LTLEventuallyIntrinsic")
     chirrtl should include("input a : UInt<1>")
-    chirrtl should include("ltl_eventually.in <= a")
+    chirrtl should include("connect ltl_eventually.in, a")
   }
 
   it should "support sequence delay operations" in {
@@ -61,9 +61,9 @@ class LTLSpec extends AnyFlatSpec with Matchers {
     chirrtl should include("inst ltl_delay_3 of LTLDelayIntrinsic_1_0")
     chirrtl should include("inst ltl_delay_4 of LTLDelayIntrinsic_0")
     chirrtl should include("inst ltl_delay_5 of LTLDelayIntrinsic_1")
-    chirrtl should include("ltl_delay.in <= a")
-    chirrtl should include("ltl_delay_1.in <= b")
-    chirrtl should include("ltl_delay_2.in <= c")
+    chirrtl should include("connect ltl_delay.in, a")
+    chirrtl should include("connect ltl_delay_1.in, b")
+    chirrtl should include("connect ltl_delay_2.in, c")
   }
 
   it should "support sequence concat operations" in {
@@ -73,14 +73,14 @@ class LTLSpec extends AnyFlatSpec with Matchers {
       val s1: Sequence = Sequence.concat(c, d, e) // (c concat d) concat e
     })
     chirrtl should include("inst ltl_concat of LTLConcatIntrinsic")
-    chirrtl should include("ltl_concat.lhs <= a")
-    chirrtl should include("ltl_concat.rhs <= b")
+    chirrtl should include("connect ltl_concat.lhs, a")
+    chirrtl should include("connect ltl_concat.rhs, b")
     chirrtl should include("inst ltl_concat_1 of LTLConcatIntrinsic")
-    chirrtl should include("ltl_concat_1.lhs <= c")
-    chirrtl should include("ltl_concat_1.rhs <= d")
+    chirrtl should include("connect ltl_concat_1.lhs, c")
+    chirrtl should include("connect ltl_concat_1.rhs, d")
     chirrtl should include("inst ltl_concat_2 of LTLConcatIntrinsic")
-    chirrtl should include("ltl_concat_2.lhs <= ltl_concat_1.out")
-    chirrtl should include("ltl_concat_2.rhs <= e")
+    chirrtl should include("connect ltl_concat_2.lhs, ltl_concat_1.out")
+    chirrtl should include("connect ltl_concat_2.rhs, e")
   }
 
   it should "support and, or, and clock operations" in {
@@ -99,29 +99,29 @@ class LTLSpec extends AnyFlatSpec with Matchers {
 
     // Sequences
     chirrtl should include("inst ltl_and of LTLAndIntrinsic")
-    chirrtl should include("ltl_and.lhs <= ltl_delay.out")
-    chirrtl should include("ltl_and.rhs <= b")
+    chirrtl should include("connect ltl_and.lhs, ltl_delay.out")
+    chirrtl should include("connect ltl_and.rhs, b")
 
     chirrtl should include("inst ltl_or of LTLOrIntrinsic")
-    chirrtl should include("ltl_or.lhs <= ltl_delay.out")
-    chirrtl should include("ltl_or.rhs <= b")
+    chirrtl should include("connect ltl_or.lhs, ltl_delay.out")
+    chirrtl should include("connect ltl_or.rhs, b")
 
     chirrtl should include("inst ltl_clock of LTLClockIntrinsic")
-    chirrtl should include("ltl_clock.in <= ltl_delay.out")
-    chirrtl should include("ltl_clock.clock <= clock")
+    chirrtl should include("connect ltl_clock.in, ltl_delay.out")
+    chirrtl should include("connect ltl_clock.clock, clock")
 
     // Properties
     chirrtl should include("inst ltl_and_1 of LTLAndIntrinsic")
-    chirrtl should include("ltl_and_1.lhs <= ltl_eventually.out")
-    chirrtl should include("ltl_and_1.rhs <= b")
+    chirrtl should include("connect ltl_and_1.lhs, ltl_eventually.out")
+    chirrtl should include("connect ltl_and_1.rhs, b")
 
     chirrtl should include("inst ltl_or_1 of LTLOrIntrinsic")
-    chirrtl should include("ltl_or_1.lhs <= ltl_eventually.out")
-    chirrtl should include("ltl_or_1.rhs <= b")
+    chirrtl should include("connect ltl_or_1.lhs, ltl_eventually.out")
+    chirrtl should include("connect ltl_or_1.rhs, b")
 
     chirrtl should include("inst ltl_clock_1 of LTLClockIntrinsic")
-    chirrtl should include("ltl_clock_1.in <= ltl_eventually.out")
-    chirrtl should include("ltl_clock_1.clock <= clock")
+    chirrtl should include("connect ltl_clock_1.in, ltl_eventually.out")
+    chirrtl should include("connect ltl_clock_1.clock, clock")
   }
 
   it should "support property not operation" in {
@@ -130,7 +130,7 @@ class LTLSpec extends AnyFlatSpec with Matchers {
       val p0: Property = Property.not(a)
     })
     chirrtl should include("inst ltl_not of LTLNotIntrinsic")
-    chirrtl should include("ltl_not.in <= a")
+    chirrtl should include("connect ltl_not.in, a")
   }
 
   it should "support property implication operation" in {
@@ -144,31 +144,31 @@ class LTLSpec extends AnyFlatSpec with Matchers {
 
     // Overlapping
     chirrtl should include("inst ltl_implication of LTLImplicationIntrinsic")
-    chirrtl should include("ltl_implication.lhs <= a")
-    chirrtl should include("ltl_implication.rhs <= b")
+    chirrtl should include("connect ltl_implication.lhs, a")
+    chirrtl should include("connect ltl_implication.rhs, b")
 
     chirrtl should include("inst ltl_implication_1 of LTLImplicationIntrinsic")
-    chirrtl should include("ltl_implication_1.lhs <= a")
-    chirrtl should include("ltl_implication_1.rhs <= b")
+    chirrtl should include("connect ltl_implication_1.lhs, a")
+    chirrtl should include("connect ltl_implication_1.rhs, b")
 
     // Non-overlapping (emitted as `a ## true |-> b`)
     chirrtl should include("inst ltl_delay of LTLDelayIntrinsic_1_0")
-    chirrtl should include("ltl_delay.in <= UInt<1>(\"h1\")")
+    chirrtl should include("connect ltl_delay.in, UInt<1>(0h1)")
     chirrtl should include("inst ltl_concat of LTLConcatIntrinsic")
-    chirrtl should include("ltl_concat.lhs <= a")
-    chirrtl should include("ltl_concat.rhs <= ltl_delay.out")
+    chirrtl should include("connect ltl_concat.lhs, a")
+    chirrtl should include("connect ltl_concat.rhs, ltl_delay.out")
     chirrtl should include("inst ltl_implication_2 of LTLImplicationIntrinsic")
-    chirrtl should include("ltl_implication_2.lhs <= ltl_concat.out")
-    chirrtl should include("ltl_implication_2.rhs <= b")
+    chirrtl should include("connect ltl_implication_2.lhs, ltl_concat.out")
+    chirrtl should include("connect ltl_implication_2.rhs, b")
 
     chirrtl should include("inst ltl_delay_1 of LTLDelayIntrinsic_1_0")
-    chirrtl should include("ltl_delay_1.in <= UInt<1>(\"h1\")")
+    chirrtl should include("connect ltl_delay_1.in, UInt<1>(0h1)")
     chirrtl should include("inst ltl_concat_1 of LTLConcatIntrinsic")
-    chirrtl should include("ltl_concat_1.lhs <= a")
-    chirrtl should include("ltl_concat_1.rhs <= ltl_delay_1.out")
+    chirrtl should include("connect ltl_concat_1.lhs, a")
+    chirrtl should include("connect ltl_concat_1.rhs, ltl_delay_1.out")
     chirrtl should include("inst ltl_implication_3 of LTLImplicationIntrinsic")
-    chirrtl should include("ltl_implication_3.lhs <= ltl_concat_1.out")
-    chirrtl should include("ltl_implication_3.rhs <= b")
+    chirrtl should include("connect ltl_implication_3.lhs, ltl_concat_1.out")
+    chirrtl should include("connect ltl_implication_3.rhs, b")
   }
 
   it should "support property eventually operation" in {
@@ -177,7 +177,7 @@ class LTLSpec extends AnyFlatSpec with Matchers {
       val p0: Property = a.eventually
     })
     chirrtl should include("inst ltl_eventually of LTLEventuallyIntrinsic")
-    chirrtl should include("ltl_eventually.in <= a")
+    chirrtl should include("connect ltl_eventually.in, a")
   }
 
   it should "support property disable operation" in {
@@ -186,8 +186,8 @@ class LTLSpec extends AnyFlatSpec with Matchers {
       val p0: Property = a.disable(b)
     })
     chirrtl should include("inst ltl_disable of LTLDisableIntrinsic")
-    chirrtl should include("ltl_disable.in <= a")
-    chirrtl should include("ltl_disable.condition <= b")
+    chirrtl should include("connect ltl_disable.in, a")
+    chirrtl should include("connect ltl_disable.condition, b")
   }
 
   it should "support simple property asserts/assumes/covers" in {
@@ -201,9 +201,9 @@ class LTLSpec extends AnyFlatSpec with Matchers {
     chirrtl should include("inst verif of VerifAssertIntrinsic")
     chirrtl should include("inst verif_1 of VerifAssumeIntrinsic")
     chirrtl should include("inst verif_2 of VerifCoverIntrinsic")
-    chirrtl should include("verif.property <= a")
-    chirrtl should include("verif_1.property <= a")
-    chirrtl should include("verif_2.property <= a")
+    chirrtl should include("connect verif.property, a")
+    chirrtl should include("connect verif_1.property, a")
+    chirrtl should include("connect verif_2.property, a")
   }
 
   it should "support labeled property asserts/assumes/covers" in {
@@ -219,9 +219,9 @@ class LTLSpec extends AnyFlatSpec with Matchers {
     chirrtl should include("inst verif of VerifAssertIntrinsic_foo0")
     chirrtl should include("inst verif_1 of VerifAssumeIntrinsic_foo1")
     chirrtl should include("inst verif_2 of VerifCoverIntrinsic_foo2")
-    chirrtl should include("verif.property <= a")
-    chirrtl should include("verif_1.property <= a")
-    chirrtl should include("verif_2.property <= a")
+    chirrtl should include("connect verif.property, a")
+    chirrtl should include("connect verif_1.property, a")
+    chirrtl should include("connect verif_2.property, a")
   }
 
   it should "support assert shorthands with clock and disable" in {
@@ -235,27 +235,27 @@ class LTLSpec extends AnyFlatSpec with Matchers {
 
     // with clock; emitted as `assert(clock(a, c))`
     chirrtl should include("inst ltl_clock of LTLClockIntrinsic")
-    chirrtl should include("ltl_clock.in <= a")
-    chirrtl should include("ltl_clock.clock <= c")
+    chirrtl should include("connect ltl_clock.in, a")
+    chirrtl should include("connect ltl_clock.clock, c")
     chirrtl should include("inst verif of VerifAssertIntrinsic")
-    chirrtl should include("verif.property <= ltl_clock.out")
+    chirrtl should include("connect verif.property, ltl_clock.out")
 
     // with disable; emitted as `assert(disable(a, b))`
     chirrtl should include("inst ltl_disable of LTLDisableIntrinsic")
-    chirrtl should include("ltl_disable.in <= a")
-    chirrtl should include("ltl_disable.condition <= b")
+    chirrtl should include("connect ltl_disable.in, a")
+    chirrtl should include("connect ltl_disable.condition, b")
     chirrtl should include("inst verif_1 of VerifAssertIntrinsic")
-    chirrtl should include("verif_1.property <= ltl_disable.out")
+    chirrtl should include("connect verif_1.property, ltl_disable.out")
 
     // with clock and disable; emitted as `assert(clock(disable(a, b), c))`
     chirrtl should include("inst ltl_disable_1 of LTLDisableIntrinsic")
-    chirrtl should include("ltl_disable_1.in <= a")
-    chirrtl should include("ltl_disable_1.condition <= b")
+    chirrtl should include("connect ltl_disable_1.in, a")
+    chirrtl should include("connect ltl_disable_1.condition, b")
     chirrtl should include("inst ltl_clock_1 of LTLClockIntrinsic")
-    chirrtl should include("ltl_clock_1.in <= ltl_disable_1.out")
-    chirrtl should include("ltl_clock_1.clock <= c")
+    chirrtl should include("connect ltl_clock_1.in, ltl_disable_1.out")
+    chirrtl should include("connect ltl_clock_1.clock, c")
     chirrtl should include("inst verif_2 of VerifAssertIntrinsic")
-    chirrtl should include("verif_2.property <= ltl_clock_1.out")
+    chirrtl should include("connect verif_2.property, ltl_clock_1.out")
   }
 
   it should "support Sequence(...) convenience constructor" in {
@@ -270,44 +270,44 @@ class LTLSpec extends AnyFlatSpec with Matchers {
       AssertProperty(Sequence(a, Delay(9001, None), b))
     })
     // a
-    chirrtl should include("verif.property <= a")
+    chirrtl should include("connect verif.property, a")
 
     // a b
-    chirrtl should include("ltl_concat.lhs <= a")
-    chirrtl should include("ltl_concat.rhs <= b")
-    chirrtl should include("verif_1.property <= ltl_concat.out")
+    chirrtl should include("connect ltl_concat.lhs, a")
+    chirrtl should include("connect ltl_concat.rhs, b")
+    chirrtl should include("connect verif_1.property, ltl_concat.out")
 
     // Delay() a
     chirrtl should include("inst ltl_delay of LTLDelayIntrinsic_1_0")
-    chirrtl should include("ltl_delay.in <= a")
-    chirrtl should include("verif_2.property <= ltl_delay.out")
+    chirrtl should include("connect ltl_delay.in, a")
+    chirrtl should include("connect verif_2.property, ltl_delay.out")
 
     // a Delay() b
     chirrtl should include("inst ltl_delay_1 of LTLDelayIntrinsic_1_0")
-    chirrtl should include("ltl_delay_1.in <= b")
-    chirrtl should include("ltl_concat_1.lhs <= a")
-    chirrtl should include("ltl_concat_1.rhs <= ltl_delay_1")
-    chirrtl should include("verif_3.property <= ltl_concat_1.out")
+    chirrtl should include("connect ltl_delay_1.in, b")
+    chirrtl should include("connect ltl_concat_1.lhs, a")
+    chirrtl should include("connect ltl_concat_1.rhs, ltl_delay_1")
+    chirrtl should include("connect verif_3.property, ltl_concat_1.out")
 
     // a Delay(2) b
     chirrtl should include("inst ltl_delay_2 of LTLDelayIntrinsic_2_0")
-    chirrtl should include("ltl_delay_2.in <= b")
-    chirrtl should include("ltl_concat_2.lhs <= a")
-    chirrtl should include("ltl_concat_2.rhs <= ltl_delay_2")
-    chirrtl should include("verif_4.property <= ltl_concat_2.out")
+    chirrtl should include("connect ltl_delay_2.in, b")
+    chirrtl should include("connect ltl_concat_2.lhs, a")
+    chirrtl should include("connect ltl_concat_2.rhs, ltl_delay_2")
+    chirrtl should include("connect verif_4.property, ltl_concat_2.out")
 
     // a Delay(42, 1337) b
     chirrtl should include("inst ltl_delay_3 of LTLDelayIntrinsic_42_1295")
-    chirrtl should include("ltl_delay_3.in <= b")
-    chirrtl should include("ltl_concat_3.lhs <= a")
-    chirrtl should include("ltl_concat_3.rhs <= ltl_delay_3")
-    chirrtl should include("verif_5.property <= ltl_concat_3.out")
+    chirrtl should include("connect ltl_delay_3.in, b")
+    chirrtl should include("connect ltl_concat_3.lhs, a")
+    chirrtl should include("connect ltl_concat_3.rhs, ltl_delay_3")
+    chirrtl should include("connect verif_5.property, ltl_concat_3.out")
 
     // a Delay(9001, None) b
     chirrtl should include("inst ltl_delay_4 of LTLDelayIntrinsic_9001")
-    chirrtl should include("ltl_delay_4.in <= b")
-    chirrtl should include("ltl_concat_4.lhs <= a")
-    chirrtl should include("ltl_concat_4.rhs <= ltl_delay_4")
-    chirrtl should include("verif_6.property <= ltl_concat_4.out")
+    chirrtl should include("connect ltl_delay_4.in, b")
+    chirrtl should include("connect ltl_concat_4.lhs, a")
+    chirrtl should include("connect ltl_concat_4.rhs, ltl_delay_4")
+    chirrtl should include("connect verif_6.property, ltl_concat_4.out")
   }
 }

--- a/src/test/scala/chiselTests/LiteralToTargetSpec.scala
+++ b/src/test/scala/chiselTests/LiteralToTargetSpec.scala
@@ -23,6 +23,6 @@ class LiteralToTargetSpec extends AnyFreeSpec with Matchers {
       }
 
       ChiselStage.emitCHIRRTL(new Foo)
-    } should have).message("Illegal component name: UInt<1>(\"h01\") (note: literals are illegal)")
+    } should have).message("Illegal component name: UInt<1>(0h01) (note: literals are illegal)")
   }
 }

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -493,14 +493,14 @@ class SRAMSpec extends ChiselFunSpec {
             val rdPortName = s"mem_out_readPorts_${rd}_data_MPORT"
             chirrtl should include(s"when mem.readPorts[$rd].enable")
             chirrtl should include(s"read mport $rdPortName")
-            chirrtl should include(s"mem.readPorts[$rd].data <= $rdPortName")
+            chirrtl should include(s"connect mem.readPorts[$rd].data, $rdPortName")
           }
 
           for (wr <- 0 until numWR) {
             val wrPortName = s"mem_MPORT${if (wr == 0) "" else s"_$wr"}"
             chirrtl should include(s"when mem.writePorts[$wr].enable")
             chirrtl should include(s"write mport $wrPortName")
-            chirrtl should include(s"$wrPortName <= mem.writePorts[$wr].data")
+            chirrtl should include(s"connect $wrPortName, mem.writePorts[$wr].data")
           }
 
           for (rw <- 0 until numRW) {
@@ -508,7 +508,7 @@ class SRAMSpec extends ChiselFunSpec {
             chirrtl should include(s"when mem.readwritePorts[$rw].enable")
             chirrtl should include(s"rdwr mport $rwPortName")
             chirrtl should include(s"when mem.readwritePorts[$rw].isWrite")
-            chirrtl should include(s"$rwPortName <= mem.readwritePorts[$rw].writeData")
+            chirrtl should include(s"connect $rwPortName, mem.readwritePorts[$rw].writeData")
           }
         }
     }
@@ -538,10 +538,12 @@ class SRAMSpec extends ChiselFunSpec {
 
     for (i <- 0 until 3) {
       chirrtl should include(s"when mem.writePorts[0].mask[$i]")
-      chirrtl should include(s"mem_MPORT[$i] <= mem.writePorts[0].data[$i]")
+      chirrtl should include(s"connect mem_MPORT[$i], mem.writePorts[0].data[$i]")
 
       chirrtl should include(s"when mem.readwritePorts[0].mask[$i]")
-      chirrtl should include(s"mem_out_readwritePorts_0_readData_MPORT[$i] <= mem.readwritePorts[0].writeData[$i]")
+      chirrtl should include(
+        s"connect mem_out_readwritePorts_0_readData_MPORT[$i], mem.readwritePorts[0].writeData[$i]"
+      )
     }
   }
   describe("Read-only SRAM") {

--- a/src/test/scala/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala/chiselTests/MixedVecSpec.scala
@@ -67,7 +67,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
       io.outMono := (io.inMono: Data)
       io.outBi <> io.inBi
     })
-    chirrtl should include("io.outMono <= io.inMono")
-    chirrtl should include("io.outBi <= io.inBi")
+    chirrtl should include("connect io.outMono, io.inMono")
+    chirrtl should include("connect io.outBi, io.inBi")
   }
 }

--- a/src/test/scala/chiselTests/MuxSpec.scala
+++ b/src/test/scala/chiselTests/MuxSpec.scala
@@ -66,9 +66,9 @@ class MuxLookupWrapper(keyWidth: Int, default: Int, mapping: () => Seq[(UInt, UI
 class MuxLookupExhaustiveSpec extends ChiselPropSpec {
   val keyWidth = 2
   val default = 9 // must be less than 10 to avoid hex/decimal mismatches
-  val firrtlLit = s"""UInt<4>("h$default")"""
+  val firrtlLit = s"""UInt<4>(0h$default)"""
 
-  // Assumes there are no literals with 'UInt<4>("h09")' in the output FIRRTL
+  // Assumes there are no literals with 'UInt<4>(0h09)' in the output FIRRTL
   // Assumes no binary recoding in output
 
   val incomplete = () => Seq(0.U -> 1.U, 1.U -> 2.U, 2.U -> 3.U)

--- a/src/test/scala/chiselTests/PrintableSpec.scala
+++ b/src/test/scala/chiselTests/PrintableSpec.scala
@@ -247,7 +247,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers with Utils {
       printf(cf"This is here $b1%x!!!! And should print everything else")
     }
     generateAndCheck(new MyModule) {
-      case Seq(Printf("This is here %x!!!! And should print everything else", Seq("UInt<4>(\"ha\")"))) =>
+      case Seq(Printf("This is here %x!!!! And should print everything else", Seq("UInt<4>(0ha)"))) =>
     }
   }
 

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -66,8 +66,8 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
       "output io : { flip in : RWProbe<UInt<1>>, out : RWProbe<UInt<1>>}",
       "define u1.io.in = rwprobe(io.x)",
       "define u2.io.in = u1.io.out",
-      "io.y <= read(u2.io.out)",
-      "force_initial(u1.io.out, UInt<1>(\"h0\"))",
+      "connect io.y, read(u2.io.out)",
+      "force_initial(u1.io.out, UInt<1>(0h0))",
       "release_initial(u1.io.out)",
       "force(clock, io.x, u2.io.out, u1.io.out)",
       "release(clock, io.y, u2.io.out)"
@@ -92,7 +92,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
     (processChirrtl(chirrtl) should contain).allOf(
       "when in :",
       "define out = rwprobe(in)",
-      "w <= read(out)"
+      "connect w, read(out)"
     )
   }
 
@@ -124,7 +124,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
       "output p : Probe<{ a : UInt<1>, b : UInt<1>}>",
       "wire x : { a : UInt<1>, b : UInt<1>}",
       "define p = probe(x)",
-      "x <= read(f.p.b)",
+      "connect x, read(f.p.b)",
       "define y = f.p.b"
     )
   }
@@ -176,12 +176,12 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
     )
 
     (processChirrtl(chirrtl) should contain).allOf(
-      "io.in.fizz <= io.a.fizz",
-      "io.a.baz <= io.in.baz",
-      "io.b.baz <= io.in.baz",
-      "io.in.fizz <= io.c.fizz",
-      "io.d.fizz <= io.in.fizz",
-      "io.d.baz <= io.in.baz"
+      "connect io.in.fizz, io.a.fizz",
+      "connect io.a.baz, io.in.baz",
+      "connect io.b.baz, io.in.baz",
+      "connect io.in.fizz, io.c.fizz",
+      "connect io.d.fizz, io.in.fizz",
+      "connect io.d.baz, io.in.baz"
     )
   }
 

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -128,8 +128,8 @@ class RecordSpec extends ChiselFlatSpec with Utils {
     val chirrtl = ChiselStage.emitCHIRRTL(
       gen = new ConnectionTestModule(fooBarType, fooBarType)
     )
-    chirrtl should include("io.outMono <= io.inMono @")
-    chirrtl should include("io.outBi <= io.inBi @")
+    chirrtl should include("connect io.outMono, io.inMono @")
+    chirrtl should include("connect io.outBi, io.inBi @")
   }
 
   they should "not allow aliased fields" in {

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -58,7 +58,7 @@ class VecSpec extends ChiselPropSpec with Utils {
 
   private def uint(value: BigInt): String = uint(value, value.bitLength.max(1))
   private def uint(value: BigInt, width: Int): String =
-    s"""UInt<$width>(\"h${value.toString(16)}")"""
+    s"""UInt<$width>(0h${value.toString(16)})"""
 
   property("Vecs should be assignable") {
     val values = (0 until 10).toList
@@ -67,7 +67,7 @@ class VecSpec extends ChiselPropSpec with Utils {
       val v = VecInit(values.map(_.U(width.W)))
     })
     for (v <- values) {
-      chirrtl should include(s"v[$v] <= ${uint(v, width)}")
+      chirrtl should include(s"connect v[$v], ${uint(v, width)}")
     }
   }
 
@@ -81,7 +81,7 @@ class VecSpec extends ChiselPropSpec with Utils {
       out := v
     })
     chirrtl should include("output out : UInt<4>[10]")
-    chirrtl should include("out <= v")
+    chirrtl should include("connect out, v")
   }
 
   property("Vec.fill with a pure type should generate an exception") {
@@ -100,8 +100,8 @@ class VecSpec extends ChiselPropSpec with Utils {
     chirrtl should include(s"wire x : UInt<$w>[$n]")
     chirrtl should include(s"wire u : UInt<$w>[$n]")
     for (i <- 0 until n) {
-      chirrtl should include(s"x[$i] <= ${uint(i * 2)}")
-      chirrtl should include(s"u[$i] <= ${uint(i * 2)}")
+      chirrtl should include(s"connect x[$i], ${uint(i * 2)}")
+      chirrtl should include(s"connect u[$i], ${uint(i * 2)}")
     }
   }
 
@@ -115,7 +115,7 @@ class VecSpec extends ChiselPropSpec with Utils {
     chirrtl should include(s"wire v : UInt<$w>[$m][$n]")
     for (i <- 0 until n) {
       for (j <- 0 until m) {
-        chirrtl should include(s"v[$i][$j] <= ${uint(i + j)}")
+        chirrtl should include(s"connect v[$i][$j], ${uint(i + j)}")
       }
     }
   }
@@ -132,7 +132,7 @@ class VecSpec extends ChiselPropSpec with Utils {
     for (i <- 0 until n) {
       for (j <- 0 until m) {
         for (k <- 0 until o) {
-          chirrtl should include(s"v[$i][$j][$k] <= ${uint(i + j + k)}")
+          chirrtl should include(s"connect v[$i][$j][$k], ${uint(i + j + k)}")
         }
       }
     }
@@ -150,8 +150,8 @@ class VecSpec extends ChiselPropSpec with Utils {
     chirrtl should include(s"wire u : UInt<$w>[$n]")
     val valueFir = uint(value)
     for (i <- 0 until n) {
-      chirrtl should include(s"x[$i] <= $valueFir")
-      chirrtl should include(s"u[$i] <= $valueFir")
+      chirrtl should include(s"connect x[$i], $valueFir")
+      chirrtl should include(s"connect u[$i], $valueFir")
     }
   }
 
@@ -176,7 +176,7 @@ class VecSpec extends ChiselPropSpec with Utils {
     val valueFir = uint(value)
     for (i <- 0 until n) {
       for (j <- 0 until m) {
-        chirrtl should include(s"v[$i][$j] <= $valueFir")
+        chirrtl should include(s"connect v[$i][$j], $valueFir")
       }
     }
   }
@@ -195,7 +195,7 @@ class VecSpec extends ChiselPropSpec with Utils {
     for (i <- 0 until n) {
       for (j <- 0 until m) {
         for (k <- 0 until o) {
-          chirrtl should include(s"v[$i][$j][$k] <= $valueFir")
+          chirrtl should include(s"connect v[$i][$j][$k], $valueFir")
         }
       }
     }
@@ -214,8 +214,8 @@ class VecSpec extends ChiselPropSpec with Utils {
     for (i <- 0 until n) {
       for (j <- 0 until m) {
         val suffix = if (idx > 0) s"_$idx" else ""
-        chirrtl should include(s"vec2D[$i][$j].out <= vec2D_mod$suffix.io.out")
-        chirrtl should include(s"vec2D_mod$suffix.io.in <= vec2D[$i][$j].in")
+        chirrtl should include(s"connect vec2D[$i][$j].out, vec2D_mod$suffix.io.out")
+        chirrtl should include(s"connect vec2D_mod$suffix.io.in, vec2D[$i][$j].in")
         idx += 1
       }
     }
@@ -236,8 +236,8 @@ class VecSpec extends ChiselPropSpec with Utils {
       for (j <- 0 until m) {
         for (k <- 0 until o) {
           val suffix = if (idx > 0) s"_$idx" else ""
-          chirrtl should include(s"vec3D[$i][$j][$k].out <= vec3D_mod$suffix.io.out")
-          chirrtl should include(s"vec3D_mod$suffix.io.in <= vec3D[$i][$j][$k].in")
+          chirrtl should include(s"connect vec3D[$i][$j][$k].out, vec3D_mod$suffix.io.out")
+          chirrtl should include(s"connect vec3D_mod$suffix.io.in, vec3D[$i][$j][$k].in")
           idx += 1
         }
       }
@@ -257,8 +257,8 @@ class VecSpec extends ChiselPropSpec with Utils {
     for (i <- 0 until n) {
       for (j <- 0 until m) {
         val suffix = s"_${(i + 1) % n}_${(j + 2) % m}"
-        chirrtl should include(s"vec2D[$i][$j].out <= mods$suffix.io.out")
-        chirrtl should include(s"mods$suffix.io.in <= vec2D[$i][$j].in")
+        chirrtl should include(s"connect vec2D[$i][$j].out, mods$suffix.io.out")
+        chirrtl should include(s"connect mods$suffix.io.in, vec2D[$i][$j].in")
       }
     }
   }
@@ -278,8 +278,8 @@ class VecSpec extends ChiselPropSpec with Utils {
       for (j <- 0 until m) {
         for (k <- 0 until o) {
           val suffix = s"_${(i + 1) % n}_${(j + 2) % m}_$k"
-          chirrtl should include(s"vec2D[$i][$j][$k].out <= mods$suffix.io.out")
-          chirrtl should include(s"mods$suffix.io.in <= vec2D[$i][$j][$k].in")
+          chirrtl should include(s"connect vec2D[$i][$j][$k].out, mods$suffix.io.out")
+          chirrtl should include(s"connect mods$suffix.io.in, vec2D[$i][$j][$k].in")
         }
       }
     }
@@ -295,7 +295,7 @@ class VecSpec extends ChiselPropSpec with Utils {
       oneBitUnitRegVec(0) := 1.U(1.W)
     })
     chirrtl should include("reg oneBitUnitRegVec : UInt<1>[1], clock")
-    chirrtl should include("oneBitUnitRegVec[0] <= UInt<1>(\"h1\")")
+    chirrtl should include("connect oneBitUnitRegVec[0], UInt<1>(0h1)")
   }
 
   property("A Vec with zero entries should compile and have zero width") {
@@ -320,10 +320,10 @@ class VecSpec extends ChiselPropSpec with Utils {
     })
     chirrtl should include("output io : { foo : UInt<1>, bar : UInt<1>[0]}")
     chirrtl should include("wire zero : { foo : UInt<1>, bar : UInt<1>[0]}")
-    chirrtl should include("zero.foo <= UInt<1>(\"h0\")")
-    chirrtl should include("io <= zero")
+    chirrtl should include("connect zero.foo, UInt<1>(0h0)")
+    chirrtl should include("connect io, zero")
     chirrtl should include("wire w : UInt<1>[0]")
-    chirrtl should include("w <= m.io.bar")
+    chirrtl should include("connect w, m.io.bar")
   }
 
   property("It should be possible to bulk connect a Vec and a Seq") {
@@ -390,7 +390,7 @@ class VecSpec extends ChiselPropSpec with Utils {
     for (gen <- List(new EmptyBundle, new EmptyRecord)) {
       val chirrtl = ChiselStage.emitCHIRRTL(new MyModule(gen))
       chirrtl should include("input in : { }")
-      chirrtl should include("reg reg : { }[4]")
+      chirrtl should include("regreset reg : { }[4]")
     }
   }
 
@@ -400,7 +400,7 @@ class VecSpec extends ChiselPropSpec with Utils {
       val out = IO(Output(UInt(8.W)))
       out := vec(1.U)
     }))
-    chirrtl should include("out <= vec[1]")
+    chirrtl should include("connect out, vec[1]")
     log should be("")
   }
 
@@ -410,7 +410,7 @@ class VecSpec extends ChiselPropSpec with Utils {
       val out = IO(Output(UInt(8.W)))
       out := vec(10.U)
     }))
-    chirrtl should include("""out <= vec[UInt<2>("h2")]""")
+    chirrtl should include("""connect out, vec[UInt<2>(0h2)]""")
     log should include("Dynamic index with width 4 is too wide for Vec of size 4 (expected index width 2)")
   }
 

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -78,11 +78,11 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "Vec literals should work when used to initialize a reg of vec" in {
     val firrtl = ChiselStage.emitCHIRRTL(new HasVecInit)
-    firrtl should include("""_y_WIRE[0] <= UInt<8>("hab")""")
-    firrtl should include("""_y_WIRE[1] <= UInt<8>("hcd")""")
-    firrtl should include("""_y_WIRE[2] <= UInt<8>("hef")""")
-    firrtl should include("""_y_WIRE[3] <= UInt<8>("hff")""")
-    firrtl should include("""      reset => (reset, _y_WIRE)""".stripMargin)
+    firrtl should include("""connect _y_WIRE[0], UInt<8>(0hab)""")
+    firrtl should include("""connect _y_WIRE[1], UInt<8>(0hcd)""")
+    firrtl should include("""connect _y_WIRE[2], UInt<8>(0hef)""")
+    firrtl should include("""connect _y_WIRE[3], UInt<8>(0hff)""")
+    firrtl should include("""regreset y : UInt<8>[4], clock, reset, _y_WIRE""".stripMargin)
   }
 
   //NOTE: I had problems where this would not work if this class declaration was inside test scope
@@ -93,11 +93,11 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "Vec literals should work when used to partially initialize a reg of vec" in {
     val firrtl = ChiselStage.emitCHIRRTL(new HasPartialVecInit)
-    firrtl should include("""_y_WIRE[0] <= UInt<8>("hab")""")
-    firrtl should include("""_y_WIRE[1] is invalid""")
-    firrtl should include("""_y_WIRE[2] <= UInt<8>("hef")""")
-    firrtl should include("""_y_WIRE[3] <= UInt<8>("hff")""")
-    firrtl should include("""      reset => (reset, _y_WIRE)""".stripMargin)
+    firrtl should include("""connect _y_WIRE[0], UInt<8>(0hab)""")
+    firrtl should include("""invalidate _y_WIRE[1]""")
+    firrtl should include("""connect _y_WIRE[2], UInt<8>(0hef)""")
+    firrtl should include("""connect _y_WIRE[3], UInt<8>(0hff)""")
+    firrtl should include("""regreset y : UInt<8>[4], clock, reset, _y_WIRE""".stripMargin)
   }
 
   class ResetRegWithPartialVecLiteral extends Module {
@@ -426,8 +426,8 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
     }
 
     val firrtl = ChiselStage.emitCHIRRTL(new VecExample5)
-    firrtl should include("""out[0] <= UInt<4>("ha")""")
-    firrtl should include("""out[1] <= UInt<4>("hb")""")
+    firrtl should include("""connect out[0], UInt<4>(0ha)""")
+    firrtl should include("""connect out[1], UInt<4>(0hb)""")
   }
 
   class SubBundle extends Bundle {
@@ -446,10 +446,10 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "vec literals can contain bundles and should not be bulk connected" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new VecExample)
-    chirrtl should include("""out[0].bar <= UInt<5>("h16")""")
-    chirrtl should include("""out[0].foo <= UInt<6>("h2a")""")
-    chirrtl should include("""out[1].bar <= UInt<2>("h3")""")
-    chirrtl should include("""out[1].foo <= UInt<3>("h7")""")
+    chirrtl should include("""connect out[0].bar, UInt<5>(0h16)""")
+    chirrtl should include("""connect out[0].foo, UInt<6>(0h2a)""")
+    chirrtl should include("""connect out[1].bar, UInt<2>(0h3)""")
+    chirrtl should include("""connect out[1].foo, UInt<3>(0h7)""")
   }
 
   "vec literals can have bundle children" in {

--- a/src/test/scala/chiselTests/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/VerificationSpec.scala
@@ -34,13 +34,13 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
 
     // reset guard around the verification statement
     assertContains(lines, "when _T_2 : ")
-    assertContains(lines, "cover(clock, _T, UInt<1>(\"h1\"), \"\")")
+    assertContains(lines, "cover(clock, _T, UInt<1>(0h1), \"\")")
 
     assertContains(lines, "when _T_6 : ")
-    assertContains(lines, "assume(clock, _T_4, UInt<1>(\"h1\"), \"\")")
+    assertContains(lines, "assume(clock, _T_4, UInt<1>(0h1), \"\")")
 
     assertContains(lines, "when _T_10 : ")
-    assertContains(lines, "assert(clock, _T_8, UInt<1>(\"h1\"), \"\")")
+    assertContains(lines, "assert(clock, _T_8, UInt<1>(0h1), \"\")")
   }
 
   property("annotation of verification constructs should work") {

--- a/src/test/scala/chiselTests/experimental/DataView.scala
+++ b/src/test/scala/chiselTests/experimental/DataView.scala
@@ -66,7 +66,7 @@ class DataViewSpec extends ChiselFlatSpec {
       out := in.viewAs[BundleB]
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("out.bar <= in.foo")
+    chirrtl should include("connect out.bar, in.foo")
   }
 
   it should "be a bidirectional mapping" in {
@@ -77,7 +77,7 @@ class DataViewSpec extends ChiselFlatSpec {
       out.viewAs[BundleA] := in
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("out.bar <= in.foo")
+    chirrtl should include("connect out.bar, in.foo")
   }
 
   it should "handle viewing UInts as UInts" in {
@@ -89,8 +89,8 @@ class DataViewSpec extends ChiselFlatSpec {
       bar.viewAs[UInt] := in
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("foo <= in")
-    chirrtl should include("bar <= in")
+    chirrtl should include("connect foo, in")
+    chirrtl should include("connect bar, in")
   }
 
   it should "handle viewing Analogs as Analogs" in {
@@ -115,8 +115,8 @@ class DataViewSpec extends ChiselFlatSpec {
       buzz.viewAs[MyBundle] := in
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("fizz <= in")
-    chirrtl should include("buzz <= in")
+    chirrtl should include("connect fizz, in")
+    chirrtl should include("connect buzz, in")
   }
 
   it should "handle viewing Vecs as their same concrete type" in {
@@ -128,8 +128,8 @@ class DataViewSpec extends ChiselFlatSpec {
       buzz.viewAs[Vec[UInt]] := in
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("fizz <= in")
-    chirrtl should include("buzz <= in")
+    chirrtl should include("connect fizz, in")
+    chirrtl should include("connect buzz, in")
   }
 
   it should "handle viewing Vecs as Bundles and vice versa" in {
@@ -142,10 +142,10 @@ class DataViewSpec extends ChiselFlatSpec {
       out2.viewAs[MyBundle] := in
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("out[0] <= in.bar")
-    chirrtl should include("out[1] <= in.foo")
-    chirrtl should include("out2[0] <= in.bar")
-    chirrtl should include("out2[1] <= in.foo")
+    chirrtl should include("connect out[0], in.bar")
+    chirrtl should include("connect out[1], in.foo")
+    chirrtl should include("connect out2[0], in.bar")
+    chirrtl should include("connect out2[1], in.foo")
   }
 
   it should "work with bidirectional connections for nested types" in {
@@ -158,14 +158,14 @@ class DataViewSpec extends ChiselFlatSpec {
       deq2.viewAs[DecoupledIO[FizzBuzz]] <> enq
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("deq.valid <= enq.valid")
-    chirrtl should include("enq.ready <= deq.ready")
-    chirrtl should include("deq.fizz <= enq.bits.fizz")
-    chirrtl should include("deq.buzz <= enq.bits.buzz")
-    chirrtl should include("deq2.valid <= enq.valid")
-    chirrtl should include("enq.ready <= deq2.ready")
-    chirrtl should include("deq2.fizz <= enq.bits.fizz")
-    chirrtl should include("deq2.buzz <= enq.bits.buzz")
+    chirrtl should include("connect deq.valid, enq.valid")
+    chirrtl should include("connect enq.ready, deq.ready")
+    chirrtl should include("connect deq.fizz, enq.bits.fizz")
+    chirrtl should include("connect deq.buzz, enq.bits.buzz")
+    chirrtl should include("connect deq2.valid, enq.valid")
+    chirrtl should include("connect enq.ready, deq2.ready")
+    chirrtl should include("connect deq2.fizz, enq.bits.fizz")
+    chirrtl should include("connect deq2.buzz, enq.bits.buzz")
   }
 
   it should "support viewing a Bundle as a Parent Bundle type" in {
@@ -185,8 +185,8 @@ class DataViewSpec extends ChiselFlatSpec {
       fooOut := barIn.viewAsSupertype(new Foo)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("barOut.foo <= fooIn.foo")
-    chirrtl should include("fooOut.foo <= barIn.foo")
+    chirrtl should include("connect barOut.foo, fooIn.foo")
+    chirrtl should include("connect fooOut.foo, barIn.foo")
   }
 
   it should "support viewing a Record as a Parent Record type" in {
@@ -210,8 +210,8 @@ class DataViewSpec extends ChiselFlatSpec {
       fooOut := barIn.viewAsSupertype(new Foo)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("barOut.foo <= fooIn.foo")
-    chirrtl should include("fooOut.foo <= barIn.foo")
+    chirrtl should include("connect barOut.foo, fooIn.foo")
+    chirrtl should include("connect fooOut.foo, barIn.foo")
   }
 
   it should "fail if you try viewing a Record as a poorly inherited Parent Record type" in {
@@ -250,8 +250,8 @@ class DataViewSpec extends ChiselFlatSpec {
       ifcMon.viewAsSupertype(chiselTypeOf(ifc)) :>= ifc
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("ifc.foo.bits is invalid")
-    chirrtl should include("ifc.foo.ready <= ifcMon.foo.ready")
+    chirrtl should include("invalidate ifc.foo.bits")
+    chirrtl should include("connect ifc.foo.ready, ifcMon.foo.ready")
   }
 
   it should "be easy to make a PartialDataView viewing a Bundle as a Parent Bundle type" in {
@@ -272,8 +272,8 @@ class DataViewSpec extends ChiselFlatSpec {
       fooOut := barIn.viewAs[Foo]
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("barOut.foo <= fooIn.foo")
-    chirrtl should include("fooOut.foo <= barIn.foo")
+    chirrtl should include("connect barOut.foo, fooIn.foo")
+    chirrtl should include("connect fooOut.foo, barIn.foo")
   }
 
   it should "support viewing structural supertypes" in {
@@ -303,10 +303,10 @@ class DataViewSpec extends ChiselFlatSpec {
       io.outa.viewAsSupertype(new C) <> io.inc
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("io.b.x <= io.a.x")
-    chirrtl should include("io.c.z <= io.a.z")
-    chirrtl should include("io.outa.z <= io.inc.z")
-    chirrtl should include("io.outa.y <= io.inc.y")
+    chirrtl should include("connect io.b.x, io.a.x")
+    chirrtl should include("connect io.c.z, io.a.z")
+    chirrtl should include("connect io.outa.z, io.inc.z")
+    chirrtl should include("connect io.outa.y, io.inc.y")
   }
 
   it should "support viewing structural supertypes with bundles" in {
@@ -339,11 +339,11 @@ class DataViewSpec extends ChiselFlatSpec {
       io.outa.viewAsSupertype(new C) <> io.inc
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("io.b.x <= io.a.x")
-    chirrtl should include("io.c.z <= io.a.z")
-    chirrtl should include("io.outa.foo <= io.inc.foo")
-    chirrtl should include("io.b.foo <= io.a.foo")
-    chirrtl should include("io.c.foo <= io.a.foo")
+    chirrtl should include("connect io.b.x, io.a.x")
+    chirrtl should include("connect io.c.z, io.a.z")
+    chirrtl should include("connect io.outa.foo, io.inc.foo")
+    chirrtl should include("connect io.b.foo, io.a.foo")
+    chirrtl should include("connect io.c.foo, io.a.foo")
   }
 
   it should "error during elaboration for sub-type errors that cannot be found at compile-time" in {
@@ -469,13 +469,13 @@ class DataViewSpec extends ChiselFlatSpec {
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     val expected = List(
       "node x = and(a, b.value)",
-      "and <= x",
+      "connect and, x",
       "node y = mux(cond, a, b.value)",
-      "mux <= y",
+      "connect mux, y",
       "node aBits = bits(a, 3, 0)",
       "node bBits = bits(b.value, 3, 0)",
       "node abCat = cat(aBits, bBits)",
-      "bitsCat <= abCat"
+      "connect bitsCat, abCat"
     )
     for (line <- expected) {
       chirrtl should include(line)
@@ -492,7 +492,7 @@ class DataViewSpec extends ChiselFlatSpec {
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
     chirrtl should include("node cat = cat(barIn.foo, barIn.bar)")
-    chirrtl should include("fooOut <= cat")
+    chirrtl should include("connect fooOut, cat")
   }
 
   it should "be composable" in {
@@ -513,8 +513,8 @@ class DataViewSpec extends ChiselFlatSpec {
       z := b.viewAs[Bar].viewAs[Fizz]
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("y.fizz <= a.foo")
-    chirrtl should include("z.fizz <= b.foo")
+    chirrtl should include("connect y.fizz, a.foo")
+    chirrtl should include("connect z.fizz, b.foo")
   }
 
   it should "enable using Seq like Data" in {
@@ -579,8 +579,8 @@ class DataViewSpec extends ChiselFlatSpec {
       dataOut := selected
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("vec[addr] <= dataIn")
-    chirrtl should include("dataOut <= vec[addr]")
+    chirrtl should include("connect vec[addr], dataIn")
+    chirrtl should include("connect dataOut, vec[addr]")
   }
 
   it should "support dynamic indexing for Vecs that correspond 1:1 in a view" in {
@@ -609,8 +609,8 @@ class DataViewSpec extends ChiselFlatSpec {
       dataOut := selected
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("vec[addrReg] <= dataIn")
-    chirrtl should include("dataOut <= vec[addrReg]")
+    chirrtl should include("connect vec[addrReg], dataIn")
+    chirrtl should include("connect dataOut, vec[addrReg]")
   }
 
   it should "allow views between reset types" in {
@@ -642,8 +642,8 @@ class DataViewSpec extends ChiselFlatSpec {
       .split('\n')
       .map(_.takeWhile(_ != '@'))
       .map(_.trim) should contain).allOf(
-      "a.bool <= b.reset_0",
-      "a.asyncreset <= b.reset_1"
+      "connect a.bool, b.reset_0",
+      "connect a.asyncreset, b.reset_1"
     )
   }
 
@@ -777,7 +777,7 @@ class DataViewSpec extends ChiselFlatSpec {
     }
 
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    val expected = ('a' to 'f').map(c => s"$c is invalid")
+    val expected = ('a' to 'f').map(c => s"invalidate $c")
     for (line <- expected) {
       chirrtl should include(line)
     }

--- a/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
+++ b/src/test/scala/chiselTests/experimental/FlatIOSpec.scala
@@ -22,7 +22,7 @@ class FlatIOSpec extends ChiselFlatSpec {
     val chirrtl = emitCHIRRTL(new MyModule)
     chirrtl should include("input in : UInt<8>")
     chirrtl should include("output out : UInt<8>")
-    chirrtl should include("out <= in")
+    chirrtl should include("connect out, in")
   }
 
   it should "support bulk connections between FlatIOs and regular IOs" in {
@@ -32,8 +32,8 @@ class FlatIOSpec extends ChiselFlatSpec {
       out := in
     }
     val chirrtl = emitCHIRRTL(new MyModule)
-    chirrtl should include("out.bits <= bits")
-    chirrtl should include("out.valid <= valid")
+    chirrtl should include("connect out.bits, bits")
+    chirrtl should include("connect out.valid, valid")
   }
 
   it should "dynamically indexing Vecs inside of FlatIOs" in {
@@ -46,7 +46,7 @@ class FlatIOSpec extends ChiselFlatSpec {
       io.out(io.addr) := io.in(io.addr)
     }
     val chirrtl = emitCHIRRTL(new MyModule)
-    chirrtl should include("out[addr] <= in[addr]")
+    chirrtl should include("connect out[addr], in[addr]")
   }
 
   it should "support Analog members" in {
@@ -62,7 +62,7 @@ class FlatIOSpec extends ChiselFlatSpec {
       io.out <> io.in
     }
     val chirrtl = emitCHIRRTL(new MyModule)
-    chirrtl should include("out.foo <= in.foo")
+    chirrtl should include("connect out.foo, in.foo")
     chirrtl should include("attach (out.bar, in.bar)")
   }
 }

--- a/src/test/scala/chiselTests/experimental/OpaqueTypeSpec.scala
+++ b/src/test/scala/chiselTests/experimental/OpaqueTypeSpec.scala
@@ -178,10 +178,10 @@ class OpaqueTypeSpec extends ChiselFlatSpec with Utils {
     val nestedRecordChirrtl = ChiselStage.emitCHIRRTL { new NestedRecordModule }
     nestedRecordChirrtl should include("input in : UInt<8>")
     nestedRecordChirrtl should include("output out : UInt<8>")
-    nestedRecordChirrtl should include("inst.io.foo <= in")
-    nestedRecordChirrtl should include("out <= inst.io.bar")
+    nestedRecordChirrtl should include("connect inst.io.foo, in")
+    nestedRecordChirrtl should include("connect out, inst.io.bar")
     nestedRecordChirrtl should include("output io : { flip foo : UInt<8>, bar : UInt<8>}")
-    nestedRecordChirrtl should include("io.bar <= io.foo")
+    nestedRecordChirrtl should include("connect io.bar, io.foo")
   }
 
   they should "throw an error when map contains a named element and OpaqueType is mixed in" in {
@@ -200,7 +200,7 @@ class OpaqueTypeSpec extends ChiselFlatSpec with Utils {
     val chirrtl = ChiselStage.emitCHIRRTL(new NotActuallyOpaqueTypeModule)
     chirrtl should include("input in : { y : UInt<8>, x : UInt<8>}")
     chirrtl should include("output out : { y : UInt<8>, x : UInt<8>}")
-    chirrtl should include("out <= in")
+    chirrtl should include("connect out, in")
   }
 
   they should "support conditional OpaqueTypes via traits and factory methods" in {
@@ -238,7 +238,7 @@ class OpaqueTypeSpec extends ChiselFlatSpec with Utils {
     }
     // First check that it works when it should
     val chirrtl = ChiselStage.emitCHIRRTL(new AsUIntTester(new MaybeNoAsUInt(false)))
-    chirrtl should include("out <= in")
+    chirrtl should include("connect out, in")
 
     val e = the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL(new AsUIntTester(new MaybeNoAsUInt(true)), Array("--throw-on-first-error"))

--- a/src/test/scala/chiselTests/experimental/Tuple.scala
+++ b/src/test/scala/chiselTests/experimental/Tuple.scala
@@ -31,10 +31,10 @@ class TupleSpec extends ChiselFlatSpec {
       ((w, x), (y, z)) := ((a, b), (c, d))
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("w <= a")
-    chirrtl should include("x <= b")
-    chirrtl should include("y <= c")
-    chirrtl should include("z <= d")
+    chirrtl should include("connect w, a")
+    chirrtl should include("connect x, b")
+    chirrtl should include("connect y, c")
+    chirrtl should include("connect z, d")
   }
 
   it should "enable using Tuple3 like Data" in {

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -546,8 +546,8 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
         "~Top|MyModule>sum".rt -> "bar"
       )
       val expectedLines = List(
-        "i.in <= foo",
-        "bar <= i.out"
+        "connect i.in, foo",
+        "connect bar, i.out"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize
@@ -583,8 +583,8 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
         "~Top|MyModule>a.foo".rt -> "in_bar"
       )
       val expectedLines = List(
-        "i.a <= foo",
-        "bar <= i.b.foo"
+        "connect i.a, foo",
+        "connect bar, i.b.foo"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -61,10 +61,10 @@ class InstanceSpec extends ChiselFunSpec with Utils {
       val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
       chirrtl should include("inst i0 of AddOneBlackBox")
       chirrtl should include("inst i1 of AddOneBlackBox")
-      chirrtl should include("i0.in <= in")
-      chirrtl should include("out <= i0.out")
-      chirrtl should include("i1.in <= io.in")
-      chirrtl should include("io.out <= i1.out")
+      chirrtl should include("connect i0.in, in")
+      chirrtl should include("connect out, i0.out")
+      chirrtl should include("connect i1.in, io.in")
+      chirrtl should include("connect io.out, i1.out")
     }
   }
   describe("(1) Annotations on instances in same chisel compilation") {
@@ -324,8 +324,8 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         "~Top|Top/i:HasSubFieldAccess>in.bits".rt -> "bits"
       )
       val lines = List(
-        "i.in.valid <= input.valid",
-        "i.in.bits <= input.bits"
+        "connect i.in.valid, input.valid",
+        "connect i.in.bits, input.bits"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize
@@ -405,13 +405,13 @@ class InstanceSpec extends ChiselFunSpec with Utils {
     }
     it("(3.p): should make connectable IOs on nested IsInstantiables that have IO Datas in them") {
       val (chirrtl, _) = getFirrtlAndAnnos(new AddTwoNestedInstantiableData(4))
-      exactly(3, chirrtl.serialize.split('\n')) should include("i1.in <= i0.out")
+      exactly(3, chirrtl.serialize.split('\n')) should include("connect i1.in, i0.out")
     }
     it(
       "(3.q): should make connectable IOs on nested IsInstantiables's Data when the Instance and Definition do not have the same parent"
     ) {
       val (chirrtl, _) = getFirrtlAndAnnos(new AddTwoNestedInstantiableDataWrapper(4))
-      exactly(3, chirrtl.serialize.split('\n')) should include("i1.in <= i0.out")
+      exactly(3, chirrtl.serialize.split('\n')) should include("connect i1.in, i0.out")
     }
   }
   describe("(4) toInstance") {
@@ -673,8 +673,8 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         "~Top|Top/i:MyModule>sum".rt -> "bar"
       )
       val expectedLines = List(
-        "i.in <= foo",
-        "bar <= i.out"
+        "connect i.in, foo",
+        "connect bar, i.out"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize
@@ -720,14 +720,14 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         "~Top|Top/i:MyModule>a.valid".rt -> "enq_valid"
       )
       val expectedLines = List(
-        "i.a.valid <= foo.valid",
-        "foo.ready <= i.a.ready",
-        "i.a.fizz <= foo.bits.fizz",
-        "i.a.buzz <= foo.bits.buzz",
-        "bar.valid <= i.b.valid",
-        "i.b.ready <= bar.ready",
-        "bar.bits.fizz <= i.b.fizz",
-        "bar.bits.buzz <= i.b.buzz"
+        "connect i.a.valid, foo.valid",
+        "connect foo.ready, i.a.ready",
+        "connect i.a.fizz, foo.bits.fizz",
+        "connect i.a.buzz, foo.bits.buzz",
+        "connect bar.valid, i.b.valid",
+        "connect i.b.ready, bar.ready",
+        "connect bar.bits.fizz, i.b.fizz",
+        "connect bar.bits.buzz, i.b.buzz"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize
@@ -764,8 +764,8 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         "~Top|Top/i:MyModule>b.foo".rt -> "out_bar"
       )
       val lines = List(
-        "i.a <= foo",
-        "bar.bar <= i.b.foo"
+        "connect i.a, foo",
+        "connect bar.bar, i.b.foo"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize
@@ -799,8 +799,8 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         "~Top|Top/i:MyModule>b".rt -> "i.ports"
       )
       val lines = List(
-        "i.a <= foo",
-        "bar <= i.b"
+        "connect i.a, foo",
+        "connect bar, i.b"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize
@@ -843,8 +843,8 @@ class InstanceSpec extends ChiselFunSpec with Utils {
         s"$inst>out".rt -> "outerView.out"
       )
       val expectedLines = List(
-        "i.in <= foo",
-        "bar <= i.out"
+        "connect i.in, foo",
+        "connect bar, i.out"
       )
       val (chirrtl, annos) = getFirrtlAndAnnos(new Top)
       val text = chirrtl.serialize

--- a/src/test/scala/chiselTests/util/PipeSpec.scala
+++ b/src/test/scala/chiselTests/util/PipeSpec.scala
@@ -17,11 +17,11 @@ class PipeSpec extends ChiselFlatSpec {
       bar := Pipe(foo.valid, bar.bits, 2)
     }
     val chirrtl = emitCHIRRTL(new MyModule)
-    chirrtl should include("reg bar_pipe_v")
-    chirrtl should include("reg bar_pipe_pipe_v")
+    chirrtl should include("regreset bar_pipe_v")
+    chirrtl should include("regreset bar_pipe_pipe_v")
     chirrtl should include("wire bar_pipe_pipe_out")
-    chirrtl should include("bar_pipe_pipe_out.valid <= bar_pipe_pipe_v")
-    chirrtl should include("bar <= bar_pipe_pipe_out")
+    chirrtl should include("connect bar_pipe_pipe_out.valid, bar_pipe_pipe_v")
+    chirrtl should include("connect bar, bar_pipe_pipe_out")
   }
 
   it should "Have decent names for Pipe(0)" in {
@@ -33,7 +33,7 @@ class PipeSpec extends ChiselFlatSpec {
     val chirrtl = emitCHIRRTL(new MyModule)
     (chirrtl should not).include("pipe")
     chirrtl should include("wire bar_out")
-    chirrtl should include("bar_out.valid <= foo.valid")
-    chirrtl should include("bar <= bar_out")
+    chirrtl should include("connect bar_out.valid, foo.valid")
+    chirrtl should include("connect bar, bar_out")
   }
 }

--- a/src/test/scala/chiselTests/util/circt/PlusArgsValueSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/PlusArgsValueSpec.scala
@@ -37,7 +37,7 @@ class PlusArgsValueSpec extends AnyFlatSpec with Matchers {
       "intrinsic = circt_plusargs_value",
       "parameter FORMAT = \"FOO=%d\"",
       "parameter FORMAT = \"BAR=%d\"",
-      "node _zv_T = mux(PlusArgsValueIntrinsic_2.found, PlusArgsValueIntrinsic_2.result, UInt<6>(\"h2a\")) "
+      "node _zv_T = mux(PlusArgsValueIntrinsic_2.found, PlusArgsValueIntrinsic_2.result, UInt<6>(0h2a)) "
     )
   }
 }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -949,7 +949,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
       val text = ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo(hasDontTouch = true))
       info("found a version string")
-      text should include("FIRRTL version 2.0.0")
+      text should include("FIRRTL version 3.0.0")
       info("found an Annotation")
       text should include("firrtl.transforms.DontTouchAnnotation")
       info("found a circuit")


### PR DESCRIPTION
Change FIRRTL emission to use "connect a, b", "invalidate c", "regreset d: UInt<1>, e, f, g", and "UInt(0hdeadbeef)".  These are newer styles that are much easier for FIRRTL compilers to parse as they are either simpler, do not require lookahead, or avoid conflation between strings and numbers.

Migrate all tests to new syntax.

This PR is broken up into two logical commits which should be squashed when merging:

1. The change is made to the serializer.
2. All tests are migrated.

It may be useful to check these individually.

This should be merged after a bump to `firtool` 1.44.0 as this requires the commit which adds support for this syntax to CIRCT. This was handled by this PR: https://github.com/chipsalliance/chisel/pull/3368

This reflects these changes in the FIRRTL spec: 
  - https://github.com/chipsalliance/firrtl-spec/commit/40e64dcf4c82f22f18a1d3c3016528510478e1bb This change appears in v2.1.0 of the FIRRTL spec.
  - https://github.com/chipsalliance/firrtl-spec/commit/59ea9604c7b3352cc420206aa8f4dec4b3c9fb1f
  - https://github.com/chipsalliance/firrtl-spec/pull/91
  - https://github.com/chipsalliance/firrtl-spec/pull/99

#### Release Notes

Change FIRRTL emission to use "connect a, b", "invalidate c", "regreset d: UInt<1>, e, f, g", and "UInt(0hdeadbeef)".  These are newer styles that are much easier for FIRRTL compilers to parse as they are either simpler, do not require lookahead, or avoid conflation between strings and numbers.