### PR TITLE
Change ports in Interface to be a val

### DIFF
--- a/src/main/scala/chisel3/interface/Interface.scala
+++ b/src/main/scala/chisel3/interface/Interface.scala
@@ -25,7 +25,7 @@ sealed trait InterfaceCommon {
   private[interface] type Ports <: Record
 
   /** Returns the Record that is the port-level interface. */
-  private[interface] def ports(): Ports
+  private[interface] val ports: Ports
 
 }
 
@@ -84,7 +84,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
       * instantiated by any user of this interface, i.e., a test harness.
       */
     final class BlackBox extends chisel3.BlackBox with Entity {
-      final val io = IO(ports())
+      final val io = IO(ports)
 
       override final def desiredName = interfaceName
     }
@@ -96,7 +96,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
       implicit conformance: Conformance[B])
         extends RawModule
         with Entity {
-      final val io = FlatIO(ports())
+      final val io = FlatIO(ports)
 
       // Use a dummy clock and reset connection when constructing the module.
       // This is fine as we rely on DataView to catch missing connections to
@@ -109,7 +109,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
       }
 
       private implicit val pm = PartialDataView[B, Ports](
-        _ => ports(),
+        _ => ports.cloneType,
         conformance.portMap: _*
       )
 
@@ -131,7 +131,7 @@ trait Interface extends InterfaceCommon { self: Singleton =>
       * just tied off.
       */
     final class Stub extends RawModule with Entity {
-      final val io = FlatIO(ports())
+      final val io = FlatIO(ports)
       io := DontCare
       dontTouch(io)
     }

--- a/src/test/scala/chiselTests/interface/InterfaceSpec.scala
+++ b/src/test/scala/chiselTests/interface/InterfaceSpec.scala
@@ -25,7 +25,7 @@ class InterfaceSpec extends AnyFunSpec with Matchers {
     override type Ports = BarBundle
 
     /** Generate the ports given the parameters. */
-    override def ports() = new Ports
+    override val ports = new Ports
 
   }
 

--- a/src/test/scala/chiselTests/interface/ParametricInterfaceSpec.scala
+++ b/src/test/scala/chiselTests/interface/ParametricInterfaceSpec.scala
@@ -26,7 +26,7 @@ class ParametricInterfaceSpec extends AnyFunSpec with Matchers {
 
     override type Ports = BarBundle
 
-    override def ports() = new BarBundle(width)
+    override val ports = new BarBundle(width)
 
   }
 


### PR DESCRIPTION
Change an abstract def to a val when specifying the ports of an Interface.  This improves the static nature of the Interface and prevents abuse as leaving this a s a def (a function) makes it a generator.

h/t @azidar