### PR TITLE
[bugfix] Fix BoringUtils up--down bug

### DIFF
--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -381,10 +381,10 @@ object DataMirror {
     val rightPath = modulePath(right, None)
     rightPath.collectFirst { case p if leftPathSet.contains(p) => p }
   }
-  // Returns LCA paths if a common ancestor exists
+  // Returns LCA paths if a common ancestor exists.  The returned paths includes the LCA.
   private[chisel3] def findLCAPaths(left: HasId, right: HasId): Option[(Seq[BaseModule], Seq[BaseModule])] = {
     leastCommonAncestorModule(left, right).map { lca =>
-      (modulePath(left, Some(lca)), modulePath(right, Some(lca)))
+      (Seq(lca) ++ modulePath(left, Some(lca)), Seq(lca) ++ modulePath(right, Some(lca)))
     }
   }
 }

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -228,7 +228,9 @@ object BoringUtils {
             module.addSecretIO(bore)
             if (up) {
               module.asInstanceOf[RawModule].secretConnection(bore, rhs)
-            } else parent(rhs).asInstanceOf[RawModule].secretConnection(bore, rhs)
+            } else {
+              module.asInstanceOf[RawModule].secretConnection(rhs, bore)
+            }
             bore
           }
       }
@@ -259,12 +261,13 @@ object BoringUtils {
       return DontCare
     }
     val (upPath, downPath) = lcaResult.get
-    val lcaSource = drill(source, upPath, true)
-    val sink = drill(lcaSource, downPath.reverse, false)
+    val lcaSource = drill(source, upPath.tail, true)
 
-    /** Creating an intermediate wire so secret stuff never escapes */
+    /** Creating a wire to assign the result to.  We will return this. */
     val bore = Wire(purePortType)
-    thisModule.asInstanceOf[RawModule].secretConnection(bore, sink)
+    val sink = drill(bore, downPath.tail, false)
+
+    upPath.head.asInstanceOf[RawModule].secretConnection(sink, lcaSource)
     bore
   }
 }


### PR DESCRIPTION
Fix a bug in the new BoringUtils.bore API where this would generate invalid FIRRTL if the user did boring which created a path that went up to an LCA and then down.  Change the internal leastCommonAncestor utility to also return the LCA module as this avoids a second call to compute the LCA.

Fixes #3239.

Skipping release notes on this as the new BoringUtils API is not in a release.