### PR TITLE
[ci] Move CIRCT version to JSON file

### DIFF
--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -9,6 +9,9 @@ inputs:
     required: true
     default: ${{ github.token }}
 
+env:
+  circt-config: ./etc/circt.json
+
 runs:
   using: composite
   steps:
@@ -23,7 +26,7 @@ runs:
       if: inputs.version != 'nightly' && steps.cache-circt.outputs.cache-hit != 'true'
       run: |
         if [[ "${{ inputs.version }}" == "default" ]]; then
-          export VERSION="firtool-1.48.0"
+          export VERSION=`jq .version < ${{ env.circt-config }}`
         else
           export VERSION="${{ inputs.version }}"
         fi

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,5 @@
+This directory contains metadata and configuration information related to
+Chisel.  This information is kept separate from the `.github/` directory to
+enable automatic updating of metadata and configuration information by GitHub
+Actions which, by default, cannot update the `.github/` directory without
+elevated permissions.

--- a/etc/circt.json
+++ b/etc/circt.json
@@ -1,0 +1,3 @@
+{
+    "version": "firtool-1.48.0"
+}


### PR DESCRIPTION
Change the way that the current CIRCT version is specified.  Previously, this was code inside a GitHub Action.  Now this is data inside a JSON file.  This is done to enable other GitHub actions to update the JSON without having to have permissions to update workflows.