### PR TITLE
Revert checks for size 0 Vecs in connections

### DIFF
--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -2,7 +2,7 @@
 
 package chisel3.connectable
 
-import chisel3.{Aggregate, BiConnectException, Data, DontCare, InternalErrorException, RawModule, Vec}
+import chisel3.{Aggregate, BiConnectException, Data, DontCare, InternalErrorException, RawModule}
 import chisel3.internal.{BiConnect, Builder}
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.DefInvalid
@@ -204,15 +204,6 @@ private[chisel3] object Connection {
         // Recursive Case 4: non-empty orientations
         case (conAlign: NonEmptyAlignment, proAlign: NonEmptyAlignment) =>
           (conAlign.member, proAlign.member) match {
-            // Check for zero-width Vectors: both Vecs must be type equivalent, e.g.
-            // a UInt<8>[0] should not be connectable with a SInt<8>[0]
-            // TODO: This is a "band-aid" fix and needs to be unified with the existing logic in a
-            // more generalized and robust way
-            case (consumer: Vec[Data @unchecked], producer: Vec[Data @unchecked])
-                if (consumer.length == 0 && !consumer.typeEquivalent(producer)) =>
-              errors =
-                (s"Consumer (${consumer.cloneType.toString}) and producer (${producer.cloneType.toString}) have different types.") +: errors
-
             case (consumer: Aggregate, producer: Aggregate) =>
               matchingZipOfChildren(Some(conAlign), Some(proAlign)).foreach {
                 case (ceo, peo) =>

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -108,14 +108,6 @@ private[chisel3] object BiConnect {
           throw MismatchedVecException
         }
 
-        // Check for zero-width Vectors: both Vecs must be type equivalent, e.g.
-        // a UInt<8>[0] should not be connectable with a SInt<8>[0]
-        // TODO: This is a "band-aid" fix and needs to be unified with the existing logic in a
-        // more generalized and robust way, to account for things like Views
-        if (left_v.length == 0 && !left_v.typeEquivalent(right_v)) {
-          throw MismatchedException(left_v.cloneType.toString, right_v.cloneType.toString)
-        }
-
         val leftReified:  Option[Aggregate] = if (isView(left_v)) reifyToAggregate(left_v) else Some(left_v)
         val rightReified: Option[Aggregate] = if (isView(right_v)) reifyToAggregate(right_v) else Some(right_v)
 

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -125,14 +125,6 @@ private[chisel3] object MonoConnect {
       case (sink_v: Vec[Data @unchecked], source_v: Vec[Data @unchecked]) =>
         if (sink_v.length != source_v.length) { throw MismatchedVecException }
 
-        // Check for zero-width Vectors: both Vecs must be type equivalent, e.g.
-        // a UInt<8>[0] should not be connectable with a SInt<8>[0]
-        // TODO: This is a "band-aid" fix and needs to be unified with the existing logic in a
-        // more generalized and robust way, to account for things like Views
-        if (sink_v.length == 0 && !sink_v.typeEquivalent(source_v)) {
-          throw MismatchedException(sink, source)
-        }
-
         val sinkReified:   Option[Aggregate] = if (isView(sink_v)) reifyToAggregate(sink_v) else Some(sink_v)
         val sourceReified: Option[Aggregate] = if (isView(source_v)) reifyToAggregate(source_v) else Some(source_v)
 


### PR DESCRIPTION
Fixes #3200 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?


#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
