### PR TITLE
Convert Vec dynamic index with a literal to static index

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -297,6 +297,12 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     requireIsHardware(this, "vec")
     requireIsHardware(p, "vec index")
 
+    // Don't bother with complex dynamic indexing logic when the index is a literal and therefore static
+    p.litOption match {
+      case Some(idx) if idx < length => return this.apply(idx.intValue)
+      case _                         => // Fall through to control flow below
+    }
+
     // Special handling for views
     if (isView(this)) {
       reifySingleData(this) match {

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -393,4 +393,24 @@ class VecSpec extends ChiselPropSpec with Utils {
       chirrtl should include("reg reg : { }[4]")
     }
   }
+
+  property("Vecs should emit static indices when indexing with a literal UInt") {
+    val chirrtl = emitCHIRRTL(new RawModule {
+      val vec = IO(Input(Vec(4, UInt(8.W))))
+      val out = IO(Output(UInt(8.W)))
+      out := vec(1.U)
+    })
+    chirrtl should include("out <= vec[1]")
+  }
+
+  // This is checking existing behavior, not because it's good but because we accidentally broke it.
+  // This behavior is slated to be deprecated and removed.
+  property("Vecs should support out-of-bounds dynamic indices") {
+    val chirrtl = emitCHIRRTL(new RawModule {
+      val vec = IO(Input(Vec(4, UInt(8.W))))
+      val out = IO(Output(UInt(8.W)))
+      out := vec(10.U)
+    })
+    chirrtl should include("""out <= vec[UInt<2>("h2")]""")
+  }
 }

--- a/src/test/scala/chiselTests/VecToTargetSpec.scala
+++ b/src/test/scala/chiselTests/VecToTargetSpec.scala
@@ -72,7 +72,7 @@ class VecToTargetSpec extends ChiselFunSpec with VecToTargetSpecUtils {
     }
 
     describe("with a Chisel literal") {
-      (it should behave).like(conversionFails(foo.vecSubaccessChiselLit))
+      (it should behave).like(conversionSucceeds(foo.vecSubaccessChiselLit))
     }
 
     describe("with a Node") {


### PR DESCRIPTION
This reduces the amount of work that both Chisel and firtool have to do.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Performance improvement



#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
