### PR TITLE
Add FirtoolBinaryPath option

### DIFF
--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -103,15 +103,15 @@ case class EmittedMLIR(
 
 case object FirtoolBinaryPath extends HasShellOptions {
   override def options = Seq(
-    new ShellOption[Unit](
+    new ShellOption(
       longOption = "firtool-binary-path",
-      toAnnotationSeq = path => Seq(FirtoolBinaryPath(path)),
-      helpText =
-        """Specifies the path to the "firtool" binary Chisel should use.""",
-      helpValueName = "path"
+      toAnnotationSeq = (path: String) => Seq(FirtoolBinaryPath(path)),
+      helpText = """Specifies the path to the "firtool" binary Chisel should use.""",
+      helpValueName = Some("path")
     )
   )
 }
+
 /** Annotation that tells [[circt.stage.phases.CIRCT CIRCT]] what firtool executable to use */
 case class FirtoolBinaryPath(option: String) extends NoTargetAnnotation with CIRCTOption
 

--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -101,7 +101,7 @@ case class EmittedMLIR(
 
 }
 
-case object FirtoolBinaryPath extends HasShellOptions {
+private[stage] case object FirtoolBinaryPath extends HasShellOptions {
   override def options = Seq(
     new ShellOption(
       longOption = "firtool-binary-path",

--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -101,6 +101,7 @@ case class EmittedMLIR(
 
 }
 
+/** Annotation that tells [[circt.stage.phases.CIRCT CIRCT]] what firtool executable to use */
 case class FirtoolBinaryPath(option: String) extends NoTargetAnnotation with CIRCTOption
 
 case class FirtoolOption(option: String) extends NoTargetAnnotation with CIRCTOption

--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -101,6 +101,17 @@ case class EmittedMLIR(
 
 }
 
+case object FirtoolBinaryPath extends HasShellOptions {
+  override def options = Seq(
+    new ShellOption[Unit](
+      longOption = "firtool-binary-path",
+      toAnnotationSeq = path => Seq(FirtoolBinaryPath(path)),
+      helpText =
+        """Specifies the path to the "firtool" binary Chisel should use.""",
+      helpValueName = "path"
+    )
+  )
+}
 /** Annotation that tells [[circt.stage.phases.CIRCT CIRCT]] what firtool executable to use */
 case class FirtoolBinaryPath(option: String) extends NoTargetAnnotation with CIRCTOption
 

--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -101,6 +101,8 @@ case class EmittedMLIR(
 
 }
 
+case class FirtoolBinaryPath(option: String) extends NoTargetAnnotation with CIRCTOption
+
 case class FirtoolOption(option: String) extends NoTargetAnnotation with CIRCTOption
 
 /** Annotation that indicates that firtool should run using the

--- a/src/main/scala/circt/stage/CIRCTOptions.scala
+++ b/src/main/scala/circt/stage/CIRCTOptions.scala
@@ -26,6 +26,7 @@ class CIRCTOptions private[stage] (
     firtoolOptions:    Seq[String] = firtoolOptions,
     splitVerilog:      Boolean = splitVerilog,
     firtoolBinaryPath: Option[String] = firtoolBinaryPath
-  ): CIRCTOptions = new CIRCTOptions(outputFile, preserveAggregate, target, firtoolOptions, splitVerilog, firtoolBinaryPath)
+  ): CIRCTOptions =
+    new CIRCTOptions(outputFile, preserveAggregate, target, firtoolOptions, splitVerilog, firtoolBinaryPath)
 
 }

--- a/src/main/scala/circt/stage/CIRCTOptions.scala
+++ b/src/main/scala/circt/stage/CIRCTOptions.scala
@@ -16,14 +16,16 @@ class CIRCTOptions private[stage] (
   val preserveAggregate: Option[PreserveAggregate.Type] = None,
   val target:            Option[CIRCTTarget.Type] = None,
   val firtoolOptions:    Seq[String] = Seq.empty,
-  val splitVerilog:      Boolean = false) {
+  val splitVerilog:      Boolean = false,
+  val firtoolBinaryPath: Option[String] = None) {
 
   private[stage] def copy(
     outputFile:        Option[File] = outputFile,
     preserveAggregate: Option[PreserveAggregate.Type] = preserveAggregate,
     target:            Option[CIRCTTarget.Type] = target,
     firtoolOptions:    Seq[String] = firtoolOptions,
-    splitVerilog:      Boolean = splitVerilog
-  ): CIRCTOptions = new CIRCTOptions(outputFile, preserveAggregate, target, firtoolOptions, splitVerilog)
+    splitVerilog:      Boolean = splitVerilog,
+    firtoolBinaryPath: Option[String] = firtoolBinaryPath
+  ): CIRCTOptions = new CIRCTOptions(outputFile, preserveAggregate, target, firtoolOptions, splitVerilog, firtoolBinaryPath)
 
 }

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -41,7 +41,8 @@ trait CLI { this: BareShell =>
     WarningConfigurationAnnotation,
     WarningConfigurationFileAnnotation,
     SourceRootAnnotation,
-    SplitVerilog
+    SplitVerilog,
+    FirtoolBinaryPath
   ).foreach(_.addOptions(parser))
 }
 

--- a/src/main/scala/circt/stage/package.scala
+++ b/src/main/scala/circt/stage/package.scala
@@ -24,7 +24,7 @@ package object stage {
             case OutputFileAnnotation(a)  => acc.copy(outputFile = Some(new File(a)))
             case CIRCTTargetAnnotation(a) => acc.copy(target = Some(a))
             case PreserveAggregate(a)     => acc.copy(preserveAggregate = Some(a))
-            case FirtoolBinaryPath(a)         => acc.copy(firtoolBinaryPath = Some(a))
+            case FirtoolBinaryPath(a)     => acc.copy(firtoolBinaryPath = Some(a))
             case FirtoolOption(a)         => acc.copy(firtoolOptions = acc.firtoolOptions :+ a)
             case SplitVerilog             => acc.copy(splitVerilog = true)
             case _                        => acc

--- a/src/main/scala/circt/stage/package.scala
+++ b/src/main/scala/circt/stage/package.scala
@@ -24,6 +24,7 @@ package object stage {
             case OutputFileAnnotation(a)  => acc.copy(outputFile = Some(new File(a)))
             case CIRCTTargetAnnotation(a) => acc.copy(target = Some(a))
             case PreserveAggregate(a)     => acc.copy(preserveAggregate = Some(a))
+            case FirtoolBinaryPath(a)         => acc.copy(firtoolBinaryPath = Some(a))
             case FirtoolOption(a)         => acc.copy(firtoolOptions = acc.firtoolOptions :+ a)
             case SplitVerilog             => acc.copy(splitVerilog = true)
             case _                        => acc

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -185,7 +185,7 @@ class CIRCT extends Phase {
 
     val circtAnnotationFilename = "circt.anno.json"
 
-    val binary = "firtool"
+    val binary = circtOptions.firtoolBinaryPath.getOrElse("firtool")
 
     val cmd =
       Seq(binary, "-format=fir", "-warn-on-unprocessed-annotations", "-dedup") ++


### PR DESCRIPTION
In certain environments, such as when running tests via `bloop`, it may be difficult to influence which `firtool` CIRCT uses via the PATH environment variable (the only method currently available). This allows us to replace the version of `firtool` that is used at runtime (or point Chisel to the correct firtool binary in scenarios where it isn't on your PATH).

This will also be helpful if we want to package firtool in the Chisel jar @jackkoenig, since we will probably be extracting it to a temporary directory and not in the PATH.

#### Type of Improvement

- Feature (or new API)

#### Release Notes

- Add `FirtoolBinaryPathOption` to select a different `firtool` binary at runtime.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
