### PR TITLE
Add support for configurable warnings

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -308,16 +308,18 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     }
 
     if (length == 0) {
-      Builder.warning(s"Cannot extract from Vec of size 0.")
+      Builder.warning(Warning(WarningID.ExtractFromVecSizeZero, s"Cannot extra from Vec of size 0."))
     } else {
       p.widthOption.foreach { pWidth =>
         val correctWidth = BigInt(length - 1).bitLength
-        def warn(msg: String) =
-          Builder.warning(
-            s"Dynamic index with width $pWidth is too $msg for Vec of size $length (expected index width $correctWidth)."
-          )
-        if (pWidth > correctWidth) warn("wide")
-        else if (pWidth < correctWidth) warn("narrow")
+        def mkMsg(msg: String): String =
+          s"Dynamic index with width $pWidth is too $msg for Vec of size $length (expected index width $correctWidth)."
+
+        if (pWidth > correctWidth) {
+          Builder.warning(Warning(WarningID.DynamicIndexTooWide, mkMsg("wide")))
+        } else if (pWidth < correctWidth) {
+          Builder.warning(Warning(WarningID.DynamicIndexTooNarrow, mkMsg("narrow")))
+        }
       }
     }
 

--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -15,7 +15,7 @@ import chisel3.internal.sourceinfo.{
 }
 import chisel3.internal.firrtl.PrimOp._
 import _root_.firrtl.{ir => firrtlir}
