### PR TITLE
Add ClockGate intrinsic

### DIFF
--- a/src/main/scala/chisel3/util/circt/ClockGate.scala
+++ b/src/main/scala/chisel3/util/circt/ClockGate.scala
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.util.circt
+
+import chisel3._
+import chisel3.experimental.IntrinsicModule
+import chisel3.internal.Builder
+
+import circt.Intrinsic
+
+/** A clock gate intrinsic.
+  */
+private class ClockGateIntrinsic extends IntrinsicModule("circt_clock_gate") {
+  val in = IO(Input(Clock()))
+  val en = IO(Input(Bool()))
+  val out = IO(Output(Clock()))
+}
+
+object ClockGate {
+
+  /** Creates an intrinsic which enables and disables a clock safely, without
+    * glitches, based on a boolean enable value. If the enable input is 1, the
+    * output clock produced by the clock gate is identical to the input clock.
+    * If the enable input is 0, the output clock is a constant zero.
+    *
+    * @example {{{
+    * gateClock := ClockGate(clock, enable)
+    * }}}
+    */
+  def apply(input: Clock, enable: Bool): Clock = {
+    val inst = Module(new ClockGateIntrinsic)
+    inst.in := input
+    inst.en := enable
+    inst.out
+  }
+}

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests.util
 
 import chisel3.util.BitPat
-import circt.stage.ChiselStage
+import _root_.circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/chiselTests/util/BitSetSpec.scala
+++ b/src/test/scala/chiselTests/util/BitSetSpec.scala
@@ -2,6 +2,7 @@ package chiselTests.util
 
 import chisel3.util.experimental.BitSet
 import chisel3.util.BitPat
