### PR TITLE
[ci] Remove caching of firtool

### DIFF
--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -9,24 +9,15 @@ inputs:
     required: true
     default: ${{ github.token }}
 
-env:
-  circt-config: ./etc/circt.json
-
 runs:
   using: composite
   steps:
-    - id: cache-circt
+    - name: Download release `firtool` binary
+      shell: bash
       if: inputs.version != 'nightly'
-      uses: actions/cache@v3
-      with:
-        path: circt
-        key: circt-${{ runner.os }}-${{ inputs.version }}
-
-    - shell: bash
-      if: inputs.version != 'nightly' && steps.cache-circt.outputs.cache-hit != 'true'
       run: |
         if [[ "${{ inputs.version }}" == "default" ]]; then
-          export VERSION=`jq .version < ${{ env.circt-config }}`
+          export VERSION=`jq .version < ./etc/circt.json`
         else
           export VERSION="${{ inputs.version }}"
         fi

--- a/.github/workflows/install-circt/action.yml
+++ b/.github/workflows/install-circt/action.yml
@@ -17,7 +17,7 @@ runs:
       if: inputs.version != 'nightly'
       run: |
         if [[ "${{ inputs.version }}" == "default" ]]; then
-          export VERSION=`jq .version < ./etc/circt.json`
+          export VERSION=`jq -r .version < ./etc/circt.json`
         else
           export VERSION="${{ inputs.version }}"
         fi


### PR DESCRIPTION
Remove caching of the `firtool` binary.  Caching empirically provides no measurable benefit over downloading the binary from a GitHub Release every time.

This has the effect of avoiding a bug where the "default" old version would incorrectly hit when the `firtool` version is updated via a change to the `./etc/circt.json` file.