-import chisel3.internal.{castToInt, Builder}
+import chisel3.internal.{castToInt, Builder, Warning, WarningID}
 
 /** Exists to unify common interfaces of [[Bits]] and [[Reset]].
   *
@@ -163,9 +163,11 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
       } else {
         x.widthOption.foreach { xWidth =>
           if (xWidth >= 31 || (1 << (xWidth - 1)) >= thisWidth) {
-            Builder.warning(s"Dynamic index with width $xWidth is too large for extractee of width $thisWidth")
+            val msg = s"Dynamic index with width $xWidth is too large for extractee of width $thisWidth"
+            Builder.warning(Warning(WarningID.DynamicBitSelectTooWide, msg))
           } else if ((1 << xWidth) < thisWidth) {
-            Builder.warning(s"Dynamic index with width $xWidth is too small for extractee of width $thisWidth")
+            val msg = s"Dynamic index with width $xWidth is too small for extractee of width $thisWidth"
+            Builder.warning(Warning(WarningID.DynamicBitSelectTooNarrow, msg))
           }
         }
       }

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -11,7 +11,16 @@ import chisel3.internal.Builder.pushOp
 import chisel3.internal.firrtl.PrimOp._
 import chisel3.internal.firrtl._
 import chisel3.internal.sourceinfo._
-import chisel3.internal.{throwException, Binding, Builder, BuilderContextCache, ChildBinding, ConstrainedBinding}
+import chisel3.internal.{
+  throwException,
+  Binding,
+  Builder,
+  BuilderContextCache,
+  ChildBinding,
+  ConstrainedBinding,
+  Warning,
+  WarningID
+}
 
 import chisel3.experimental.EnumAnnotations._
 
@@ -306,10 +315,11 @@ abstract class ChiselEnum {
     } else if (n.getWidth > this.getWidth) {
       throwException(s"The UInt being cast to $enumTypeName is wider than $enumTypeName's width ($getWidth)")
     } else {
+      // TODO fold this into warning filters
       if (!Builder.suppressEnumCastWarning && warn && !this.isTotal) {
-        Builder.warning(
+        val msg =
           s"Casting non-literal UInt to $enumTypeName. You can use $enumTypeName.safe to cast without this warning."
-        )
+        Builder.warning(Warning(WarningID.UnsafeUIntCastToEnum, msg))
       }
       val glue = Wire(new UnsafeEnum(width))
       glue := n

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -101,7 +101,7 @@ object Definition extends SourceInfoDoc {
   ): Definition[T] = {
     val dynamicContext = {
       val context = Builder.captureContext()
-      new DynamicContext(Nil, context.throwOnFirstError, context.warningsAsErrors, context.sourceRoots)
+      new DynamicContext(Nil, context.throwOnFirstError, context.warningFilters, context.sourceRoots)
     }
     Builder.globalNamespace.copyTo(dynamicContext.globalNamespace)
     dynamicContext.inDefinition = true

--- a/core/src/main/scala/chisel3/internal/Warning.scala
+++ b/core/src/main/scala/chisel3/internal/Warning.scala
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.internal
+
+import chisel3.experimental.{SourceInfo, SourceLineNoCol, UnlocatableSourceInfo}
+
+///////////////////////////////////////////////////
+// Never remove IDs and only ever add to the end //
+///////////////////////////////////////////////////
+
+// TODO should deprecations be included here?
+private[chisel3] object WarningID extends Enumeration {
+  type WarningID = Value
+
+  val NoID = Value(0) // Reserved
+  val UnsafeUIntCastToEnum = Value(1)
+  val DynamicBitSelectTooWide = Value(2)
+  val DynamicBitSelectTooNarrow = Value(3)
+  val DynamicIndexTooWide = Value(4)
+  val DynamicIndexTooNarrow = Value(5)
+  val ExtractFromVecSizeZero = Value(6)
+}
+import WarningID.WarningID
+
+// Argument order differs from apply below to avoid type signature collision with apply method below
+private[chisel3] case class Warning(info: SourceInfo, id: WarningID, msg: String)
+private[chisel3] object Warning {
+  def apply(id: WarningID, msg: String)(implicit info: SourceInfo): Warning = {
+    val num = f"[W${id.id}%03d] "
+    new Warning(info, id, num + msg)
+  }
+  def noInfo(id: WarningID, msg: String): Warning = {
+    implicit val info = SourceLineNoCol.materialize.getOrElse(UnlocatableSourceInfo)
+    Warning(id, msg)
+  }
+}

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -47,6 +47,7 @@ private[chisel3] object Converter {
   def convert(info: SourceInfo): fir.Info = info match {
     case _: NoSourceInfo => fir.NoInfo
     case SourceLine(fn, line, col) => fir.FileInfo.fromUnescaped(s"$fn $line:$col")
+    case SourceLineNoCol(fn, line) => fir.FileInfo.fromUnescaped(s"$fn $line")
   }
 
   def convert(op: PrimOp): fir.PrimOp = firrtl.PrimOps.fromString(op.name)

--- a/docs/src/explanations/explanations.md
+++ b/docs/src/explanations/explanations.md
@@ -43,5 +43,6 @@ read these documents in the following order:
 * [Intrinsic Modules](intrinsics)
 * [Annotations](annotations)
 * [Source Locators](source-locators)
+* [Warnings](warnings)
 * [Deep Dive into Legacy Connection Operators](connection-operators)
 

--- a/docs/src/explanations/warnings.md
+++ b/docs/src/explanations/warnings.md
@@ -1,0 +1,147 @@
+---
+layout: docs
+title:  "Warnings"
+section: "chisel3"
+---
+
+# Warnings
+
+Warnings in Chisel are used for deprecating old APIs or semantics for later removal.
+As a matter of good software practice, Chisel users are encouraged to treat warnings as errors with `--warnings-as-errors`;
+however, the coarse-grained nature of this option can be problematic when bumping Chisel which may introduce many warnings.
+See [Warning Configuration](#warning-configuration) below for techniques to help deal with large numbers of warnings.
+
+## Warning Configuration
+
+Inspired by `-Wconf` [in Scala](https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html),
+Chisel supports fine-grain control of warning behavior via the CLI options `--warn-conf` and `--warn-conf-file`.
+
+### Basic Operation
+
+`--warn-conf` accepts a comma-separated sequence of `<filter>:<action>` pairs.
+When a warning is hit in Chisel, the sequence of pairs are checked from left-to-right to see if the `filter` matches the warning.
+The `action` associated with the first matching `filter` is the one used for the specific warning.
+If no `filters` match, then the default behavior is to issue the warning.
+
+`--warn-conf` can be specified any number of times.
+Earlier uses of `--warn-conf` take priority over later ones in the same left-to-right decreasing priority as the `filters` are checked within a single `--warn-conf`.
+As a mental model, the user can pretend that all `--warn-conf` arguments concatenated together (separated by `,`) into a single argument.
+
+### Warning Configuration Files
+
+`--warn-conf-file` accepts a file which contains the same format of `<filter>:<action>` pairs, separated by newlines.
+Lines starting with `#` will be treated as comments and ignored.
+`filters` are checked in decreasing priority from top-to-bottom of the file.
+
+A single command-line can contain any number of `--warn-conf-file` and any number of `--warn-conf` arguments.
+The filters from all `--warn-conf*` arguments will be applied in the same left-to-right decreasing priority order.
+
+### Filters
+
+The supported filters are:
+
+* `any` - matches all warnings
+* `id=<integer>` - matches warnings with the integer id
+* `src=<glob>` - matches warnings when `<glob>` matches the source locator filename where the warning occurs
+
+`id` and `src` filters can be combined with `&`.
+Any filter can have at most one `id` and at most one `src` listed.
+`any` cannot be combined with any other filters.
+
+### Actions
+
+The supported actions are:
+
+* `:s` - suppress matching warnings
+* `:w` - report matching warnings as warnings (default behavior)
+* `:e` - error on matching warnings
+
+### Examples
+
+The following example issues a warning when elaborated normally
+
+```scala mdoc:invisible:reset
+// Some other test is clobbering the global Logger which breaks the warnings below
+// Setting the output stream to the Console fixes the issue
+logger.Logger.setConsole()
+// Helper to throw away return value so it doesn't show up in mdoc
+def compile(gen: => chisel3.RawModule, args: Array[String] = Array()): Unit = {
+  circt.stage.ChiselStage.emitCHIRRTL(gen, args = args)
+}
+```
+
+```scala mdoc
+import circt.stage.ChiselStage.emitSystemVerilog
+import chisel3._
+class TooWideIndexModule extends RawModule {
+  val in = IO(Input(Vec(4, UInt(8.W))))
+  val idx = IO(Input(UInt(8.W))) // This index is wider than necessary
+  val out = IO(Output(UInt(8.W)))
+
+  out := in(idx)
+}
+compile(new TooWideIndexModule)
+```
+
+As shown in the warning, this warning is `W004` (which can be fixed [as described below](#w004-dynamic-index-too-wide)), we can suppress it with an `id` filter which will suppress all instances of this warning in the elaboration run.
+
+```scala mdoc
+compile(new TooWideIndexModule, args = Array("--warn-conf", "id=4:s"))
+```
+
+It is generally advisable to make warning suppressions as precise as possible, so we could combine this `id` filter with a `src` glob filter for just this file:
+
+```scala mdoc
+compile(new TooWideIndexModule, args = Array("--warn-conf", "id=4&src=**warnings.md:s"))
+```
+
+Finally, users are encouraged to treat warnings as errors to the extend possible,
+so they should always end any warning configuration with `any:e` to elevate all unmatched warnings to errors:
+
+```scala mdoc
+compile(new TooWideIndexModule, args = Array("--warn-conf", "id=4&src=**warnings.md:s,any:e"))
+// Or
+compile(new TooWideIndexModule, args = Array("--warn-conf", "id=4&src=**warnings.md:s", "--warn-conf", "any:e"))
+// Or
+compile(new TooWideIndexModule, args = Array("--warn-conf", "id=4&src=**warnings.md:s", "--warnings-as-errors"))
+```
+
+## Warning Glossary
+
+Chisel warnings have a unique identifier number to make them easier to lookup as well as so they can be configured as described above.
+
+### [W001] Unsafe UInt cast to ChiselEnum
+
+This warning occurs when casting a `UInt` to a `ChiselEnum` when there are values the `UInt` could take that are not legal states in the enumeration.
+See the [ChiselEnum explanation](chisel-enum#casting) for more information and how to fix this warning.
+
+**Note:** This is the only warning that is not currently scheduled for become an error.
+
+### [W002] Dynamic bit select too wide
+
+This warning occurs when dynamically indexing a `UInt` or an `SInt` with an index that is wider than necessary to address all bits in the indexee.
+It indicates that some of the high-bits of the index are ignored by the indexing operation.
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+
+### [W003] Dynamic bit select too narrow
+
+This warning occurs when dynamically indexing a `UInt` or an `SInt` with an index that is to small to address all bits in the indexee.
+It indicates that some bits of the indexee cannot be reached by the indexing operation.
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+
+### [W004] Dynamic index too wide
+
+This warning occurs when dynamically indexing a `Vec` with an index that is wider than necessary to address all elements of the `Vec`.
+It indicates that some of the high-bits of the index are ignored by the indexing operation.
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+
+### [W005] Dynamic index too narrow
+
+This warning occurs when dynamically indexing a `Vec` with an index that is to small to address all elements in the `Vec`.
+It indicates that some elements of the `Vec` cannot be reached by the indexing operation.
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+
+### [W006] Extract from Vec of size 0
+
+This warning occurs when indexing a `Vec` with no elements.
+It can be fixed by removing the indexing operation for the size zero `Vec` (perhaps via guarding with an `if-else` or `Option.when`).

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -61,7 +61,7 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
         new DynamicContext(
           annotationsInAspect,
           chiselOptions.throwOnFirstError,
-          chiselOptions.warningsAsErrors,
+          chiselOptions.warningFilters,
           chiselOptions.sourceRoots
         )
       // Add existing module names into the namespace. If injection logic instantiates new modules

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -16,10 +16,11 @@ import firrtl.options.internal.WriteableCircuitAnnotation
 import firrtl.options.Viewer.view
 import chisel3.{deprecatedMFCMessage, ChiselException, Module}
 import chisel3.RawModule
-import chisel3.internal.Builder
+import chisel3.internal.{Builder, WarningFilter}
 import chisel3.internal.firrtl.{Circuit, Converter}
 import firrtl.AnnotationSeq
 import firrtl.ir.{CircuitWithAnnos, Serializer}
+import scala.util.control.NonFatal
 import java.io.{BufferedWriter, File, FileWriter}
 import java.lang.reflect.InvocationTargetException
 
@@ -79,6 +80,99 @@ case object WarningsAsErrorsAnnotation
     )
   )
 
+  private[chisel3] def asFilter: WarningFilter = WarningFilter(None, None, WarningFilter.Error)
+}
+
+// TODO shoud this be Unserializable or should it be propagated to MFC? Perhaps in a different form?
+case class WarningConfigurationAnnotation(value: String)
+    extends NoTargetAnnotation
+    with Unserializable
+    with ChiselOption {
+
+  // This is eager so that the validity of the value String can be checked right away
+  private[chisel3] val filters: Seq[WarningFilter] = {
+    import chisel3.internal.ListSyntax
+    val filters = value.split(",")
+    filters.toList
+      // Add accumulating index to each filter for error reporting
+      .mapAccumulate(0) { case (idx, s) => (idx + 1 + s.length, (idx, s)) } // + 1 for removed ','
+      ._2 // Discard accumulator
+      .map {
+        case (idx, s) =>
+          WarningFilter.parse(s) match {
+            case Right(wf) => wf
+            case Left((jdx, msg)) =>
+              val carat = (" " * (idx + jdx)) + "^"
+              // Note tab before value and carat
+              throw new Exception(s"Failed to parse configuration: $msg\n  $value\n  $carat")
+          }
+      }
+  }
+}
+
+object WarningConfigurationAnnotation extends HasShellOptions {
+  val options = Seq(
+    new ShellOption[String](
+      longOption = "warn-conf",
+      toAnnotationSeq = { value =>
+        try {
+          Seq(WarningConfigurationAnnotation(value))
+        } catch {
+          case NonFatal(e) => throw new OptionsException(e.getMessage)
+        }
+      },
+      helpText = "Warning configuration",
+      helpValueName = Some("<value>")
+    )
+  )
+}
+
+// TODO shoud this be Unserializable or should it be propagated to MFC? Perhaps in a different form?
+case class WarningConfigurationFileAnnotation(value: File)
+    extends NoTargetAnnotation
+    with Unserializable
+    with ChiselOption {
+
+  // This is eager so that the validity of the value String can be checked right away
+  private[chisel3] val filters: Seq[WarningFilter] = {
+    require(value.exists, s"Warning configuration file '$value' must exist!")
+    require(value.isFile && value.canRead, s"Warning configuration file '$value' must be a readable file!")
+    val lines = scala.io.Source.fromFile(value).getLines()
+    lines.zipWithIndex.flatMap {
+      case (contents, lineNo) =>
+        // Strip line comments (denoted with #)
+        val str = contents.takeWhile(_ != '#')
+        Option.when(str.nonEmpty) {
+          WarningFilter.parse(str) match {
+            case Right(wf) => wf
+            case Left((idx, msg)) =>
+              val carat = (" " * idx) + "^"
+              val info = s"$value:${lineNo + 1}:$idx" // +1 to lineNo because we start at 0 but files start with 1
+              // Note tab before value and carat
+              throw new Exception(
+                s"Failed to parse configuration at $info: $msg\n  $contents\n  $carat"
+              )
+          }
+        }
+    }.toVector
+  }
+}
+
+object WarningConfigurationFileAnnotation extends HasShellOptions {
+  val options = Seq(
+    new ShellOption[File](
+      longOption = "warn-conf-file",
+      toAnnotationSeq = { value =>
+        try {
+          Seq(WarningConfigurationFileAnnotation(value))
+        } catch {
+          case NonFatal(e) => throw new OptionsException(e.getMessage)
+        }
+      },
+      helpText = "Warning configuration",
+      helpValueName = Some("<value>")
+    )
+  )
 }
 
 /** A root directory for source files, used for enhanced error reporting

--- a/src/main/scala/chisel3/stage/ChiselOptions.scala
+++ b/src/main/scala/chisel3/stage/ChiselOptions.scala
@@ -3,32 +3,33 @@
 package chisel3.stage
 
 import chisel3.internal.firrtl.Circuit
+import chisel3.internal.WarningFilter
 import java.io.File
 
 class ChiselOptions private[stage] (
   val printFullStackTrace: Boolean = false,
   val throwOnFirstError:   Boolean = false,
-  val warningsAsErrors:    Boolean = false,
   val outputFile:          Option[String] = None,
   val chiselCircuit:       Option[Circuit] = None,
-  val sourceRoots:         Vector[File] = Vector.empty) {
+  val sourceRoots:         Vector[File] = Vector.empty,
+  val warningFilters:      Vector[WarningFilter] = Vector.empty) {
 
   private[stage] def copy(
     printFullStackTrace: Boolean = printFullStackTrace,
     throwOnFirstError:   Boolean = throwOnFirstError,
-    warningsAsErrors:    Boolean = warningsAsErrors,
     outputFile:          Option[String] = outputFile,
     chiselCircuit:       Option[Circuit] = chiselCircuit,
-    sourceRoots:         Vector[File] = sourceRoots
+    sourceRoots:         Vector[File] = sourceRoots,
+    warningFilters:      Vector[WarningFilter] = warningFilters
   ): ChiselOptions = {
 
     new ChiselOptions(
       printFullStackTrace = printFullStackTrace,
       throwOnFirstError = throwOnFirstError,
-      warningsAsErrors = warningsAsErrors,
       outputFile = outputFile,
       chiselCircuit = chiselCircuit,
-      sourceRoots = sourceRoots
+      sourceRoots = sourceRoots,
+      warningFilters = warningFilters
     )
 
   }

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -22,10 +22,13 @@ package object stage {
         x match {
           case PrintFullStackTraceAnnotation => c.copy(printFullStackTrace = true)
           case ThrowOnFirstErrorAnnotation   => c.copy(throwOnFirstError = true)
-          case WarningsAsErrorsAnnotation    => c.copy(warningsAsErrors = true)
+          case WarningsAsErrorsAnnotation =>
+            c.copy(warningFilters = c.warningFilters :+ WarningsAsErrorsAnnotation.asFilter)
           case ChiselOutputFileAnnotation(f) => c.copy(outputFile = Some(f))
           case ChiselCircuitAnnotation(a)    => c.copy(chiselCircuit = Some(a))
           case SourceRootAnnotation(s)       => c.copy(sourceRoots = c.sourceRoots :+ s)
+          case a: WarningConfigurationAnnotation     => c.copy(warningFilters = c.warningFilters ++ a.filters)
+          case a: WarningConfigurationFileAnnotation => c.copy(warningFilters = c.warningFilters ++ a.filters)
         }
       }
 

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -33,7 +33,7 @@ class Elaborate extends Phase {
           new DynamicContext(
             annotations,
             chiselOptions.throwOnFirstError,
-            chiselOptions.warningsAsErrors,
+            chiselOptions.warningFilters,
             chiselOptions.sourceRoots
           )
         val (circuit, dut) =

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -10,6 +10,8 @@ import chisel3.stage.{
   PrintFullStackTraceAnnotation,
   SourceRootAnnotation,
   ThrowOnFirstErrorAnnotation,
+  WarningConfigurationAnnotation,
+  WarningConfigurationFileAnnotation,
   WarningsAsErrorsAnnotation
 }
 import chisel3.stage.CircuitSerializationAnnotation.FirrtlFileFormat
@@ -36,6 +38,8 @@ trait CLI { this: BareShell =>
     PrintFullStackTraceAnnotation,
     ThrowOnFirstErrorAnnotation,
     WarningsAsErrorsAnnotation,
+    WarningConfigurationAnnotation,
+    WarningConfigurationFileAnnotation,
     SourceRootAnnotation,
     SplitVerilog
   ).foreach(_.addOptions(parser))

--- a/src/test/scala/chisel3/testers/TestUtils.scala
+++ b/src/test/scala/chisel3/testers/TestUtils.scala
@@ -5,19 +5,22 @@ package chisel3.testers
 import chisel3.RawModule
 import chisel3.stage.ChiselGeneratorAnnotation
 import chisel3.testers.TesterDriver.Backend
-import circt.stage.{CIRCTTarget, CIRCTTargetAnnotation, ChiselStage}
+import chisel3.experimental.SourceInfo
+import chisel3.internal.{Builder, Warning, WarningID}
+import circt.stage.ChiselStage
 import firrtl.AnnotationSeq
 import firrtl.annotations.Annotation
 import firrtl.ir.Circuit
-import firrtl.options.{Dependency, TargetDirAnnotation}
 import firrtl.stage.FirrtlCircuitAnnotation
 import firrtl.util.BackendCompilationUtilities.createTestDirectory
-import org.scalatest.Assertions.fail
 
 object TestUtils {
   // Useful because TesterDriver.Backend is chisel3 package private
   def containsBackend(annos: AnnotationSeq): Boolean =
     annos.collectFirst { case b: Backend => b }.isDefined
+
+  /** Helper for checking warnings, not really valid in normal Chisel */
+  def warn(id: Int, msg: String)(implicit sourceInfo: SourceInfo): Unit = Builder.warning(Warning(WarningID(1), msg))
 
   // This used for backward support of test that rely on chisel3 chirrtl generation and access to the annotations
   // produced by it. New tests should not utilize this or getFirrtlAndAnnos

