### PR TITLE
Allow out-of-package svsim backend implementations

### DIFF
--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -34,122 +34,123 @@ final class Backend(
     extends svsim.Backend {
   type CompilationSettings = Backend.CompilationSettings
 
-  private[svsim] def invocationSettings(
+  def generateParameters(
     outputBinaryName:        String,
     topModuleName:           String,
     additionalHeaderPaths:   Seq[String],
     commonSettings:          CommonCompilationSettings,
     backendSpecificSettings: CompilationSettings
-  ): svsim.Backend.InvocationSettings = {
+  ): svsim.Backend.Parameters = {
     import CommonCompilationSettings._
     import Backend.CompilationSettings._
     //format: off
-    svsim.Backend.InvocationSettings(
+    svsim.Backend.Parameters(
       compilerPath = executablePath,
-      compilerArguments = Seq[Seq[String]](
-        Seq( 
-          "--cc", // "Create C++ output"
-          "--exe", // "Link to create executable"
-          "--build", // "Build model executable/library after Verilation"
-          "-o", s"../$outputBinaryName", // "Name of final executable"
-          "--top-module", topModuleName, // "Name of top-level input module"
-          "--Mdir", "verilated-sources",  // "Name of output object directory"
-        ),
+      compilerInvocation = svsim.Backend.Parameters.Invocation(
+        arguments = Seq[Seq[String]](
+          Seq( 
+            "--cc", // "Create C++ output"
+            "--exe", // "Link to create executable"
+            "--build", // "Build model executable/library after Verilation"
+            "-o", s"../$outputBinaryName", // "Name of final executable"
+            "--top-module", topModuleName, // "Name of top-level input module"
+            "--Mdir", "verilated-sources",  // "Name of output object directory"
+          ),
 
-        commonSettings.libraryExtensions match {
-          case None => Seq()
-          case Some(extensions) => Seq((Seq("+libext") ++ extensions).mkString("+"))
-        },
-
-        commonSettings.libraryPaths match {
-          case None => Seq()
-          case Some(paths) => paths.flatMap(Seq("-y", _))
-        },
-
-        commonSettings.defaultTimescale match {
-          case Some(Timescale.FromString(value)) => Seq("--timescale", value)
-          case None => Seq()
-        },
-
-        backendSpecificSettings.traceStyle match {
-          case Some(TraceStyle.Vcd(traceUnderscore)) => 
-            if (traceUnderscore) {
-              Seq("--trace", "--trace-underscore")
-            } else {
-              Seq("--trace")
-            }
-          case None => Seq()
-        },
-
-        Seq(
-          ("-Wno-fatal", backendSpecificSettings.disableFatalExitOnWarnings),
-          ("--assert", backendSpecificSettings.enableAllAssertions),
-        ).collect {
-          case (flag, true) => flag
-        },
-        
-        backendSpecificSettings.disabledWarnings.map("-Wno-" + _),
-
-        commonSettings.optimizationStyle match {
-          case OptimizationStyle.Default => Seq()
-          case OptimizationStyle.OptimizeForCompilationSpeed => Seq("-O1")
-        },
-
-        Seq[(String, Option[String])](
-          ("--output-split", backendSpecificSettings.outputSplit.map(_.toString())), // "Split .cpp files into pieces"
-          ("--output-split-cfuncs", backendSpecificSettings.outputSplitCFuncs.map(_.toString())), // "Split model functions"
-        ).collect {
-          /// Only include flags that have a value
-          case (flag, Some(value)) => Seq(flag, value)
-        }.flatten,
-
-        Seq(
-           ("-MAKEFLAGS", Seq(
-            commonSettings.availableParallelism match {
-              case AvailableParallelism.Default => Seq()
-              case AvailableParallelism.UpTo(value) => Seq("-j", value.toString())
-            },
-          ).flatten),
-          ("-CFLAGS", Seq(
-            commonSettings.optimizationStyle match {
-              case OptimizationStyle.Default => Seq()
-              case OptimizationStyle.OptimizeForCompilationSpeed => Seq("-O1")
-            },
-
-            Seq("-std=c++11"),
-              
-            additionalHeaderPaths.map { path => s"-I${path}" },
-            
-            Seq(
-              // Use verilator support
-              s"-D${svsim.Backend.enableVerilatorSupportFlag}",
-            ),
-
-            backendSpecificSettings.traceStyle match {
-              case Some(_) => Seq(s"-D${svsim.Backend.enableVerilatorTraceFlag}")
-              case None => Seq()
-            },
-          ).flatten)
-        ).collect {
-          /// Only include flags that have one or more values
-          case (flag, value) if !value.isEmpty => {
-            Seq(flag, value.mkString(" "))
-          }
-        }.flatten,
-
-        Seq(
-          commonSettings.verilogPreprocessorDefines,
-          backendSpecificSettings.traceStyle match {
+          commonSettings.libraryExtensions match {
             case None => Seq()
-            case Some(value) => Seq(
-              VerilogPreprocessorDefine(svsim.Backend.enableVcdTracingFlag)
-            )
+            case Some(extensions) => Seq((Seq("+libext") ++ extensions).mkString("+"))
           },
-        ).flatten.map(_.toCommandlineArgument),
-      ).flatten,
-      compilerEnvironment = Seq(),
-      simulationArguments = Seq(),
-      simulationEnvironment = Seq()
+
+          commonSettings.libraryPaths match {
+            case None => Seq()
+            case Some(paths) => paths.flatMap(Seq("-y", _))
+          },
+
+          commonSettings.defaultTimescale match {
+            case Some(Timescale.FromString(value)) => Seq("--timescale", value)
+            case None => Seq()
+          },
+
+          backendSpecificSettings.traceStyle match {
+            case Some(TraceStyle.Vcd(traceUnderscore)) => 
+              if (traceUnderscore) {
+                Seq("--trace", "--trace-underscore")
+              } else {
+                Seq("--trace")
+              }
+            case None => Seq()
+          },
+
+          Seq(
+            ("-Wno-fatal", backendSpecificSettings.disableFatalExitOnWarnings),
+            ("--assert", backendSpecificSettings.enableAllAssertions),
+          ).collect {
+            case (flag, true) => flag
+          },
+        
+          backendSpecificSettings.disabledWarnings.map("-Wno-" + _),
+
+          commonSettings.optimizationStyle match {
+            case OptimizationStyle.Default => Seq()
+            case OptimizationStyle.OptimizeForCompilationSpeed => Seq("-O1")
+          },
+
+          Seq[(String, Option[String])](
+            ("--output-split", backendSpecificSettings.outputSplit.map(_.toString())), // "Split .cpp files into pieces"
+            ("--output-split-cfuncs", backendSpecificSettings.outputSplitCFuncs.map(_.toString())), // "Split model functions"
+          ).collect {
+            /// Only include flags that have a value
+            case (flag, Some(value)) => Seq(flag, value)
+          }.flatten,
+
+          Seq(
+            ("-MAKEFLAGS", Seq(
+              commonSettings.availableParallelism match {
+                case AvailableParallelism.Default => Seq()
+                case AvailableParallelism.UpTo(value) => Seq("-j", value.toString())
+              },
+            ).flatten),
+            ("-CFLAGS", Seq(
+              commonSettings.optimizationStyle match {
+                case OptimizationStyle.Default => Seq()
+                case OptimizationStyle.OptimizeForCompilationSpeed => Seq("-O1")
+              },
+
+              Seq("-std=c++11"),
+                
+              additionalHeaderPaths.map { path => s"-I${path}" },
+              
+              Seq(
+                // Use verilator support
+                s"-D${svsim.Backend.HarnessCompilationFlags.enableVerilatorSupport}",
+              ),
+
+              backendSpecificSettings.traceStyle match {
+                case Some(_) => Seq(s"-D${svsim.Backend.HarnessCompilationFlags.enableVerilatorTrace}")
+                case None => Seq()
+              },
+            ).flatten)
+          ).collect {
+            /// Only include flags that have one or more values
+            case (flag, value) if !value.isEmpty => {
+              Seq(flag, value.mkString(" "))
+            }
+          }.flatten,
+
+          Seq(
+            commonSettings.verilogPreprocessorDefines,
+            backendSpecificSettings.traceStyle match {
+              case None => Seq()
+              case Some(value) => Seq(
+                VerilogPreprocessorDefine(svsim.Backend.HarnessCompilationFlags.enableVcdTracingSupport)
+              )
+            },
+          ).flatten.map(_.toCommandlineArgument),
+        ).flatten,
+        environment = Seq()
+      ),
+      simulationInvocation = svsim.Backend.Parameters.Invocation(Seq(), Seq())
     )
     //format: on
   }

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -23,9 +23,31 @@ class VCSSpec extends BackendSpec {
   }
 }
 
+/**
+  * A Backend trivially wrapping the Verilator backend to demonstrate custom out-of-package backends.
+  */
+case class CustomVerilatorBackend(actualBackend: verilator.Backend) extends Backend {
+  type CompilationSettings = verilator.Backend.CompilationSettings
+  def generateParameters(
+    outputBinaryName:        String,
+    topModuleName:           String,
+    additionalHeaderPaths:   Seq[String],
+    commonSettings:          CommonCompilationSettings,
+    backendSpecificSettings: CompilationSettings
+  ): Backend.Parameters = {
+    actualBackend.generateParameters(
+      outputBinaryName,
+      topModuleName,
+      additionalHeaderPaths,
+      commonSettings,
+      backendSpecificSettings
+    )
+  }
+}
+
 class VerilatorSpec extends BackendSpec {
   import verilator.Backend.CompilationSettings._
-  val backend = verilator.Backend.initializeFromProcessEnvironment()
+  val backend = CustomVerilatorBackend(verilator.Backend.initializeFromProcessEnvironment())
   val compilationSettings = verilator.Backend.CompilationSettings(
     traceStyle = Some(TraceStyle.Vcd(traceUnderscore = false))
   )


### PR DESCRIPTION
#### Type of Improvement

- Feature (or new API)

#### Release Notes

- Allow users of chisel to specify their own `svsim.Backend` implementations outside of Chisel. This is useful since in-tree backends may not support all versions of the specified backend (and we don't necessarily want them to). 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
