### PR TITLE
[ci] Change CIRCT version to exist in one place  

### DIFF
--- a/.github/workflows/build-scala-cli-template.yml
+++ b/.github/workflows/build-scala-cli-template.yml
@@ -2,6 +2,11 @@ name: Build and Test Scala-CLI Template
 
 on:
   workflow_call:
+    inputs:
+      circt:
+        description: 'The version of CIRCT to use'
+        required: true
+        type: string
 
 jobs:
   build_template:
@@ -17,6 +22,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
+          version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       - name: Cache Scala-CLI
         uses: coursier/cache-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,31 @@ on:
       - main
       - '*.x'
 
+env:
+  circt: "firtool-1.48.0"
+
 jobs:
+  set-circt-versions:
+    name: Set the CIRCT version from the env
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set CIRCT Version
+        id: set-circt-version
+        run: |
+          echo versions='["${{ env.circt }}"]' >> $GITHUB_OUTPUT
+    outputs:
+      circt-versions: ${{ steps.set-circt-version.outputs.versions }}
+
   ci:
     name: ci
+    needs: [set-circt-versions]
     strategy:
       matrix:
         system: ["ubuntu-20.04"]
         jvm: [8]
         scala: ["2.13.11"]
         espresso: ["2.4"]
-        circt: ["firtool-1.48.0"]
+        circt: ${{ fromJSON(needs.set-circt-versions.outputs.circt-versions) }}
     uses: ./.github/workflows/test.yml
     with:
       system: ${{ matrix.system }}
@@ -79,6 +94,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
+          version: ${{ env.circt }}
           github-token: ${{ github.token }}
       - name: Setup Scala
         uses: actions/setup-java@v3

--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -3,8 +3,7 @@ name: Install CIRCT
 inputs:
   version:
     description: 'version to install ("nightly" installs latest nightly)'
-    required: false
-    default: 'firtool-1.48.0'
+    required: true
   github-token:
     description: 'The GitHub token used to download CIRCT nightly'
     required: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
+          version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       - name: Compile Mill
         run: mill __.compile
@@ -92,6 +93,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
+          version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       - name: Check Formatting
         run: sbt fmtCheck
@@ -115,6 +117,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
+          version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       - name: Integration Tests
         run: sbt integrationTests/test
@@ -165,6 +168,7 @@ jobs:
       - name: Install CIRCT
         uses: ./.github/workflows/install-circt
         with:
+          version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
         #TODO: make the microsite building include building ScalaDoc
       - name: Build the docs
@@ -184,3 +188,5 @@ jobs:
   scala-cli-template:
     name: Test Scala-CLI Template
     uses: ./.github/workflows/build-scala-cli-template.yml
+    with:
+      circt: ${{ inputs.circt }}


### PR DESCRIPTION
Change how the CIRCT version is specified for non-nightly flows to a single environment variable in the ci.yml script.  This makes things easier for either: (1) a human to update this or (2) a machine to update this in a CD flow.