### PR TITLE
Add support for sequences of Properties, including values.

### DIFF
--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -163,6 +163,4 @@ case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 case class VecLitBinding(litMap: VectorMap[Data, LitArg]) extends LitBinding
 // Literal binding attached to a Property.
-private[chisel3] case class PropertyLitBinding(litProp: PropertyLit[_])
-    extends UnconstrainedBinding
-    with ReadOnlyBinding
+private[chisel3] case object PropertyValueBinding extends UnconstrainedBinding with ReadOnlyBinding

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -178,13 +178,22 @@ private[chisel3] case class PropertyLit[T: PropertyTypeclass](lit: T) extends Ar
   def minWidth: Int = 0
   def cloneWithWidth(newWidth: Width): this.type = PropertyLit[T](lit).asInstanceOf[this.type]
 
+  def propertyType: PropertyTypeclass[T] = implicitly[PropertyTypeclass[T]]
+
   /** Expose a bindLitArg API for PropertyLit, similar to LitArg.
     */
   def bindLitArg(elem: Property[T]): Property[T] = {
-    elem.bind(PropertyLitBinding(this))
+    elem.bind(PropertyValueBinding)
     elem.setRef(this)
     elem
   }
+}
+
+private[chisel3] case class PropertySeqValue[T: PropertyTypeclass](values: Seq[Arg]) extends Arg {
+  // TODO in theory this should be the valid FIRRTL representation
+  def name: String = s"PropertySeqValue($values)"
+
+  def propertyType: PropertyTypeclass[T] = implicitly[PropertyTypeclass[T]]
 }
 
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
@@ -296,6 +305,7 @@ object MemPortDirection {
 private[chisel3] sealed trait PropertyType
 private[chisel3] case object IntegerPropertyType extends PropertyType
 private[chisel3] case object StringPropertyType extends PropertyType
+private[chisel3] case class SequencePropertyType(elementType: PropertyType) extends PropertyType
 
 @deprecated(deprecatedPublicAPIMsg, "Chisel 3.6")
 abstract class Command {

--- a/docs/src/explanations/properties.md
+++ b/docs/src/explanations/properties.md
@@ -35,6 +35,7 @@ The following are legal `Property` types:
 * `Property[Long]`
 * `Property[BigInt]`
 * `Property[String]`
+* `Property[Seq[A]]` (where `A` is itself a `Property`)
 
 ## Using Properties
 
@@ -77,15 +78,32 @@ Connections are only supported between the same `Property` type. For example, a
 `Property[Int]` may only be connected to a `Property[Int]`. This is enforced by
 the Scala compiler.
 
-### Property Literals
+### Property Values
 
-The legal `Property` types may be used to construct literals by applying the
-`Property` object to a literal value of the `Property` type. For example, a
-`Property` literal may be connected to an output `Property` type port:
+The legal `Property` types may be used to construct values by applying the
+`Property` object to a value of the `Property` type. For example, a
+`Property` value may be connected to an output `Property` type port:
 
 ```scala mdoc:silent
 class LiteralExample extends RawModule {
   val outPort = IO(Output(Property[Int]()))
   outPort := Property(123)
+}
+```
+
+### Property Sequences
+
+Similarly to the primitive `Property` types, sequences of `Properties` may also be
+for creating ports and values and they may also be connected:
+
+```scala mdoc:silent
+class SequenceExample extends RawModule {
+  val inPort = IO(Input(Property[Int]()))
+  val outPort1 = IO(Output(Property[Seq[Int]]()))
+  val outPort2 = IO(Output(Property[Seq[Int]]()))
+  // A Seq of literals can by turned into a Property
+  outPort1 := Property(Seq(123, 456))
+  // Property ports and literals can be mixed together into a Seq
+  outPort2 := Property(Seq(inPort, Property(789)))
 }
 ```

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -242,6 +242,8 @@ case class StringPropertyLiteral(value: String) extends Expression with UseSeria
   val width = UnknownWidth
 }
 
+case class SequencePropertyValue(tpe: Type, values: Seq[Expression]) extends Expression with UseSerializer
+
 case class DoPrim(op: PrimOp, args: Seq[Expression], consts: Seq[BigInt], tpe: Type)
     extends Expression
     with UseSerializer
@@ -513,9 +515,13 @@ case object AsyncResetType extends GroundType with UseSerializer {
 }
 case class AnalogType(width: Width) extends GroundType with UseSerializer
 
-case object IntegerPropertyType extends Type with UseSerializer
+sealed abstract class PropertyType extends Type with UseSerializer
 
-case object StringPropertyType extends Type with UseSerializer
+case object IntegerPropertyType extends PropertyType
+
+case object StringPropertyType extends PropertyType
+
+case class SequencePropertyType(tpe: PropertyType) extends PropertyType
 
 case object UnknownType extends Type with UseSerializer
 

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -112,6 +112,15 @@ object Serializer {
       b ++= "Integer("; b ++= value.toString(10); b ++= ")"
     case StringPropertyLiteral(value) =>
       b ++= "String(\""; b ++= value; b ++= "\")"
+    case SequencePropertyValue(tpe, values) =>
+      b ++= "List<"; s(tpe); b ++= ">(";
+      val lastIdx = values.size - 1
+      values.zipWithIndex.foreach {
+        case (value, idx) =>
+          s(value)
+          if (idx != lastIdx) b ++= ", "
+      }
+      b += ')'
     case ProbeExpr(expr, _)   => b ++= "probe("; s(expr); b += ')'
     case RWProbeExpr(expr, _) => b ++= "rwprobe("; s(expr); b += ')'
     case ProbeRead(expr, _)   => b ++= "read("; s(expr); b += ')'
@@ -357,16 +366,17 @@ object Serializer {
     }
     case UIntType(width: Width) => b ++= "UInt"; s(width)
     case SIntType(width: Width) => b ++= "SInt"; s(width)
-    case BundleType(fields)    => b ++= "{ "; sField(fields, ", "); b += '}'
-    case VectorType(tpe, size) => s(tpe, lastEmittedConst); b += '['; b ++= size.toString; b += ']'
-    case ClockType             => b ++= "Clock"
-    case ResetType             => b ++= "Reset"
-    case AsyncResetType        => b ++= "AsyncReset"
-    case AnalogType(width)     => b ++= "Analog"; s(width)
-    case IntegerPropertyType   => b ++= "Integer"
-    case StringPropertyType    => b ++= "String"
-    case UnknownType           => b += '?'
-    case other                 => b ++= other.serialize // Handle user-defined nodes
+    case BundleType(fields)        => b ++= "{ "; sField(fields, ", "); b += '}'
+    case VectorType(tpe, size)     => s(tpe, lastEmittedConst); b += '['; b ++= size.toString; b += ']'
+    case ClockType                 => b ++= "Clock"
+    case ResetType                 => b ++= "Reset"
+    case AsyncResetType            => b ++= "AsyncReset"
+    case AnalogType(width)         => b ++= "Analog"; s(width)
+    case IntegerPropertyType       => b ++= "Integer"
+    case StringPropertyType        => b ++= "String"
+    case SequencePropertyType(tpe) => b ++= "List<"; s(tpe, lastEmittedConst); b += '>'
+    case UnknownType               => b += '?'
+    case other                     => b ++= other.serialize // Handle user-defined nodes
   }
 
   private def s(node: Direction)(implicit b: StringBuilder, indent: Int): Unit = node match {


### PR DESCRIPTION
This includes the API, Chisel IR, Converter, FIRRTL IR, and Serializer support for Seqs of Properties (and Property of Seq). This includes support for values are Seqs of Properties which themselves may or may not be literals.

#### TODO
- [x] add docs

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
