### PR TITLE
Add new workflow to fixup backports for release notes

### DIFF
--- a/.github/workflows/backport-fixup.yml
+++ b/.github/workflows/backport-fixup.yml
@@ -1,0 +1,90 @@
+# Fixes up Mergify-created backport PRs to include necessary labels and other
+# information for release notes generation
+
+name: Backport Fixup
+
+on:
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'Number of the Pull Request to Fixup'
+        require: true
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  resolve_prs:
+    name: Resolve PRs
+    runs-on: ubuntu-latest
+    # If triggering PR actually is a backport, then original_pr will be set
+    outputs:
+        backport_pr: ${{ steps.backport.outputs.pr }}
+        original_pr: ${{ steps.original.outputs.pr }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Figure out backport PR number
+        id: backport
+        run: |
+          if [[ -z "${{ inputs.pr }}" ]]; then
+            echo "pr=${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr=${{ inputs.pr }}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Figure out original PR number (if one exists)
+        id: original
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BP_PR=${{ steps.backport.outputs.pr }}
+          TITLE=$(gh pr view --json title --jq '.title' $BP_PR)
+          if [[ "$TITLE" =~ \(backport\ #([0-9]+)\) ]]; then
+            echo "pr=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "$BP_PR is not a backport PR!" >> $GITHUB_STEP_SUMMARY
+          fi
+
+  fixup_backport:
+    name: Fixup the backport PR
+    runs-on: ubuntu-latest
+    needs: [resolve_prs]
+    if: ${{ needs.resolve_prs.outputs.original_pr }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Copy over labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BP_PR=${{ needs.resolve_prs.outputs.backport_pr }}
+          ORIG_PR=${{ needs.resolve_prs.outputs.original_pr }}
+          LABELS=$(gh pr view --json labels --jq '.labels | .[].name | select(. != "Backported")' $ORIG_PR)
+          for label in $LABELS; do
+            gh pr edit $BP_PR --add-label $label
+          done
+      - name: Copy over body
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BP_PR=${{ needs.resolve_prs.outputs.backport_pr }}
+          ORIG_PR=${{ needs.resolve_prs.outputs.original_pr }}
+
+          gh pr view --json body --jq '.body' $ORIG_PR > orig_body.txt
+          gh pr view --json body --jq '.body' $BP_PR > bp_body.txt
+
+          if grep -q '# Original PR Body' bp_body.txt; then
+            # Copy BP PR body but remove original PR body from bottom
+            sed '/# Original PR Body/q' bp_body.txt > new_bp_body.txt
+            echo "" >> new_bp_body.txt
+          else
+            cp bp_body.txt new_bp_body.txt
+            echo -e "\n----\n\n# Original PR Body\n" >> new_bp_body.txt
+          fi
+
+          cat orig_body.txt >> new_bp_body.txt
+
+          gh pr edit $BP_PR --body-file new_bp_body.txt


### PR DESCRIPTION
The Mergify-generated backports do not currently include the information needed by the release notes generation automation. This new workflow will copy such information over to backport PRs.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy


- Squash

#### Release Notes

Improve backport automation so that release notes generation from backport PRs works properly.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
