### PR TITLE
Make SourceLineNoCol public

### DIFF
--- a/core/src/main/scala/chisel3/experimental/SourceInfo.scala
+++ b/core/src/main/scala/chisel3/experimental/SourceInfo.scala
@@ -57,11 +57,11 @@ case class SourceLine(filename: String, line: Int, col: Int) extends SourceInfo 
   *
   * Only used for warning and error reporting when no [[SourceLine]] is available
   */
-private[chisel3] case class SourceLineNoCol(filename: String, line: Int) extends SourceInfo {
+case class SourceLineNoCol(filename: String, line: Int) extends SourceInfo {
   def makeMessage(f: String => String): String = f(s"@[$filename $line]")
   def filenameOption: Option[String] = Some(filename)
 }
-private[chisel3] object SourceLineNoCol {
+object SourceLineNoCol {
 
   /** Returns the best guess at the first stack frame that belongs to user code.
     */


### PR DESCRIPTION
Adding the private method is already a source-incompatible change because SourceInfo is sealed. Having it package private makes it impossible for user-code to handle it properly for things like serialization.

Fixes a bug in https://github.com/chipsalliance/chisel/pull/3414

Will need to be included in #3430 and #3431.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- BugFix

(This is fixing something in something that hasn't been released)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
