### PR TITLE
[codegen] Emit literal identifiers for numeric ids

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -312,7 +312,7 @@ object Serializer {
   }
 
   private def sStmtName(lbl: String)(implicit b: StringBuilder): Unit = {
-    if (lbl.nonEmpty) { b ++= s" : $lbl" }
+    if (lbl.nonEmpty) { b ++= s" : ${legalize(lbl)}" }
   }
 
   private def s(node: Width)(implicit b: StringBuilder, indent: Int): Unit = node match {

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -357,5 +357,31 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
         firrtl.MRead
       )
     ) should include("mport `42_memport` = `42_mem`[UInt<1>(0h0)], `42_clock`")
+
+    info("labeled statement okay!")
+    Serializer.serialize(
+      Stop(NoInfo, 1, Reference("42_clock"), Reference("42_enable"), "42_label")
+    ) should include("stop(`42_clock`, `42_enable`, 1) : `42_label`")
+    Serializer.serialize(
+      Print(
+        NoInfo,
+        StringLit("hello %x"),
+        Seq(Reference("42_arg")),
+        Reference("42_clock"),
+        Reference("42_enable"),
+        "42_label"
+      )
+    ) should include("""printf(`42_clock`, `42_enable`, "hello %x", `42_arg`) : `42_label`""")
+    Serializer.serialize(
+      Verification(
+        Formal.Assert,
+        NoInfo,
+        Reference("42_clock"),
+        Reference("42_predicate"),
+        Reference("42_enable"),
+        StringLit("message"),
+        "42_label"
+      )
+    ) should include("""assert(`42_clock`, `42_predicate`, `42_enable`, "message") : `42_label`""")
   }
 }

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -338,7 +338,7 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
         )
       )
       .split('\n')
-      .map(_.strip) should contain).allOf(
+      .map(_.dropWhile(_ == ' ')) should contain).allOf(
       "mem `42_mem` :",
       "reader => `42_r`",
       "writer => `42_w`",

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -282,4 +282,80 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
       "Once we traverse the serializer, everything should execute"
     )
   }
+
+  it should "add backticks to names which begin with a numeric character" in {
+    info("circuit okay!")
+    Serializer.serialize(Circuit(NoInfo, Seq.empty[DefModule], "42_Circuit")) should include("circuit `42_Circuit`")
+
+    info("modules okay!")
+    Serializer.serialize(Module(NoInfo, "42_module", Seq.empty, Block(Seq.empty))) should include("module `42_module`")
+    // TODO: an external module with a numeric defname should probably be rejected
+    Serializer.serialize(ExtModule(NoInfo, "42_extmodule", Seq.empty, "<TODO>", Seq.empty)) should include(
+      "extmodule `42_extmodule`"
+    )
+    Serializer.serialize(IntModule(NoInfo, "42_intmodule", Seq.empty, "foo", Seq.empty)) should include(
+      "intmodule `42_intmodule`"
+    )
+
+    info("ports okay!")
+    Serializer.serialize(Port(NoInfo, "42_port", Input, UIntType(IntWidth(1)))) should include("input `42_port`")
+
+    info("types okay!")
+    Serializer.serialize(BundleType(Seq(Field("42_field", Default, UIntType(IntWidth(1)))))) should include(
+      "{ `42_field` : UInt<1>}"
+    )
+
+    info("declarations okay!")
+    Serializer.serialize(DefNode(NoInfo, "42_dest", Reference("42_src"))) should include("node `42_dest` = `42_src`")
+    Serializer.serialize(DefWire(NoInfo, "42_wire", UIntType(IntWidth(1)))) should include("wire `42_wire`")
+    Serializer.serialize(DefRegister(NoInfo, "42_reg", UIntType(IntWidth(1)), Reference("42_clock"))) should include(
+      "reg `42_reg` : UInt<1>, `42_clock`"
+    )
+    Serializer.serialize(
+      DefRegisterWithReset(
+        NoInfo,
+        "42_regreset",
+        UIntType(IntWidth(1)),
+        Reference("42_clock"),
+        Reference("42_reset"),
+        Reference("42_init")
+      )
+    ) should include("regreset `42_regreset` : UInt<1>, `42_clock`, `42_reset`, `42_init`")
+    Serializer.serialize(DefInstance(NoInfo, "42_inst", "42_module")) should include("inst `42_inst` of `42_module`")
+    (Serializer
+      .serialize(
+        DefMemory(
+          NoInfo,
+          "42_mem",
+          UIntType(IntWidth(1)),
+          8,
+          1,
+          1,
+          Seq("42_r"),
+          Seq("42_w"),
+          Seq("42_rw"),
+          ReadUnderWrite.Undefined
+        )
+      )
+      .split('\n')
+      .map(_.strip) should contain).allOf(
+      "mem `42_mem` :",
+      "reader => `42_r`",
+      "writer => `42_w`",
+      "readwriter => `42_rw`"
+    )
+    Serializer.serialize(
+      CDefMemory(NoInfo, "42_cmem", UIntType(IntWidth(1)), 8, true, ReadUnderWrite.Undefined)
+    ) should include("smem `42_cmem`")
+    Serializer.serialize(
+      firrtl.CDefMPort(
+        NoInfo,
+        "42_memport",
+        UIntType(IntWidth(1)),
+        "42_mem",
+        Seq(UIntLiteral(0, IntWidth(1)), Reference("42_clock")),
+        firrtl.MRead
+      )
+    ) should include("mport `42_memport` = `42_mem`[UInt<1>(0h0)], `42_clock`")
+  }
 }


