### PR TITLE
Add a new `take` method on `Bits` that returns the requested number

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -143,6 +143,11 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   final def do_apply(x: Int)(implicit sourceInfo: SourceInfo): Bool =
     do_extract(BigInt(x))
 
+  /** Grab the bottom n bits.  Return 0.U(0.W) if n==0. */
+  final def take(n: Int): UInt = macro SourceInfoTransform.nArg
+
+  final def do_take(n: Int)(implicit sourceInfo: SourceInfo): UInt = this.apply(n - 1, 0)
+
   /** Returns the specified bit on this wire as a [[Bool]], dynamically addressed.
     *
     * @param x a hardware component whose value will be used for dynamic addressing

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -87,6 +87,12 @@ class UIntOpsTester(a: Long, b: Long) extends BasicTester {
   assert(dut.io.lesseqout === (a <= b).B)
   assert(dut.io.greateqout === (a >= b).B)
 
+  val zeroWidthWire = dut.io.greatout.take(0)
+  assert(zeroWidthWire.getWidth == 0, "take(0) should return a zero width")
+
+  val oneWidthWire = dut.io.greatout.take(1)
+  assert(oneWidthWire.getWidth == 1, "take(1) should return a one width")
+
   stop()
 }
 


### PR DESCRIPTION
Add a new `take` method on Bits that returns the requested number of low order bits as a `UInt`
Add a simple test that `take(0)` return a zero width `UInt`

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

Adds to API a `take` method on `Bits`, can return a zeroWidth UInt if argument is zero

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
`take` will accept an argument of zero and will return a zero-length UInt

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
