### PR TITLE
Add Scala 2.13.11 and 2.12.18 to plugin cross versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -277,6 +277,7 @@ lazy val pluginScalaVersions = Seq(
   "2.12.15",
   "2.12.16",
   "2.12.17",
+  "2.12.18",
   "2.13.0",
   "2.13.1",
   "2.13.2",
@@ -287,7 +288,8 @@ lazy val pluginScalaVersions = Seq(
   "2.13.7",
   "2.13.8",
   "2.13.9",
-  "2.13.10"
+  "2.13.10",
+  "2.13.11"
 )
 
 lazy val plugin = (project in file("plugin"))


### PR DESCRIPTION
This enables Chisel users to use these newer Scala versions.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Dependency update



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
