### PR TITLE
[interface] Fix Wrapper.Stub Name

### DIFF
--- a/src/main/scala/chisel3/interface/Interface.scala
+++ b/src/main/scala/chisel3/interface/Interface.scala
@@ -76,6 +76,8 @@ trait Interface extends InterfaceCommon { self: Singleton =>
 
   sealed trait Entity { this: BaseModule =>
     val io: Ports
+
+    override final def desiredName = interfaceName
   }
 
   object Wrapper {
@@ -85,8 +87,6 @@ trait Interface extends InterfaceCommon { self: Singleton =>
       */
     final class BlackBox extends chisel3.BlackBox with Entity {
       final val io = IO(ports)
-
-      override final def desiredName = interfaceName
     }
 
     /** The module that wraps any module which conforms to this Interface.
@@ -123,8 +123,6 @@ trait Interface extends InterfaceCommon { self: Singleton =>
             e
           )
       }
-
-      override def desiredName = interfaceName
     }
 
     /** A stub module that implements the interface. All IO of this module are

--- a/src/test/scala/chiselTests/interface/InterfaceSpec.scala
+++ b/src/test/scala/chiselTests/interface/InterfaceSpec.scala
@@ -150,6 +150,24 @@ class InterfaceSpec extends AnyFunSpec with Matchers {
 
     }
 
+    it("should compile a stub") {
+
+      val dir = new java.io.File("test_run_dir/interface/InterfaceSpec/should-compile-a-stub")
+
+      import CompilationUnit2.bazConformance
+
+      info("compile okay!")
+      Drivers.compile(
+        dir,
+        Drivers.CompilationUnit(() => new CompilationUnit3.Foo),
+        Drivers.CompilationUnit(() => new (BarInterface.Wrapper.Stub))
+      )
+
+      info("link okay!")
+      Drivers.link(dir, "compile-0/Foo.sv")
+
+    }
+
   }
 
   describe("Error behavior of Interfaces") {


### PR DESCRIPTION
Fix a bug where the name of the Stub module (a module auto-generated from an Interface without an implementation available) would be called "Stub" as opposed to the name of the Interface.  This could create a linker error if the Stub was used.  Fix this by correctly setting the "desiredName". Add a test that this works.