### PR TITLE
Optimize source locator escaping when emitting FIRRTL

### DIFF
--- a/src/test/scala/chiselTests/SourceLocatorSpec.scala
+++ b/src/test/scala/chiselTests/SourceLocatorSpec.scala
@@ -2,7 +2,10 @@
 
 package chiselTests
 
+import circt.stage.ChiselStage.emitCHIRRTL
 import chisel3._
+import chisel3.experimental.SourceLine
+import firrtl.ir.FileInfo
 
 class SourceLocatorSpec extends ChiselFunSpec with Utils {
   describe("(0) Relative source paths") {
@@ -12,6 +15,30 @@ class SourceLocatorSpec extends ChiselFunSpec with Utils {
       }
       val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
       chirrtl should include("@[src/test/scala/chiselTests/SourceLocatorSpec.scala")
+    }
+  }
+
+  describe("(1) Source locators with special characters") {
+    val filename = "I need escaping\n\\\t].scala"
+    val escaped = "I need escaping\\n\\\\\\t\\].scala"
+    val info = SourceLine(filename, 123, 456)
+    it("(1.a): are properly escaped when converting to FIRRTL") {
+      val firrtl = FileInfo.fromUnescaped(filename)
+      firrtl should equal(FileInfo(escaped))
+    }
+    it("(1.b): are properly escaped to FIRRTL through Chisel elaboration") {
+      implicit val sl = info
+
+      val chirrtl = emitCHIRRTL(new RawModule {
+        val in = IO(Input(UInt(8.W)))
+        val out = IO(Output(UInt(8.W)))
+        out := in
+      })
+      chirrtl should include(escaped)
+    }
+    it("(1.c): can be properly unescaped") {
+      val escapedInfo = FileInfo(escaped)
+      escapedInfo.unescaped should equal(filename)
     }
   }
 }


### PR DESCRIPTION
Speeds up serialization a little bit, for a very large design (~ 11 GB of .fir) it speeds up serialization from ~200 s to ~160 s.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Performance improvement



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Only escape/unescape source locators that need it, avoids a String copy in the common case.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
