### PR TITLE
Deprecate old BoringUtils API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,6 +71,7 @@ lazy val warningSuppression = Seq(
     "msg=undefined in comment for method cf in class PrintableHelper:s",
     // This is deprecated for external users but not internal use
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
+    "cat=deprecation&origin=chisel\\.util\\.experimental\\.BoringUtils:s",
     // Suppress Scala 3 behavior requiring explicit types on implicit definitions
     "cat=other-implicit-type:s"
   ).mkString(",")

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val warningSuppression = Seq(
     "msg=undefined in comment for method cf in class PrintableHelper:s",
     // This is deprecated for external users but not internal use
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
-    "cat=deprecation&origin=chisel\\.util\\.experimental\\.BoringUtils:s",
+    "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils:s",
     // Suppress Scala 3 behavior requiring explicit types on implicit definitions
     "cat=other-implicit-type:s"
   ).mkString(",")

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ lazy val warningSuppression = Seq(
     "msg=undefined in comment for method cf in class PrintableHelper:s",
     // This is deprecated for external users but not internal use
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
-    "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils:s",
+    "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
     // Suppress Scala 3 behavior requiring explicit types on implicit definitions
     "cat=other-implicit-type:s"
   ).mkString(",")

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -128,7 +128,10 @@ object BoringUtils {
     * @return the name used
     * @note if a uniqueName is not specified, the returned name may differ from the user-provided name
     */
-  @deprecated("Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0", "Chisel 7.0")
+  @deprecated(
+    "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
+    "Chisel 7.0"
+  )
   def addSource(
     component:    NamedComponent,
     name:         String,
@@ -161,7 +164,10 @@ object BoringUtils {
     * @param forceExists if true, require that the provided `name` parameter already exists in the global namespace
     * @throws BoringUtilsException if name is expected to exist and it doesn't
     */
-  @deprecated("Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0", "Chisel 7.0")
+  @deprecated(
+    "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
+    "Chisel 7.0"
+  )
   def addSink(
     component:    InstanceId,
     name:         String,
@@ -195,7 +201,10 @@ object BoringUtils {
     * @note the returned name will be based on the name of the source
     * component
     */
-  @deprecated("Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0", "Chisel 7.0")
+  @deprecated(
+    "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
+    "Chisel 7.0"
+  )
   def bore(source: Data, sinks: Seq[Data]): String = {
     val boringName =
       try {

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -130,7 +130,7 @@ object BoringUtils {
     */
   @deprecated(
     "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
-    "Chisel 7.0"
+    "Chisel 6.0"
   )
   def addSource(
     component:    NamedComponent,
@@ -166,7 +166,7 @@ object BoringUtils {
     */
   @deprecated(
     "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
-    "Chisel 7.0"
+    "Chisel 6.0"
   )
   def addSink(
     component:    InstanceId,
@@ -203,7 +203,7 @@ object BoringUtils {
     */
   @deprecated(
     "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
-    "Chisel 7.0"
+    "Chisel 6.0"
   )
   def bore(source: Data, sinks: Seq[Data]): String = {
     val boringName =

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -128,6 +128,7 @@ object BoringUtils {
     * @return the name used
     * @note if a uniqueName is not specified, the returned name may differ from the user-provided name
     */
+  @deprecated("Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0", "Chisel 7.0")
   def addSource(
     component:    NamedComponent,
     name:         String,
@@ -160,6 +161,7 @@ object BoringUtils {
     * @param forceExists if true, require that the provided `name` parameter already exists in the global namespace
     * @throws BoringUtilsException if name is expected to exist and it doesn't
     */
+  @deprecated("Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0", "Chisel 7.0")
   def addSink(
     component:    InstanceId,
     name:         String,
@@ -193,6 +195,7 @@ object BoringUtils {
     * @note the returned name will be based on the name of the source
     * component
     */
+  @deprecated("Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0", "Chisel 7.0")
   def bore(source: Data, sinks: Seq[Data]): String = {
     val boringName =
       try {


### PR DESCRIPTION
Simply deprecates the old BoringUtils `bore(source, sinks)`, `addSource`, `addSink` in favor of the new API.
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API deprecation

#### Desired Merge Strategy
Squash

#### Release Notes
`BoringUtils.bore(source, sinks)`, `BoringUtils.addSource` and `BoringUtils.addSink` are now deprecated in favor of the new BoringUtils APIs: `BoringUtils.bore(source)`, `BoringUtils.tap(source)` ...

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