--- a/src/test/scala/chiselTests/ConstSpec.scala
+++ b/src/test/scala/chiselTests/ConstSpec.scala
@@ -25,7 +25,7 @@ class ConstSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot create register with constant value.")
+    exc.getMessage should include("Cannot create register with constant value.")
   }
 
   "Const modifier on I/O" should "emit FIRRTL const descriptors" in {
@@ -68,7 +68,7 @@ class ConstSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Mem type cannot be const.")
+    exc.getMessage should include("Mem type cannot be const.")
   }
 
   "Const of Probe" should "fail" in {
@@ -80,7 +80,7 @@ class ConstSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot create Const of a Probe.")
+    exc.getMessage should include("Cannot create Const of a Probe.")
   }
 
   class FooBundle extends Bundle {

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -202,7 +202,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot use connectables with probe types. Exclude them prior to connection.")
+    exc.getMessage should include("Cannot use connectables with probe types. Exclude them prior to connection.")
   }
 
   ":= connector with probe" should "fail" in {
@@ -218,7 +218,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be(
+    exc.getMessage should include(
       "Connection between sink (ProbeSpec_Anon.io.out: IO[Bool]) and source (ProbeSpec_Anon.io.in: IO[Bool]) failed @: Sink io.out in ProbeSpec_Anon of Probed type cannot participate in a mono connection (:=)"
     )
   }
@@ -236,7 +236,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be(
+    exc.getMessage should include(
       "Connection between sink (ProbeSpec_Anon.io.out: IO[Bool[2]]) and source (ProbeSpec_Anon.io.in: IO[Bool[2]]) failed @: Sink io.out in ProbeSpec_Anon of Probed type cannot participate in a mono connection (:=)"
     )
   }
@@ -273,7 +273,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot define a probe on a non-equivalent type.")
+    exc.getMessage should include("Cannot define a probe on a non-equivalent type.")
   }
 
   "Probe of a probe type" should "fail" in {
@@ -285,7 +285,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot probe a probe.")
+    exc.getMessage should include("Cannot probe a probe.")
   }
 
   "Probes of aggregates containing probes" should "fail" in {
@@ -299,7 +299,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot create a probe of an aggregate containing a probe.")
+    exc.getMessage should include("Cannot create a probe of an aggregate containing a probe.")
   }
 
   "Wire() of a probe" should "fail" in {
@@ -311,7 +311,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot make a wire of a Chisel type with a probe modifier.")
+    exc.getMessage should include("Cannot make a wire of a Chisel type with a probe modifier.")
   }
 
   "WireInit of a probe" should "fail" in {
@@ -323,7 +323,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot make a wire of a Chisel type with a probe modifier.")
+    exc.getMessage should include("Cannot make a wire of a Chisel type with a probe modifier.")
   }
 
   "Reg() of a probe" should "fail" in {
@@ -335,7 +335,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot make a register of a Chisel type with a probe modifier.")
+    exc.getMessage should include("Cannot make a register of a Chisel type with a probe modifier.")
   }
 
   "RegInit of a probe" should "fail" in {
@@ -347,7 +347,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot make a register of a Chisel type with a probe modifier.")
+    exc.getMessage should include("Cannot make a register of a Chisel type with a probe modifier.")
   }
 
   "Memories of probes" should "fail" in {
@@ -359,7 +359,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot make a Mem of a Chisel type with a probe modifier.")
+    exc.getMessage should include("Cannot make a Mem of a Chisel type with a probe modifier.")
   }
 
   "Defining a Probe with a rwprobe()" should "work" in {
@@ -385,7 +385,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot use a non-writable probe expression to define a writable probe.")
+    exc.getMessage should include("Cannot use a non-writable probe expression to define a writable probe.")
   }
 
   "Force of a non-writable Probe" should "fail" in {
@@ -399,7 +399,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot force a non-writable Probe.")
+    exc.getMessage should include("Cannot force a non-writable Probe.")
   }
 
   "Probes of Const type" should "work" in {
@@ -421,7 +421,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Cannot create a writable probe of a const type.")
+    exc.getMessage should include("Cannot create a writable probe of a const type.")
   }
 
   "Probe force methods" should "properly extend values that are not wide enough" in {
@@ -452,7 +452,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Data width 7 is larger than 2.")
+    exc.getMessage should include("Data width 7 is larger than 2.")
   }
 
   it should "error out on Wires of unknown widths" in {
@@ -466,7 +466,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Data width unknown.")
+    exc.getMessage should include("Data width unknown.")
   }
 
   it should "error out on probes of unknown widths" in {
@@ -480,7 +480,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should be("Probe width unknown.")
+    exc.getMessage should include("Probe width unknown.")
   }
 
 }

