### PR TITLE
SRAM API: Add multiple-clocked port API

### DIFF
--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -201,7 +201,7 @@ object SRAM {
       None,
       sourceInfo
     )
-  
+
   /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
     * of read, write, and read/write ports. This SRAM abstraction has both read and write capabilities: that is,
     * it contains at least one read accessor (a read-only or read-write port), and at least one write accessor
@@ -218,8 +218,8 @@ object SRAM {
     * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
     */
   def apply[T <: Data](
-    size:              BigInt,
-    tpe:               T,
+    size:                BigInt,
+    tpe:                 T,
     readPortClocks:      Seq[Clock],
     writePortClocks:     Seq[Clock],
     readwritePortClocks: Seq[Clock]
@@ -312,7 +312,7 @@ object SRAM {
       Some(evidence),
       sourceInfo
     )
-  
+
   /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
     * of read, write, and read/write ports, with masking capability on all write and read/write ports.
     * This SRAM abstraction has both read and write capabilities: that is, it contains at least one read
@@ -412,8 +412,8 @@ object SRAM {
     readwritePortClocks: Seq[Clock],
     memoryFile:          MemoryFile
   )(
-    implicit evidence:   T <:< Vec[_],
-    sourceInfo:          SourceInfo
+    implicit evidence: T <:< Vec[_],
+    sourceInfo:        SourceInfo
   ): SRAMInterface[T] =
     memInterface_impl(
       size,
@@ -428,15 +428,13 @@ object SRAM {
       sourceInfo
     )
 
-  private def memInterface_impl[T <: Data]
-  (
-    size:                 BigInt,
-    tpe:                  T
-  )(
-    readPortClocks:       Seq[Clock],
-    writePortClocks:      Seq[Clock],
-    readwritePortClocks:  Seq[Clock],
-    memoryFile:           Option[MemoryFile]
+  private def memInterface_impl[T <: Data](
+    size:                BigInt,
+    tpe:                 T
+  )(readPortClocks:      Seq[Clock],
+    writePortClocks:     Seq[Clock],
+    readwritePortClocks: Seq[Clock],
+    memoryFile:          Option[MemoryFile]
   )(
     implicit evidenceOpt: Option[T <:< Vec[_]],
     sourceInfo:           SourceInfo

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -148,11 +148,11 @@ object SRAM {
     * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
     */
   def apply[T <: Data](
-    size:              BigInt,
-    tpe:               T,
-    numReadPorts:      Int,
-    numWritePorts:     Int,
-    numReadwritePorts: Int
+    size:                BigInt,
+    tpe:                 T,
+    numReadPorts:        Int,
+    numWritePorts:       Int,
+    numReadwritePorts:   Int
   )(
     implicit sourceInfo: SourceInfo
   ): SRAMInterface[T] =
@@ -183,12 +183,12 @@ object SRAM {
     * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
     */
   def apply[T <: Data](
-    size:              BigInt,
-    tpe:               T,
-    numReadPorts:      Int,
-    numWritePorts:     Int,
-    numReadwritePorts: Int,
-    memoryFile:        MemoryFile
+    size:                BigInt,
+    tpe:                 T,
+    numReadPorts:        Int,
+    numWritePorts:       Int,
+    numReadwritePorts:   Int,
+    memoryFile:          MemoryFile
   )(
     implicit sourceInfo: SourceInfo
   ): SRAMInterface[T] =
@@ -372,8 +372,8 @@ object SRAM {
     writePortClocks:     Seq[Clock],
     readwritePortClocks: Seq[Clock]
   )(
-    implicit evidence: T <:< Vec[_],
-    sourceInfo:        SourceInfo
+    implicit evidence:   T <:< Vec[_],
+    sourceInfo:          SourceInfo
   ): SRAMInterface[T] =
     memInterface_impl(
       size,
@@ -412,8 +412,8 @@ object SRAM {
     readwritePortClocks: Seq[Clock],
     memoryFile:          MemoryFile
   )(
-    implicit evidence: T <:< Vec[_],
-    sourceInfo:        SourceInfo
+    implicit evidence:   T <:< Vec[_],
+    sourceInfo:          SourceInfo
   ): SRAMInterface[T] =
     memInterface_impl(
       size,
@@ -436,8 +436,8 @@ object SRAM {
     readwritePortClocks: Seq[Clock],
     memoryFile:          Option[MemoryFile]
   )(
-    implicit evidenceOpt: Option[T <:< Vec[_]],
-    sourceInfo:           SourceInfo
+    evidenceOpt:         Option[T <:< Vec[_]],
+    sourceInfo:          SourceInfo
   ): SRAMInterface[T] = {
     val numReadPorts = readPortClocks.size
     val numWritePorts = writePortClocks.size

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -148,11 +148,11 @@ object SRAM {
     * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
     */
   def apply[T <: Data](
-    size:                BigInt,
-    tpe:                 T,
-    numReadPorts:        Int,
-    numWritePorts:       Int,
-    numReadwritePorts:   Int
+    size:              BigInt,
+    tpe:               T,
+    numReadPorts:      Int,
+    numWritePorts:     Int,
+    numReadwritePorts: Int
   )(
     implicit sourceInfo: SourceInfo
   ): SRAMInterface[T] =
@@ -183,12 +183,12 @@ object SRAM {
     * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
     */
   def apply[T <: Data](
-    size:                BigInt,
-    tpe:                 T,
-    numReadPorts:        Int,
-    numWritePorts:       Int,
-    numReadwritePorts:   Int,
-    memoryFile:          MemoryFile
+    size:              BigInt,
+    tpe:               T,
+    numReadPorts:      Int,
+    numWritePorts:     Int,
+    numReadwritePorts: Int,
+    memoryFile:        MemoryFile
   )(
     implicit sourceInfo: SourceInfo
   ): SRAMInterface[T] =
@@ -372,8 +372,8 @@ object SRAM {
     writePortClocks:     Seq[Clock],
     readwritePortClocks: Seq[Clock]
   )(
-    implicit evidence:   T <:< Vec[_],
-    sourceInfo:          SourceInfo
+    implicit evidence: T <:< Vec[_],
+    sourceInfo:        SourceInfo
   ): SRAMInterface[T] =
     memInterface_impl(
       size,
@@ -412,8 +412,8 @@ object SRAM {
     readwritePortClocks: Seq[Clock],
     memoryFile:          MemoryFile
   )(
-    implicit evidence:   T <:< Vec[_],
-    sourceInfo:          SourceInfo
+    implicit evidence: T <:< Vec[_],
+    sourceInfo:        SourceInfo
   ): SRAMInterface[T] =
     memInterface_impl(
       size,
@@ -435,8 +435,7 @@ object SRAM {
     writePortClocks:     Seq[Clock],
     readwritePortClocks: Seq[Clock],
     memoryFile:          Option[MemoryFile]
-  )(
-    evidenceOpt:         Option[T <:< Vec[_]],
+  )(evidenceOpt:         Option[T <:< Vec[_]],
     sourceInfo:          SourceInfo
   ): SRAMInterface[T] = {
     val numReadPorts = readPortClocks.size

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -201,6 +201,82 @@ object SRAM {
       None,
       sourceInfo
     )
+  
+  /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
+    * of read, write, and read/write ports. This SRAM abstraction has both read and write capabilities: that is,
+    * it contains at least one read accessor (a read-only or read-write port), and at least one write accessor
+    * (a write-only or read-write port).
+    *
+    * @param size The desired size of the inner `SyncReadMem`
+    * @tparam T The data type of the memory element
+    * @param numReadPorts The number of desired read ports >= 0, and (numReadPorts + numReadwritePorts) > 0
+    * @param numWritePorts The number of desired write ports >= 0, and (numWritePorts + numReadwritePorts) > 0
+    * @param numReadwritePorts The number of desired read/write ports >= 0, and the above two conditions must hold
+    *
+    * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
+    * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle
+    * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
+    */
+  def apply[T <: Data](
+    size:              BigInt,
+    tpe:               T,
+    readPortClocks:      Seq[Clock],
+    writePortClocks:     Seq[Clock],
+    readwritePortClocks: Seq[Clock]
+  )(
+    implicit sourceInfo: SourceInfo
+  ): SRAMInterface[T] =
+    memInterface_impl(
+      size,
+      tpe
+    )(
+      readPortClocks,
+      writePortClocks,
+      readwritePortClocks,
+      None
+    )(
+      None,
+      sourceInfo
+    )
+
+  /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
+    * of read, write, and read/write ports. This SRAM abstraction has both read and write capabilities: that is,
+    * it contains at least one read accessor (a read-only or read-write port), and at least one write accessor
+    * (a write-only or read-write port).
+    *
+    * @param size The desired size of the inner `SyncReadMem`
+    * @tparam T The data type of the memory element
+    * @param numReadPorts The number of desired read ports >= 0, and (numReadPorts + numReadwritePorts) > 0
+    * @param numWritePorts The number of desired write ports >= 0, and (numWritePorts + numReadwritePorts) > 0
+    * @param numReadwritePorts The number of desired read/write ports >= 0, and the above two conditions must hold
+    * @param memoryFile A memory file whose path is emitted as Verilog directives to initialize the inner `SyncReadMem`
+    *
+    * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
+    * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle
+    * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
+    */
+  def apply[T <: Data](
+    size:                BigInt,
+    tpe:                 T,
+    readPortClocks:      Seq[Clock],
+    writePortClocks:     Seq[Clock],
+    readwritePortClocks: Seq[Clock],
+    memoryFile:          MemoryFile
+  )(
+    implicit sourceInfo: SourceInfo
+  ): SRAMInterface[T] =
+    memInterface_impl(
+      size,
+      tpe
+    )(
+      readPortClocks,
+      writePortClocks,
+      readwritePortClocks,
+      Some(memoryFile)
+    )(
+      None,
+      sourceInfo
+    )
 
   /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
     * of read, write, and read/write ports, with masking capability on all write and read/write ports.
@@ -236,7 +312,7 @@ object SRAM {
       Some(evidence),
       sourceInfo
     )
-
+  
   /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
     * of read, write, and read/write ports, with masking capability on all write and read/write ports.
     * This SRAM abstraction has both read and write capabilities: that is, it contains at least one read
@@ -274,7 +350,86 @@ object SRAM {
       sourceInfo
     )
 
-  private def memInterface_impl[T <: Data](
+  /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
+    * of read, write, and read/write ports, with masking capability on all write and read/write ports.
+    * Each port is clocked with its own explicit `Clock`, rather than being given the implicit clock.
+    *
+    * @param size The desired size of the inner `SyncReadMem`
+    * @tparam T The data type of the memory element
+    * @param readPortClocks A sequence of clocks for each read port; and (numReadPorts + numReadwritePorts) > 0
+    * @param writePortClocks A sequence of clocks for each write port; and (numWritePorts + numReadwritePorts) > 0
+    * @param readwritePortClocks A sequence of clocks for each read-write port; and the above two conditions must hold
+    *
+    * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
+    * @note The size of each `Clock` sequence determines the corresponding number of read, write, and read-write ports
+    * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle
+    * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
+    */
+  def masked[T <: Data](
+    size:                BigInt,
+    tpe:                 T,
+    readPortClocks:      Seq[Clock],
+    writePortClocks:     Seq[Clock],
+    readwritePortClocks: Seq[Clock]
+  )(
+    implicit evidence: T <:< Vec[_],
+    sourceInfo:        SourceInfo
+  ): SRAMInterface[T] =
+    memInterface_impl(
+      size,
+      tpe
+    )(
+      readPortClocks,
+      writePortClocks,
+      readwritePortClocks,
+      None
+    )(
+      Some(evidence),
+      sourceInfo
+    )
+
+  /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
+    * of read, write, and read/write ports, with masking capability on all write and read/write ports.
+    * Each port is clocked with its own explicit `Clock`, rather than being given the implicit clock.
+    *
+    * @param size The desired size of the inner `SyncReadMem`
+    * @tparam T The data type of the memory element
+    * @param readPortClocks A sequence of clocks for each read port; and (numReadPorts + numReadwritePorts) > 0
+    * @param writePortClocks A sequence of clocks for each write port; and (numWritePorts + numReadwritePorts) > 0
+    * @param readwritePortClocks A sequence of clocks for each read-write port; and the above two conditions must hold
+    * @param memoryFile A memory file whose path is emitted as Verilog directives to initialize the inner `SyncReadMem`
+    *
+    * @return A new `SRAMInterface` wire containing the control signals for each instantiated port
+    * @note The size of each `Clock` sequence determines the corresponding number of read, write, and read-write ports
+    * @note This does *not* return the `SyncReadMem` itself, you must interact with it using the returned bundle
+    * @note Read-only memories (R >= 1, W === 0, RW === 0) and write-only memories (R === 0, W >= 1, RW === 0) are not supported by this API, and will result in an error if declared.
+    */
+  def masked[T <: Data](
+    size:                BigInt,
+    tpe:                 T,
+    readPortClocks:      Seq[Clock],
+    writePortClocks:     Seq[Clock],
+    readwritePortClocks: Seq[Clock],
+    memoryFile:          MemoryFile
+  )(
+    implicit evidence:   T <:< Vec[_],
+    sourceInfo:          SourceInfo
+  ): SRAMInterface[T] =
+    memInterface_impl(
+      size,
+      tpe
+    )(
+      readPortClocks,
+      writePortClocks,
+      readwritePortClocks,
+      Some(memoryFile)
+    )(
+      Some(evidence),
+      sourceInfo
+    )
+
+  private def memInterface_impl[T <: Data]
+  (
     size:                 BigInt,
     tpe:                  T
   )(

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -304,17 +304,19 @@ object SRAM {
   )(
     implicit evidence: T <:< Vec[_],
     sourceInfo:        SourceInfo
-  ): SRAMInterface[T] =
+  ): SRAMInterface[T] = {
+    val clock = Builder.forcedClock
     memInterface_impl(
       size,
       tpe,
-      Seq.fill(numReadPorts)(Builder.forcedClock),
-      Seq.fill(numWritePorts)(Builder.forcedClock),
-      Seq.fill(numReadwritePorts)(Builder.forcedClock),
+      Seq.fill(numReadPorts)(clock),
+      Seq.fill(numWritePorts)(clock),
+      Seq.fill(numReadwritePorts)(clock),
       None,
       Some(evidence),
       sourceInfo
     )
+  }
 
   /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
     * of read, write, and read/write ports, with masking capability on all write and read/write ports.
@@ -342,17 +344,19 @@ object SRAM {
   )(
     implicit evidence: T <:< Vec[_],
     sourceInfo:        SourceInfo
-  ): SRAMInterface[T] =
+  ): SRAMInterface[T] = {
+    val clock = Builder.forcedClock
     memInterface_impl(
       size,
       tpe,
-      Seq.fill(numReadPorts)(Builder.forcedClock),
-      Seq.fill(numWritePorts)(Builder.forcedClock),
-      Seq.fill(numReadwritePorts)(Builder.forcedClock),
+      Seq.fill(numReadPorts)(clock),
+      Seq.fill(numWritePorts)(clock),
+      Seq.fill(numReadwritePorts)(clock),
       Some(memoryFile),
       Some(evidence),
       sourceInfo
     )
+  }
 
   /** Generates a [[SyncReadMem]] within the current module, connected to an explicit number
     * of read, write, and read/write ports, with masking capability on all write and read/write ports.

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -537,10 +537,10 @@ class SRAMSpec extends ChiselFunSpec {
 
       for (i <- 0 until 3) {
         chirrtl should include(s"when mem.writePorts[0].mask[$i]")
-        chirrtl should include(s"mem_MPORT[$i] <= mem.writePorts[0].data[$i]")
+        chirrtl should include(s"connect mem_MPORT[$i], mem.writePorts[0].data[$i]")
 
         chirrtl should include(s"when mem.readwritePorts[0].mask[$i]")
-        chirrtl should include(s"mem_out_readwritePorts_0_readData_MPORT[$i] <= mem.readwritePorts[0].writeData[$i]")
+        chirrtl should include(s"connect mem_out_readwritePorts_0_readData_MPORT[$i], mem.readwritePorts[0].writeData[$i]")
       }
     }
 

--- a/src/test/scala/chiselTests/Mem.scala
+++ b/src/test/scala/chiselTests/Mem.scala
@@ -540,7 +540,9 @@ class SRAMSpec extends ChiselFunSpec {
         chirrtl should include(s"connect mem_MPORT[$i], mem.writePorts[0].data[$i]")
 
         chirrtl should include(s"when mem.readwritePorts[0].mask[$i]")
-        chirrtl should include(s"connect mem_out_readwritePorts_0_readData_MPORT[$i], mem.readwritePorts[0].writeData[$i]")
+        chirrtl should include(
+          s"connect mem_out_readwritePorts_0_readData_MPORT[$i], mem.readwritePorts[0].writeData[$i]"
+        )
       }
     }
 


### PR DESCRIPTION
It is sometimes desirable to instantiate a memory with ports clocked with different clocks (e.g. clock domain crossing). This PR adds additional APIs to `SRAM` which allow users to drive ports using a sequence of clocks:

```
// Create a multi-clocked 3R, 2W SRAM
val mem = SRAM(
  1024, 
  UInt(8.W), 
  Seq(clock1, clock2, clock3), // Memory read port clocks
  Seq(clock4, clock5),         // Memory write port clocks
  Seq.empty                    // Memory read-write port clocks
)
```

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
Squash

#### Release Notes
Add new `SRAM` APIs that take three `Clock` sequences as parameters instead of the number of read/write/read-write ports. This will sequentially instantiate a memory port for each clock in the `Clock` sequence and drive them accordingly.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
