### PR TITLE
Read previousVersions for bincompat checking from a file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ThisBuild / firtoolVersion := {
 //   eg. unipublish/src/main/mima-filters/5.0.0.backwards.excludes
 val previousVersions = settingKey[Set[String]]("Previous versions for binary compatibility checking")
 ThisBuild / previousVersions := {
-  val file = new java.io.File("project/previous-versions.txt")
+  val file = new java.io.File("project", "previous-versions.txt")
   if (file.isFile) {
     scala.io.Source.fromFile(file).getLines.toSet
   } else {


### PR DESCRIPTION
This makes it much easier to automate checking new versions as they are released.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy


- Squash

#### Release Notes

We can now simply append versions as they are released to `project/previous-versions.txt` on relevant release branches. `build.sbt` also now contains instructions are how to waive binary compatibility breakages.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