--- a/src/test/scala/chiselTests/stage/WarningConfigurationSpec.scala
+++ b/src/test/scala/chiselTests/stage/WarningConfigurationSpec.scala
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.stage
+
+import chisel3._
+import chisel3.testers.TestUtils
+import chisel3.experimental.SourceInfo
+import circt.stage.ChiselStage
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import firrtl.options.OptionsException
+
+import java.io.File
+
+object WarningConfigurationSpec {
+  class ModuleWithWarning extends RawModule {
+    val in = IO(Input(UInt(8.W)))
+    val out = IO(Output(UInt(8.W)))
+    TestUtils.warn(1, "sample warning")
+    out := in
+  }
+
+  // Examples of every existing warning
+  // These will eventually become errors
+  class UnsafeUIntCastToEnum extends RawModule {
+    object MyEnum extends ChiselEnum {
+      val a, b, c = Value
+    }
+    val in = IO(Input(UInt(2.W)))
+    val out = IO(Output(MyEnum()))
+    out := in.asTypeOf(MyEnum())
+  }
+  class DynamicBitSelectTooWide extends RawModule {
+    val in = IO(Input(UInt(4.W)))
+    val idx = IO(Input(UInt(3.W)))
+    in(idx)
+  }
+  class DynamicBitSelectTooNarrow extends RawModule {
+    val in = IO(Input(UInt(8.W)))
+    val idx = IO(Input(UInt(2.W)))
+    in(idx)
+  }
+  class DynamicIndexTooWide extends RawModule {
+    val in = IO(Input(Vec(4, UInt(8.W))))
+    val idx = IO(Input(UInt(3.W)))
+    in(idx)
+  }
+  class DynamicIndexTooNarrow extends RawModule {
+    val in = IO(Input(Vec(8, UInt(8.W))))
+    val idx = IO(Input(UInt(2.W)))
+    in(idx)
+  }
+  class ExtractFromVecSizeZero extends RawModule { // = Value(6)
+    val in = IO(Input(Vec(0, UInt(8.W))))
+    val idx = IO(Input(UInt(8.W)))
+    in(idx)
+  }
+}
+
+class WarningConfigurationSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
+  import WarningConfigurationSpec._
+
+  private def checkInvalid(wconf: String, carat: String, expected: String): Unit = {
+    val args = Array("--warn-conf", wconf)
+    val e = the[OptionsException] thrownBy (ChiselStage.emitCHIRRTL(new ModuleWithWarning, args))
+    val msg = e.getMessage()
+    val lines = msg.split("\n")
+    msg should include(expected)
+    lines should contain("  " + wconf)
+    lines should contain("  " + carat)
+  }
+
+  private def checkInvalid(wconf: File, badLine: String, carat: String, expected: String): Unit = {
+    val args = Array("--warn-conf-file", wconf.toString)
+    val e = the[OptionsException] thrownBy (ChiselStage.emitCHIRRTL(new ModuleWithWarning, args))
+    val msg = e.getMessage()
+    val lines = msg.split("\n")
+    msg should include(expected)
+    lines should contain("  " + badLine)
+    lines should contain("  " + carat)
+  }
+
+  private lazy val buildDir = {
+    val testRunDir = os.pwd / os.RelPath(firrtl.util.BackendCompilationUtilities.TestDirectory)
+    val suiteDir = testRunDir / suiteName
+    os.remove.all(suiteDir) // clear it each time
+    os.makeDir.all(suiteDir)
+    suiteDir
+  }
+
+  private def makeFile(name: String)(contents: String): java.io.File = {
+    val file = buildDir / name
+    os.write(file, contents)
+    file.toIO
+  }
+
+  describe("Warning Configuration") {
+
+    it("should support warnings as errors") {
+      info("In form --warn-conf any:e")
+      val args = Array("--warn-conf", "any:e", "--throw-on-first-error")
+      val e = the[ChiselException] thrownBy { ChiselStage.emitCHIRRTL(new ModuleWithWarning, args) }
+      e.getMessage should include("sample warning")
+
+      info("Also in form --warnings-as-errors")
+      val args2 = Array("--warnings-as-errors", "--throw-on-first-error")
+      val e2 = the[ChiselException] thrownBy { ChiselStage.emitCHIRRTL(new ModuleWithWarning, args2) }
+      e2.getMessage should include("sample warning")
+    }
+
+    it("should support id filters") {
+      info("For suppressing warnings")
+      val args = Array("--warn-conf", "id=1:s,any:e", "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args)
+
+      info("For keeping them as warnings despite --warnings-as-errors")
+      val args2 = Array("--warn-conf", "id=1:w,any:e", "--throw-on-first-error")
+      val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new ModuleWithWarning, args2))
+      log should include("sample warning")
+      log should include("There were 1 warning(s) during hardware elaboration.")
+
+      info("For elevating individual warnings to errors")
+      val args3 = Array("--warn-conf", "id=1:e", "--throw-on-first-error")
+      val e = the[ChiselException] thrownBy { ChiselStage.emitCHIRRTL(new ModuleWithWarning, args3) }
+      e.getMessage should include("sample warning")
+    }
+
+    it("should support source filters") {
+      val thisFile = implicitly[SourceInfo].filenameOption.get
+      info("For suppressing warnings")
+      val args = Array("--warn-conf", s"src=$thisFile:s,any:e", "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args)
+
+      info("For keeping them as warnings despite --warnings-as-errors")
+      val args2 = Array("--warn-conf", s"src=$thisFile:w,any:e", "--throw-on-first-error")
+      val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new ModuleWithWarning, args2))
+      log should include("sample warning")
+      log should include("There were 1 warning(s) during hardware elaboration.")
+
+      info("For elevating individual warnings to errors")
+      val args3 = Array("--warn-conf", s"src=$thisFile:e", "--throw-on-first-error")
+      val e = the[ChiselException] thrownBy { ChiselStage.emitCHIRRTL(new ModuleWithWarning, args3) }
+      e.getMessage should include("sample warning")
+    }
+
+    it("should support source filter globs") {
+      info("as simple extension matches")
+      val args = Array("--warn-conf", "src=**.scala:s,any:e", "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args)
+
+      info("including some intermediate directories")
+      val args2 = Array("--warn-conf", "src=**/stage/WarningConfigurationSpec.scala:s,any:e", "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args2)
+
+      info("including when rooted")
+      val args3 =
+        Array("--warn-conf", "src=src/test/scala/**/WarningConfigurationSpec.scala:s,any:e", "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args3)
+    }
+
+    it("should support being specified multiple times") {
+      val suppress = Array("--warn-conf", "any:s")
+      val error = Array("--warn-conf", "any:e")
+      val extra = Array("--throw-on-first-error")
+      val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new ModuleWithWarning, suppress ++ error ++ extra))
+      log should be("")
+      val e = the[ChiselException] thrownBy ChiselStage.emitCHIRRTL(new ModuleWithWarning, error ++ suppress ++ extra)
+      e.getMessage should include("sample warning")
+    }
+
+    it("should error on a missing action") {
+      val wconf = "potato"
+      val carat = "     ^"
+      val msg = "Filter 'potato' is missing an action"
+      checkInvalid(wconf, carat, msg)
+    }
+
+    it("should error on an invalid action") {
+      val wconf = "id=1:x"
+      val carat = "    ^"
+      val msg = "Invalid action ':x'"
+      checkInvalid(wconf, carat, msg)
+
+      info("and be able to point to an invalid action in a later filter")
+      val wconf2 = "id=1:s,src=**.scala:x"
+      val carat2 = "                   ^"
+      val msg2 = "Invalid action ':x'"
+      checkInvalid(wconf2, carat2, msg2)
+    }
+
+    it("should error on an invalid category") {
+      val wconf = "id=1:s,id=2&foo=sample warning:e"
+      val carat = "            ^"
+      val msg = "Invalid category 'foo'"
+      checkInvalid(wconf, carat, msg)
+    }
+
+    it("should error on a duplicate id") {
+      val wconf = "id=1:s,id=2&id=3:e"
+      val carat = "            ^"
+      val msg = "Cannot have duplicates of the same category"
+      checkInvalid(wconf, carat, msg)
+    }
+
+    it("should error on a duplicate src") {
+      val wconf = "id=1:s,src=hi&src=bye:e"
+      val carat = "              ^"
+      val msg = "Cannot have duplicates of the same category"
+      checkInvalid(wconf, carat, msg)
+    }
+
+    it("should error when combining any other category with 'any'") {
+      val wconf = "id=1:s,any&src=bye:e"
+      val carat = "           ^"
+      val msg = "'any' cannot be combined with other filters"
+      checkInvalid(wconf, carat, msg)
+
+      info("In any order with any")
+      val wconf2 = "id=1:s,src=bye&any:e"
+      val carat2 = "               ^"
+      val msg2 = "'any' cannot be combined with other filters"
+      checkInvalid(wconf2, carat2, msg2)
+
+      info("Even multiple 'any'")
+      val wconf3 = "id=1:s,any&any:e"
+      val carat3 = "           ^"
+      val msg3 = "'any' cannot be combined with other filters"
+      checkInvalid(wconf3, carat3, msg3)
+    }
+  }
+
+  describe("Warning Configuration File") {
+
+    it("should support filters") {
+      info("For suppressing warnings")
+      val file = makeFile("basic_suppressing.conf")(
+        """|id=1:s
+           |any:e
+           |""".stripMargin
+      )
+      val args = Array("--warn-conf-file", file.toString, "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args)
+
+      info("Including source filters")
+      val file2 = makeFile("with_source_filter.conf")(
+        """|id=1&src=**/WarningConfigurationSpec.scala:s
+           |any:e""".stripMargin
+      )
+      val args2 = Array("--warn-conf-file", file2.toString, "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args2)
+    }
+
+    it("should support line comments") {
+      val file = makeFile("with_comments.conf")(
+        """|# Here is a comment
+           |id=1:s
+           |# And another one!
+           |any:e
+           |""".stripMargin
+      )
+      val args = Array("--warn-conf-file", file.toString, "--throw-on-first-error")
+      ChiselStage.emitCHIRRTL(new ModuleWithWarning, args)
+    }
+
+    it("should have good error messages") {
+      info("For invalid actions")
+      val badln = "id=1:x"
+      val carat = "    ^"
+      val badAction = makeFile("bad_action.conf")(
+        s"""|$badln
+            |any:e""".stripMargin
+      )
+      checkInvalid(badAction, badln, carat, "Invalid action ':x'")
+
+      info("Including across multiple lines")
+      val badln2 = "id=1&id=3:e"
+      val carat2 = "     ^"
+      val badAction2 = makeFile("bad_action2.conf")(
+        s"""|# How about a comment?
+            |id=4&src=**.scala:s
+            |$badln2
+            |any:w""".stripMargin
+      )
+      checkInvalid(badAction2, badln2, carat2, "Cannot have duplicates of the same category")
+    }
+
+    it("should work when specified multiple times") {
+      val suppressConf = makeFile("supress_all.conf")(
+        """|any:s
+           |""".stripMargin
+      )
+      val errorConf = makeFile("error_all.conf")(
+        """|any:e
+           |""".stripMargin
+      )
+      val suppress = Array("--warn-conf-file", suppressConf.toString)
+      val errorFile = Array("--warn-conf-file", errorConf.toString)
+      val errorArgs = Array("--warn-conf", "any:e")
+      val extra = Array("--throw-on-first-error")
+
+      info("For suppressing")
+      val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new ModuleWithWarning, suppress ++ errorFile ++ extra))
+      log should be("")
+
+      info("For erroring")
+      val e =
+        the[ChiselException] thrownBy ChiselStage.emitCHIRRTL(new ModuleWithWarning, errorFile ++ suppress ++ extra)
+      e.getMessage should include("sample warning")
+
+      info("Also when composed with --warn-conf")
+      val e2 =
+        the[ChiselException] thrownBy ChiselStage.emitCHIRRTL(new ModuleWithWarning, errorArgs ++ suppress ++ extra)
+      e2.getMessage should include("sample warning")
+    }
+  }
+
+  // Important to test the specific numbering of existing warnings to guard against accidental changes
+  describe("Warning Configuration Numbering") {
+
+    it("should number UnsafeUIntCastToEnum as 1") {
+      val args = Array("--warn-conf", "id=1:e,any:s", "--throw-on-first-error")
+      val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new UnsafeUIntCastToEnum, args)
+      (e.getMessage should include).regex("""\[W001\] Casting non-literal UInt to.*MyEnum""")
+    }
+
+    it("should number DynamicBitSelectTooWide as 2") {
+      val args = Array("--warn-conf", "id=2:e,any:s", "--throw-on-first-error")
+      val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new DynamicBitSelectTooWide, args)
+      e.getMessage should include("[W002] Dynamic index with width 3 is too large for extractee of width 4")
+    }
+
+    it("should number DynamicBitSelectTooNarrow as 3") {
+      val args = Array("--warn-conf", "id=3:e,any:s", "--throw-on-first-error")
+      val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new DynamicBitSelectTooNarrow, args)
+      e.getMessage should include("[W003] Dynamic index with width 2 is too small for extractee of width 8")
+    }
+
+    it("should number DynamicIndexTooWide as 4") {
+      val args = Array("--warn-conf", "id=4:e,any:s", "--throw-on-first-error")
+      val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new DynamicIndexTooWide, args)
+      e.getMessage should include("[W004] Dynamic index with width 3 is too wide for Vec of size 4")
+    }
+
+    it("should number DynamicIndexTooNarrow as 5") {
+      val args = Array("--warn-conf", "id=5:e,any:s", "--throw-on-first-error")
+      val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new DynamicIndexTooNarrow, args)
+      e.getMessage should include("[W005] Dynamic index with width 2 is too narrow for Vec of size 8")
+    }
+
+    it("should number ExtractFromVecSizeZero as 6") {
+      val args = Array("--warn-conf", "id=6:e,any:s", "--throw-on-first-error")
+      val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new ExtractFromVecSizeZero, args)
+      e.getMessage should include("[W006] Cannot extra from Vec of size 0")
+    }
+  }
+}

