### PR TITLE
BoringUtils writable tap (rwTap) API

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -110,10 +110,11 @@ abstract class RawModule extends BaseModule {
 
   private[chisel3] def secretConnection(left: Data, right: Data)(implicit si: SourceInfo): Unit = {
     val rhs = (left.probeInfo.nonEmpty, right.probeInfo.nonEmpty) match {
-      case (true, true)   => ProbeDefine(si, left.lref, Node(right))
-      case (true, false)  => ProbeDefine(si, left.lref, ProbeExpr(Node(right)))
-      case (false, true)  => Connect(si, left.lref, ProbeRead(Node(right)))
-      case (false, false) => Connect(si, left.lref, Node(right))
+      case (true, true)                                 => ProbeDefine(si, left.lref, Node(right))
+      case (true, false) if left.probeInfo.get.writable => ProbeDefine(si, left.lref, RWProbeExpr(Node(right)))
+      case (true, false)                                => ProbeDefine(si, left.lref, ProbeExpr(Node(right)))
+      case (false, true)                                => Connect(si, left.lref, ProbeRead(Node(right)))
+      case (false, false)                               => Connect(si, left.lref, Node(right))
     }
     val secretCommands = if (_closed) {
       _component.get.asInstanceOf[DefModule].secretCommands

--- a/integration-tests/src/test/scala/chiselTest/util/experimental/TapSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/util/experimental/TapSpec.scala
@@ -9,76 +9,44 @@ import chisel3.testers.BasicTester
 import chisel3.util.experimental.BoringUtils._
 import org.scalacheck._
 import chiselTests.{ChiselFlatSpec, Utils}
-import chisel3.probe._
 
+class LeftLower(tapSignal: UInt) extends Module {
+  val readTap = Wire(UInt(8.W))
+  readTap := tapAndRead(tapSignal)
+  chisel3.assert(readTap === 123.U)
+  stop()
+}
 
+class LeftUpper(tapSignal: UInt) extends Module {
+  val leftLower = Module(new LeftLower(tapSignal))
+}
+
+class RightLower extends Module {
+  val tapMe = Wire(UInt(8.W))
+  tapMe := 123.U
+  dontTouch(tapMe)
+}
+
+class RightUpper extends Module {
+  val rightLower = Module(new RightLower)
+}
+
+class UpDownTest extends BasicTester {
+  val rightUpper = Module(new RightUpper)
+  val leftUpper = Module(new LeftUpper(rightUpper.rightLower.tapMe))
+}
+
+/** Circuit follows this layout:
+  *
+  *           UpDownTest
+  *             /     \
+  *       LeftUpper   RightUpper
+  *          /           \
+  *    LeftLower       RightLower
+  * 
+  * Tap a signal in RightLower from LeftLower and check that it contains the
+  * correct value.
+  */
 class TapSpec extends ChiselFlatSpec with Utils {
-  /** Circuit follows this layout:
-    *
-    *           UpDownTest
-    *             /     \
-    *       LeftUpper   RightUpper
-    *          /           \
-    *    LeftLower       RightLower
-    *
-    * Tap a signal in RightLower from LeftLower and check that it contains the
-    * correct value.
-    */
-  "Up-and-down tap" should "work" in {
-    class LeftLower(tapSignal: UInt) extends Module {
-      val readTap = Wire(UInt(8.W))
-      readTap := tapAndRead(tapSignal)
-      chisel3.assert(readTap === 123.U)
-      stop()
-    }
-
-    class LeftUpper(tapSignal: UInt) extends Module {
-      val leftLower = Module(new LeftLower(tapSignal))
-    }
-
-    class RightLower extends Module {
-      val tapMe = Wire(UInt(8.W))
-      tapMe := 123.U
-      dontTouch(tapMe)
-    }
-
-    class RightUpper extends Module {
-      val rightLower = Module(new RightLower)
-    }
-
-    class UpDownTest extends BasicTester {
-      val rightUpper = Module(new RightUpper)
-      val leftUpper = Module(new LeftUpper(rightUpper.rightLower.tapMe))
-    }
-
-    assertTesterPasses(new UpDownTest)
-  }
-
-  "Writable taps with forces" should "work" in {
-    class Grandchild extends Module {
-      val tapMe = Wire(UInt(8.W))
-      tapMe := 0.U
-      dontTouch(tapMe)
-    }
-
-    class Child extends Module {
-      val grandchild = Module(new Grandchild)
-    }
-
-    class WritableTapTest extends BasicTester {
-      val grandChildTap = IO(RWProbe(UInt(8.W)))
-      val child = Module(new Child)
-
-      define(grandChildTap, rwTap(child.grandchild.tapMe))
-      force(clock, true.B, grandChildTap, 123.U(8.W))
-      forceInitial(grandChildTap, 123.U(8.W))
-
-      // this test passes on compile and does not perform any checks
-      // due to unexpected behavior with `force` and Verilator
-
-      stop()
-    }
-
-    assertTesterPasses(new WritableTapTest)
-  }
+  assertTesterPasses(new UpDownTest)
 }

--- a/integration-tests/src/test/scala/chiselTest/util/experimental/TapSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/util/experimental/TapSpec.scala
@@ -9,44 +9,76 @@ import chisel3.testers.BasicTester
 import chisel3.util.experimental.BoringUtils._
 import org.scalacheck._
 import chiselTests.{ChiselFlatSpec, Utils}
+import chisel3.probe._
 
-class LeftLower(tapSignal: UInt) extends Module {
-  val readTap = Wire(UInt(8.W))
-  readTap := tapAndRead(tapSignal)
-  chisel3.assert(readTap === 123.U)
-  stop()
-}
 
-class LeftUpper(tapSignal: UInt) extends Module {
-  val leftLower = Module(new LeftLower(tapSignal))
-}
-
-class RightLower extends Module {
-  val tapMe = Wire(UInt(8.W))
-  tapMe := 123.U
-  dontTouch(tapMe)
-}
-
-class RightUpper extends Module {
-  val rightLower = Module(new RightLower)
-}
-
-class UpDownTest extends BasicTester {
-  val rightUpper = Module(new RightUpper)
-  val leftUpper = Module(new LeftUpper(rightUpper.rightLower.tapMe))
-}
-
-/** Circuit follows this layout:
-  *
-  *           UpDownTest
-  *             /     \
-  *       LeftUpper   RightUpper
-  *          /           \
-  *    LeftLower       RightLower
-  * 
-  * Tap a signal in RightLower from LeftLower and check that it contains the
-  * correct value.
-  */
 class TapSpec extends ChiselFlatSpec with Utils {
-  assertTesterPasses(new UpDownTest)
+  /** Circuit follows this layout:
+    *
+    *           UpDownTest
+    *             /     \
+    *       LeftUpper   RightUpper
+    *          /           \
+    *    LeftLower       RightLower
+    *
+    * Tap a signal in RightLower from LeftLower and check that it contains the
+    * correct value.
+    */
+  "Up-and-down tap" should "work" in {
+    class LeftLower(tapSignal: UInt) extends Module {
+      val readTap = Wire(UInt(8.W))
+      readTap := tapAndRead(tapSignal)
+      chisel3.assert(readTap === 123.U)
+      stop()
+    }
+
+    class LeftUpper(tapSignal: UInt) extends Module {
+      val leftLower = Module(new LeftLower(tapSignal))
+    }
+
+    class RightLower extends Module {
+      val tapMe = Wire(UInt(8.W))
+      tapMe := 123.U
+      dontTouch(tapMe)
+    }
+
+    class RightUpper extends Module {
+      val rightLower = Module(new RightLower)
+    }
+
+    class UpDownTest extends BasicTester {
+      val rightUpper = Module(new RightUpper)
+      val leftUpper = Module(new LeftUpper(rightUpper.rightLower.tapMe))
+    }
+
+    assertTesterPasses(new UpDownTest)
+  }
+
+  "Writable taps with forces" should "work" in {
+    class Grandchild extends Module {
+      val tapMe = Wire(UInt(8.W))
+      tapMe := 0.U
+      dontTouch(tapMe)
+    }
+
+    class Child extends Module {
+      val grandchild = Module(new Grandchild)
+    }
+
+    class WritableTapTest extends BasicTester {
+      val grandChildTap = IO(RWProbe(UInt(8.W)))
+      val child = Module(new Child)
+
+      define(grandChildTap, rwTap(child.grandchild.tapMe))
+      force(clock, true.B, grandChildTap, 123.U(8.W))
+      forceInitial(grandChildTap, 123.U(8.W))
+
+      // this test passes on compile and does not perform any checks
+      // due to unexpected behavior with `force` and Verilator
+
+      stop()
+    }
+
+    assertTesterPasses(new WritableTapTest)
+  }
 }

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -471,10 +471,11 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       out := probe.read(BoringUtils.rwTap(foo.bar.internalWire))
     }
     val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
+    println(chirrtl)
     matchesAndOmits(chirrtl)(
       "module Bar :",
       "output out_bore : RWProbe<UInt<1>>",
-      "define out_bore = probe(internalWire)",
+      "define out_bore = rwprobe(internalWire)",
       "module Foo :",
       "output out_bore : RWProbe<UInt<1>>",
       "define out_bore = bar.out_bore",

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -469,6 +469,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       val foo = Module(new Foo)
       val out = IO(Bool())
       out := probe.read(BoringUtils.rwTap(foo.bar.internalWire))
+      probe.forceInitial(BoringUtils.rwTap(foo.bar.internalWire), false.B)
     }
     val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
     println(chirrtl)
@@ -480,7 +481,8 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "output out_bore : RWProbe<UInt<1>>",
       "define out_bore = bar.out_bore",
       "module Top :",
-      "out <= read(foo.out_bore)"
+      "out <= read(foo.out_bore)",
+      "force_initial(foo.bore, UInt<1>(\"h0\"))"
     )()
   }
 

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -457,4 +457,65 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       "foo.b_bore <= read(bar.b_bore)"
     )()
   }
