### PR TITLE
Add support for zero-width bit extraction

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -185,25 +185,34 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
     *
     * @example
     * {{{
-    * myBits = 0x5 = 0b101
-    * myBits(1,0) => 0b01  // extracts the two least significant bits
+    *   val myBits = "0b101".U
+    *   myBits(1, 0) // "0b01".U  // extracts the two least significant bits
+    *
+    *   // Note that zero-width ranges are also legal
+    *   myBits(-1, 0) // 0.U(0.W) // zero-width UInt
     * }}}
     * @param x the high bit
     * @param y the low bit
-    * @return a hardware component contain the requested bits
+    * @return a hardware component containing the requested bits
     */
   final def apply(x: Int, y: Int): UInt = macro SourceInfoTransform.xyArg
 
   /** @group SourceInfoTransformMacro */
   final def do_apply(x: Int, y: Int)(implicit sourceInfo: SourceInfo): UInt = {
-    if (x < y || y < 0) {
-      Builder.error(s"Invalid bit range ($x,$y)")
+    if ((x < y && !(x == -1 && y == 0)) || y < 0) {
+      val zeroWidthSuggestion =
+        if (x == y - 1) {
+          s". If you are trying to extract zero-width range, right-shift by 'lo' before extracting."
+        } else {
+          ""
+        }
+      Builder.error(s"Invalid bit range [hi=$x, lo=$y]$zeroWidthSuggestion")
     }
-    val w = x - y + 1
+    val resultWidth = x - y + 1
     // This preserves old behavior while a more more consistent API is under debate
     // See https://github.com/freechipsproject/chisel3/issues/867
     litOption.map { value =>
-      ((value >> y) & ((BigInt(1) << w) - 1)).asUInt(w.W)
+      ((value >> y) & ((BigInt(1) << resultWidth) - 1)).asUInt(resultWidth.W)
     }.getOrElse {
       requireIsHardware(this, "bits to be sliced")
 
@@ -214,21 +223,28 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
         case _                 =>
       }
 
-      pushOp(DefPrim(sourceInfo, UInt(Width(w)), BitsExtractOp, this.ref, ILit(x), ILit(y)))
+      // FIRRTL does not yet support empty extraction so we must return the zero-width wire here:
+      if (resultWidth == 0) {
+        0.U(0.W)
+      } else {
+        pushOp(DefPrim(sourceInfo, UInt(Width(resultWidth)), BitsExtractOp, this.ref, ILit(x), ILit(y)))
+      }
     }
   }
 
-  // REVIEW TODO: again, is this necessary? Or just have this and use implicits?
   /** Returns a subset of bits on this $coll from `hi` to `lo` (inclusive), statically addressed.
     *
     * @example
     * {{{
-    * myBits = 0x5 = 0b101
-    * myBits(1,0) => 0b01  // extracts the two least significant bits
+    *   val myBits = "0b101".U
+    *   myBits(1, 0) // "0b01".U  // extracts the two least significant bits
+    *
+    *   // Note that zero-width ranges are also legal
+    *   myBits(-1, 0) // 0.U(0.W) // zero-width UInt
     * }}}
     * @param x the high bit
     * @param y the low bit
-    * @return a hardware component contain the requested bits
+    * @return a hardware component containing the requested bits
     */
   final def apply(x: BigInt, y: BigInt): UInt = macro SourceInfoTransform.xyArg
 

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -171,4 +171,31 @@ class SIntOpsSpec extends ChiselPropSpec with Utils {
       WireDefault(chiselTypeOf(op), op)
     }
   }
+
+  property("Zero-width bit extractions should be supported") {
+    assertKnownWidth(0) {
+      val x = WireDefault(SInt(8.W), DontCare)
+      val op = x(-1, 0)
+      WireDefault(chiselTypeOf(op), op)
+    }
+    assertKnownWidth(0) {
+      val x = WireDefault(SInt(8.W), DontCare)
+      val hi = 5
+      val lo = 6
+      val op = (x >> lo)(hi - lo, 0)
+      WireDefault(chiselTypeOf(op), op)
+    }
+  }
+
+  property("Zero-width bit extractions from the middle of an SInt should give an actionable error") {
+    val (log, x) = grabLog(intercept[Exception](ChiselStage.emitCHIRRTL(new RawModule {
+      val x = WireDefault(SInt(8.W), DontCare)
+      val op = x(5, 6)
+      WireDefault(chiselTypeOf(op), op)
+    })))
+    log should include(
+      "Invalid bit range [hi=5, lo=6]. If you are trying to extract zero-width range, right-shift by 'lo' before extracting."
+    )
+  }
+
 }


### PR DESCRIPTION
With https://github.com/chipsalliance/chisel/pull/3321, it becomes very important that users can extract zero bits. While the `(-1, 0)` looks a little funny, it is the correct API for parameterized code.

Motivating example:
```scala
import chisel3._
import chisel3.util.log2Ceil
import circt.stage.ChiselStage.emitCHIRRTL

class Example(size: Int) extends Module {
  val vec  = IO(Input(Vec(size, UInt(8.W))))
  // Say we have a value we will use as an index but its width is unrelated to the Vec
  val addr  = IO(Input(UInt(8.W)))
  val out   = IO(Output(UInt(8.W)))

  // Chisel warns on mismatched widths so we bit extract
  val safeIdx = addr(log2Ceil(size) - 1, 0)
  out := vec(safeIdx)
}

// Normal sizes work great!
emitCHIRRTL(new Example(8))

// What happens with the size of the Vec is 1?
emitCHIRRTL(new Example(1))
// [error] src/main/scala/main.scala:14:21: Invalid bit range (-1,0)
// [error]   val safeIdx = addr(log2Ceil(size) - 1, 0)
// [error]                     ^
// [error] There were 1 error(s) during hardware elaboration.
```
(Scastie link: https://scastie.scala-lang.org/d6prKTmSRgeo2wOJErImTQ)

This change makes the extraction from `(-1, 0)` legal. We could make the extraction for any `hi = lo - 1` legal, but I am concerned about users accidentally writing things like `myUInt(5, 6)` when they meant `myUInt(6, 5)`. So instead, Chisel will give a specific suggestion in that case:
```
[error] .../Main.scala:13:22: Invalid bit range [hi=5, lo=6]. If you are trying to extract zero-width range, right-shift by 'lo' before extracting.
[error]       val op = myUInt(x, y)
[error]                      ^
[error] There were 1 error(s) during hardware elaboration.
```
The user should instead write:
```scala
val op = (myUInt >> y)(x - y, 0)
```

We will soon also add `.take` which will make it possible to write `(myUInt >> y).take(x - y)`

Note all of this is static so there is no hardware overhead to the shift.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
