### PR TITLE
[ci] Add "nightly" option to install-circt action

### DIFF
--- a/.github/workflows/build-scala-cli-template/action.yml
+++ b/.github/workflows/build-scala-cli-template/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Install CIRCT
       uses: ./.github/workflows/install-circt
       with:
-        github-token: ${{ gitub.token }}
+        github-token: ${{ github.token }}
     - name: Cache Scala-CLI
       uses: coursier/cache-action@v6
     - name: Setup Scala-CLI

--- a/.github/workflows/build-scala-cli-template/action.yml
+++ b/.github/workflows/build-scala-cli-template/action.yml
@@ -5,6 +5,8 @@ runs:
   steps:
     - name: Install CIRCT
       uses: ./.github/workflows/install-circt
+      with:
+        github-token: ${{ gitub.token }}
     - name: Cache Scala-CLI
       uses: coursier/cache-action@v6
     - name: Setup Scala-CLI

--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -2,24 +2,54 @@ name: Install CIRCT
 
 inputs:
   version:
-    description: 'version to install'
+    description: 'version to install ("nightly" installs latest nightly)'
     required: false
     default: 'firtool-1.48.0'
+  github-token:
+    description: 'The GitHub token used to download CIRCT nightly'
+    required: true
+    default: ${{ github.token }}
 
 runs:
   using: composite
   steps:
     - id: cache-circt
+      if: inputs.version != 'nightly'
       uses: actions/cache@v3
       with:
         path: circt
         key: circt-${{ runner.os }}-${{ inputs.version }}
 
     - shell: bash
-      if: steps.cache-circt.outputs.cache-hit != 'true'
+      if: inputs.version != 'nightly' && steps.cache-circt.outputs.cache-hit != 'true'
       run: |
         mkdir circt
         wget -q -O - https://github.com/llvm/circt/releases/download/${{ inputs.version }}/firrtl-bin-linux-x64.tar.gz | tar -zx -C circt/ --strip-components 1
 
+    - name: Download Latest Nighlty `firtool` binary
+      shell: bash
+      if: inputs.version == 'nightly'
+      run: |
+        ARTIFACT_NAME=firrtl-bin-linux-x64.tar.gz
+        ARTIFACT_ID=$(
+          curl -L \
+               -H "Accept: application/vnd.github+json" \
+               -H "Authorization: Bearer ${{ inputs.github-token }}" \
+               -H "X-GitHub-Api-Version: 2022-11-28" \
+               "https://api.github.com/repos/llvm/circt/actions/artifacts?name=$ARTIFACT_NAME&per_page=1" | \
+            jq '.artifacts[0].id')
+        echo $ARTIFACT_ID
+        curl -L \
+             -H "Accept: application/vnd.github+json" \
+             -H "Authorization: Bearer ${{ inputs.github-token }}" \
+             -H "X-GitHub-Api-Version: 2022-11-28" \
+             "https://api.github.com/repos/llvm/circt/actions/artifacts/$ARTIFACT_ID/zip" \
+             --output download.zip
+        mkdir circt/
+        unzip -p download.zip | tar -zx -C circt/ --strip-components 1
+        rm download.zip
+
     - shell: bash
-      run: echo "$(pwd)/circt/bin" >> $GITHUB_PATH
+      run: |
+        echo "$(pwd)/circt/bin" >> $GITHUB_PATH
+        ./circt/bin/firtool -version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
-          github-token: ${{ gitub.token }}
+          github-token: ${{ github.token }}
       - name: Compile Mill
         run: mill __.compile
 
@@ -81,7 +81,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
-          github-token: ${{ gitub.token }}
+          github-token: ${{ github.token }}
       - name: Check Formatting
         run: sbt fmtCheck
 
@@ -104,7 +104,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
-          github-token: ${{ gitub.token }}
+          github-token: ${{ github.token }}
       - name: Integration Tests
         run: sbt integrationTests/test
 
@@ -154,7 +154,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
-          github-token: ${{ gitub.token }}
+          github-token: ${{ github.token }}
         #TODO: make the microsite building include building ScalaDoc
       - name: Build the docs
         run: sbt doc
@@ -235,7 +235,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
-          github-token: ${{ gitub.token }}
+          github-token: ${{ github.token }}
       - name: Setup Scala
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
         uses: ./.github/workflows/install-circt
         with:
           version: ${{ matrix.circt }}
+          github-token: ${{ github.token }}
       - name: Test
         run: sbt ++${{ matrix.scala }} test
       - name: Binary compatibility
@@ -60,6 +61,8 @@ jobs:
           mill-version: 0.11.0
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
+        with:
+          github-token: ${{ gitub.token }}
       - name: Compile Mill
         run: mill __.compile
 
@@ -77,6 +80,8 @@ jobs:
           cache: 'sbt'
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
+        with:
+          github-token: ${{ gitub.token }}
       - name: Check Formatting
         run: sbt fmtCheck
 
@@ -98,6 +103,8 @@ jobs:
           cache: 'sbt'
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
+        with:
+          github-token: ${{ gitub.token }}
       - name: Integration Tests
         run: sbt integrationTests/test
 
@@ -146,6 +153,8 @@ jobs:
           gem install jekyll-redirect-from
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
+        with:
+          github-token: ${{ gitub.token }}
         #TODO: make the microsite building include building ScalaDoc
       - name: Build the docs
         run: sbt doc
@@ -225,6 +234,8 @@ jobs:
           fetch-depth: 0
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
+        with:
+          github-token: ${{ gitub.token }}
       - name: Setup Scala
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Add support for grabbing the latest nightly version of `firtool` to the
install-circt action.  This requires passing the "github.token" so that
the GitHub API can be used.  Note that the token is marked as "required",
however, it is only actually needed when using a nightly build.