### PR TITLE
add HasExtModuleDefine.define for creating ProbeType in BlackBox

### DIFF
--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -112,4 +112,22 @@ package object probe extends SourceInfoDoc {
     pushCommand(ProbeRelease(sourceInfo, clock.ref, cond.ref, probe.ref))
   }
 
+  /** The mixin to define the probe signal for BlackBox. */
+  trait HasExtModuleDefine extends chisel3.util.HasExtModuleInline { this: chisel3.experimental.ExtModule =>
+
+    /** Create a ProbeType for external sources.
+      * @param tpe is the Chisel type of signal.
+      * @param path is the internal path of the signal see [[https://github.com/chipsalliance/firrtl-spec/blob/main/abi.md]]
+      */
+    def define[T <: chisel3.Element](tpe: T, path: Seq[String]): T = {
+      setInline(
+        s"firrtl_abi_definition_${path.mkString("_")}.sv",
+        s"`define ref_${path.mkString("_")} ${path.last}"
+      )
+      // it's not IO, but BlackBox can only bind IO
+      val io = IO(tpe).suggestName(path.last)
+      require(chisel3.reflect.DataMirror.hasProbeTypeModifier(io), "tpe should be a ProbeType")
+      io
+    }
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
Add HasExtModuleDefine.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
