### PR TITLE
Deprecate calling .viewAs on non-hardware

### DIFF
--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -103,6 +103,9 @@ package object dataview {
       // that are actually members of the target or view
       val tex = unfoldView(te).find(x => targetContains(x) || x.isLit || x == DontCare).getOrElse(err("Target", te))
       val vex = unfoldView(ve).find(viewFieldLookup.contains).getOrElse(err("View", ve))
+      if (!tex.isSynthesizable) {
+        Builder.deprecated(s".viewAs should only be called on hardware, this will become an error in Chisel 6.0.0")
+      }
 
       (tex, vex) match {
         /* Allow views where the types are equal. */

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -811,9 +811,18 @@ private[chisel3] object Builder extends LazyLogging {
       val absTarget = view.toAbsoluteTarget
       val elts = getRecursiveFields.lazily(view, "").collect { case (elt: Element, _) => elt }
       for (elt <- elts) {
-        val targetOfView = reify(elt)
-        renames.record(localTarget, targetOfView.toTarget)
-        renames.record(absTarget, targetOfView.toAbsoluteTarget)
+        // This is a hack to not crash when .viewAs is called on non-hardware
+        // It can be removed in Chisel 6.0.0 when it becomes illegal to call .viewAs on non-hardware
+        val targetOfViewOpt =
+          try {
+            Some(reify(elt))
+          } catch {
+            case _: NoSuchElementException => None
+          }
+        targetOfViewOpt.foreach { targetOfView =>
+          renames.record(localTarget, targetOfView.toTarget)
+          renames.record(absTarget, targetOfView.toAbsoluteTarget)
+        }
       }
     }
     renames

--- a/src/test/scala/chiselTests/experimental/DataView.scala
+++ b/src/test/scala/chiselTests/experimental/DataView.scala
@@ -804,6 +804,17 @@ class DataViewSpec extends ChiselFlatSpec {
     }
   }
 
+  // In Chisel 6.0.0 this will become an error, but for now it at least needs to not crash
+  it should "not crash when calling .viewAs on unbound hardware" in {
+    class MyBundle(val foo: UInt, val bar: UInt) extends Bundle
+    implicit val view =
+      DataView[(UInt, UInt), MyBundle](x => new MyBundle(x._1.cloneType, x._2.cloneType), _._1 -> _.foo, _._2 -> _.bar)
+    class MyModule extends Module {
+      (UInt(8.W), UInt(8.W)).viewAs[MyBundle]
+    }
+    ChiselStage.emitCHIRRTL(new MyModule)
+  }
+
   it should "handle viewing Probes as their referenced type" in {
     class MyModule extends Module {
       val a = IO(Output(Probe(Bool())))


### PR DESCRIPTION
It's an error in most cases already, and in the cases it isn't, make it a warning. Also fix a crash that could occur when viewing a non-Data containing non-hardware Data.

I will immediately follow this PR with one turning it into an error, but I want to fix the crash in Chisel 5 and 3.6 because the errors are super opaque.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Also fix a crash that could occur when viewing a non-Data containing non-hardware Data.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x` or `3.6.x` depending on impact, API modification or big change: `5.0.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
