### PR TITLE
[ci] Make test.yml a reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,111 @@
+name: Continuous Integration
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+      - '*.x'
+
+jobs:
+  ci:
+    name: ci
+    strategy:
+      matrix:
+        system: ["ubuntu-20.04"]
+        jvm: [8]
+        scala: ["2.13.11"]
+        espresso: ["2.4"]
+        circt: ["firtool-1.48.0"]
+    uses: ./.github/workflows/test.yml
+    with:
+      system: ${{ matrix.system }}
+      jvm: ${{ matrix.jvm }}
+      scala: ${{ matrix.scala }}
+      espresso: ${{ matrix.espresso }}
+      circt: ${{ matrix.circt }}
+
+  # Sentinel job to simplify how we specify which checks need to pass in branch
+  # protection and in Mergify. This job checks that all matrix jobs were
+  # successful.
+  check-tests:
+    name: "check tests"
+    needs: ci
+    runs-on: ubuntu-20.04
+    outputs:
+      success: ${{ steps.setoutput.outputs.success }}
+    steps:
+      - id: setoutput
+        run: echo "success=true" >> $GITHUB_OUTPUT
+
+  # Related to check-tests above, this job _always_ runs (even if tests fail
+  # and thus check-steps is skipped). This two sentinel job approach avoids an
+  # issue where failing tests causes a single sentinel job to be skipped which
+  # counts as passing for purposes of branch protection.
+  #
+  # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  all_tests_passed:
+    name: "all tests passed"
+    runs-on: ubuntu-20.04
+    if: always() # Always run so that we never skip this check
+    needs: check-tests
+      # Pass only if check-tests set its output value
+    steps:
+      - run: PASSED=${{ needs.check-tests.outputs.success }}
+
+  # sbt ci-release publishes all cross versions so this job needs to be
+  # separate from a Scala versions build matrix to avoid duplicate publishing
+  publish:
+    needs: [all_tests_passed]
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'push'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install CIRCT
+        uses: ./.github/workflows/install-circt
+        with:
+          github-token: ${{ github.token }}
+      - name: Setup Scala
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '8'
+          cache: 'sbt'
+      - name: Setup GPG (for Publish)
+        uses: olafurpg/setup-gpg@v3
+      - name: Publish
+        run: sbt ci-release
+        env:
+          CI_SNAPSHOT_RELEASE: "+unipublish/publish"
+          CI_SONATYPE_RELEASE: "+unipublish/publishSigned"
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.CHIPSALLIANCE_SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.CHIPSALLIANCE_SONATYPE_USERNAME }}
+
+  deploy_website:
+    name: Deploy Website
+    runs-on: ubuntu-latest
+    needs: [all_tests_passed]
+    # Only Deploy website on pushes to main, may change to a stable branch
+    if: (github.event_name == 'push') && (github.ref_name == 'main')
+    steps:
+      - name: Download built website
+        uses: actions/download-artifact@v3
+        with:
+          name: website
+      - name: Untar built website
+        run: tar zxf website.tar.gz
+      - name: Deploy Website to GitHub Pages (From Main Branch)
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: website/docs/target/site

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,26 +1,37 @@
-name: Continuous Integration
+name: Test Chisel
 
 on:
-  workflow_dispatch:
-  pull_request:
-  push:
-    tags:
-      - '*'
-    branches:
-      - main
-      - '*.x'
+  workflow_call:
+    inputs:
+      system:
+        description: 'The GitHub runner to use'
+        default: 'ubuntu-20.04'
+        required: true
+        type: string
+      jvm:
+        description: 'The Java version to use'
+        default: 8
+        required: true
+        type: number
+      scala:
+        description: 'The Scala version to use'
+        default: '2.13.11'
+        required: true
+        type: string
+      espresso:
+        description: 'The espresso version to use'
+        default: '2.4'
+        required: true
+        type: string
+      circt:
+        description: 'The CIRCT version to use (must be a valid release tag or "nightly")'
+        required: true
+        type: string
 
 jobs:
   ci:
     name: ci
-    strategy:
-      matrix:
-        system: ["ubuntu-20.04"]
-        jvm: ["8"]
-        scala: ["2.13.11"]
-        espresso: ["2.4"]
-        circt: ["firtool-1.48.0"]
-    runs-on: ${{ matrix.system }}
+    runs-on: ${{ inputs.system }}
 
     steps:
       - name: Checkout
@@ -30,24 +41,24 @@ jobs:
       - name: Install Espresso
         uses: ./.github/workflows/install-espresso
         with:
