### PR TITLE
ChiselPlugin: prefix destructuring assignments

### DIFF
--- a/src/test/scala/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala/chiselTests/naming/NamePluginSpec.scala
@@ -267,7 +267,7 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
     }
   }
 
-  "Unapply assignments" should "name (but not prefix) local vals on the RHS" in {
+  "Unapply assignments" should "name and prefix local vals on the RHS" in {
     class Test extends Module {
       {
         val (a, b) = {
@@ -279,7 +279,7 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
     }
 
     aspectTest(() => new Test) { top: Test =>
-      Select.wires(top).map(_.instanceName) should be(List("a", "b", "sum"))
+      Select.wires(top).map(_.instanceName) should be(List("a", "b", "a_b_sum"))
     }
   }
 
@@ -324,7 +324,7 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
     }
 
     aspectTest(() => new Test) { top: Test =>
-      Select.wires(top).map(_.instanceName) should be(List("w", "a", "_WIRE"))
+      Select.wires(top).map(_.instanceName) should be(List("w", "a", "_a_c_WIRE"))
     }
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Backend code generation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
ChiselPlugin will now prefix temporaries generated by the right-hand side of a destructuring assignment e.g. `val (a, b, _) = (Wire(Bool()), Wire(Bool()), Wire(Bool()))` will generate name `_a_b_WIRE` instead of `_WIRE` for the third element.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
