### PR TITLE
Remove SourceLineNoCol

### DIFF
--- a/core/src/main/scala/chisel3/internal/Error.scala
+++ b/core/src/main/scala/chisel3/internal/Error.scala
@@ -13,7 +13,7 @@ import java.nio.file.{FileSystems, PathMatcher, Paths}
 import java.util.regex.PatternSyntaxException
 import scala.io.Source
 
-import chisel3.experimental.{NoSourceInfo, SourceInfo, SourceLine, SourceLineNoCol, UnlocatableSourceInfo}
+import chisel3.experimental.{NoSourceInfo, SourceInfo, SourceLine, UnlocatableSourceInfo}
 
 object ExceptionHelpers {
 
@@ -282,8 +282,7 @@ private[chisel3] class ErrorLog(
     */
   private def errorLocationString(si: Option[SourceInfo]): String = {
     si match {
-      case Some(sl: SourceLine) => s"${sl.filename}:${sl.line}:${sl.col}"
-      case Some(sl: SourceLineNoCol) => s"${sl.filename}:${sl.line}"
+      case Some(sl: SourceLine) => sl.serialize
       case Some(_: NoSourceInfo) => "(unknown)"
       case None => ""
     }

--- a/core/src/main/scala/chisel3/internal/Warning.scala
+++ b/core/src/main/scala/chisel3/internal/Warning.scala
@@ -2,7 +2,7 @@
 
 package chisel3.internal
 
-import chisel3.experimental.{SourceInfo, SourceLineNoCol, UnlocatableSourceInfo}
+import chisel3.experimental.SourceInfo
 
 ///////////////////////////////////////////////////
 // Never remove IDs and only ever add to the end //
@@ -30,7 +30,7 @@ private[chisel3] object Warning {
     new Warning(info, id, num + msg)
   }
   def noInfo(id: WarningID, msg: String): Warning = {
-    implicit val info = SourceLineNoCol.materialize.getOrElse(UnlocatableSourceInfo)
+    implicit val info = SourceInfo.materializeFromStacktrace
     Warning(id, msg)
   }
 }

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -45,9 +45,8 @@ private[chisel3] object Converter {
   }
 
   def convert(info: SourceInfo): fir.Info = info match {
-    case _: NoSourceInfo => fir.NoInfo
-    case SourceLine(fn, line, col) => fir.FileInfo.fromUnescaped(s"$fn $line:$col")
-    case SourceLineNoCol(fn, line) => fir.FileInfo.fromUnescaped(s"$fn $line")
+    case _:  NoSourceInfo => fir.NoInfo
+    case sl: SourceLine   => fir.FileInfo.fromUnescaped(sl.serialize)
   }
 
   def convert(op: PrimOp): fir.PrimOp = firrtl.PrimOps.fromString(op.name)

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -461,7 +461,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val lines = stdout.split("\n")
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:90:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala 90:9: Negative shift amounts are illegal (got -1)"
       )
       lines(1) should include("    3.U >> -1")
       lines(2) should include("        ^")
@@ -482,7 +482,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines.size should equal(2)
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala:90:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala 90:9: Negative shift amounts are illegal (got -1)"
       )
       (lines(1) should not).include("3.U >> -1")
     }
@@ -507,7 +507,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
       val lines = stdout.split("\n")
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
-      lines(0) should include("Foo:3:10: Negative shift amounts are illegal (got -1)")
+      lines(0) should include("Foo 3:10: Negative shift amounts are illegal (got -1)")
       lines(1) should include("I am the file in sourceroot1")
       lines(2) should include("         ^")
     }
@@ -532,7 +532,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
       val lines = stdout.split("\n")
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
-      lines(0) should include("Foo:3:10: Negative shift amounts are illegal (got -1)")
+      lines(0) should include("Foo 3:10: Negative shift amounts are illegal (got -1)")
       lines(1) should include("I am the file in sourceroot2")
       lines(2) should include("         ^")
     }


### PR DESCRIPTION
It causes issues in downstream codebases and really adding it just isn't worth the pain.

Removes an API added in https://github.com/chipsalliance/chisel/pull/3414

Will need to be included in #3430 and #3431.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

No release notes

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification
- BugFix

(Modification of an API that is not-yet-released)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash
#### Release Notes

Tweak emission of source locators in error messages to match format in emitting FIRRTL (removed the `:` between filename and line number).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
