### PR TITLE
Fix empty aggregate width

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -82,7 +82,9 @@ sealed abstract class Aggregate extends Data {
   }
 
   override def do_asUInt(implicit sourceInfo: SourceInfo): UInt = {
-    SeqUtils.do_asUInt(flatten.map(_.asUInt))
+    val flattened = flatten.map(_.do_asUInt)
+    // Special-case empty because SeqUtils.do_asUInt returns 0.U (which is 0.U(0.W))
+    if (flattened.isEmpty) 0.U(0.W) else SeqUtils.do_asUInt(flattened)
   }
 
   private[chisel3] override def connectFromBits(

--- a/src/test/scala/chiselTests/WidthSpec.scala
+++ b/src/test/scala/chiselTests/WidthSpec.scala
@@ -55,16 +55,11 @@ class WidthSpec extends ChiselFlatSpec {
     assertKnownWidth(0) {
       Wire(new EmptyBundle)
     }
-  }
-
-  // This is a bug that has existed for basically forever
-  // This really should be assertKnownWidth(0)
-  they should "result in a 1-bit UInt when calling .asUInt" in {
-    assertInferredWidth(1) {
+    assertKnownWidth(0) {
       val x = Wire(Vec(0, UInt(8.W)))
       WireInit(x.asUInt)
     }
-    assertInferredWidth(1) {
+    assertKnownWidth(0) {
       val x = Wire(new EmptyBundle)
       WireInit(x.asUInt)
     }


### PR DESCRIPTION
Split out focused fix from https://github.com/chipsalliance/chisel/pull/3344#discussion_r1227398218

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, calling `.asUInt` on an empty Aggregate would return `0.U(1.W)`, now it returns `0.U(0.W)`. This can affect width propagation and inference.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
