### PR TITLE
[svsim] Don't redirect simulation stderr to a pipe

### DIFF
--- a/svsim/src/main/scala/Simulation.scala
+++ b/svsim/src/main/scala/Simulation.scala
@@ -31,6 +31,7 @@ final class Simulation private[svsim] (
     val command = Seq(s"$workingDirectoryPath/$executableName") ++ settings.arguments
     val processBuilder = new ProcessBuilder(command: _*)
     processBuilder.directory(new File(cwd))
+    processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT)
     val environment = settings.environment ++ Seq(
       Some("SVSIM_EXECUTION_SCRIPT" -> executionScriptPath),
       executionScriptLimit.map("SVSIM_EXECUTION_SCRIPT_LIMIT" -> _.toString)


### PR DESCRIPTION
By default, `stderr` is redirected to `PIPE`, which has a limited buffer size. Once that buffer is filled, the OS will block writes until data is read from the buffer. Since `svsim` never reads data from that buffer, this could result in the simulation hanging. Instead, we have the simulation inherit it's `stderr` from the parent process.

#### Type of Improvement

- Bugfix

#### Release Notes

- Fixes an issue where simulations that logged to `stderr` could hang

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
