### PR TITLE
Don't emit implicit clock warnings for `SyncReadMem.readWrite` when explicit clocks are used

### DIFF
--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -484,7 +484,7 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
   )(
     implicit sourceInfo: SourceInfo
   ): T =
-    _readWrite_impl(idx, data, en, isWrite, clock, true)
+    _readWrite_impl(idx, data, en, isWrite, clock, false)
 
   /** @group SourceInfoTransformMacro */
   private def _readWrite_impl(
@@ -605,7 +605,7 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
   )(
     implicit evidence: T <:< Vec[_],
     sourceInfo:        SourceInfo
-  ) = masked_readWrite_impl(idx, writeData, mask, en, isWrite, clock, true)
+  ) = masked_readWrite_impl(idx, writeData, mask, en, isWrite, clock, false)
 
   private def masked_readWrite_impl(
     addr:    UInt,


### PR DESCRIPTION
Fixes a bug where calling `SyncReadMem.readWrite` with an explicit `Clock` that is different from the memory's clock raises an implicit clock warning anyways, when this shouldn't be the case.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