+import _root_.circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -92,7 +93,7 @@ class BitSetSpec extends AnyFlatSpec with Matchers {
     import chisel3.util.experimental.decode.decoder
     // [0 - 256] part into: [0 - 31], [32 - 47, 64 - 127], [192 - 255]
     // "0011????" "10??????" is empty to error
-    circt.stage.ChiselStage.emitSystemVerilog(new Module {
+    ChiselStage.emitSystemVerilog(new Module {
       val in = IO(Input(UInt(8.W)))
       val out = IO(Output(UInt(4.W)))
       out := decoder.bitset(
@@ -120,7 +121,7 @@ class BitSetSpec extends AnyFlatSpec with Matchers {
     import chisel3.util.experimental.decode.decoder
     // [0 - 256] part into: [0 - 31], [32 - 47, 64 - 127], [192 - 255]
     // "0011????" "10??????" is empty to error
-    circt.stage.ChiselStage.emitSystemVerilog(new Module {
+    ChiselStage.emitSystemVerilog(new Module {
       val in = IO(Input(UInt(8.W)))
       val out = IO(Output(UInt(4.W)))
       out := decoder.bitset(

--- a/src/test/scala/chiselTests/util/BitwiseSpec.scala
+++ b/src/test/scala/chiselTests/util/BitwiseSpec.scala
@@ -2,7 +2,7 @@ package chiselTests.util
 
 import chisel3._
 import chisel3.util.{Fill, FillInterleaved, PopCount, Reverse}
-import circt.stage.ChiselStage
+import _root_.circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/chiselTests/util/CatSpec.scala
+++ b/src/test/scala/chiselTests/util/CatSpec.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.util.Cat
 import chisel3.experimental.noPrefix
 import chiselTests.ChiselFlatSpec
-import circt.stage.ChiselStage
+import _root_.circt.stage.ChiselStage
 
 object CatSpec {
 

--- a/src/test/scala/chiselTests/util/PipeSpec.scala
+++ b/src/test/scala/chiselTests/util/PipeSpec.scala
@@ -5,7 +5,7 @@ package chiselTests.util
 import chisel3._
 import chisel3.util.{Pipe, Valid}
 import chiselTests.ChiselFlatSpec
-import circt.stage.ChiselStage.emitCHIRRTL
+import _root_.circt.stage.ChiselStage.emitCHIRRTL
 
 class PipeSpec extends ChiselFlatSpec {
   behavior.of("Pipe")

--- a/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
+++ b/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.testers.BasicTester
 import chisel3.util.{Counter, PriorityMux}
 import chiselTests.ChiselFlatSpec
-import circt.stage.ChiselStage.emitCHIRRTL
+import _root_.circt.stage.ChiselStage.emitCHIRRTL
 
 class PriorityMuxTester extends BasicTester {
 

--- a/src/test/scala/chiselTests/util/RegSpec.scala
+++ b/src/test/scala/chiselTests/util/RegSpec.scala
@@ -2,7 +2,7 @@ package chiselTests.util
 
 import chisel3._
 import chisel3.util.{RegEnable, ShiftRegister, ShiftRegisters}
-import circt.stage.ChiselStage
+import _root_.circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/chiselTests/util/circt/ClockGate.scala
+++ b/src/test/scala/chiselTests/util/circt/ClockGate.scala
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.util.circt
+
+import chisel3._
+import chisel3.testers.BasicTester
+import chisel3.util.circt.ClockGate
+import circt.stage.ChiselStage
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.io.Source
+
+private class ClockGateTop extends RawModule {
+  val clock = IO(Input(Clock()))
+  val enable = IO(Input(Bool()))
+  val gatedClock = IO(Output(Clock()))
+  gatedClock := ClockGate(clock, enable)
+}
+
+class ClockGateSpec extends AnyFlatSpec with Matchers {
+  it should "gate clocks" in {
+    val fir = ChiselStage.emitCHIRRTL(new ClockGateTop)
+    (fir.split('\n').map(_.trim) should contain).allOf(
+      "intmodule ClockGateIntrinsic :",
+      "input in : Clock",
+      "input en : UInt<1>",
+      "output out : Clock",
+      "intrinsic = circt_clock_gate"
+    )
+  }
+}

--- a/src/test/scala/chiselTests/util/circt/IsXSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/IsXSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.util
+package chiselTests.util.circt
 
 import chisel3._
 import chisel3.stage.ChiselGeneratorAnnotation
@@ -31,9 +31,8 @@ private class IsXTop extends Module {
 }
 
 class IsXSpec extends AnyFlatSpec with Matchers {
-  it should "Should work for types" in {
+  it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new IsXTop)
-    println(fir)
     (
       (fir.split('\n').map(_.trim) should contain).allOf(
         "intmodule IsXIntrinsic :",

--- a/src/test/scala/chiselTests/util/circt/PlusArgsTestSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/PlusArgsTestSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.util
+package chiselTests.util.circt
 
 import chisel3._
 import chisel3.testers.BasicTester
@@ -21,9 +21,8 @@ private class PlusArgsTestTop extends Module {
 }
 
 class PlusArgsTestSpec extends AnyFlatSpec with Matchers {
-  it should "Should work for types" in {
+  it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new PlusArgsTestTop)
-    println(fir)
     (fir.split('\n').map(_.trim) should contain).allOf(
       "intmodule PlusArgsTestIntrinsic :",
       "output found : UInt<1>",

--- a/src/test/scala/chiselTests/util/circt/PlusArgsValueSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/PlusArgsValueSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.util
+package chiselTests.util.circt
 
 import chisel3._
 import chisel3.testers.BasicTester
@@ -28,9 +28,8 @@ private class PlusArgsValueTop extends Module {
 }
 
 class PlusArgsValueSpec extends AnyFlatSpec with Matchers {
-  it should "Should work for types" in {
+  it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new PlusArgsValueTop)
-    println(fir)
     (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain).inOrder(
       "intmodule PlusArgsValueIntrinsic :",
       "output found : UInt<1>",

--- a/src/test/scala/chiselTests/util/circt/SizeOfSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/SizeOfSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.util
+package chiselTests.util.circt
 
 import chisel3._
 import chisel3.testers.BasicTester
@@ -27,9 +27,8 @@ private class SizeOfTop extends Module {
 }
 
 class SizeOfSpec extends AnyFlatSpec with Matchers {
-  it should "Should work for types" in {
+  it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new SizeOfTop)
-    println(fir)
     (fir.split('\n').map(_.trim) should contain)
       .allOf("intmodule SizeOfIntrinsic :", "input i : UInt<65>", "output size : UInt<32>", "intrinsic = circt_sizeof")
   }


### PR DESCRIPTION
Add the `circt.clock_gate` intrinsic. This is not yet used anywhere and has no impact on existing code. Also move CIRCT-specific tests into a `circt` subpackage of `chiselTests.util` to reflect the main package structure.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- New API

#### Desired Merge Strategy

- Squash

#### Release Notes

Add support for the `circt.clock_gate` intrinsic.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
