### PR TITLE
[ci] Use 'default' as version string for typical CIRCT version

### DIFF
--- a/.github/workflows/build-scala-cli-template.yml
+++ b/.github/workflows/build-scala-cli-template.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       circt:
         description: 'The version of CIRCT to use'
-        required: true
+        default: 'default'
         type: string
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - '*.x'
 
 env:
-  circt: "firtool-1.48.0"
+  circt: "default"
 
 jobs:
   set-circt-versions:

--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -3,7 +3,7 @@ name: Install CIRCT
 inputs:
   version:
     description: 'version to install ("nightly" installs latest nightly)'
-    required: true
+    default: 'default'
   github-token:
     description: 'The GitHub token used to download CIRCT nightly'
     required: true
@@ -22,8 +22,13 @@ runs:
     - shell: bash
       if: inputs.version != 'nightly' && steps.cache-circt.outputs.cache-hit != 'true'
       run: |
+        if [[ "${{ inputs.version }}" == "default" ]]; then
+          export VERSION="firtool-1.48.0"
+        else
+          export VERSION="${{ inputs.version }}"
+        fi
         mkdir circt
-        wget -q -O - https://github.com/llvm/circt/releases/download/${{ inputs.version }}/firrtl-bin-linux-x64.tar.gz | tar -zx -C circt/ --strip-components 1
+        wget -O - https://github.com/llvm/circt/releases/download/$VERSION/firrtl-bin-linux-x64.tar.gz | tar -zx -C circt/ --strip-components 1
 
     - name: Download Latest Nighlty `firtool` binary
       shell: bash


### PR DESCRIPTION
Make it such that using "Install CIRCT" does not require specifying a CIRCT version, instead using the string 'default' as a way to pick the "default version". The "default version" is the version that Chisel is tested and released against.

This fixes "Generate Scala CLI Template" which does not care to specify a CIRCT version.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes

Make it such that using "Install CIRCT" does not require specifying a CIRCT version, instead using the string 'default' as a way to pick the "default version". The "default version" is the version that Chisel is tested and released against.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
