### PR TITLE
Fix Instantiate for Product parameters

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/Instantiate.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/Instantiate.scala
@@ -98,9 +98,10 @@ object Instantiate {
 
   // Recursively box all Data (by traversing Products and Iterables) in DataBoxes
   private def boxAllData(a: Any): Any = a match {
-    case d:  Data        => new DataBox(d) // Must check this before Iterable because Vec is Iterable
+    case d: Data => new DataBox(d) // Must check this before Iterable because Vec is Iterable
+    // Must check before Product, because many Iterables are Products, but can still be equal, eg. List(1) == Vector(1)
     case it: Iterable[_] => it.map(boxAllData(_))
-    case p:  Product     => p.productIterator.map(boxAllData(_)).toSeq
+    case p:  Product     => Vector(p.getClass) ++ p.productIterator.map(boxAllData(_))
     case other => other
   }
 

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
@@ -116,6 +116,32 @@ object InstantiateSpec {
     @public val out = IO(Output(gen))
     out := in
   }
+
+  sealed trait MyEnumeration
+  case object FooEnum extends MyEnumeration
+  case object BarEnum extends MyEnumeration
+  case class FizzEnum(value: Int) extends MyEnumeration
+  case class BuzzEnum(value: Int) extends MyEnumeration
+
+  class ModuleParameterizedByProductTypes(param: MyEnumeration) extends Module {
+    override def desiredName = s"${this.getClass.getSimpleName}_$param"
+    val gen = param match {
+      case FooEnum     => UInt(8.W)
+      case BarEnum     => SInt(8.W)
+      case FizzEnum(n) => Vec(n, UInt(8.W))
+      case BuzzEnum(n) => Vec(n, SInt(8.W))
+    }
+    @public val in = IO(Input(gen))
+    @public val out = IO(Output(gen))
+    out := in
+  }
+
+  class ModuleParameterizedBySeq(param: Seq[Int]) extends Module {
+    override def desiredName = s"${this.getClass.getSimpleName}_" + param.mkString("_")
+    @public val in = param.map(w => IO(Input(UInt(w.W))))
+    @public val out = param.map(w => IO(Output(UInt(w.W))))
+    out.zip(in).foreach { case (o, i) => o := i }
+  }
 }
 
 class InstantiateSpec extends ChiselFunSpec with Utils {
@@ -295,6 +321,46 @@ class InstantiateSpec extends ChiselFunSpec with Utils {
       // Building the same thing a second time should work
       val modules2 = convert(new MyTop).modules.map(_.name)
       assert(modules2 == Seq("OneArg", "Top"))
+    }
+
+    it("should properly handle case objects as parameters") {
+      class MyTop extends Top {
+        val inst0 = Instantiate(new ModuleParameterizedByProductTypes(FooEnum))
+        val inst1 = Instantiate(new ModuleParameterizedByProductTypes(BarEnum))
+      }
+      val modules = convert(new MyTop).modules.map(_.name)
+      assert(
+        modules == Seq("ModuleParameterizedByProductTypes_FooEnum", "ModuleParameterizedByProductTypes_BarEnum", "Top")
+      )
+    }
+
+    it("should properly handle case classes as parameters") {
+      class MyTop extends Top {
+        val inst0 = Instantiate(new ModuleParameterizedByProductTypes(FizzEnum(3)))
+        val inst1 = Instantiate(new ModuleParameterizedByProductTypes(BuzzEnum(3)))
+      }
+      val modules = convert(new MyTop).modules.map(_.name)
+      assert(
+        modules == Seq(
+          "ModuleParameterizedByProductTypes_FizzEnum3",
+          "ModuleParameterizedByProductTypes_BuzzEnum3",
+          "Top"
+        )
+      )
+    }
+
+    it("should properly handle Iterables") {
+      class MyTop extends Top {
+        val inst0 = Instantiate(new ModuleParameterizedBySeq(List(1, 2, 3)))
+        val inst1 = Instantiate(new ModuleParameterizedBySeq(Vector(1, 2, 3)))
+      }
+      val modules = convert(new MyTop).modules.map(_.name)
+      assert(
+        modules == Seq(
+          "ModuleParameterizedBySeq_1_2_3",
+          "Top"
+        )
+      )
     }
   }
 


### PR DESCRIPTION
Instantiate was released in 3.6.0 and 5.0.0-RC1

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

- Squash

#### Release Notes

Instantiate previously erased type information for case classes and case objects which could result in incorrect behavior.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
