### PR TITLE
Disable argument extensions when in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,5 +85,8 @@ RUN cd /circt/source && \
       --build ../build \
       --target install-firtool
     
+# Disable Chisel argument extensions, which cause issues when running tests from the VSCode UI
+ENV CHISEL_ARGUMENT_EXTENSIONS=DISABLE
+
 # Use VSCode for writing commit messages
 ENV GIT_EDITOR="code --wait"

--- a/firrtl/src/main/scala/firrtl/options/Shell.scala
+++ b/firrtl/src/main/scala/firrtl/options/Shell.scala
@@ -60,7 +60,9 @@ class Shell(applicationName: String) extends BareShell(applicationName) {
   }
 
   override protected def parserSetup(): Unit = {
-    registeredLibraries
+    if (sys.env.get("CHISEL_ARGUMENT_EXTENSIONS") != Some("DISABLE")) {
+      registeredLibraries
+    }
   }
 
   parser.note("Shell Options")


### PR DESCRIPTION
The additional-commandline-arguments functionality in Chisel does not work with the way Metals works for VSCode's TestExplorer UI, and as a result we have not been able to use VSCode's Test Explorer prior to this fix, which creates an environment variable to disable the command line argument extension functionality.

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Release Notes

- VSCode's Metal's Test Explorer UI can now run tests when the `CHISEL_ARGUMENT_EXTENSIONS` environment variable is set to `DISABLE`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
