### PR TITLE
[Feature] Add Interface, ConformsTo for Separate Compilation

### DIFF
--- a/src/main/scala/chisel3/interface/Interface.scala
+++ b/src/main/scala/chisel3/interface/Interface.scala
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+package chisel3.interface
+
+import chisel3.{BlackBox => _, Module => _, _}
+import chisel3.experimental.{BaseModule, FlatIO}
+import chisel3.experimental.dataview._
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(
+  "this method requires information from the separable compilation implementation, please bring one into scope as an `implicit val`. You can also consult the team that owns the implementation to refer to which one you should use!"
+)
+trait ConformsTo[Intf <: Interface, Mod <: BaseModule] {
+
+  /** Return the module that conforms to a port-level interface. */
+  private[interface] def genModule(): Mod
+
+  /** Define how this module hooks up to the port-level interface. */
+  private[interface] def portMap: Seq[(Mod, Intf#Ports) => (Data, Data)]
+
+}
+
+/** Functionality which is common */
+sealed trait InterfaceCommon {
+
+  private[interface] type Ports <: Record
+
+  /** Returns the Record that is the port-level interface. */
+  private[interface] def ports(): Ports
+
+}
+
+/** A generator of different Interfaces. Currently, this is just an Interface
+  * that is not a Singleton.
+  */
+trait InterfaceGenerator extends InterfaceCommon
+
+/** An interface between hardware units. Any module that implements this
+  * interface may be separately compiled from any module that instantiates this
+  * interface.
+  */
+trait Interface extends InterfaceCommon { self: Singleton =>
+
+  /** This types represents the type of a valid conformance to this Interface.
+    */
+  private type Conformance[Mod <: RawModule] = ConformsTo[this.type, Mod]
+
+  /** The name of this interface. This will be used as the name of any module
+    * that implements this interface.
+    * I.e., this is the name of the `BlackBox` and `Module` that are provided
+    * below. The implementation of this method is just coming up with a good
+    * name derived from the class name. (The name of the Interface in FIRRTL
+    * will be the name of the Scala class that extends the Interface.)
+    */
+  private[interface] def interfaceName: String = {
+    val className = getClass().getName()
+    className
+      .drop(className.lastIndexOf('.') + 1)
+      .split('$')
+      .toSeq
+      .filter {
+        case str if str.forall(_.isDigit) => false
+        case str                          => true
+      }
+      .last
+  }
+
+  sealed trait Entity { this: BaseModule =>
+    val io: Ports
+  }
+
+  object Wrapper {
+
+    /** The black box that has the same ports as this interface. This is what is
+      * instantiated by any user of this interface, i.e., a test harness.
+      */
+    final class BlackBox extends chisel3.BlackBox with Entity {
+      final val io = IO(ports())
+
+      override final def desiredName = interfaceName
+    }
+
+    /** The module that wraps any module which conforms to this Interface.
+      */
+    final class Module[B <: RawModule](
+    )(
+      implicit conformance: Conformance[B])
+        extends RawModule
+        with Entity {
+      final val io = FlatIO(ports())
+
+      // Use a dummy clock and reset connection when constructing the module.
+      // This is fine as we rely on DataView to catch missing connections to
+      // clock and reset.  The dummy clock and reset will never be used.
+      private val internal = withClockAndReset(
+        WireInit(Clock(), DontCare),
+        WireInit(Reset(), DontCare)
+      ) {
+        chisel3.Module(conformance.genModule())
+      }
+
+      private implicit val pm = PartialDataView[B, Ports](
+        _ => ports(),
+        conformance.portMap: _*
+      )
+      io :<>= internal.viewAs[Ports]
+
+      override def desiredName = interfaceName
+    }
+
+    /** A stub module that implements the interface. All IO of this module are
+      * just tied off.
+      */
+    final class Stub extends RawModule with Entity {
+      final val io = FlatIO(ports())
+      io := DontCare
+      dontTouch(io)
+    }
+
+  }
+
+}

--- a/src/main/scala/chisel3/interface/Interface.scala
+++ b/src/main/scala/chisel3/interface/Interface.scala
@@ -56,7 +56,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
 
   /** This types represents the type of a valid conformance to this Interface.
     */
-  private type Conformance[Mod <: RawModule] = ConformsTo[this.type, Mod]
+  private type Conformance[Mod <: BaseModule] = ConformsTo[this.type, Mod]
 
   /** The name of this interface. This will be used as the name of any module
     * that implements this interface.
@@ -95,7 +95,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
 
     /** The module that wraps any module which conforms to this Interface.
       */
-    final class Module[B <: RawModule](
+    final class Module[B <: BaseModule](
     )(
       implicit conformance: Conformance[B])
         extends RawModule

--- a/src/main/scala/chisel3/interface/Interface.scala
+++ b/src/main/scala/chisel3/interface/Interface.scala
@@ -70,11 +70,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
     className
       .drop(className.lastIndexOf('.') + 1)
       .split('$')
-      .toSeq
-      .filter {
-        case str if str.forall(_.isDigit) => false
-        case str                          => true
-      }
+      .filterNot(_.forall(_.isDigit))
       .last
   }
 
@@ -117,7 +113,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
         conformance.portMap: _*
       )
 
-      // If the view fails, report this witha  slightly better error message.
+      // If the view fails, report this with a slightly better error message.
       try {
         io :<>= internal.viewAs[Ports]
       } catch {

--- a/src/test/scala/chiselTests/interface/Drivers.scala
+++ b/src/test/scala/chiselTests/interface/Drivers.scala
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiselTests.interface
+
+import java.io.File
+import chisel3.RawModule
+import chisel3.stage.ChiselGeneratorAnnotation
+import circt.stage.{ChiselStage, FirtoolOption}
+import firrtl.AnnotationSeq
+import firrtl.options.{StageError, StageUtils}
+import sys.process._
+
+object Drivers {
+
+  private val stage = new ChiselStage
+
+  case class CompilationUnit(
+    generator:   () => RawModule,
+    args:        Array[String] = Array.empty,
+    annotations: AnnotationSeq = Seq.empty)
+
+  /** Compile one or more Chisel Modules into an output directory. The first
+    * compile will be put into the output directory. All subsequent compiles
+    * will be put in directories called "compile-n" with "n" starting at 0 and
+    * incrementing.
+    */
+  def compile(
+    dir:   java.io.File,
+    main:  CompilationUnit,
+    other: CompilationUnit*
+  ) = {
+    (main +: other).zipWithIndex.foreach {
+      case (CompilationUnit(generator, args, annotations), i) =>
+        stage.execute(
+          Array(
+            "--target",
+            "systemverilog",
+            "--target-dir",
+            dir.getPath() + "/firrtl"
+          ) ++ args,
+          Seq(
+            ChiselGeneratorAnnotation(generator),
+            FirtoolOption("-split-verilog"),
+            FirtoolOption("-o"),
+            FirtoolOption(dir.getPath() + s"/compile-$i"),
+            FirtoolOption("-disable-annotation-unknown"),
+            FirtoolOption("-disable-all-randomization"),
+            FirtoolOption("-strip-debug-info")
+          ) ++ annotations
+        )
+    }
+  }
+
+  /** Perform a pseudo-link by running Verilator --lint-only on one or more
+    * compiles done using the `compile` method above.
+    */
+  def link(dir: File, top: String) = {
+
+    /** Generate includes from any subdirectories of "dir". */
+    val includes = dir
+      .listFiles()
+      .collect {
+        case f if f.isDirectory && f.getName().startsWith("compile") => f
+      }
+      .map(dir => s"-I${dir.getPath()}")
+
+    val cmd: Seq[String] = Seq(
+      "verilator",
+      "-lint-only",
+      new File(dir, top).getPath(),
+      s"-I${dir.getPath()}"
+    ) ++ includes
+
+    val stdoutStream, stderrStream = new java.io.ByteArrayOutputStream
+    val stdoutWriter = new java.io.PrintWriter(stdoutStream)
+    val stderrWriter = new java.io.PrintWriter(stderrStream)
+    val exitValue =
+      (cmd).!(ProcessLogger(stdoutWriter.println, stderrWriter.println))
+
+    stdoutWriter.close()
+    stderrWriter.close()
+    val result = stdoutStream.toString
+    val errors = stderrStream.toString
+
+    if (exitValue != 0) {
+      StageUtils.dramaticError(
+        s"${cmd} failed.\nExitCode:\n${exitValue}\nSTDOUT:\n${result}\nSTDERR:\n${errors}"
+      )
+      throw new StageError()
+    }
+
+  }
+
+}

--- a/src/test/scala/chiselTests/interface/InterfaceSpec.scala
+++ b/src/test/scala/chiselTests/interface/InterfaceSpec.scala
@@ -3,6 +3,7 @@ package chiselTests.interface
 
 import chisel3._
 import chisel3.interface.{ConformsTo, Interface}
+import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -147,6 +148,28 @@ class InterfaceSpec extends AnyFunSpec with Matchers {
       info("link okay!")
       Drivers.link(dir, "compile-0/Foo.sv")
 
+    }
+
+  }
+
+  describe("Error behavior of Interfaces") {
+
+    it("should error if an Interface is not connected to") {
+
+      class Qux extends RawModule {
+        val a = IO(Input(Bool()))
+      }
+
+      implicit val quxConformance = new ConformsTo[BarInterface.type, Qux] {
+
+        override def genModule() = new Qux
+
+        override def portMap = Seq()
+      }
+
+      val exception = the[Exception] thrownBy circt.stage.ChiselStage.emitCHIRRTL(new (BarInterface.Wrapper.Module))
+
+      exception.getMessage() should include("unable to conform module 'Qux' to interface 'BarInterface'")
     }
 
   }

--- a/src/test/scala/chiselTests/interface/InterfaceSpec.scala
+++ b/src/test/scala/chiselTests/interface/InterfaceSpec.scala
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiselTests.interface
+
+import chisel3._
+import chisel3.interface.{ConformsTo, Interface}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+/** This modifies the `separableTests.SeparableBlackBoxSpec` to make the
+  * generation of that example's `BarBlackBox` and `BarWrapper` automated using
+  * `separable.Interface` and `separable.ConformsTo`.
+  */
+class InterfaceSpec extends AnyFunSpec with Matchers {
+
+  /** This is the definition of the interface. */
+  object BarInterface extends Interface {
+
+    case class Struct(a: Int, b: String, c: Data)
+
+    /** This is the agreed-upon port-level interface. */
+    final class BarBundle extends Bundle {
+      val a = Input(Bool())
+      val b = Output(Bool())
+    }
+
+    override type Ports = BarBundle
+
+    /** Generate the ports given the parameters. */
+    override def ports() = new Ports
+
+    /** This is a Scala integer value on the Interface. */
+    final val int = 42
+
+    /** This is a Scala string value on the Interface. */
+    final val string = "hello world"
+
+  }
+
+  object CompilationUnit1 {
+
+    /** This is the "DUT" that will be compiled in one compilation unit and
+      * reused multiple times. The designer is free to do whatever they want
+      * with this, internally or at the boundary. The port-level interface of
+      * this module does not align with the interface.
+      */
+    class Bar extends RawModule {
+      val x = IO(Input(Bool()))
+      val y = IO(Output(Bool()))
+      y := ~x
+    }
+
+    /** The owner of the "DUT" (Bar) needs to write this. This defines how to
+      * hook up the "DUT" to the specification-set interface.
+      */
+    implicit val barConformance =
+      new ConformsTo[BarInterface.type, Bar] {
+
+        override def genModule() = new Bar
+
+        override def portMap = Seq(
+          _.x -> _.a,
+          _.y -> _.b
+        )
+
+      }
+  }
+
+  object CompilationUnit2 {
+
+    /** This is an alternative "DUT" that is differnet from the actual DUT, Bar.
+      * It differs in its ports and internals.
+      */
+    class Baz extends RawModule {
+      val hello = IO(Input(Bool()))
+      val world = IO(Output(Bool()))
+      world := hello
+    }
+
+    /** The owner of the "DUT" (Bar) needs to write this. This defines how to
+      * hook up the "DUT" to the specification-set interface.
+      */
+    implicit val bazConformance =
+      new ConformsTo[BarInterface.type, Baz] {
+
+        override def genModule() = new Baz
+
+        override def portMap = Seq(
+          _.hello -> _.a,
+          _.world -> _.b
+        )
+
+      }
+  }
+
+  object CompilationUnit3 {
+
+    /** This is a module above the "DUT" (Bar). This stamps out the "DUT" twice,
+      * but using the blackbox version of it that conforms to the
+      * specification-set port list.
+      */
+    class Foo extends RawModule {
+      val a = IO(Input(Bool()))
+      val b = IO(Output(Bool()))
+
+      val bar1, bar2 = chisel3.Module(new BarInterface.Wrapper.BlackBox)
+
+      bar1.io.a := a
+      bar2.io.a := bar1.io.b
+      b := bar2.io.b
+    }
+  }
+
+  describe("Behavior of Interfaces") {
+
+    it("should compile a design separably") {
+
+      /** Now we compile the design into the "build/Interfaces" directory. Both
+        * "Foo" and one copy of the "DUT", using the utility in "BarInterface",
+        * are compiled in separate processes. Finally, Verilator is run to check
+        * that everything works.
+        */
+      val dir = new java.io.File("test_run_dir/interface/InterfaceSpec/should-compile-a-design-separably")
+
+      /** Bring the conformance into scope so that we can build the wrapper
+        * module. If this is not brought into scope, trying to build a
+        * `BarInterface.Module` will fail during Scala compilation.
+        */
+      import CompilationUnit1.barConformance
+
+      info("compile okay!")
+      Drivers.compile(
+        dir,
+        Drivers.CompilationUnit(() => new CompilationUnit3.Foo),
+        Drivers.CompilationUnit(() => new (BarInterface.Wrapper.Module))
+      )
+
+      info("link okay!")
+      Drivers.link(dir, "compile-0/Foo.sv")
+
+    }
+
+    it("should compile an alternative design separately") {
+
+      val dir = new java.io.File("test_run_dir/interface/InterfaceSpec/should-compile-an-alternative-design-separably")
+
+      import CompilationUnit2.bazConformance
+
+      info("compile okay!")
+      Drivers.compile(
+        dir,
+        Drivers.CompilationUnit(() => new CompilationUnit3.Foo),
+        Drivers.CompilationUnit(() => new (BarInterface.Wrapper.Module))
+      )
+
+      info("link okay!")
+      Drivers.link(dir, "compile-0/Foo.sv")
+
+    }
+
+  }
+
+}

--- a/src/test/scala/chiselTests/interface/InterfaceSpec.scala
+++ b/src/test/scala/chiselTests/interface/InterfaceSpec.scala
@@ -15,8 +15,6 @@ class InterfaceSpec extends AnyFunSpec with Matchers {
   /** This is the definition of the interface. */
   object BarInterface extends Interface {
 
-    case class Struct(a: Int, b: String, c: Data)
-
     /** This is the agreed-upon port-level interface. */
     final class BarBundle extends Bundle {
       val a = Input(Bool())
@@ -27,12 +25,6 @@ class InterfaceSpec extends AnyFunSpec with Matchers {
 
     /** Generate the ports given the parameters. */
     override def ports() = new Ports
-
-    /** This is a Scala integer value on the Interface. */
-    final val int = 42
-
-    /** This is a Scala string value on the Interface. */
-    final val string = "hello world"
 
   }
 

--- a/src/test/scala/chiselTests/interface/ParametricInterfaceSpec.scala
+++ b/src/test/scala/chiselTests/interface/ParametricInterfaceSpec.scala
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+package chiselTests.interface
+
+import chisel3._
+import chisel3.interface.{ConformsTo, Interface, InterfaceGenerator}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+/** This modifies `InterfaceSpec` to make the interface take a Scala parameter.
+  * Notably, a concrete interface object with the parameter resolved is then
+  * used. The interface is not generated from either the client or the
+  * component, but used to configure both.
+  */
+class ParametricInterfaceSpec extends AnyFunSpec with Matchers {
+
+  /** This is the agreed-upon port-level interface. */
+  class BarBundle(width: Int) extends Bundle {
+    val a = Input(UInt(width.W))
+    val b = Output(UInt(width.W))
+  }
+
+  /** This is an Interface Generator. It can be used to assist in the definition
+    * of multiple copies of a related Interface.
+    */
+  class BarInterfaceGenerator private[interface] (val width: Int) extends InterfaceGenerator {
+
+    override type Ports = BarBundle
+
+    override def ports() = new BarBundle(width)
+
+  }
+
+  /** This is a package of different BarInterfaces. */
+  object Package {
+
+    /** A BarInterfaceGenerator with width 32. */
+    object BarInterface32 extends BarInterfaceGenerator(32) with Interface
+
+    /** A BarInterfaceGenerator with width 64. */
+    object BarInterface64 extends BarInterfaceGenerator(64) with Interface
+
+  }
+
+  /** Bring necessary things from the Package into scope. */
+  import Package.{BarInterface32, BarInterface64}
+
+  object CompilationUnit1 {
+
+    /** This is the "DUT" that will be compiled in one compilation unit and
+      * reused multiple times. The designer is free to do whatever they want
+      * with this, internally or at the boundary. The port-level interface of
+      * this module does not align with the interface. The width of the ports is
+      * Scala-parametric.
+      */
+    class Bar32 extends RawModule {
+      val x = IO(Input(UInt(32.W)))
+      val y = IO(Output(UInt(32.W)))
+      y := ~x
+    }
+
+    /** Define how a Bar32 conforms to a BarInterface32. This is a straight
+      * mapping of ports.
+      */
+    implicit val bar32Conformance =
+      new ConformsTo[BarInterface32.type, Bar32] {
+
+        override def genModule() = new Bar32
+
+        override def portMap = Seq(
+          _.x -> _.a,
+          _.y -> _.b
+        )
+
+      }
+
+  }
+
+  object CompilationUnit2 {
+
+    /** This is a module above the "DUT" (Bar). This stamps out the "DUT" twice,
+      * but using the blackbox version of it that conforms to the
+      * specification-set port list. This is dependent upon having a
+      * `BarInterface` in order to configure itself. This is an example of
+      * bottom-up parameterization where something at the leaf of the instance
+      * hierarchy (an `iface.BlackBox`) affects its parents.
+      */
+    class Foo32 extends RawModule {
+      val a = IO(Input(UInt(32.W)))
+      val b = IO(Output(UInt(32.W)))
+
+      private val intf = Package.BarInterface32
+      private val bar1, bar2 = chisel3.Module(new intf.Wrapper.BlackBox)
+
+      bar1.io.a := a
+      bar2.io.a := bar1.io.b
+      b := bar2.io.b
+    }
+  }
+
+  object CompilationUnit3 {
+
+    /** This testharness wants to use a different, 64-bit Interface.
+      */
+    class Foo64 extends RawModule {
+      val a = IO(Input(UInt(64.W)))
+      val b = IO(Output(UInt(64.W)))
+
+      private val intf = Package.BarInterface64
+      private val bar1, bar2 = chisel3.Module(new intf.Wrapper.BlackBox)
+
+      bar1.io.a := a
+      bar2.io.a := bar1.io.b
+      b := bar2.io.b
+    }
+  }
+
+  /** Now we compile the design into the "build/Interfaces" directory. Both
+    * "Foo" and one copy of the "DUT", using the utility in "BarInterface", are
+    * compiled in separate processes. Finally, Verilator is run to check that
+    * everything works.
+    */
+  describe("Behavior of Parametric Interfaces") {
+
+    it(
+      "should compile a design separably for a 32-bit variant of the Interface"
+    ) {
+
+      val dir = new java.io.File(
+        "test_run_dir/interface/ParametricInterfaceSpec/should-compile-a-design-separably-for-a-32-bit-variant-of-the-Interface"
+      )
+
+      /** Import Bar's conformance so that we can build it's conforming wrapper.
+        */
+      import CompilationUnit1.bar32Conformance
+
+      info("compile okay!")
+      Drivers.compile(
+        dir,
+        Drivers.CompilationUnit(() => new CompilationUnit2.Foo32),
+        Drivers.CompilationUnit(() => new (BarInterface32.Wrapper.Module))
+      )
+
+      info("link okay!")
+      Drivers.link(dir, "compile-0/Foo32.sv")
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Migrate work from [seldridge/chisel-separable](https://github.com/seldridge/chisel-separable) on separate compilation into upstream Chisel.  This defines an Interface and a Conformance.  An Interface is a Singleton Object that maps to a FIRRTL external module with pre-defined IO.  A Conformance is a type-class whose implementations define how a Chisel module aligns itself to the Interface.  Used together, these enable separate compilation of a client that uses an Interface from a component that implements the Interface.

This originally came from https://github.com/seldridge/chisel-separable/. We've used this internally in non-load-bearing ways and it's becoming unwieldy to continue to maintain out-of-tree.

This API may change rapidly in the future.

#### Release Notes

Add Interface/ConformsTo APIs for separate compilation.