### PR TITLE
Fix overeager type checking for connecting size 0 Vecs

### DIFF
--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -112,8 +112,10 @@ private[chisel3] object BiConnect {
         // a UInt<8>[0] should not be connectable with a SInt<8>[0]
         // TODO: This is a "band-aid" fix and needs to be unified with the existing logic in a
         // more generalized and robust way, to account for things like Views
-        if (left_v.length == 0 && !left_v.typeEquivalent(right_v)) {
-          throw MismatchedException(left_v.cloneType.toString, right_v.cloneType.toString)
+        if (left_v.length == 0) {
+          left_v.findFirstTypeMismatch(right_v, strictTypes = false, strictWidths = false).foreach { msg =>
+            Builder.error(s"Illegal connection to ${left_v.earlyName}$msg")(sourceInfo)
+          }
         }
 
         val leftReified:  Option[Aggregate] = if (isView(left_v)) reifyToAggregate(left_v) else Some(left_v)

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -129,8 +129,10 @@ private[chisel3] object MonoConnect {
         // a UInt<8>[0] should not be connectable with a SInt<8>[0]
         // TODO: This is a "band-aid" fix and needs to be unified with the existing logic in a
         // more generalized and robust way, to account for things like Views
-        if (sink_v.length == 0 && !sink_v.typeEquivalent(source_v)) {
-          throw MismatchedException(sink, source)
+        if (sink_v.length == 0) {
+          sink_v.findFirstTypeMismatch(source_v, strictTypes = false, strictWidths = false).foreach { msg =>
+            Builder.error(s"Illegal connection to ${sink_v.earlyName}$msg")(sourceInfo)
+          }
         }
 
         val sinkReified:   Option[Aggregate] = if (isView(sink_v)) reifyToAggregate(sink_v) else Some(sink_v)


### PR DESCRIPTION
Fixes #3200 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
