### PR TITLE
[bugfix] Fix naming module with Unit parameter

### DIFF
--- a/core/src/main/scala/chisel3/naming/Identifier.scala
+++ b/core/src/main/scala/chisel3/naming/Identifier.scala
@@ -33,7 +33,7 @@ object IdentifierProposer {
         }
       }
     }
-    if (s == "") s
+    if (s == "" || firstOkChar == -1) ""
     else
       s.substring(firstOkChar, if (finalChar == -1) lastOkChar + 1 else finalChar).map { x =>
         if (!legal(x)) '_' else x

--- a/src/test/scala/chiselTests/naming/IdentifierProposerSpec.scala
+++ b/src/test/scala/chiselTests/naming/IdentifierProposerSpec.scala
@@ -25,5 +25,6 @@ class IdentifierProposerSpec extends ChiselFunSpec {
     assert(IdentifierProposer.getProposal(Seq(1, 2, 3)) == "1_2_3")
     assert(IdentifierProposer.getProposal(List(1, 2, 3)) == "1_2_3")
     assert(IdentifierProposer.getProposal((1, 2)) == "1_2")
+    assert(IdentifierProposer.getProposal(()) == "")
   }
 }


### PR DESCRIPTION
Fix a bug in naming where a Module that took a Unit parameter could cause naming to crash.  This is, admittedly, a very weird pattern, but can occur if you have a type-parametric module where certain type parameterizations can be Unit.

Fix #3245.

#### Release Notes

Fix bag where a Module with a Unit parameter crashes.