### PR TITLE
[ci] Add CIRCT nightly CI

### DIFF
--- a/.github/workflows/ci-circt-nightly.yml
+++ b/.github/workflows/ci-circt-nightly.yml
@@ -16,12 +16,104 @@ on:
   # Run on PRs that target the
   pull_request:
     branches:
-      - ${{ branch-name }}
+      - ci/ci-circt-nightly
 
 jobs:
-  hello:
-    name: Hello World
+  update-branch:
+    name: Integrate staging branch with default branch
     runs-on: ubuntu-20.04
     steps:
-      - name: Hello
-        run: echo "World"
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - run: |
+          # Leave the staging branch unchanged if this is a PR.  This is not a
+          # GitHub Actions-level "if" because we want this job to return success
+          # (so that subsequent jobs run).
+          if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+            exit 0
+          fi
+
+          # Rebase the staging branch on the default branch.  Create the staging
+          # branch if it doesn't exist.
+          git checkout -b ${{ env.branch-name }}
+          if [[ `git fetch origin ${{ env.branch-name }}` ]]; then
+            git reset --hard origin ${{ env.branch-name }}
+            git rebase origin/main
+          fi
+
+          git push --force origin ${{ env.branch-name }}
+
+  # If this is running on a PR, then use the branch of the PR.  Otherwise, use
+  # the staging branch.
+  determine-branch:
+    name: Determine what branch to run tests on
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Determine Branch
+        id: determine-branch
+        run: |
+          if [[ ${{ github.event_name }} != 'pull_request' ]]; then
+            echo branches='["${{ env.branch-name }}"]' >> $GITHUB_OUTPUT
+          else
+            echo branches='["${{ github.ref }}"]' >> $GITHUB_OUTPUT
+          fi
+    outputs:
+      branches: ${{ steps.determine-branch.outputs.branches }}
+
+  ci:
+    name: ci
+    needs: [update-branch, determine-branch]
+    strategy:
+      matrix:
+        system: ["ubuntu-20.04"]
+        jvm: [8]
+        scala: ["2.13.11"]
+        espresso: ["2.4"]
+        circt: ["nightly"]
+        ref: ${{ fromJSON(needs.determine-branch.outputs.branches) }}
+    uses: ./.github/workflows/test.yml
+    with:
+      system: ${{ matrix.system }}
+      jvm: ${{ matrix.jvm }}
+      scala: ${{ matrix.scala }}
+      espresso: ${{ matrix.espresso }}
+      circt: ${{ matrix.circt }}
+      ref: ${{ matrix.ref }}
+
+  # Sentinel job to simplify how we specify which checks need to pass in branch
+  # protection and in Mergify. This job checks that all matrix jobs were
+  # successful.
+  check-tests:
+    name: "check tests"
+    needs: [ci]
+    runs-on: ubuntu-20.04
+    outputs:
+      success: ${{ steps.setoutput.outputs.success }}
+    steps:
+      - id: setoutput
+        run: echo "success=true" >> $GITHUB_OUTPUT
+
+  # Related to check-tests above, this job _always_ runs (even if tests fail
+  # and thus check-steps is skipped). This two sentinel job approach avoids an
+  # issue where failing tests causes a single sentinel job to be skipped which
+  # counts as passing for purposes of branch protection.
+  #
+  # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  all_tests_passed:
+    name: "all tests passed"
+    runs-on: ubuntu-20.04
+    if: always() # Always run so that we never skip this check
+    needs: check-tests
+      # Pass only if check-tests set its output value
+    steps:
+      - run: |
+          PASSED=${{ needs.check-tests.outputs.success }}
+          if [[ $PASSED == "true" ]]; then
+            echo "### All tests passed! :rocket:" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          else
+            echo "### One or more tests FAILED! :bangbang:" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Continuous Integration
 on:
   workflow_dispatch:
   pull_request:
+    branches-ignore:
+      - ci/ci-circt-nightly
   push:
     tags:
       - '*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,11 @@ on:
         description: 'The CIRCT version to use (must be a valid release tag or "nightly")'
         required: true
         type: string
+      ref:
+        description: 'The branch, tag, or git hash to checkout'
+        default: ''
+        required: false
+        type: string
 
 jobs:
   ci:
@@ -36,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Install Espresso
@@ -66,6 +73,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install Mill
         uses: jodersky/setup-mill@v0.3.0
         with:
@@ -84,6 +93,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Setup Scala
         uses: actions/setup-java@v3
         with:
@@ -104,6 +115,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Install Espresso
@@ -131,6 +144,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Setup Scala
@@ -151,6 +166,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       - name: Setup Scala
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Add nightly testing of Chisel "main" branch with the nighlty published
"firtool" binary.  This testing will also be run on PRs targeting the
staging branch, "ci/ci-circt-nightly".

---

This runs nightly testing using the published `firtool` binary made available through this action on CIRCT: https://github.com/llvm/circt/actions/workflows/uploadFirrtlReleaseArtifacts.yml. The Chisel action (that this PR introduces) is setup to run one hour after the CIRCT one starts.

The nightly testing relies on a staging branch, `ci/ci-circt-nightly`, to deal with changes that are necessary for the nightly to pass. Nightly testing will try to update this branch (via rebase) onto the `main` branch before it builds.

Patches can be included in the `ci/ci-circt-nightly` branch by either manually updating it or by making PRs against it. If PRs are made against it, then this action will also run, but without updating the `ci/ci-circt-nightly` branch first.

For an example of how this all composes, consider the following live example. Currently, `firtool` nightly includes changes which fix a bug in the Trace API. Current Chisel `main` includes which check that the incorrect behavior occurs, i.e., the tests are wrong. Consequently, Chisel `main` w/ the `firtool` nightly will fail. This can be seen if manually triggering the nightly action here: https://github.com/chipsalliance/chisel/actions/runs/5768453794 However, the PR that fixes this will pass: https://github.com/chipsalliance/chisel/actions/runs/5768391177?pr=3451

Summarizing the complete workflow:

1. Nightly is broken as discovered by this action running.
2. A user makes a PR to update the `ci/ci-circt-nightly` branch.
3. This action is used to check that it fixed nightly.
4. The PR is merged.
5. Nightly now passes as checked by this PR.