### PR TITLE
[api-modification] Remove deprecated stuff

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1288,16 +1288,6 @@ package experimental {
   class BundleLiteralException(message: String) extends chisel3.ChiselException(message)
   class VecLiteralException(message: String) extends chisel3.ChiselException(message)
 
-  /** Indicates that the compiler plugin should generate [[cloneType]] for this type
-    *
-    * All user-defined [[Record]]s should mix this trait in as it will be required for upgrading to Chisel 3.6.
-    */
-  @deprecated("AutoCloneType is now always enabled, no need to mix it in", "Chisel 3.6")
-  trait AutoCloneType { self: Record =>
-
-    override def cloneType: this.type = _cloneTypeImpl.asInstanceOf[this.type]
-
-  }
 }
 
 /** Base class for data types defined as a bundle of other data types.

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -168,18 +168,6 @@ abstract class Module extends RawModule {
   //   Chisel.QueueCompatibility which extends chisel3.Queue which extends chisel3.Module
   private var _override_clock: Option[Clock] = None
   private var _override_reset: Option[Bool] = None
-  @deprecated("Use withClock at Module instantiation", "Chisel 3.5")
-  protected def override_clock: Option[Clock] = _override_clock
-  @deprecated("Use withClock at Module instantiation", "Chisel 3.5")
-  protected def override_reset: Option[Bool] = _override_reset
-  @deprecated("Use withClock at Module instantiation", "Chisel 3.5")
-  protected def override_clock_=(rhs: Option[Clock]): Unit = {
-    _override_clock = rhs
-  }
-  @deprecated("Use withClock at Module instantiation", "Chisel 3.5")
-  protected def override_reset_=(rhs: Option[Bool]): Unit = {
-    _override_reset = rhs
-  }
 
   private[chisel3] def mkReset: Reset = {
     // Top module and compatibility mode use Bool for reset

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -21,13 +21,6 @@ package object experimental {
   implicit def fromDoubleToDoubleParam(x: Double): DoubleParam = DoubleParam(x)
   implicit def fromStringToStringParam(x: String): StringParam = StringParam(x)
 
-  @deprecated("This type has moved to chisel3", "Chisel 3.5")
-  type ChiselEnum = chisel3.ChiselEnum
-  @deprecated("This type has moved to chisel3", "Chisel 3.5")
-  type EnumType = chisel3.EnumType
-  @deprecated("This type has moved to chisel3", "Chisel 3.5")
-  val suppressEnumCastWarning = chisel3.suppressEnumCastWarning
-
   // Rocket Chip-style clonemodule
 
   /** A record containing the results of CloneModuleAsRecord
@@ -514,6 +507,4 @@ package object experimental {
     )
   }
 
-  @deprecated("This value has moved to chisel3.reflect", "Chisel 3.6")
-  val DataMirror = chisel3.reflect.DataMirror
 }

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -8,13 +8,11 @@ import chisel3.internal.firrtl.LitArg
 
 import scala.collection.immutable.VectorMap
 
-@deprecated(deprecatedPublicAPIMsg + ". Use chisel3.experimental.requireIsHardware instead", "Chisel 3.6")
-object requireIsHardware {
+private[chisel3] object requireIsHardware {
   def apply(node: Data, msg: String = ""): Unit = chisel3.experimental.requireIsHardware.apply(node, msg)
 }
 
-@deprecated(deprecatedPublicAPIMsg + ". Use chisel3.experimental.requireIsChiselType instead", "Chisel 3.6")
-object requireIsChiselType {
+private[chisel3] object requireIsChiselType {
   def apply(node: Data, msg: String = ""): Unit = chisel3.experimental.requireIsChiselType.apply(node, msg)
 }
 
@@ -86,50 +84,41 @@ sealed trait ConditionalDeclarable extends TopBinding {
 
 // TODO(twigg): Ops between unenclosed nodes can also be unenclosed
 // However, Chisel currently binds all op results to a module
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class PortBinding(enclosure: BaseModule) extends ConstrainedBinding
+private[chisel3] case class PortBinding(enclosure: BaseModule) extends ConstrainedBinding
 
 // Added to handle BoringUtils in Chisel
 private[chisel3] case class SecretPortBinding(enclosure: BaseModule) extends ConstrainedBinding
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class OpBinding(enclosure: RawModule, visibility: Option[WhenContext])
+private[chisel3] case class OpBinding(enclosure: RawModule, visibility: Option[WhenContext])
     extends ConstrainedBinding
     with ReadOnlyBinding
     with ConditionalDeclarable
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class MemoryPortBinding(enclosure: RawModule, visibility: Option[WhenContext])
+private[chisel3] case class MemoryPortBinding(enclosure: RawModule, visibility: Option[WhenContext])
     extends ConstrainedBinding
     with ConditionalDeclarable
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class RegBinding(enclosure: RawModule, visibility: Option[WhenContext])
+private[chisel3] case class RegBinding(enclosure: RawModule, visibility: Option[WhenContext])
     extends ConstrainedBinding
     with ConditionalDeclarable
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class WireBinding(enclosure: RawModule, visibility: Option[WhenContext])
+private[chisel3] case class WireBinding(enclosure: RawModule, visibility: Option[WhenContext])
     extends ConstrainedBinding
     with ConditionalDeclarable
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class ChildBinding(parent: Data) extends Binding {
+private[chisel3] case class ChildBinding(parent: Data) extends Binding {
   def location: Option[BaseModule] = parent.topBinding.location
 }
 
 /** Special binding for Vec.sample_element */
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class SampleElementBinding[T <: Data](parent: Vec[T]) extends Binding {
+private[chisel3] case class SampleElementBinding[T <: Data](parent: Vec[T]) extends Binding {
   def location = parent.topBinding.location
 }
 
 /** Special binding for Mem types */
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class MemTypeBinding[T <: Data](parent: MemBase[T]) extends Binding {
+private[chisel3] case class MemTypeBinding[T <: Data](parent: MemBase[T]) extends Binding {
   def location: Option[BaseModule] = parent._parent
 }
 // A DontCare element has a specific Binding, somewhat like a literal.
 // It is a source (RHS). It may only be connected/applied to sinks.
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DontCareBinding() extends UnconstrainedBinding
+private[chisel3] case class DontCareBinding() extends UnconstrainedBinding
 
 // Views currently only support 1:1 Element-level mappings
 private[chisel3] case class ViewBinding(target: Element) extends UnconstrainedBinding
@@ -147,18 +136,14 @@ private[chisel3] case class AggregateViewBinding(childMap: Map[Data, Data]) exte
 }
 
 /** Binding for Data's returned from accessing an Instance/Definition members, if not readable/writable port */
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 private[chisel3] case object CrossModuleBinding extends TopBinding {
   def location = None
 }
 
 sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
 // Literal binding attached to a element that is not part of a Bundle.
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class ElementLitBinding(litArg: LitArg) extends LitBinding
+private[chisel3] case class ElementLitBinding(litArg: LitArg) extends LitBinding
 // Literal binding attached to the root of a Bundle, containing literal values of its children.
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
+private[chisel3] case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
 // Literal binding attached to the root of a Vec, containing literal values of its children.
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class VecLitBinding(litMap: VectorMap[Data, LitArg]) extends LitBinding
+private[chisel3] case class VecLitBinding(litMap: VectorMap[Data, LitArg]) extends LitBinding

--- a/core/src/main/scala/chisel3/internal/SourceInfo.scala
+++ b/core/src/main/scala/chisel3/internal/SourceInfo.scala
@@ -12,47 +12,4 @@
 
 package chisel3.internal
 
-package object sourceinfo {
-  import chisel3.experimental._
-  import scala.language.experimental.macros
-  import scala.reflect.macros.blackbox.Context
-
-  @deprecated(
-    "APIs in chisel3.internal are not intended to be public. Use chisel3.experimental.SourceInfo",
-    "Chisel 3.6"
-  )
-  type SourceInfo = chisel3.experimental.SourceInfo
-
-  @deprecated(
-    "APIs in chisel3.internal are not intended to be public. Use chisel3.experimental.NoSourceInfo",
-    "Chisel 3.6"
-  )
-  type NoSourceInfo = chisel3.experimental.NoSourceInfo
-
-  @deprecated(
-    "APIs in chisel3.internal are not intended to be public. Use chisel3.experimental.UnlocatableSourceInfo",
-    "Chisel 3.6"
-  )
-  val UnlocatableSourceInfo = chisel3.experimental.UnlocatableSourceInfo
-
-  @deprecated(
-    "APIs in chisel3.internal are not intended to be public. Use chisel3.experimental.DeprecatedSourceInfo",
-    "Chisel 3.6"
-  )
-  val DeprecatedSourceInfo = chisel3.experimental.DeprecatedSourceInfo
-
-  @deprecated(
-    "APIs in chisel3.internal are not intended to be public. Use chisel3.experimental.SourceLine",
-    "Chisel 3.6"
-  )
-  type SourceLine = chisel3.experimental.SourceLine
-
-  @deprecated(
-    "APIs in chisel3.internal are not intended to be public. Use chisel3.experimental.SourceInfo",
-    "Chisel 3.6"
-  )
-  object SourceInfo {
-    implicit def materialize: SourceInfo = macro SourceInfoMacro.generate_source_info
-  }
-
-}
+package object sourceinfo

--- a/core/src/main/scala/chisel3/internal/SourceInfoMacro.scala
+++ b/core/src/main/scala/chisel3/internal/SourceInfoMacro.scala
@@ -7,8 +7,7 @@ import scala.reflect.macros.blackbox.Context
 
 /** Provides a macro that returns the source information at the invocation point.
   */
-@deprecated("Public APIs in chisel3.internal are deprecated", "Chisel 3.6")
-object SourceInfoMacro {
+private[chisel3] object SourceInfoMacro {
   def generate_source_info(c: Context): c.Tree = {
     import c.universe._
     val p = c.enclosingPosition

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -15,13 +15,11 @@ import scala.math.BigDecimal.RoundingMode
 import scala.annotation.nowarn
 import scala.collection.mutable
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class PrimOp(name: String) {
+private[chisel3] case class PrimOp(name: String) {
   override def toString: String = name
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-object PrimOp {
+private[chisel3] object PrimOp {
   val AddOp = PrimOp("add")
   val SubOp = PrimOp("sub")
   val TailOp = PrimOp("tail")
@@ -73,8 +71,7 @@ sealed abstract class Arg {
   def name: String
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Node(id: HasId) extends Arg {
+private[chisel3] case class Node(id: HasId) extends Arg {
   override def contextualName(ctx: Component): String = id.getOptionRef match {
     case Some(arg) => arg.contextualName(ctx)
     case None      => id.instanceName
@@ -89,8 +86,7 @@ case class Node(id: HasId) extends Arg {
   }
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-object Arg {
+private[chisel3] object Arg {
   def earlyLocalName(id: HasId): String = earlyLocalName(id, true)
 
   def earlyLocalName(id: HasId, includeRoot: Boolean): String = id.getOptionRef match {
@@ -109,8 +105,7 @@ object Arg {
   }
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-abstract class LitArg(val num: BigInt, widthArg: Width) extends Arg {
+private[chisel3] abstract class LitArg(val num: BigInt, widthArg: Width) extends Arg {
   private[chisel3] def forcedWidth = widthArg.known
   private[chisel3] def width: Width = if (forcedWidth) widthArg else Width(minWidth)
   override def contextualName(ctx: Component): String = name
@@ -138,12 +133,10 @@ abstract class LitArg(val num: BigInt, widthArg: Width) extends Arg {
   }
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class ILit(n: BigInt) extends Arg {
+private[chisel3] case class ILit(n: BigInt) extends Arg {
   def name: String = n.toString
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 case class ULit(n: BigInt, w: Width) extends LitArg(n, w) {
   def name:     String = "UInt" + width + "(\"h0" + num.toString(16) + "\")"
   def minWidth: Int = (if (w.known) 0 else 1).max(n.bitLength)
@@ -155,8 +148,7 @@ case class ULit(n: BigInt, w: Width) extends LitArg(n, w) {
   require(n >= 0, s"UInt literal ${n} is negative")
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class SLit(n: BigInt, w: Width) extends LitArg(n, w) {
+private[chisel3] case class SLit(n: BigInt, w: Width) extends LitArg(n, w) {
   def name: String = {
     val unsigned = if (n < 0) (BigInt(1) << width.get) + n else n
     s"asSInt(${ULit(unsigned, width).name})"
@@ -168,15 +160,13 @@ case class SLit(n: BigInt, w: Width) extends LitArg(n, w) {
   }
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Ref(name: String) extends Arg
+private[chisel3] case class Ref(name: String) extends Arg
 
 /** Arg for ports of Modules
   * @param mod the module this port belongs to
   * @param name the name of the port
   */
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class ModuleIO(mod: BaseModule, name: String) extends Arg {
+private[chisel3] case class ModuleIO(mod: BaseModule, name: String) extends Arg {
   override def contextualName(ctx: Component): String =
     if (mod eq ctx.id) name else s"${mod.getRef.name}.$name"
 }
@@ -185,15 +175,13 @@ case class ModuleIO(mod: BaseModule, name: String) extends Arg {
   * @param mod The original module for which these ports are a clone
   * @param name the name of the module instance
   */
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class ModuleCloneIO(mod: BaseModule, name: String) extends Arg {
+private[chisel3] case class ModuleCloneIO(mod: BaseModule, name: String) extends Arg {
   override def localName = ""
   override def contextualName(ctx: Component): String =
     // NOTE: mod eq ctx.id only occurs in Target and Named-related APIs
     if (mod eq ctx.id) localName else name
 }
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Slot(imm: Node, name: String) extends Arg {
+private[chisel3] case class Slot(imm: Node, name: String) extends Arg {
   override def contextualName(ctx: Component): String = {
     val immName = imm.contextualName(ctx)
     if (immName.isEmpty) name else s"$immName.$name"
@@ -204,14 +192,12 @@ case class Slot(imm: Node, name: String) extends Arg {
   }
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class OpaqueSlot(imm: Node) extends Arg {
+private[chisel3] case class OpaqueSlot(imm: Node) extends Arg {
   override def contextualName(ctx: Component): String = imm.contextualName(ctx)
   override def name: String = imm.name
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Index(imm: Arg, value: Arg) extends Arg {
+private[chisel3] case class Index(imm: Arg, value: Arg) extends Arg {
   def name: String = s"[$value]"
   override def contextualName(ctx: Component): String = s"${imm.contextualName(ctx)}[${value.contextualName(ctx)}]"
   override def localName: String = s"${imm.localName}[${value.localName}]"
@@ -225,8 +211,7 @@ private[chisel3] case class ProbeExpr(probe: Arg) extends Arg with ProbeDetails
 private[chisel3] case class RWProbeExpr(probe: Arg) extends Arg with ProbeDetails
 private[chisel3] case class ProbeRead(probe: Arg) extends Arg with ProbeDetails
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-object Width {
+private[chisel3] object Width {
   def apply(x: Int): Width = KnownWidth(x)
   def apply(): Width = UnknownWidth()
 }
@@ -274,37 +259,29 @@ object MemPortDirection {
   object INFER extends MemPortDirection("infer")
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-abstract class Command {
+private[chisel3] abstract class Command {
   def sourceInfo: SourceInfo
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-abstract class Definition extends Command {
+private[chisel3] abstract class Definition extends Command {
   def id: HasId
   def name: String = id.getRef.name
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefPrim[T <: Data](sourceInfo: SourceInfo, id: T, op: PrimOp, args: Arg*) extends Definition
+private[chisel3] case class DefPrim[T <: Data](sourceInfo: SourceInfo, id: T, op: PrimOp, args: Arg*) extends Definition
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefInvalid(sourceInfo: SourceInfo, arg: Arg) extends Command
+private[chisel3] case class DefInvalid(sourceInfo: SourceInfo, arg: Arg) extends Command
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefWire(sourceInfo: SourceInfo, id: Data) extends Definition
+private[chisel3] case class DefWire(sourceInfo: SourceInfo, id: Data) extends Definition
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefReg(sourceInfo: SourceInfo, id: Data, clock: Arg) extends Definition
+private[chisel3] case class DefReg(sourceInfo: SourceInfo, id: Data, clock: Arg) extends Definition
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefRegInit(sourceInfo: SourceInfo, id: Data, clock: Arg, reset: Arg, init: Arg) extends Definition
+private[chisel3] case class DefRegInit(sourceInfo: SourceInfo, id: Data, clock: Arg, reset: Arg, init: Arg)
+    extends Definition
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefMemory(sourceInfo: SourceInfo, id: HasId, t: Data, size: BigInt) extends Definition
+private[chisel3] case class DefMemory(sourceInfo: SourceInfo, id: HasId, t: Data, size: BigInt) extends Definition
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefSeqMemory(
+private[chisel3] case class DefSeqMemory(
   sourceInfo:     SourceInfo,
   id:             HasId,
   t:              Data,
@@ -312,8 +289,7 @@ case class DefSeqMemory(
   readUnderWrite: fir.ReadUnderWrite.Value)
     extends Definition
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefMemPort[T <: Data](
+private[chisel3] case class DefMemPort[T <: Data](
   sourceInfo: SourceInfo,
   id:         T,
   source:     Node,
@@ -322,34 +298,20 @@ case class DefMemPort[T <: Data](
   clock:      Arg)
     extends Definition
 
-@nowarn("msg=class Port") // delete when Port becomes private
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefInstance(sourceInfo: SourceInfo, id: BaseModule, ports: Seq[Port]) extends Definition
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class WhenBegin(sourceInfo: SourceInfo, pred: Arg) extends Command
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class WhenEnd(sourceInfo: SourceInfo, firrtlDepth: Int, hasAlt: Boolean = false) extends Command
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class AltBegin(sourceInfo: SourceInfo) extends Command
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class OtherwiseEnd(sourceInfo: SourceInfo, firrtlDepth: Int) extends Command
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Connect(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Attach(sourceInfo: SourceInfo, locs: Seq[Node]) extends Command
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Definition
+private[chisel3] case class DefInstance(sourceInfo: SourceInfo, id: BaseModule, ports: Seq[Port]) extends Definition
+private[chisel3] case class WhenBegin(sourceInfo: SourceInfo, pred: Arg) extends Command
+private[chisel3] case class WhenEnd(sourceInfo: SourceInfo, firrtlDepth: Int, hasAlt: Boolean = false) extends Command
+private[chisel3] case class AltBegin(sourceInfo: SourceInfo) extends Command
+private[chisel3] case class OtherwiseEnd(sourceInfo: SourceInfo, firrtlDepth: Int) extends Command
+private[chisel3] case class Connect(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
+private[chisel3] case class Attach(sourceInfo: SourceInfo, locs: Seq[Node]) extends Command
+private[chisel3] case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
+private[chisel3] case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Definition
 // Note this is just deprecated which will cause deprecation warnings, use @nowarn
-@deprecated(
-  "This API should never have been public, for Module port reflection, use DataMirror.modulePorts",
-  "Chisel 3.5"
-)
-case class Port(id: Data, dir: SpecifiedDirection, sourceInfo: SourceInfo)
+private[chisel3] case class Port(id: Data, dir: SpecifiedDirection, sourceInfo: SourceInfo)
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Printf(id: printf.Printf, sourceInfo: SourceInfo, clock: Arg, pable: Printable) extends Definition
+private[chisel3] case class Printf(id: printf.Printf, sourceInfo: SourceInfo, clock: Arg, pable: Printable)
+    extends Definition
 
 private[chisel3] case class ProbeDefine(sourceInfo: SourceInfo, sink: Arg, probe: Arg) extends Command
 private[chisel3] case class ProbeForceInitial(sourceInfo: SourceInfo, probe: Arg, value: Arg) extends Command
@@ -358,15 +320,13 @@ private[chisel3] case class ProbeForce(sourceInfo: SourceInfo, clock: Arg, cond:
     extends Command
 private[chisel3] case class ProbeRelease(sourceInfo: SourceInfo, clock: Arg, cond: Arg, probe: Arg) extends Command
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-object Formal extends Enumeration {
+private[chisel3] object Formal extends Enumeration {
   val Assert = Value("assert")
   val Assume = Value("assume")
   val Cover = Value("cover")
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Verification[T <: VerificationStatement](
+private[chisel3] case class Verification[T <: VerificationStatement](
   id:         T,
   op:         Formal.Value,
   sourceInfo: SourceInfo,
@@ -375,7 +335,6 @@ case class Verification[T <: VerificationStatement](
   message:    String)
     extends Definition
 
-@nowarn("msg=class Port") // delete when Port becomes private
 abstract class Component extends Arg {
   def id:    BaseModule
   def name:  String
@@ -383,15 +342,12 @@ abstract class Component extends Arg {
   val secretPorts: mutable.ArrayBuffer[Port] = id.secretPorts
 }
 
-@nowarn("msg=class Port") // delete when Port becomes private
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefModule(id: RawModule, name: String, ports: Seq[Port], commands: Seq[Command]) extends Component {
+private[chisel3] case class DefModule(id: RawModule, name: String, ports: Seq[Port], commands: Seq[Command])
+    extends Component {
   val secretCommands: mutable.ArrayBuffer[Command] = mutable.ArrayBuffer[Command]()
 }
 
-@nowarn("msg=class Port") // delete when Port becomes private
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class DefBlackBox(
+private[chisel3] case class DefBlackBox(
   id:     BaseBlackBox,
   name:   String,
   ports:  Seq[Port],
@@ -399,7 +355,6 @@ case class DefBlackBox(
   params: Map[String, Param])
     extends Component
 
-@nowarn("msg=class Port") // delete when Port becomes private
 private[chisel3] case class DefIntrinsicModule(
   id:     BaseIntrinsicModule,
   name:   String,
@@ -408,17 +363,12 @@ private[chisel3] case class DefIntrinsicModule(
   params: Map[String, Param])
     extends Component
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-case class Circuit(
-  name:       String,
-  components: Seq[Component],
-  @deprecated("Do not use annotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
-    "Chisel 3.5")
-  annotations: Seq[ChiselAnnotation],
-  renames:     RenameMap,
-  @deprecated("Do not use newAnnotations val of Circuit directly - use firrtlAnnotations instead. Will be removed in a future release",
-    "Chisel 3.5")
-
+private[chisel3] case class Circuit(
+  name:                         String,
+  components:                   Seq[Component],
+  private[chisel3] annotations: Seq[ChiselAnnotation],
+  renames:                      RenameMap,
+  private[chisel3]
   newAnnotations: Seq[ChiselMultiAnnotation]) {
 
   def this(name: String, components: Seq[Component], annotations: Seq[ChiselAnnotation], renames: RenameMap) =
@@ -438,8 +388,7 @@ case class Circuit(
 
 }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
-object Circuit
+private[chisel3] object Circuit
     extends scala.runtime.AbstractFunction4[String, Seq[Component], Seq[ChiselAnnotation], RenameMap, Circuit] {
   def unapply(c: Circuit): Option[(String, Seq[Component], Seq[ChiselAnnotation], RenameMap)] = {
     Some((c.name, c.components, c.annotations, c.renames))

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -13,17 +13,6 @@ import scala.annotation.{implicitNotFound, nowarn}
 
 package object internal {
 
-  @deprecated("This function has moved to chisel3.experimental", "Chisel 3.6")
-  val prefix = chisel3.experimental.prefix
-  @deprecated("This function has moved to chisel3.experimental", "Chisel 3.6")
-  val noPrefix = chisel3.experimental.noPrefix
-
-  @deprecated("This type has moved to chisel3", "Chisel 3.6")
-  type ChiselException = chisel3.ChiselException
-
-  @deprecated("This type has moved to chisel3", "Chisel 3.6")
-  type InstanceId = chisel3.InstanceId
-
   @implicitNotFound("You are trying to access a macro-only API. Please use the @public annotation instead.")
   trait MacroGenerated
 

--- a/src/main/scala/chisel3/Driver.scala
+++ b/src/main/scala/chisel3/Driver.scala
@@ -8,8 +8,7 @@ import firrtl.util.{BackendCompilationUtilities => FirrtlBackendCompilationUtili
 import java.io._
 import _root_.logger.LazyLogging
 
-@deprecated("Use object firrtl.util.BackendCompilationUtilities instead", "Chisel 3.5")
-trait BackendCompilationUtilities extends LazyLogging {
+private[chisel3] trait BackendCompilationUtilities extends LazyLogging {
 
   import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
 

--- a/src/main/scala/chisel3/util/Mux.scala
+++ b/src/main/scala/chisel3/util/Mux.scala
@@ -61,21 +61,6 @@ object PriorityMux {
   */
 object MuxLookup extends SourceInfoDoc {
 
-  /** Creates a cascade of n Muxs to search for a key value.
-    *
-    * @example {{{
-    * MuxLookup(idx, default, Seq(0.U -> a, 1.U -> b))
-    * }}}
-    *
-    * @param key a key to search for
-    * @param default a default value if nothing is found
-    * @param mapping a sequence to search of keys and values
-    * @return the value found or the default if not
-    */
-  @deprecated("Use MuxLookup(key, default)(mapping) instead", "Chisel 3.6")
-  def apply[S <: UInt, T <: Data](key: S, default: T, mapping: Seq[(S, T)]): T =
-    do_apply(key, default, mapping)
-
   /** @param key a key to search for
     * @param default a default value if nothing is found
     * @param mapping a sequence to search of keys and values

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -221,31 +221,6 @@ object ChiselStage {
       Seq(ChiselGeneratorAnnotation(() => gen)) ++ firtoolOpts.map(FirtoolOption(_))
     )
 
-  /** Return a Chisel circuit for a Chisel module
-    *
-    * @param gen a call-by-name Chisel module
-    */
-  @deprecated(
-    "this exposes the internal Chisel circuit which was not supposed to be public---use either ChiselStage.convert or ChiselStage.emitCHIRRTL instead",
-    "Chisel 5.0"
-  )
-  def elaborate(
-    gen:  => RawModule,
-    args: Array[String] = Array.empty
-  ): chisel3.internal.firrtl.Circuit = {
-    val annos = Seq(
-      ChiselGeneratorAnnotation(() => gen),
-      CIRCTTargetAnnotation(CIRCTTarget.CHIRRTL)
-    ) ++ (new BareShell("circt") with CLI).parse(args)
-
-    phase
-      .transform(annos)
-      .collectFirst {
-        case ChiselCircuitAnnotation(a) => a
-      }
-      .get
-  }
-
 }
 
 /** Command line entry point to [[ChiselStage]] */

--- a/src/test/scala/chisel3/stage/ChiselOptionsViewSpec.scala
+++ b/src/test/scala/chisel3/stage/ChiselOptionsViewSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.stage
+package chisel3.stage
 
 import firrtl.options.Viewer.view
 import firrtl.RenameMap


### PR DESCRIPTION
Remove all methods that were deprecated in Chisel 3.5 or Chisel 3.6.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Remove all things deprecated since Chisel 3.5 or 3.6.