-          version: ${{ matrix.espresso }}
+          version: ${{ inputs.espresso }}
       - name: Setup Scala
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: ${{ matrix.jvm }}
+          java-version: ${{ inputs.jvm }}
           cache: 'sbt'
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
-          version: ${{ matrix.circt }}
+          version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       - name: Test
-        run: sbt ++${{ matrix.scala }} test
+        run: sbt ++${{ inputs.scala }} test
       - name: Binary compatibility
         # TODO either make this also check the plugin or decide that we don't
         #      support binary compatibility for the plugin
-        run: sbt ++${{ matrix.scala }} unipublish/mimaReportBinaryIssues
+        run: sbt ++${{ inputs.scala }} unipublish/mimaReportBinaryIssues
 
   mill:
     name: compile project with mill
@@ -126,9 +137,9 @@ jobs:
           java-version: '11'
           cache: 'sbt'
       - name: Check Formatting
-        run: sbt ++${{ matrix.scala }} standardLibrary/scalafmtCheckAll
+        run: sbt ++${{ inputs.scala }} standardLibrary/scalafmtCheckAll
       - name: Unit Tests
-        run: sbt ++${{ matrix.scala }} standardLibrary/test
+        run: sbt ++${{ inputs.scala }} standardLibrary/test
 
   website:
     name: Build Mdoc & Website
@@ -173,96 +184,3 @@ jobs:
   scala-cli-template:
     name: Test Scala-CLI Template
     uses: ./.github/workflows/build-scala-cli-template.yml
-
-  # Sentinel job to simplify how we specify which checks need to pass in branch
-  # protection and in Mergify. This job checks that all jobs were successful.
-  #
-  # When adding new jobs, please add them to `needs` below
-  check-tests:
-    name: "check tests"
-    needs: [mill, ci, std, integration, doc, website, scala-cli-template]
-    runs-on: ubuntu-20.04
-    if: success() # only run if all tests have passed
-    outputs:
-      success: ${{ steps.setoutput.outputs.success }}
-    steps:
-      - id: setoutput
-        run: echo "success=true" >> $GITHUB_OUTPUT
-
-  # Related to check-tests above, this job _always_ runs (even if tests fail
-  # and thus check-steps is skipped). This two sentinel job approach avoids an
-  # issue where failing tests causes a single sentinel job to be skipped which
-  # counts as passing for purposes of branch protection.
-  #
-  # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
-  all_tests_passed:
-    name: "all tests passed"
-    runs-on: ubuntu-20.04
-    if: always() # Always run so that we never skip this check
-    needs: check-tests
-      # Pass only if check-tests set its output value
-    steps:
-      - run: |
-          PASSED="${{ needs.check-tests.outputs.success }}"
-          if [[ $PASSED == "true" ]]; then
-            echo "### All tests passed! :rocket:" >> $GITHUB_STEP_SUMMARY
-            exit 0
-          else
-            echo "### One or more tests FAILED! :bangbang:" >> $GITHUB_STEP_SUMMARY
-            exit 1
-          fi
-
-  # sbt ci-release publishes all cross versions so this job needs to be
-  # separate from a Scala versions build matrix to avoid duplicate publishing
-  publish:
-    needs: [all_tests_passed]
-    runs-on: ubuntu-20.04
-    if: github.event_name == 'push'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install CIRCT
-        uses: ./.github/workflows/install-circt
-        with:
-          github-token: ${{ github.token }}
-      - name: Setup Scala
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: '8'
-          cache: 'sbt'
-      - name: Setup GPG (for Publish)
-        uses: olafurpg/setup-gpg@v3
-      - name: Publish
-        run: sbt ci-release
-        env:
-          CI_SNAPSHOT_RELEASE: "+unipublish/publish"
-          CI_SONATYPE_RELEASE: "+unipublish/publishSigned"
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.CHIPSALLIANCE_SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.CHIPSALLIANCE_SONATYPE_USERNAME }}
-
-
-  deploy_website:
-    name: Deploy Website
-    runs-on: ubuntu-latest
-    needs: [all_tests_passed]
-    # Only Deploy website on pushes to main, may change to a stable branch
-    if: (github.event_name == 'push') && (github.ref_name == 'main')
-    steps:
-      - name: Download built website
-        uses: actions/download-artifact@v3
-        with:
-          name: website
-      - name: Untar built website
-        run: tar zxf website.tar.gz
-      - name: Deploy Website to GitHub Pages (From Main Branch)
-        uses: JamesIves/github-pages-deploy-action@3.7.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: website/docs/target/site


### PR DESCRIPTION
Change test.yml to be a reusable workflow so that this can be called with different inputs (different matrix arguments) for different test scenarios.  One PR scenario is testing PRs, branches, and releases.  This is added in the ci.yml workflow.  The other, future scenario is nightly testing with CIRCT.

This PR is stacked on #3457.