### PR TITLE
Report Builder errors even when exception is thrown

### DIFF
--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -562,6 +562,20 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val version = chisel3.BuildInfo.firtoolVersion.getOrElse("<unknown>")
       e.getMessage should include(s"firtool version $version")
     }
+
+    it("should properly report Builder.errors even if there is a later Exception") {
+      val (log, _) = grabLog {
+        intercept[java.lang.Exception] {
+          import chisel3._
+          ChiselStage.emitCHIRRTL(new Module {
+            val in = IO(Input(UInt(8.W)))
+            val y = in >> -1
+            require(false) // This should not suppress reporting the negative shift
+          })
+        }
+      }
+      log should include("Negative shift amounts are illegal (got -1)")
+    }
   }
 
   describe("ChiselStage custom transform support") {


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/chisel/issues/1089

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
Chisel will to report multiple errors, but this can be cut short by any thrown Exception which would then take precedence over the previously encountered errors. Now Chisel will prioritize reporting errors even if an Exception is thrown.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
