### PR TITLE
Enable .viewAsSupertype to work on Records

### DIFF
--- a/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
@@ -610,11 +610,8 @@ object PartialDataView {
           val aElts = a._elements
           val bElts = b._elements
           val bKeys = bElts.keySet
-          println(s"key set is $bKeys")
           val keys = aElts.keysIterator.filter(bKeys.contains)
-          val result = keys.map(k => aElts(k) -> bElts(k)).toSeq
-          println(s"result is $result")
-          result
+          keys.map(k => aElts(k) -> bElts(k)).toSeq
       }
     )
 }

--- a/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/DataView.scala
@@ -592,12 +592,12 @@ object PartialDataView {
   ): DataView[T, V] =
     new DataView[T, V](mkView, mapping, _total = false)
 
-  /** Constructs a non-total [[DataView]] mapping from a [[Bundle]] type to a parent [[Bundle]] type
+  /** Constructs a non-total [[DataView]] mapping from a [[Bundle]] or [[Record]] type to a parent [[Bundle]] or [[Record]] type
     *
     * @param mkView a function constructing an instance `V` from an instance of `T`
-    * @return the [[DataView]] that enables viewing instances of a [[Bundle]] as instances of a parent type
+    * @return the [[DataView]] that enables viewing instances of a [[Bundle]]/[[Record]] as instances of a parent type
     */
-  def supertype[T <: Bundle, V <: Bundle](
+  def supertype[T <: Record, V <: Record](
     mkView: T => V
   )(
     implicit ev: ChiselSubtypeOf[T, V],
@@ -610,8 +610,11 @@ object PartialDataView {
           val aElts = a._elements
           val bElts = b._elements
           val bKeys = bElts.keySet
+          println(s"key set is $bKeys")
           val keys = aElts.keysIterator.filter(bKeys.contains)
-          keys.map(k => aElts(k) -> bElts(k)).toSeq
+          val result = keys.map(k => aElts(k) -> bElts(k)).toSeq
+          println(s"result is $result")
+          result
       }
     )
 }

--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -82,7 +82,9 @@ package object dataview {
     // Kept separate from Aggregates for totality checking
     val elementBindings =
       new mutable.LinkedHashMap[Data, mutable.ListBuffer[Element]] ++
-        getRecursiveFields(view, "_").collect { case (elt: Element, name) => elt }
+        getRecursiveFields
+          .lazilyNoPath(view)
+          .collect { case (elt: Element) => elt }
           .map(_ -> new mutable.ListBuffer[Element])
 
     // Record any Aggregates that correspond 1:1 for reification

--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -157,7 +157,6 @@ package object dataview {
         val targetsx = targets match {
           case collection.Seq(target: Element) => target
           case collection.Seq() =>
-            println(s"Adding ${data.toString} to $viewNonTotalErrors")
             viewNonTotalErrors = data :: viewNonTotalErrors
             data.asInstanceOf[Element] // Return the Data itself, will error after this map, cast is safe
           case x =>
@@ -177,7 +176,6 @@ package object dataview {
     }
     if (viewNonTotalErrors != Nil || targetNonTotalErrors != Nil) {
       val viewErrors = viewNonTotalErrors.map(f => viewFieldLookup.getOrElse(f, f.toString))
-      println(s"viewErrors: $viewErrors")
       nonTotalViewException(dataView, target, view, targetNonTotalErrors, viewErrors)
     }
 

--- a/src/test/scala/chiselTests/experimental/DataView.scala
+++ b/src/test/scala/chiselTests/experimental/DataView.scala
@@ -345,41 +345,6 @@ class DataViewSpec extends ChiselFlatSpec {
     chirrtl should include("io.c.foo <= io.a.foo")
   }
 
-  it should "support viewing structural supertypes between bundles and Records" in {
-    class Foo extends Bundle {
-      val y = UInt(3.W)
-    }
-    class A extends Record {
-      override val elements = SeqMap("foo" -> new Foo, "x"-> UInt(3.W), "z" -> UInt(3.W))
-    }
-    class B extends Bundle {
-      val x = UInt(3.W)
-      val foo = new Foo
-    }
-    class C extends Bundle {
-      val foo = new Foo
-      val z = UInt(3.W)
-    }
-    class MyModule extends Module {
-      val io = IO(new Bundle {
-        val a = Input(new A)
-        val b = Output(new B)
-        val c = Output(new C)
-        val inc = Input(new C)
-        val outa = Output(new A)
-      })
-      io.b <> io.a.viewAsSupertype(new B)
-      io.c <> io.a.viewAsSupertype(new C)
-      io.outa.viewAsSupertype(new C) <> io.inc
-    }
-    val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    chirrtl should include("io.b.x <= io.a.x")
-    chirrtl should include("io.c.z <= io.a.z")
-    chirrtl should include("io.outa.foo <= io.inc.foo")
-    chirrtl should include("io.b.foo <= io.a.foo")
-    chirrtl should include("io.c.foo <= io.a.foo")
-  }
-
   it should "error during elaboration for sub-type errors that cannot be found at compile-time" in {
     class A extends Bundle {
       val x = UInt(3.W)


### PR DESCRIPTION
- fix a nondeterminism error in DataView noticeable on error reporting

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)
- Bugfix

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
* Allow .viewAsSupertype to work on Records, with additional tests.
* Ensure that errors in DataView show the problematic fields in a deterministic order.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
