### PR TITLE
Add Data.findFirstTypeMismatch for better type checking

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -178,13 +178,6 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     */
   override def typeName = s"Vec${length}_${gen.typeName}"
 
-  private[chisel3] override def typeEquivalent(that: Data): Boolean = that match {
-    case that: Vec[T] =>
-      this.length == that.length &&
-        (this.sample_element.typeEquivalent(that.sample_element))
-    case _ => false
-  }
-
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
     this.maybeAddToParentIds(target)
     binding = target
@@ -1202,18 +1195,6 @@ abstract class Record extends Aggregate {
   } catch {
     // This happens if your class is defined in an object and is anonymous
     case e: java.lang.InternalError if e.getMessage == "Malformed class name" => this.getClass.toString
-  }
-
-  private[chisel3] override def typeEquivalent(that: Data): Boolean = that match {
-    case that: Record =>
-      this.getClass == that.getClass &&
-        this._elements.size == that._elements.size &&
-        this._elements.forall {
-          case (name, model) =>
-            that._elements.contains(name) &&
-              (that._elements(name).typeEquivalent(model))
-        }
-    case _ => false
   }
 
   private[chisel3] final def allElements: Seq[Element] = elementsIterator.flatMap(_.allElements).toIndexedSeq

--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -426,9 +426,6 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
     }
   }
 
-  private[chisel3] override def typeEquivalent(that: Data): Boolean =
-    that.isInstanceOf[UInt] && this.width == that.width
-
   private[chisel3] override def cloneTypeWidth(w: Width): this.type =
     new UInt(w).asInstanceOf[this.type]
 
@@ -771,9 +768,6 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
     }
   }
 
-  private[chisel3] override def typeEquivalent(that: Data): Boolean =
-    this.getClass == that.getClass && this.width == that.width // TODO: should this be true for unspecified widths?
-
   private[chisel3] override def cloneTypeWidth(w: Width): this.type =
     new SInt(w).asInstanceOf[this.type]
 
@@ -1014,9 +1008,6 @@ final class ResetType(private[chisel3] val width: Width = Width(1)) extends Elem
 
   def cloneType: this.type = Reset().asInstanceOf[this.type]
 
-  private[chisel3] def typeEquivalent(that: Data): Boolean =
-    this.getClass == that.getClass
-
   override def litOption = None
 
   /** Not really supported */
@@ -1060,9 +1051,6 @@ sealed class AsyncReset(private[chisel3] val width: Width = Width(1)) extends El
   override def toString: String = stringAccessor("AsyncReset")
 
   def cloneType: this.type = AsyncReset().asInstanceOf[this.type]
-
-  private[chisel3] def typeEquivalent(that: Data): Boolean =
-    this.getClass == that.getClass
 
   override def litOption = None
 

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -44,11 +44,6 @@ abstract class EnumType(private[chisel3] val factory: ChiselEnum, selfAnnotating
     pushOp(DefPrim(sourceInfo, Bool(), op, this.ref, other.ref))
   }
 
