### PR TITLE
Support bulk connection for const types

### DIFF
--- a/firrtl/src/main/scala/firrtl/passes/CheckTypes.scala
+++ b/firrtl/src/main/scala/firrtl/passes/CheckTypes.scala
@@ -42,6 +42,10 @@ object CheckTypes {
                 case Flip => compare(f2.tpe, f1.tpe)
               })
           }
+      // Const connection validity is checked later on in the Firrtl compiler.
+      case (sink: ConstType, source: ConstType) => compare(sink.underlying, source.underlying)
+      case (sink, source: ConstType) => compare(sink, source.underlying)
+      case (sink: ConstType, source) => compare(sink.underlying, source)
       case _ => false
     }
 

--- a/src/test/scala/chiselTests/ConstSpec.scala
+++ b/src/test/scala/chiselTests/ConstSpec.scala
@@ -108,4 +108,37 @@ class ConstSpec extends ChiselFlatSpec with Utils {
     chirrtl should include("connect out, in")
   }
 
+  class BidirectionalBundle extends Bundle {
+    val a = UInt(4.W)
+    val b = Flipped(Bool())
+  }
+
+  "Const to const bidirection connections using ':<>='" should "emit a direct passthrough connection" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val in = IO(Const(Flipped(new BidirectionalBundle)))
+      val out = IO(Const(new BidirectionalBundle))
+      out :<>= in
+    })
+    chirrtl should include("connect out, in")
+  }
+
+  "Const to const bidirection connections using '<>'" should "emit a direct passthrough connection" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val in = IO(Const(Flipped(new BidirectionalBundle)))
+      val out = IO(Const(new BidirectionalBundle))
+      out <> in
+    })
+    chirrtl should include("connect out, in")
+  }
+
+  "Const to const coercing mono connections using ':#='" should "emit elementwise connections" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val in = IO(Const(Flipped(new BidirectionalBundle)))
+      val out = IO(Output(Const(new BidirectionalBundle)))
+      out :#= in
+    })
+    chirrtl should include("connect out.b, in.b")
+    chirrtl should include("connect out.a, in.a")
+  }
+
 }

--- a/src/test/scala/chiselTests/ConstSpec.scala
+++ b/src/test/scala/chiselTests/ConstSpec.scala
@@ -72,4 +72,40 @@ class ConstSpec extends ChiselFlatSpec with Utils {
     exc.getMessage should be("Cannot create Const of a Probe.")
   }
 
+  class FooBundle extends Bundle {
+    val a = UInt(4.W)
+    val b = Bool()
+  }
+
+  "Const to const connections" should "emit a direct passthrough connection" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val in = IO(Input(Const(new FooBundle)))
+      val out = IO(Output(Const(new FooBundle)))
+      out := in
+    })
+    chirrtl should include("connect out, in")
+  }
+
+  "Const to non-const connections" should "emit a direct passthrough connection" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val in = IO(Input(Const(new FooBundle)))
+      val out = IO(Output(new FooBundle))
+      out := in
+    })
+    chirrtl should include("connect out, in")
+  }
+
+  "Const to nested const connections" should "emit a direct passthrough connection" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val in = IO(Input(Const(new Bundle {
+        val foo = new FooBundle
+      })))
+      val out = IO(Output(Const(new Bundle {
+        val foo = Const(new FooBundle)
+      })))
+      out := in
+    })
+    chirrtl should include("connect out, in")
+  }
+
 }


### PR DESCRIPTION
This currently just ignores constness when determining if a bulk connect is valid, leaving const-checking to the firrtl compiler. I can add that checking here too, but I wasn't sure what our policy is on redundant checks between the two stages.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Backend code generation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
