### PR TITLE
Use Chisel Bot Token for automated PRs

### DIFF
--- a/.github/workflows/enable-bincompat-checking.yml
+++ b/.github/workflows/enable-bincompat-checking.yml
@@ -85,4 +85,5 @@ jobs:
           commit-message: "Enable MiMa for ${{ needs.determine_version.outputs.version }}"
           body: "Enable MiMa for ${{ needs.determine_version.outputs.version }}"
           labels: Internal
+          token: ${{ secrets.CHISEL_BOT_TOKEN }}
 


### PR DESCRIPTION
The new Chisel Bot https://github.com/chiselbot will be responsible for opening automated PRs so that:
1. CI will run when they are opened, see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs, and
2. I will be able to approve the PRs (if I used a personal token, then it would open PRs as me).