### PR TITLE
Add .unsafe to connectables

### DIFF
--- a/core/src/main/scala/chisel3/connectable/Connectable.scala
+++ b/core/src/main/scala/chisel3/connectable/Connectable.scala
@@ -24,6 +24,9 @@ final class Connectable[+T <: Data] private (
   /** True if no members are waived or squeezed or excluded */
   def notWaivedOrSqueezedOrExcluded = waived.isEmpty && squeezed.isEmpty && excluded.isEmpty
 
+  /** Connect to/from all fields regardless of Scala type, squeeze if necessary, and don't error if mismatched members */
+  def unsafe: Connectable[Data] = waiveAll.squeezeAll.asInstanceOf[Connectable[Data]]
+
   private[chisel3] def copy(
     waived:   Set[Data] = this.waived,
     squeezed: Set[Data] = this.squeezed,

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -1764,5 +1764,19 @@ class ConnectableSpec extends ChiselFunSpec with Utils {
         Nil
       )
     }
+    it("(8.k) Use unsafe") {
+      class BoolBundleA extends Bundle { val foo = UInt(); val bar = Bool() }
+      class BoolBundleB extends Bundle { val foo = UInt() }
+      class MyModule extends Module {
+        val in = IO(Flipped(new BoolBundleA))
+        val out = IO(new BoolBundleB)
+        out.unsafe :<>= in.unsafe
+      }
+      testCheck(
+        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
+        Seq("out.foo <= in.foo"),
+        Nil
+      )
+    }
   }
 }


### PR DESCRIPTION
This is a useful function when users want a connection to "try its best but don't error".

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.


#### Release Notes

Added `.unsafe`, a useful function on Connectable when users want a connection to "try its best but don't error".


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