-  private[chisel3] override def typeEquivalent(that: Data): Boolean = {
-    this.getClass == that.getClass &&
-    this.factory == that.asInstanceOf[EnumType].factory
-  }
-
   private[chisel3] override def connectFromBits(
     that: Bits
   )(

--- a/core/src/main/scala/chisel3/Clock.scala
+++ b/core/src/main/scala/chisel3/Clock.scala
@@ -19,9 +19,6 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
 
   def cloneType: this.type = Clock().asInstanceOf[this.type]
 
-  private[chisel3] def typeEquivalent(that: Data): Boolean =
-    this.getClass == that.getClass
-
   override def connect(that: Data)(implicit sourceInfo: SourceInfo): Unit =
     that match {
       case _: Clock | DontCare => super.connect(that)(sourceInfo)

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -552,7 +552,59 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   /** Whether this Data has the same model ("data type") as that Data.
     * Data subtypes should overload this with checks against their own type.
     */
-  private[chisel3] def typeEquivalent(that: Data): Boolean
+  private[chisel3] final def typeEquivalent(
+    that: Data
+  ): Boolean = findFirstTypeMismatch(that, strictTypes = true, strictWidths = true).isEmpty
+
+  /** Find and report any type mismatches
+    *
+    * @param that Data being compared to this
+    * @param strictTypes Does class of Bundles or Records need to match? Inverse of "structural".
+    * @param strictWidths do widths need to match?
+    * @return None if types are equivalent, Some String reporting the first mismatch if not
+    */
+  private[chisel3] final def findFirstTypeMismatch(
+    that:         Data,
+    strictTypes:  Boolean,
+    strictWidths: Boolean
+  ): Option[String] = {
+    def rec(left: Data, right: Data): Option[String] =
+      (left, right) match {
+        // Careful, EnumTypes are Element and if we don't implement this, then they are all always equal
+        case (e1: EnumType, e2: EnumType) =>
+          // TODO, should we implement a form of structural equality for enums?
+          if (e1.factory == e2.factory) None
+          else Some(s": Left ($e1) and Right ($e2) have different types.")
+        case (e1: Element, e2: Element) if e1.getClass == e2.getClass =>
+          if (strictWidths && e1.width != e2.width) {
+            Some(s": Left ($e1) and Right ($e2) have different widths.")
+          } else {
+            None
+          }
+        case (r1: Record, r2: Record) if !strictTypes || r1.getClass == r2.getClass =>
+          val (larger, smaller, msg) =
+            if (r1._elements.size >= r2._elements.size) (r1, r2, "Left") else (r2, r1, "Right")
+          larger._elements.collectFirst {
+            case (name, data) =>
+              val recurse = smaller._elements.get(name) match {
+                case None        => Some(s": Dangling field on $msg")
+                case Some(data2) => rec(data, data2)
+              }
+              recurse.map("." + name + _)
+          }.flatten
+        case (v1: Vec[_], v2: Vec[_]) =>
+          if (v1.size != v2.size) {
+            Some(s": Left (size ${v1.size}) and Right (size ${v2.size}) have different lengths.")
+          } else {
+            val recurse = rec(v1.sample_element, v2.sample_element)
+            recurse.map("[_]" + _)
+          }
+        case _ => Some(s": Left ($left) and Right ($right) have different types.")
+      }
+    val leftType = if (this.hasBinding) this.cloneType else this
+    val rightType = if (that.hasBinding) that.cloneType else that
+    rec(leftType, rightType)
+  }
 
   private[chisel3] def requireVisible(): Unit = {
     val mod = topBindingOpt.flatMap(_.location)
@@ -1106,8 +1158,6 @@ final case object DontCare extends Element with connectable.ConnectableDocs {
     Builder.error("DontCare does not have a UInt representation")
     0.U
   }
-  // DontCare's only match themselves.
-  private[chisel3] def typeEquivalent(that: Data): Boolean = that == DontCare
 
   /** $colonGreaterEq
     *

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -32,9 +32,6 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
     */
   override def typeName = s"Analog$width"
 
-  private[chisel3] override def typeEquivalent(that: Data): Boolean =
-    that.isInstanceOf[Analog] && this.width == that.width
-
   override def litOption: Option[BigInt] = None
 
   def cloneType: this.type = new Analog(width).asInstanceOf[this.type]

--- a/src/test/scala/chisel3/TypeEquivalenceSpec.scala
+++ b/src/test/scala/chisel3/TypeEquivalenceSpec.scala
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import circt.stage.ChiselStage.emitCHIRRTL
+import chisel3.experimental.Analog
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
+
+object TypeEquivalenceSpec {
+  class Foo(hasC: Boolean = true) extends Bundle {
+    val a = UInt(8.W)
+    val b = UInt(8.W)
+    val c = if (hasC) Some(UInt(8.W)) else None
+  }
+
+  class Bar(bWidth: Int = 8) extends Bundle {
+    val a = UInt(8.W)
+    val b = UInt(bWidth.W)
+  }
+
+  object Fizz extends ChiselEnum {
+    val e0, e1 = Value
+    val e4 = Value(4.U)
+  }
+
+  object Buzz extends ChiselEnum {
+    val e0, e1 = Value
+    val e4 = Value(4.U)
+  }
+}
+
+import TypeEquivalenceSpec._
+
+class TypeEquivalenceSpec extends AnyFlatSpec {
+  behavior.of("Data.typeEquivalent")
+
+  it should "support comparing UInts" in {
+    val x = UInt(8.W)
+    val y = UInt(8.W)
+    val z = UInt(4.W)
+    assert(x.typeEquivalent(y))
+    assert(!x.typeEquivalent(z))
+    assert(!x.typeEquivalent(UInt()))
+    assert(UInt().typeEquivalent(UInt()))
+  }
+
+  it should "support comparing SInts" in {
+    val x = SInt(8.W)
+    val y = SInt(8.W)
+    val z = SInt(4.W)
+    assert(x.typeEquivalent(y))
+    assert(!x.typeEquivalent(z))
+    assert(!x.typeEquivalent(SInt()))
+    assert(SInt().typeEquivalent(SInt()))
+  }
+
+  it should "catch comparing SInts and UInts" in {
+    val x = UInt(8.W)
+    val y = SInt(8.W)
+    assert(!x.typeEquivalent(y))
+  }
+
+  it should "support equivalent Bundles" in {
+    val x = new Foo(true)
+    val y = new Foo(true)
+    assert(x.typeEquivalent(y))
+  }
+
+  it should "reject structurally equivalent Bundles" in {
+    val x = new Foo(false)
+    val y = new Bar
+    assert(!x.typeEquivalent(y))
+  }
+
+  it should "support Vecs" in {
+    val x = Vec(2, UInt(8.W))
+    val y = Vec(2, UInt(8.W))
+    val z = Vec(3, UInt(8.W))
+    assert(x.typeEquivalent(y))
+    assert(!x.typeEquivalent(z))
+  }
+
+  it should "reject nested width mismatches" in {
+    val x = new Bar(8)
+    val y = new Bar(4)
+    assert(!x.typeEquivalent(y))
+
+    val a = Vec(4, new Bar(8))
+    val b = Vec(4, new Bar(4))
+    assert(!a.typeEquivalent(b))
+
+    val c = new Bundle {
+      val foo = new Bar(8)
+    }
+    val d = new Bundle {
+      val foo = new Bar(4)
+    }
+    assert(!c.typeEquivalent(d))
+  }
+
+  it should "support equivalent ChiselEnums" in {
+    val x = Fizz()
+    val y = Fizz()
+    val z = Buzz()
+    assert(x.typeEquivalent(y))
+    assert(!x.typeEquivalent(z))
+  }
+
+  it should "support comparing Analogs" in {
+    val x = Analog(8.W)
+    val y = Analog(8.W)
+    val z = Analog(4.W)
+    assert(x.typeEquivalent(y))
+    assert(!x.typeEquivalent(z))
+  }
+
+  it should "support DontCare" in {
+    assert(DontCare.typeEquivalent(DontCare))
+    assert(!DontCare.typeEquivalent(UInt()))
+  }
+
+  it should "support AsyncReset" in {
+    assert(AsyncReset().typeEquivalent(AsyncReset()))
+    assert(!AsyncReset().typeEquivalent(Bool()))
+    assert(!AsyncReset().typeEquivalent(Clock()))
+    assert(!AsyncReset().typeEquivalent(Reset()))
+  }
+
+  it should "support Clock" in {
+    assert(Clock().typeEquivalent(Clock()))
+  }
+
+  it should "support abstract Reset" in {
+    assert(Reset().typeEquivalent(Reset()))
+  }
+
+  behavior.of("Data.findFirstTypeMismatch")
+
+  it should "support comparing UInts" in {
+    val x = UInt(8.W)
+    val y = UInt(8.W)
+    val z = UInt(4.W)
+    val zz = UInt()
+    x.findFirstTypeMismatch(y, true, true) should be(None)
+    x.findFirstTypeMismatch(z, true, true) should be(
+      Some(": Left (UInt<8>) and Right (UInt<4>) have different widths.")
+    )
+    x.findFirstTypeMismatch(z, true, false) should be(None)
+    x.findFirstTypeMismatch(zz, true, true) should be(Some(": Left (UInt<8>) and Right (UInt) have different widths."))
+    x.findFirstTypeMismatch(zz, true, false) should be(None)
+  }
+
+  it should "support comparing SInts" in {
+    val x = SInt(8.W)
+    val y = SInt(8.W)
+    val z = SInt(4.W)
+    val zz = SInt()
+    x.findFirstTypeMismatch(y, true, true) should be(None)
+    x.findFirstTypeMismatch(z, true, true) should be(
+      Some(": Left (SInt<8>) and Right (SInt<4>) have different widths.")
+    )
+    x.findFirstTypeMismatch(z, true, false) should be(None)
+    x.findFirstTypeMismatch(zz, true, true) should be(Some(": Left (SInt<8>) and Right (SInt) have different widths."))
+    x.findFirstTypeMismatch(zz, true, false) should be(None)
+  }
+
+  it should "catch comparing SInts and UInts" in {
+    val x = UInt(8.W)
+    val y = SInt(8.W)
+    x.findFirstTypeMismatch(y, true, true) should be(Some(": Left (UInt<8>) and Right (SInt<8>) have different types."))
+  }
+
+  it should "support equivalent Bundles" in {
+    val x = new Foo(true)
+    val y = new Foo(true)
+    x.findFirstTypeMismatch(y, true, true) should be(None)
+  }
+
+  it should "support structurally equivalent Bundles" in {
+    val x = new Foo(false)
+    val y = new Bar
+    x.findFirstTypeMismatch(y, true, true) should be(Some(": Left (Foo) and Right (Bar) have different types."))
+    x.findFirstTypeMismatch(y, false, true) should be(None)
+  }
+
+  it should "support Vecs" in {
+    val x = Vec(2, UInt(8.W))
+    val y = Vec(2, UInt(8.W))
+    val z = Vec(3, UInt(8.W))
+    x.findFirstTypeMismatch(y, true, true) should be(None)
+    x.findFirstTypeMismatch(z, true, true) should be(Some(": Left (size 2) and Right (size 3) have different lengths."))
+  }
+
+  it should "support nested width mismatches" in {
+    val x = new Bar(8)
+    val y = new Bar(4)
+    x.findFirstTypeMismatch(y, true, false) should be(None)
+    x.findFirstTypeMismatch(y, true, true) should be(
+      Some(".b: Left (UInt<8>) and Right (UInt<4>) have different widths.")
+    )
+
+    val a = Vec(4, new Bar(8))
+    val b = Vec(4, new Bar(4))
+    a.findFirstTypeMismatch(b, true, false) should be(None)
+    a.findFirstTypeMismatch(b, true, true) should be(
+      Some("[_].b: Left (UInt<8>) and Right (UInt<4>) have different widths.")
+    )
+
+    val c = new Bundle {
+      val foo = new Bar(8)
+    }
+    val d = new Bundle {
+      val foo = new Bar(4)
+    }
+    c.findFirstTypeMismatch(d, false, false) should be(None)
+    c.findFirstTypeMismatch(d, false, true) should be(
+      Some(".foo.b: Left (UInt<8>) and Right (UInt<4>) have different widths.")
+    )
+  }
+
+  it should "support equivalent ChiselEnums" in {
+    val x = Fizz()
+    val y = Fizz()
+    val z = Buzz()
+    x.findFirstTypeMismatch(y, true, true) should be(None)
+    x.findFirstTypeMismatch(z, true, true) should be(Some(": Left (Fizz) and Right (Buzz) have different types."))
+    // TODO should there be some form of structural typing for ChiselEnums?
+    x.findFirstTypeMismatch(z, false, true) should be(Some(": Left (Fizz) and Right (Buzz) have different types."))
+  }
+
+  it should "support comparing Analogs" in {
+    val x = Analog(8.W)
+    val y = Analog(8.W)
+    val z = Analog(4.W)
+    x.findFirstTypeMismatch(y, true, true) should be(None)
+    x.findFirstTypeMismatch(z, true, true) should be(
+      Some(": Left (Analog<8>) and Right (Analog<4>) have different widths.")
+    )
+    x.findFirstTypeMismatch(z, true, false) should be(None)
+  }
+
+  it should "support DontCare" in {
+    DontCare.findFirstTypeMismatch(DontCare, true, true) should be(None)
+  }
+
+  it should "support AsyncReset" in {
+    AsyncReset().findFirstTypeMismatch(AsyncReset(), true, true) should be(None)
+    AsyncReset().findFirstTypeMismatch(Bool(), true, true) should be(
+      Some(": Left (AsyncReset) and Right (Bool) have different types.")
+    )
+    AsyncReset().findFirstTypeMismatch(Clock(), true, true) should be(
+      Some(": Left (AsyncReset) and Right (Clock) have different types.")
+    )
+    AsyncReset().findFirstTypeMismatch(Reset(), true, true) should be(
+      Some(": Left (AsyncReset) and Right (Reset) have different types.")
+    )
+  }
+
+  it should "support Clock" in {
+    Clock().findFirstTypeMismatch(Clock(), true, true) should be(None)
+  }
+
+  it should "support abstract Reset" in {
+    Reset().findFirstTypeMismatch(Reset(), true, true) should be(None)
+  }
+}


### PR DESCRIPTION
This utility provides a way to check different versions of type equivalence in Chisel internals and generates error messages for when mismatches are found. Specifically, it handles structural vs. nominal typing as well as strict vs. non-strict width checking.

This helps fix (but does not actually include the fix) https://github.com/chipsalliance/chisel/issues/3200.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?


#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
