### PR TITLE
Avoid emitting 'const const' for const vecs of const elements

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -341,7 +341,14 @@ object Serializer {
     // Types
     case ProbeType(underlying: Type) => b ++= "Probe<"; s(underlying); b += '>'
     case RWProbeType(underlying: Type) => b ++= "RWProbe<"; s(underlying); b += '>'
-    case ConstType(underlying: Type) => b ++= "const "; s(underlying)
+    case ConstType(underlying: Type) => {
+      // Avoid emitting 'const const' for const vectors of const elements
+      underlying match {
+        case VectorType(ConstType(_), _) =>
+        case _                           => b ++= "const "
+      }
+      s(underlying)
+    }
     case UIntType(width: Width) => b ++= "UInt"; s(width)
     case SIntType(width: Width) => b ++= "SInt"; s(width)
     case BundleType(fields)    => b ++= "{ "; sField(fields, ", "); b += '}'

--- a/src/test/scala/chiselTests/ConstSpec.scala
+++ b/src/test/scala/chiselTests/ConstSpec.scala
@@ -48,6 +48,15 @@ class ConstSpec extends ChiselFlatSpec with Utils {
     chirrtl should include("output io : const { flip in : const AsyncReset[5], out : const UInt<1>}")
   }
 
+  "Const modifier on vectors of const elements" should "emit a single FIRRTL const descriptor" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val foo = Wire(Const(Vec(3, Const(UInt(8.W)))))
+      val bar = Wire(Const(Vec(3, Const(Vec(2, Const(UInt(8.W)))))))
+    })
+    chirrtl should include("wire foo : const UInt<8>[3]")
+    chirrtl should include("wire bar : const UInt<8>[2][3]")
+  }
+
   "Memories of Const type" should "fail" in {
     val exc = intercept[chisel3.ChiselException] {
       ChiselStage.emitCHIRRTL(

--- a/src/test/scala/chiselTests/ConstSpec.scala
+++ b/src/test/scala/chiselTests/ConstSpec.scala
@@ -52,9 +52,11 @@ class ConstSpec extends ChiselFlatSpec with Utils {
     val chirrtl = ChiselStage.emitCHIRRTL(new Module {
       val foo = Wire(Const(Vec(3, Const(UInt(8.W)))))
       val bar = Wire(Const(Vec(3, Const(Vec(2, Const(UInt(8.W)))))))
+      val baz = Wire(Const(Vec(3, Vec(2, Const(UInt(8.W))))))
     })
     chirrtl should include("wire foo : const UInt<8>[3]")
     chirrtl should include("wire bar : const UInt<8>[2][3]")
+    chirrtl should include("wire baz : const UInt<8>[2][3]")
   }
 
   "Memories of Const type" should "fail" in {


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Multiple consecutive 'const' modifiers are no longer emitted when emitting a const vector of const elements.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you do one of the following when ready to merge:
  - [x] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