### PR DESCRIPTION
Change the FIRRTL serializer to use literal identifiers if any identifiers begin with a leading digit.  This is a FIRRTL 3.0.0 feature that simplifies parsing.

This enables literal identifier emission anywhere.  However, this code path is only reachable via MixedVec due to mangling of numeric names to add a leading underscore in all other circumstances.  In the future, this commit will enable removing this restriction and switching to literal identifiers when this happens.

No changes are made to annotation targets.  E.g., the literal identifier, "wire `42`" in circuit "Foo" and module "Bar" is still referred to by a local target "~Foo|Bar>42".  This is intentional (for now).  Targets don't have parsing ambiguity like FIRRTL text and the name of this wire is still "42" not "`42`".  It follows that the storage of this name in FIRRTL IR is not changed.  This is the same way that this is handled in CIRCT.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Use FIRRTL 3.0.0 emission of literal identifiers when a Chisel name begins with a digit.

#### Notes

This PR is stacked on #3188 (and should be merged after it).

#### Example

```scala
import chisel3._
import chisel3.util.MixedVec
import circt.stage.ChiselStage

class `9000` extends RawModule {
  val `0` = IO(Input(MixedVec(Bool())))
  val `1` = IO(Output(MixedVec(Bool())))

  val `2` = Wire(MixedVec(Bool()))
  dontTouch(`2`(0))
  `2`(0) := `0`(0)

  `1` := `2`
}

println(ChiselStage.emitCHIRRTL(new `9000`))
println(ChiselStage.emitSystemVerilog(new `9000`))
```

With this commit, this will produce the following FIRRTL and Verilog:

```
FIRRTL version 3.0.0
circuit iw :%[[
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~iw|iw>_2"
  }
]]
  module iw :
    input _0 : { `0` : UInt<1>}
    output _1 : { `0` : UInt<1>}

    wire _2 : { `0` : UInt<1>}
    connect _2.`0`, _0.`0`
    connect _1, _2
```

```verilog
module iw(
  input  _0_0,
  output _1_0
);

  wire _2_0 = _0_0;
  assign _1_0 = _2_0;
endmodule
```

With further changes that go beyond this PR< this should emit as:

```
FIRRTL version 3.0.0
circuit iw :%[[
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~iw|iw>2"
  }
]]
  module iw :
    input `0` : { `0` : UInt<1>}
    output `1` : { `0` : UInt<1>}

    wire `2` : { `0` : UInt<1>}
    connect `2`.`0`, `0`.`0`
    connect `1`,`2`
```