--- a/website/docs/src/main/resources/microsite/data/menu.yml
+++ b/website/docs/src/main/resources/microsite/data/menu.yml
@@ -160,6 +160,10 @@ options:
         url: chisel3/docs/explanations/source-locators.html
         menu_type: chisel3
         menu_section: source-locators
+      - title: Warnings
+        url: chisel3/docs/explanations/warnings.html
+        menu_type: chisel3
+        menu_section: warnings
       - title: Deep Dive into Connection Operators
         url: chisel3/docs/explanations/connection-operators.html
         menu_type: chisel3


### PR DESCRIPTION
Currently opened as a draft but I would like to get the ball rolling on this.

This is heavily inspired by [configurable warnings in Scala](https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html), but is a little more limited.


#### TODO
- [x] Audit warning numbering (want to backport to 3.6, so make sure warnings existing there are first in order)
- [x] Add warning number to warning messages
- [x] ~Make new warnings more clear that they are deprecations~ I'm going to do this in a follow on PR
- [x] Write a docs page
- [x] Write release notes
- [x] Add support for `--warn-conf-file` which is the same syntax but with `\n` separated pairs in a file rather than `,` separated pairs in a String.
- [x] Add tests mixing `--warn-conf-file` with `--warn-conf`

The commit text gives a pretty good overview:
```
Add support for configurable warnings

Warnings have been assigned unique integers to use as identifiers for
purposes of documentation and configuration.

New CLI option --warn-conf accepts a comma-separated sequence of
<filter>:<action> pairs for customizing warnings.

Supported filters are:
* any          - matches all warnings
* id=<integer> - matches warnings with the integer id
* src=<glob>   - matches warnings where <glob> matches the warning
                 source file

id and src filters can be combined with &.

Supported actions are:
* :s - suppress the warning
* :w - report the warning as a warning (default behavior)
* :e - error on the warning

For example, the new Vec dynamic width matching warning can be
suppressed for source files in src/main/scala while all other warnings
elevated to errors with:
  --warn-conf "id=4&src=src/main/scala/**:s,any:e"

The is also --warn-conf-file which works similarly to --warn-conf except
the <filter>:<action> pairs are newline separated in a file. # is used
for line comments.
```

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

- Squash

#### Release Notes

Add support for configurable warnings, see https://www.chisel-lang.org/chisel3/docs/explanations/warnings.html

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [x] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