+
+  "Downwards writable tap from grandparent to grandchild" should "work" in {
+    class Bar extends RawModule {
+      val internalWire = Wire(Bool())
+    }
+    class Foo extends RawModule {
+      val bar = Module(new Bar)
+    }
+    class Top extends RawModule {
+      val foo = Module(new Foo)
+      val out = IO(Bool())
+      out := probe.read(BoringUtils.rwTap(foo.bar.internalWire))
+    }
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
+    matchesAndOmits(chirrtl)(
+      "module Bar :",
+      "output out_bore : RWProbe<UInt<1>>",
+      "define out_bore = probe(internalWire)",
+      "module Foo :",
+      "output out_bore : RWProbe<UInt<1>>",
+      "define out_bore = bar.out_bore",
+      "module Top :",
+      "out <= read(foo.out_bore)"
+    )()
+  }
+
+  "Upwards writable tap from child to parent" should "not work" in {
+    class Foo(parentData: Data) extends RawModule {
+      val outProbe = IO(probe.RWProbe(Bool()))
+      probe.define(outProbe, BoringUtils.rwTap(parentData))
+    }
+    class Top extends RawModule {
+      val parentWire = Wire(Bool())
+      val foo = Module(new Foo(parentWire))
+    }
+    val e = intercept[Exception] {
+      circt.stage.ChiselStage.emitCHIRRTL(new Top, Array("--throw-on-first-error"))
+    }
+    e.getMessage should include("Cannot drill writable probes upwards.")
+  }
+
+  "Writable tap from child to sibling at different levels" should "not work" in {
+    class Bar extends RawModule {
+      val a = Wire(Bool())
+    }
+    class Baz(_a: Bool) extends RawModule {
+      val b = Output(probe.RWProbe(Bool()))
+      b := BoringUtils.rwTap(_a)
+    }
+    class Foo(_a: Bool) extends RawModule {
+      val baz = Module(new Baz(_a))
+    }
+    class Top extends RawModule {
+      val bar = Module(new Bar)
+      val foo = Module(new Foo(bar.a))
+    }
+    val e = intercept[Exception] {
+      circt.stage.ChiselStage.emitCHIRRTL(new Top, Array("--throw-on-first-error"))
+    }
+    e.getMessage should include("Cannot drill writable probes upwards.")
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Add writable tap (`rwTap`) API to BoringUtils, which drills writable probe ports downwards only.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
