### PR TITLE
Support Optionality of implicit clock and reset

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -98,8 +98,14 @@ object Module extends SourceInfoDoc {
   /** Returns the implicit Clock */
   def clock: Clock = Builder.forcedClock
 
+  /** Returns the implicit Clock, if it is defined */
+  def clockOption: Option[Clock] = Builder.currentClock
+
   /** Returns the implicit Reset */
   def reset: Reset = Builder.forcedReset
+
+  /** Returns the implicit Reset, if it is defined */
+  def resetOption: Option[Reset] = Builder.currentReset
 
   /** Returns the current Module */
   def currentModule: Option[BaseModule] = Builder.currentModule

--- a/core/src/main/scala/chisel3/MultiClock.scala
+++ b/core/src/main/scala/chisel3/MultiClock.scala
@@ -15,13 +15,22 @@ object withClockAndReset {
     * @param block the block of code to run with new implicit Clock and Reset
     * @return the result of the block
     */
-  def apply[T](clock: Clock, reset: Reset)(block: => T): T = {
+  def apply[T](clock: Clock, reset: Reset)(block: => T): T = apply(Some(clock), Some(reset))(block)
+
+  /** Creates a new Clock and Reset scope
+    *
+    * @param clock the new implicit Clock, None will set no implicit clock
+    * @param reset the new implicit Reset, None will set no implicit reset
+    * @param block the block of code to run with new implicit Clock and Reset
+    * @return the result of the block
+    */
+  def apply[T](clock: Option[Clock], reset: Option[Reset])(block: => T): T = {
     // Save parentScope
     val parentClock = Builder.currentClock
     val parentReset = Builder.currentReset
 
-    Builder.currentClock = Some(clock)
-    Builder.currentReset = Some(reset)
+    Builder.currentClock = clock
+    Builder.currentReset = reset
 
     val res = block // execute block
 
@@ -40,10 +49,18 @@ object withClock {
     * @param block the block of code to run with new implicit Clock
     * @return the result of the block
     */
-  def apply[T](clock: Clock)(block: => T): T = {
+  def apply[T](clock: Clock)(block: => T): T = apply(Some(clock))(block)
+
+  /** Creates a new Clock scope
+    *
+    * @param clock the new implicit Clock, None will set no implicit clock
+    * @param block the block of code to run with new implicit Clock
+    * @return the result of the block
+    */
+  def apply[T](clock: Option[Clock])(block: => T): T = {
     // Save parentScope
     val parentClock = Builder.currentClock
-    Builder.currentClock = Some(clock)
+    Builder.currentClock = clock
     val res = block // execute block
     // Return to old scope
     Builder.currentClock = parentClock
@@ -59,10 +76,18 @@ object withReset {
     * @param block the block of code to run with new implicit Reset
     * @return the result of the block
     */
-  def apply[T](reset: Reset)(block: => T): T = {
+  def apply[T](reset: Reset)(block: => T): T = apply(Some(reset))(block)
+
+  /** Creates a new Reset scope
+    *
+    * @param reset the new implicit Reset, None will set no implicit reset
+    * @param block the block of code to run with new implicit Reset
+    * @return the result of the block
+    */
+  def apply[T](reset: Option[Reset])(block: => T): T = {
     // Save parentScope
     val parentReset = Builder.currentReset
-    Builder.currentReset = Some(reset)
+    Builder.currentReset = reset
     val res = block // execute block
     // Return to old scope
     Builder.currentReset = parentReset

--- a/src/test/scala/chiselTests/ModuleSpec.scala
+++ b/src/test/scala/chiselTests/ModuleSpec.scala
@@ -129,7 +129,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
     }).getMessage should include("Module() cannot be called on a Class")
   }
 
-  property("object Module.clock should return a reference to the currently in scope clock") {
+  property("Module.clock should return a reference to the currently in scope clock") {
     ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val clock2 = Input(Clock())
@@ -138,7 +138,27 @@ class ModuleSpec extends ChiselPropSpec with Utils {
       withClock(io.clock2) { assert(Module.clock eq io.clock2) }
     })
   }
-  property("object Module.reset should return a reference to the currently in scope reset") {
+
+  property("Module.clockOption should return a reference to the currently in scope clock") {
+    ChiselStage.emitCHIRRTL(new Module {
+      val clock2 = IO(Input(Clock()))
+      Module.clockOption should be(Some(this.clock))
+      withClock(clock2) {
+        Module.clockOption should be(Some(clock2))
+      }
+      withClock(None) {
+        Module.clockOption should be(None)
+      }
+    })
+  }
+
+  property("Module.clockOption should be None for a RawModule") {
+    ChiselStage.emitCHIRRTL(new RawModule {
+      Module.clockOption should be(None)
+    })
+  }
+
+  property("Module.reset should return a reference to the currently in scope reset") {
     ChiselStage.emitCHIRRTL(new Module {
       val io = IO(new Bundle {
         val reset2 = Input(Bool())
@@ -147,6 +167,26 @@ class ModuleSpec extends ChiselPropSpec with Utils {
       withReset(io.reset2) { assert(Module.reset eq io.reset2) }
     })
   }
+
+  property("Module.resetOption should return a reference to the currently in scope reset") {
+    ChiselStage.emitCHIRRTL(new Module {
+      val reset2 = IO(Input(AsyncReset()))
+      Module.resetOption should be(Some(this.reset))
+      withReset(reset2) {
+        Module.resetOption should be(Some(reset2))
+      }
+      withReset(None) {
+        Module.resetOption should be(None)
+      }
+    })
+  }
+
+  property("Module.resetOption should be None for a RawModule") {
+    ChiselStage.emitCHIRRTL(new RawModule {
+      Module.resetOption should be(None)
+    })
+  }
+
   property("object Module.currentModule should return an Option reference to the current Module") {
     def checkModule(mod: Module): Boolean = Module.currentModule.map(_ eq mod).getOrElse(false)
     ChiselStage.emitCHIRRTL(new Module {

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -287,4 +287,24 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
       when(done) { stop() }
     })
   }
+
+  it should "support setting Clock and Reset to None" in {
+    val e1 = the[ChiselException] thrownBy {
+      ChiselStage.emitCHIRRTL(new Module {
+        withClockAndReset(None, Some(this.reset)) {
+          Reg(UInt(8.W))
+        }
+      })
+    }
+    e1.getMessage should include("No implicit clock.")
+
+    val e2 = the[ChiselException] thrownBy {
+      ChiselStage.emitCHIRRTL(new Module {
+        withClockAndReset(Some(this.clock), None) {
+          RegInit(0.U(8.W))
+        }
+      })
+    }
+    e2.getMessage should include("No implicit reset.")
+  }
 }


### PR DESCRIPTION
This is in preparation for the new LTL operators defaulting to using the current in scope clock (needs `Option[Clock]`) and making it easy to disable clock for a region of assertions.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

* withClock, withReset, and withClockAndReset now have forms that take Option[Clock] and Option[Reset]
* Module.clockOption and Module.resetOption return Option[Clock] and Option[Reset]

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
