### PR TITLE
Warn on incorrect widths for Vec dynamic indexing

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -291,16 +291,29 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     */
   def :=(that: Vec[T])(implicit sourceInfo: SourceInfo): Unit = this.connect(that)
 
-  /** Creates a dynamically indexed read or write accessor into the array.
-    */
-  def apply(p: UInt): T = {
+  override def do_apply(p: UInt)(implicit sourceInfo: SourceInfo): T = {
     requireIsHardware(this, "vec")
     requireIsHardware(p, "vec index")
 
     // Don't bother with complex dynamic indexing logic when the index is a literal and therefore static
+    // We also don't want to warn on literals that are "too small"
     p.litOption match {
       case Some(idx) if idx < length => return this.apply(idx.intValue)
       case _                         => // Fall through to control flow below
+    }
+
+    if (length == 0) {
+      Builder.warning(s"Cannot extract from Vec of size 0.")
+    } else {
+      p.widthOption.foreach { pWidth =>
+        val correctWidth = BigInt(length - 1).bitLength
+        def warn(msg: String) =
+          Builder.warning(
+            s"Dynamic index with width $pWidth is too $msg for Vec of size $length (expected index width $correctWidth)."
+          )
+        if (pWidth > correctWidth) warn("wide")
+        else if (pWidth < correctWidth) warn("narrow")
+      }
     }
 
     // Special handling for views
@@ -837,7 +850,13 @@ object VecInit extends SourceInfoDoc {
   * operations.
   */
 trait VecLike[T <: Data] extends IndexedSeq[T] with HasId with SourceInfoDoc {
-  def apply(p: UInt): T
+
+  /** Creates a dynamically indexed read or write accessor into the array.
+    */
+  def apply(p: UInt): T = macro SourceInfoTransform.pArg
+
+  /** @group SourceInfoTransformMacro */
+  def do_apply(p: UInt)(implicit sourceInfo: SourceInfo): T
 
   // IndexedSeq has its own hashCode/equals that we must not use
   override def hashCode: Int = super[HasId].hashCode

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -30,7 +30,7 @@ Please note that these examples make use of [Chisel's scala-style printing](../e
 * [How do I create an optional I/O?](#how-do-i-create-an-optional-io)
 * [How do I create I/O without a prefix?](#how-do-i-create-io-without-a-prefix)
 * [How do I minimize the number of bits used in an output vector](#how-do-i-minimize-the-number-of-bits-used-in-an-output-vector)
-* [How do I resolve `Dynamic index ... is too wide/narrow for extractee ...`?](#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee-)
+* [How do I resolve "Dynamic index ... is too wide/narrow for extractee ..."?](#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee-)
 * Predictable Naming
   * [How do I get Chisel to name signals properly in blocks like when/withClockAndReset?](#how-do-i-get-chisel-to-name-signals-properly-in-blocks-like-whenwithclockandreset)
   * [How do I get Chisel to name the results of vector reads properly?](#how-do-i-get-chisel-to-name-the-results-of-vector-reads-properly)
@@ -778,35 +778,104 @@ circt.stage.ChiselStage.emitSystemVerilog(new CountBits(4))
   .head + ");\n"
 ```
 
-### How do I resolve `Dynamic index ... is too wide/narrow for extractee ...`?
+### How do I resolve "Dynamic index ... is too wide/narrow for extractee ..."?
 
-If the index is too narrow you can use `.pad` to increase the width.
-```scala mdoc:silent
-import chisel3.util.log2Up
+Chisel will warn if a dynamic index is not the correctly-sized width for indexing a Vec or UInt.
+"Correctly-sized" means that the width of the index should be the log2 of the size of the indexee.
+If the indexee is a non-power-of-2 size, use the ceiling of the log2 result.
 
-class TooNarrow(extracteeWidth: Int, indexWidth: Int) {
-  val extractee = Wire(UInt(extracteeWidth.W))
-  val index = Wire(UInt(indexWidth.W))
-  extractee(index.pad(log2Up(extracteeWidth)))
+```scala mdoc:invisible:reset
+import chisel3._
+// Some other test is clobbering the global Logger which breaks the warnings below
+// Setting the output stream to the Console fixes the issue
+logger.Logger.setConsole()
+// Helper to throw away return value so it doesn't show up in mdoc
+def compile(gen: => chisel3.RawModule): Unit = {
+  circt.stage.ChiselStage.emitCHIRRTL(gen)
 }
 ```
 
-If the index is too wide you can use a bit extract to select the correct bits.
-```scala mdoc:silent
-class TooWide(extracteeWidth: Int, indexWidth: Int) {
-  val extractee = Wire(UInt(extracteeWidth.W))
-  val index = Wire(UInt(indexWidth.W))
-  extractee(index(log2Up(extracteeWidth) - 1, 0))
+When the index does not have enough bits to address all entries or bits in the extractee, you can `.pad` the index to increase the width.
+
+```scala mdoc
+class TooNarrow extends RawModule {
+  val extractee = Wire(UInt(7.W))
+  val index = Wire(UInt(2.W))
+  extractee(index)
 }
+compile(new TooNarrow)
 ```
 
-Or use both if you are working on a generator where the widths may be too wide or too narrow under different circumstances.
-```scala mdoc:silent
-class TooWideOrNarrow(extracteeWidth: Int, indexWidth: Int) {
-  val extractee = Wire(UInt(extracteeWidth.W))
-  val index = Wire(UInt(indexWidth.W))
-  extractee(index.pad(log2Up(indexWidth))(log2Up(extracteeWidth) - 1, 0))
+This can be fixed with `pad`:
+
+```scala mdoc
+class TooNarrowFixed extends RawModule {
+  val extractee = Wire(UInt(7.W))
+  val index = Wire(UInt(2.W))
+  extractee(index.pad(3))
 }
+compile(new TooNarrowFixed)
+```
+
+#### Use bit extraction when the index is too wide
+
+```scala mdoc
+class TooWide extends RawModule {
+  val extractee = Wire(Vec(8, UInt(32.W)))
+  val index = Wire(UInt(4.W))
+  extractee(index)
+}
+compile(new TooWide)
+```
+
+This can be fixed with bit extraction:
+
+```scala mdoc
+class TooWideFixed extends RawModule {
+  val extractee = Wire(Vec(8, UInt(32.W)))
+  val index = Wire(UInt(4.W))
+  extractee(index(2, 0))
+}
+compile(new TooWideFixed)
+```
+
+Note that size 1 `Vecs` and `UInts` should be indexed by a zero-width `UInt`:
+
+```scala mdoc
+class SizeOneVec extends RawModule {
+  val extractee = Wire(Vec(1, UInt(32.W)))
+  val index = Wire(UInt(0.W))
+  extractee(index)
+}
+compile(new SizeOneVec)
+```
+
+Because `pad` only pads if the desired width is less than the current width of the argument,
+you can use `pad` in conjunction with bit extraction when the widths may be too wide or too
+narrow under different circumstances
+
+```scala mdoc
+import chisel3.util.log2Ceil
+class TooWideOrNarrow(extracteeSize: Int, indexWidth: Int) extends Module {
+  val extractee = Wire(Vec(extracteeSize, UInt(8.W)))
+  val index = Wire(UInt(indexWidth.W))
+  val correctWidth = log2Ceil(extracteeSize)
+  extractee(index.pad(correctWidth)(correctWidth - 1, 0))
+}
+compile(new TooWideOrNarrow(8, 2))
+compile(new TooWideOrNarrow(8, 4))
+```
+
+Another option for dynamic bit selection of `UInts` (but not `Vec` dynamic indexing) is to do a dynamic
+right shift of the extractee by the index and then just bit select a single bit:
+```scala mdoc
+class TooWideOrNarrowUInt(extracteeSize: Int, indexWidth: Int) extends Module {
+  val extractee = Wire(UInt(extracteeSize.W))
+  val index = Wire(UInt(indexWidth.W))
+  (extractee >> index)(0)
+}
+compile(new TooWideOrNarrowUInt(8, 2))
+compile(new TooWideOrNarrowUInt(8, 4))
 ```
 
 ## Predictable Naming


### PR DESCRIPTION
Follow on to https://github.com/chipsalliance/chisel/pull/3033, applying the same change to Vec dynamic indices (previously it was just dynamic bit selection for UInts).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
