### PR TITLE
Bump firtool version to 1.40.0

### DIFF
--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'version to install'
     required: false
-    default: 'firtool-1.38.0'
+    default: 'firtool-1.40.0'
 
 runs:
   using: composite

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         jvm: ["8"]
         scala: ["2.13.10", "2.12.17"]
         espresso: ["2.4"]
-        circt: ["firtool-1.38.0"]
+        circt: ["firtool-1.40.0"]
     runs-on: ${{ matrix.system }}
 
     steps:


### PR DESCRIPTION
Bump firtool version to get parsing of new connect/invalidate statements.

#### Release Notes

Bump firtool from 1.38.0 to 1.40.0. See the following release notes for more information:

  - [1.39.0 Release Notes](https://github.com/llvm/circt/releases/tag/firtool-1.39.0)
  - [1.40.0 Release Notes](https://github.com/llvm/circt/releases/tag/firtool-1.40.0)