### PR TITLE
[codegen] Simpler FIRRTL Code for Reg w/o Reset

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -127,14 +127,12 @@ private[chisel3] object Converter {
           convert(info),
           e.name,
           extractType(id, info),
-          convert(clock, ctx, info),
-          firrtl.Utils.zero,
-          convert(getRef(id, info), ctx, info)
+          convert(clock, ctx, info)
         )
       )
     case e @ DefRegInit(info, id, clock, reset, init) =>
       Some(
-        fir.DefRegister(
+        fir.DefRegisterWithReset(
           convert(info),
           e.name,
           extractType(id, info),

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -229,6 +229,14 @@ case class DefRegister(
   info:  Info,
   name:  String,
   tpe:   Type,
+  clock: Expression)
+    extends Statement
+    with IsDeclaration
+    with UseSerializer
+case class DefRegisterWithReset(
+  info:  Info,
+  name:  String,
+  tpe:   Type,
   clock: Expression,
   reset: Expression,
   init:  Expression)

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -241,7 +241,9 @@ object Serializer {
       sStmtName(print.name); s(info)
     case IsInvalid(info, expr)    => s(expr); b ++= " is invalid"; s(info)
     case DefWire(info, name, tpe) => b ++= "wire "; b ++= name; b ++= " : "; s(tpe); s(info)
-    case DefRegister(info, name, tpe, clock, reset, init) =>
+    case DefRegister(info, name, tpe, clock) =>
+      b ++= "reg "; b ++= name; b ++= " : "; s(tpe); b ++= ", "; s(clock); s(info)
+    case DefRegisterWithReset(info, name, tpe, clock, reset, init) =>
       b ++= "reg "; b ++= name; b ++= " : "; s(tpe); b ++= ", "; s(clock); b ++= " with :"; newLineAndIndent(1)
       b ++= "reset => ("; s(reset); b ++= ", "; s(init); b += ')'; s(info)
     case DefInstance(info, name, module, _) => b ++= "inst "; b ++= name; b ++= " of "; b ++= module; s(info)

--- a/src/test/scala/chiselTests/util/RegSpec.scala
+++ b/src/test/scala/chiselTests/util/RegSpec.scala
@@ -16,7 +16,7 @@ class RegEnableSpec extends AnyFlatSpec with Matchers {
       out := RegEnable(in, true.B)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    val reset = """reset.*RegSpec.scala""".r
+    val reset = """reg.*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
     (chirrtl should include).regex(update)
@@ -48,7 +48,7 @@ class ShiftRegisterSpec extends AnyFlatSpec with Matchers {
       out := ShiftRegister(in, 2, true.B)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    val reset = """reset .*RegSpec.scala""".r
+    val reset = """reg .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
     (chirrtl should include).regex(update)
@@ -62,7 +62,7 @@ class ShiftRegisterSpec extends AnyFlatSpec with Matchers {
       out := ShiftRegister(in, 2)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    val reset = """reset .*RegSpec.scala""".r
+    val reset = """reg .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
     (chirrtl should include).regex(update)
@@ -95,7 +95,7 @@ class ShiftRegistersSpec extends AnyFlatSpec with Matchers {
       out := ShiftRegisters(in, 2, true.B)(0)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    val reset = """reset .*RegSpec.scala""".r
+    val reset = """reg .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
     (chirrtl should include).regex(update)
@@ -109,7 +109,7 @@ class ShiftRegistersSpec extends AnyFlatSpec with Matchers {
       out := ShiftRegisters(in, 2)(0)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new MyModule)
-    val reset = """reset .*RegSpec.scala""".r
+    val reset = """reg .*RegSpec.scala""".r
     (chirrtl should include).regex(reset)
     val update = """out_r.* in .*RegSpec.scala""".r
     (chirrtl should include).regex(update)


### PR DESCRIPTION
Change FIRRTL emission to use a simpler syntax for registers without a reset.  Previously, this used a self-reset with a zero reset signal. Simplify this to emit a register without a reset.

#### Release Notes

Skip register emission in Chisel for reset-less registers.