### PR TITLE
SRAM API: Add a parameter to initialize the memory 

### DIFF
--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -111,6 +111,7 @@ class SRAMInterface[T <: Data](
   * See concrete subclasses [[BinaryMemoryFile]] and [[HexMemoryFile]]
   */
 sealed abstract class MemoryFile(private[chisel3] val fileType: MemoryLoadFileType) {
+
   /** The path to the memory contents file */
   val path: String
 }

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -162,7 +162,7 @@ object SRAM {
     * @param numReadPorts The number of desired read ports >= 0, and (numReadPorts + numReadwritePorts) > 0
     * @param numWritePorts The number of desired write ports >= 0, and (numWritePorts + numReadwritePorts) > 0
     * @param numReadwritePorts The number of desired read/write ports >= 0, and the above two conditions must hold
-    * @param contents A filesystem path to a binary file to preload this SRAM's contents with
+    * @param memoryFile A memory file whose path is emitted as Verilog directives to initialize the inner `SyncReadMem`
     *
     * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
     * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle
@@ -217,7 +217,7 @@ object SRAM {
     * @param numReadPorts The number of desired read ports >= 0, and (numReadPorts + numReadwritePorts) > 0
     * @param numWritePorts The number of desired write ports >= 0, and (numWritePorts + numReadwritePorts) > 0
     * @param numReadwritePorts The number of desired read/write ports >= 0, and the above two conditions must hold
-    * @param memoryFile A `MemoryFile` object, containing the filesystem path to the data to preload this SRAM with
+    * @param memoryFile A memory file whose path is emitted as Verilog directives to initialize the inner `SyncReadMem`
     *
     * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
     * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -136,6 +136,59 @@ object SRAM {
     memInterface_impl(size, tpe)(numReadPorts, numWritePorts, numReadwritePorts, Builder.forcedClock, contents)
 
   /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
+    * of read, write, and read/write ports. This SRAM abstraction has both read and write capabilities: that is,
+    * it contains at least one read accessor (a read-only or read-write port), and at least one write accessor
+    * (a write-only or read-write port).
+    *
+    * @param size The desired size of the inner `SyncReadMem`
+    * @tparam T The data type of the memory element
+    * @param numReadPorts The number of desired read ports >= 0, and (numReadPorts + numReadwritePorts) > 0
+    * @param numWritePorts The number of desired write ports >= 0, and (numWritePorts + numReadwritePorts) > 0
+    * @param numReadwritePorts The number of desired read/write ports >= 0, and the above two conditions must hold
+    *
+    * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
+    * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle
+    * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
+    */
+  def apply[T <: Data](
+    size:              BigInt,
+    tpe:               T,
+    numReadPorts:      Int,
+    numWritePorts:     Int,
+    numReadwritePorts: Int
+  )(
+    implicit sourceInfo: SourceInfo
+  ): SRAMInterface[T] =
+    memInterface_impl(size, tpe)(numReadPorts, numWritePorts, numReadwritePorts, Builder.forcedClock, None)
+
+  /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
+    * of read, write, and read/write ports, with masking capability on all write and read/write ports.
+    * This SRAM abstraction has both read and write capabilities: that is, it contains at least one read
+    * accessor (a read-only or read-write port), and at least one write accessor (a write-only or read-write port).
+    *
+    * @param size The desired size of the inner `SyncReadMem`
+    * @tparam T The data type of the memory element
+    * @param numReadPorts The number of desired read ports >= 0, and (numReadPorts + numReadwritePorts) > 0
+    * @param numWritePorts The number of desired write ports >= 0, and (numWritePorts + numReadwritePorts) > 0
+    * @param numReadwritePorts The number of desired read/write ports >= 0, and the above two conditions must hold
+    *
+    * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
+    * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle
+    * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
+    */
+  def masked[T <: Data](
+    size:              BigInt,
+    tpe:               T,
+    numReadPorts:      Int,
+    numWritePorts:     Int,
+    numReadwritePorts: Int
+  )(
+    implicit evidence: T <:< Vec[_],
+    sourceInfo:        SourceInfo
+  ): SRAMInterface[T] =
+    masked_memInterface_impl(size, tpe)(numReadPorts, numWritePorts, numReadwritePorts, Builder.forcedClock, None)
+
+  /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
     * of read, write, and read/write ports, with masking capability on all write and read/write ports.
     * This SRAM abstraction has both read and write capabilities: that is, it contains at least one read
     * accessor (a read-only or read-write port), and at least one write accessor (a write-only or read-write port).

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -234,7 +234,13 @@ object SRAM {
     implicit evidence: T <:< Vec[_],
     sourceInfo:        SourceInfo
   ): SRAMInterface[T] =
-    masked_memInterface_impl(size, tpe)(numReadPorts, numWritePorts, numReadwritePorts, Builder.forcedClock, Some(memoryFile))
+    masked_memInterface_impl(size, tpe)(
+      numReadPorts,
+      numWritePorts,
+      numReadwritePorts,
+      Builder.forcedClock,
+      Some(memoryFile)
+    )
 
   private def memInterface_impl[T <: Data](
     size:              BigInt,

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -106,7 +106,12 @@ class SRAMInterface[T <: Data](
     Vec(numReadwritePorts, new MemoryReadWritePort(tpe, addrWidth, masked))
 }
 
-private[chisel3] abstract class MemoryFile(private[chisel3] val fileType: MemoryLoadFileType) {
+/** A memory file with which to preload an [[SRAM]]
+  *
+  * See concrete subclasses [[BinaryMemoryFile]] and [[HexMemoryFile]]
+  */
+sealed abstract class MemoryFile(private[chisel3] val fileType: MemoryLoadFileType) {
+  /** The path to the memory contents file */
   val path: String
 }
 
@@ -290,7 +295,7 @@ object SRAM {
     }
 
     // Emit Verilog for preloading the memory from a file if requested
-    memoryFile.map { file: MemoryFile => loadMemoryFromFileInline(mem, file.path, file.fileType) }
+    memoryFile.foreach { file: MemoryFile => loadMemoryFromFileInline(mem, file.path, file.fileType) }
 
     _out
   }
@@ -350,7 +355,7 @@ object SRAM {
     }
 
     // Emit Verilog for preloading the memory from a file if requested
-    memoryFile.map { file: MemoryFile => loadMemoryFromFileInline(mem, file.path, file.fileType) }
+    memoryFile.foreach { file: MemoryFile => loadMemoryFromFileInline(mem, file.path, file.fileType) }
 
     _out
   }


### PR DESCRIPTION
This PR adds a new String parameter to `SRAM.apply` which loads the contents of a binary file from the filesystem into the memory (invokes `loadMemoryFromFileInline` on the inner `SyncReadMem`.)
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature

#### Desired Merge Strategy

- Squash and merge

#### Release Notes

`SRAM.apply` and `SRAM.masked` now take a `contents` parameter, by default a `None`, which is a string path to a binary file on the filesystem which the SRAM should be initialized with.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
