### PR TITLE
Add --module-json option to ChiselStage

### DIFF
--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -218,6 +218,19 @@ object ChiselGeneratorAnnotation extends HasShellOptions {
     )
   )
 
+  /** Utility to write an arbitrary parameter to a JSON format that --module-json will understand.
+    * @param parameter the parameter to serialize to a JSON string
+    * @param classes a list of all classes that may exist recursively inside the parameter
+    */
+  def serializeJSON(parameter: Any, classes: List[Class[_]]): String = {
+    import org.json4s._
+    import org.json4s.native.JsonMethods._
+    import org.json4s.native.Serialization
+
+    implicit val defaultFormat = Serialization.formats(FullTypeHints(classes, "class"))
+    Serialization.write(parameter)
+  }
+
 }
 
 /** Stores a Chisel Circuit

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -153,7 +153,7 @@ object ChiselGeneratorAnnotation extends HasShellOptions {
     * @throws firrtl.options.OptionsException if the module name is not found or if no parameterless constructor for
     * that Module is found.
     */
-  def apply(name: String, parameters: Any): ChiselGeneratorAnnotation = {
+  def apply(name: String, parameters: Object): ChiselGeneratorAnnotation = {
     val gen = () =>
       try {
         Class
@@ -211,7 +211,7 @@ object ChiselGeneratorAnnotation extends HasShellOptions {
           "class"
         )
 
-        Seq(ChiselGeneratorAnnotation(clazz, obj.extract[Product]))
+        Seq(ChiselGeneratorAnnotation(clazz, obj.extract[Object]))
       },
       helpText = "A name of a Chisel module to elaborate and some JSON to deserialize as its arguments",
       helpValueName = Some("<package>.<module>,<json>")

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -344,16 +344,12 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
     }
 
     it("should allow building a module from JSON") {
-      import org.json4s._
-      import org.json4s.native.JsonMethods._
-      import org.json4s.native.Serialization
       import ChiselStageSpec.{Corge, Parameters}
 
       val targetDir = baseDir / "should-allow-building-a-module-from-JSON"
 
-      implicit val defaultFormat = Serialization.formats(FullTypeHints(List(classOf[Parameters]), "class"))
       val clazz = classOf[Corge].getName()
-      val json = Serialization.write(Parameters(42))
+      val json = ChiselGeneratorAnnotation.serializeJSON(Parameters(42), classOf[Parameters] :: Nil)
 
       info(s"using --module-json $clazz,$json")
       (new ChiselStage).execute(

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -499,7 +499,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val lines = stdout.split("\n")
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:90:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:98:9: Negative shift amounts are illegal (got -1)"
       )
       lines(1) should include("    3.U >> -1")
       lines(2) should include("        ^")
@@ -520,7 +520,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines.size should equal(2)
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:90:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:98:9: Negative shift amounts are illegal (got -1)"
       )
       (lines(1) should not).include("3.U >> -1")
     }


### PR DESCRIPTION
Add a new option, "--module-json", to construct a
ChiselGeneratorAnnotation, from a class name and some JSON text.  The JSON text, using "class" full type hints, will be deserialized to an object and passed as the single parameter to a Chisel generator.  This is intended to be used by tools which want to do "inline generation" (to call out to a Chisel generator to fill in a module body, e.g., by Firesim).

This is available by default by ChiselStage and can be used by any non-ChiselStage tool that supports ChiselGeneratorAnnotation.

CC: @nandor

#### Release Notes

Add a "--module-json" option to ChiselGeneratorAnnotation and ChiselStage.