### PR TITLE
Support literals and DontCare in DataView targets

### DIFF
--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -101,7 +101,7 @@ package object dataview {
 
       // The elements may themselves be views, look through the potential chain of views for the Elements
       // that are actually members of the target or view
-      val tex = unfoldView(te).find(targetContains).getOrElse(err("Target", te))
+      val tex = unfoldView(te).find(x => targetContains(x) || x.isLit).getOrElse(err("Target", te))
       val vex = unfoldView(ve).find(viewFieldLookup.contains).getOrElse(err("View", ve))
 
       (tex, vex) match {

--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -101,33 +101,36 @@ package object dataview {
 
       // The elements may themselves be views, look through the potential chain of views for the Elements
       // that are actually members of the target or view
-      val tex = unfoldView(te).find(x => targetContains(x) || x.isLit).getOrElse(err("Target", te))
+      val tex = unfoldView(te).find(x => targetContains(x) || x.isLit || x == DontCare).getOrElse(err("Target", te))
       val vex = unfoldView(ve).find(viewFieldLookup.contains).getOrElse(err("View", ve))
 
       (tex, vex) match {
         /* Allow views where the types are equal. */
         case (a, b) if a.getClass == b.getClass =>
+          // View width must be unknown or match target width
+          if (vex.widthKnown && vex.width != tex.width) {
+            def widthAsString(x: Element) = x.widthOption.map("<" + _ + ">").getOrElse("<unknown>")
+            val fieldName = viewFieldName(vex)
+            val vwidth = widthAsString(vex)
+            val twidth = widthAsString(tex)
+            throw InvalidViewException(
+              s"View field $fieldName has width ${vwidth} that is incompatible with target value $tex's width ${twidth}"
+            )
+          }
         /* allow bool <=> reset views. */
         case (a: Bool, _: Reset) =>
         case (_: Reset, a: Bool) =>
         /* Allow AsyncReset <=> Reset views. */
         case (a: AsyncReset, _: Reset) =>
         case (_: Reset, a: AsyncReset) =>
+        /* Allow DontCare in the target only */
+        case (DontCare, _) =>
         /* All other views produce a runtime error. */
         case _ =>
           val fieldName = viewFieldName(vex)
           throw InvalidViewException(s"Field $fieldName specified as view of non-type-equivalent value $tex")
       }
-      // View width must be unknown or match target width
-      if (vex.widthKnown && vex.width != tex.width) {
-        def widthAsString(x: Element) = x.widthOption.map("<" + _ + ">").getOrElse("<unknown>")
-        val fieldName = viewFieldName(vex)
-        val vwidth = widthAsString(vex)
-        val twidth = widthAsString(tex)
-        throw InvalidViewException(
-          s"View field $fieldName has width ${vwidth} that is incompatible with target value $tex's width ${twidth}"
-        )
-      }
+
       elementBindings(vex) += tex
     }
 


### PR DESCRIPTION
The best example of why this is useful is the test showing some possible uses with `Valid`:
```scala
object ValidExtensions {
  implicit def view[T <: Data] = DataView[T, Valid[T]](
    x => Valid(x.cloneType), // Valid will strip direction with `Output(...)` anyway
    _ -> _.bits,
    (_, v) => true.B -> v.valid
  )
}
```
This enables you to box any `T` as a `Valid[T]` where the `valid` bit is the literal true:
```scala
import ValidExtensions._
class MyModule extends Module {
  val in = IO(Input(UInt(8.W)))
  val out= IO(Output(Valid(UInt(8.W))))
  out := in.viewAs[Valid[UInt]]
}
```

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash


#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
