### PR TITLE
Undo removal of address intermediate wire in `SyncReadMem.read`, `SyncReadMem.readWrite`

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -620,8 +620,10 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
     sourceInfo:        SourceInfo
   ): T = {
     var _port: Option[T] = None
+    val _a = WireDefault(chiselTypeOf(addr), DontCare)
     when(enable) {
-      _port = Some(super.do_apply_impl(addr, clock, MemPortDirection.RDWR, warn))
+      _a := addr
+      _port = Some(super.do_apply_impl(_a, clock, MemPortDirection.RDWR, warn))
       val accessor = _port.get.asInstanceOf[Vec[Data]]
 
       when(isWrite) {

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -410,8 +410,10 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
     implicit sourceInfo: SourceInfo
   ): T = {
     var _port: Option[T] = None
+    val _a = WireDefault(chiselTypeOf(addr), DontCare)
     when(enable) {
-      _port = Some(super.do_apply_impl(addr, clock, MemPortDirection.READ, warn))
+      _a := addr
+      _port = Some(super.do_apply_impl(_a, clock, MemPortDirection.READ, warn))
     }
     _port.get
   }
@@ -496,8 +498,10 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
     implicit sourceInfo: SourceInfo
   ): T = {
     var _port: Option[T] = None
+    val _a = WireDefault(chiselTypeOf(addr), DontCare)
     when(enable) {
-      _port = Some(super.do_apply_impl(addr, clock, MemPortDirection.RDWR, warn))
+      _a := addr
+      _port = Some(super.do_apply_impl(_a, clock, MemPortDirection.RDWR, warn))
 
       when(isWrite) {
         _port.get := data

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -435,11 +435,6 @@ class MemorySpec extends ChiselPropSpec {
 
       // Should elaborate correctly
       val rdWrValue = mem.readWrite(addr, io.writeData, io.rwEnable, io.rwIsWrite)
-
-      dontTouch(io)
-      dontTouch(addr)
-      dontTouch(readValue)
-      dontTouch(rdWrValue)
     }
     ChiselStage.emitSystemVerilog(new TestModule)
   }

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -415,6 +415,9 @@ class MemorySpec extends ChiselPropSpec {
 
         val rwEnable = Input(Bool())
         val rwIsWrite = Input(Bool())
+
+        val rdReadValue = Output(UInt(2.W))
+        val rwReadValue = Output(UInt(2.W))
       })
 
       // Address value declared and driven before the SyncReadMem declaration.
@@ -428,13 +431,11 @@ class MemorySpec extends ChiselPropSpec {
       val mem = SyncReadMem(4, UInt(2.W))
 
       // Should elaborate correctly
-      val readValue = mem.read(addr, io.rdEnable)
-
+      io.rdReadValue := mem.read(addr, io.rdEnable)
       // Should elaborate correctly
       mem.write(addr, io.writeData)
-
       // Should elaborate correctly
-      val rdWrValue = mem.readWrite(addr, io.writeData, io.rwEnable, io.rwIsWrite)
+      io.rwReadValue := mem.readWrite(addr, io.writeData, io.rwEnable, io.rwIsWrite)
     }
     ChiselStage.emitSystemVerilog(new TestModule)
   }

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -412,12 +412,16 @@ class MemorySpec extends ChiselPropSpec {
       val io = IO(new Bundle {
         val rdEnable = Input(Bool())
         val writeData = Input(UInt(2.W))
+        val mrwWriteData = Input(Vec(2, UInt(2.W)))
+        val mrwWriteMask = Input(Vec(2, Bool()))
 
         val rwEnable = Input(Bool())
         val rwIsWrite = Input(Bool())
+        val mrwIsWrite = Input(Bool())
 
         val rdReadValue = Output(UInt(2.W))
         val rwReadValue = Output(UInt(2.W))
+        val mrwReadValue = Output(Vec(2, UInt(2.W)))
       })
 
       // Address value declared and driven before the SyncReadMem declaration.
@@ -429,6 +433,7 @@ class MemorySpec extends ChiselPropSpec {
       addr := 0.U
 
       val mem = SyncReadMem(4, UInt(2.W))
+      val vecMem = SyncReadMem(4, Vec(2, UInt(2.W)))
 
       // Should elaborate correctly
       io.rdReadValue := mem.read(addr, io.rdEnable)
@@ -436,6 +441,8 @@ class MemorySpec extends ChiselPropSpec {
       mem.write(addr, io.writeData)
       // Should elaborate correctly
       io.rwReadValue := mem.readWrite(addr, io.writeData, io.rwEnable, io.rwIsWrite)
+      // Should elaborate correctly
+      io.mrwReadValue := vecMem.readWrite(addr, io.mrwWriteData, io.mrwWriteMask, io.rwEnable, io.rwIsWrite)
     }
     ChiselStage.emitSystemVerilog(new TestModule)
   }


### PR DESCRIPTION
#3221 removed the usage of a temporary wire in `SyncReadMem.read` that, at first glance, appears to be redundant; however it turns out that this wire is important for helping SFC and firtool infer the correct address values for the port. This PR undoes that specific change and additionally adds an integration test to both document the behavior and test against it.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? -->
Squash and merge

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
