### PR TITLE
Optimize BitPat equals, overlap, and cover

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -327,6 +327,14 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int)
   def =/=(that: UInt):   Bool = macro SourceInfoTransform.thatArg
   def ##(that:  BitPat): BitPat = macro SourceInfoTransform.thatArg
 
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case that: BitPat => this.value == that.value && this.mask == that.mask && this.width == that.width
+      case that: BitSet => super.equals(obj)
+      case _ => false
+    }
+  }
+
   override def hashCode: Int =
     MurmurHash3.seqHash(Seq(this.value, this.mask, this.width))
 
@@ -362,14 +370,20 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int)
     * @param that `BitPat` to be checked.
     * @return true if this and that `BitPat` have overlap.
     */
-  def overlap(that: BitPat): Boolean = ((mask & that.mask) & (value ^ that.value)) == 0
+  override def overlap(that: BitSet): Boolean = that match {
+    case that: BitPat => ((mask & that.mask) & (value ^ that.value)) == 0
+    case _ => super.overlap(that)
+  }
 
   /** Check whether this `BitSet` covers that (i.e. forall b matches that, b also matches this)
     *
     * @param that `BitPat` to be covered
     * @return true if this `BitSet` can cover that `BitSet`
     */
-  def cover(that: BitPat): Boolean = (mask & (~that.mask | (value ^ that.value))) == 0
+  override def cover(that: BitSet): Boolean = that match {
+    case that: BitPat => (mask & (~that.mask | (value ^ that.value))) == 0
+    case _ => super.cover(that)
+  }
 
   /** Intersect `this` and `that` `BitPat`.
     *

--- a/src/test/scala/chiselTests/util/BitSetSpec.scala
+++ b/src/test/scala/chiselTests/util/BitSetSpec.scala
@@ -54,6 +54,57 @@ class BitSetSpec extends AnyFlatSpec with Matchers {
     expected.equals(aBitSet.subtract(bBitSet)) should be(true)
   }
 
+  it should "support checking equality" in {
+    val set = BitSet.fromString("""b100
+                                  |b101""".stripMargin)
+    val a = BitPat("b10?")
+    val a2 = BitPat("b10?")
+    val b = BitPat("b1??")
+
+    // Check both ways because BitPat overloads equals
+    assert(a != b)
+    assert(b != a)
+    assert(a == a2)
+    assert(a2 == a)
+    assert(set == a)
+    assert(a == set)
+  }
+
+  it should "support checking for cover" in {
+    val set = BitSet.fromString("""b110
+                                  |b100
+                                  |b101""".stripMargin)
+    val a = BitPat("b10?")
+    val b = BitPat("b1??")
+
+    a.cover(b) should be(false)
+    b.cover(a) should be(true)
+    set.cover(a) should be(true)
+    a.cover(set) should be(false)
+    set.cover(b) should be(false)
+    b.cover(set) should be(true)
+
+  }
+
+  it should "support checking for overlap" in {
+    val set = BitSet.fromString("""b01?0
+                                  |b0000""".stripMargin)
+    val a = BitPat("b00??")
+    val b = BitPat("b01?0")
+    val c = BitPat("b0000")
+    val d = BitPat("b1000")
+
+    a.overlap(b) should be(false)
+    a.overlap(c) should be(true)
+    b.overlap(c) should be(false)
+
+    // Check both ways because BitPat overloads overlap
+    set.overlap(a) should be(true)
+    a.overlap(set) should be(true)
+    set.overlap(d) should be(false)
+    d.overlap(set) should be(false)
+  }
+
   it should "be generated from BitPat union" in {
     val aBitSet = BitSet.fromString("""b001?0
                                       |b000??""".stripMargin)


### PR DESCRIPTION
I also added some focused tests.

I am making this change because I noticed slow performance for a `TruthTable` that has 65k entries. The performance of just `==` on that `TruthTable` was pretty bad. Note that `==` for `BitSet` uses `cover`, so I first optimized that, then went ahead and also optimized `equals`, and then `overlap` was free so did that too. See benchmark for equality of two copies of a `TruthTable` with 65k entries:

| Change | Runtime | Speedup over Baseline |
| --- | --- | --- |
| Baseline | 68 ms | -  |
| Optimize cover | 3.9 ms | 17x |
| Optimize equals | 1.3 ms | 52x |

There are other improvements to be made, but this is pretty good and constrained.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Performance improvement

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).


#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
