### PR TITLE
Make LTL properties use Clock and Disable by default

### DIFF
--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -231,7 +231,7 @@ sealed trait Property {
   def clock(clock: Clock): Property = Property.clock(this, clock)
 
   /** See `Property.disable`. */
-  def disable(cond: Bool): Property = Property.disable(this, cond)
+  def disable(cond: Disable): Property = Property.disable(this, cond)
 }
 
 /** Prefix-style utilities to work with properties.
@@ -322,10 +322,10 @@ object Property {
     * condition is true at any time during the evaluation of the property, the
     * evaluation is aborted. Equivalent to `disable iff (cond) prop` in SVA.
     */
-  def disable(prop: Property, cond: Bool): Property = {
+  def disable(prop: Property, cond: Disable): Property = {
     val ltl_disable = Module(new LTLDisableIntrinsic)
     ltl_disable.in := prop.inner
-    ltl_disable.condition := cond
+    ltl_disable.condition := cond.value
     OpaqueProperty(ltl_disable.out)
   }
 }
@@ -350,8 +350,8 @@ sealed abstract class AssertPropertyLike {
     */
   def apply(
     prop:    Property,
-    clock:   Option[Clock] = None,
-    disable: Option[Bool] = None,
+    clock:   Option[Clock] = Module.clockOption,
+    disable: Option[Disable] = Module.disableOption,
     label:   Option[String] = None
   ): Unit = {
     val disabled = disable.fold(prop)(prop.disable(_))


### PR DESCRIPTION
Built on top of https://github.com/chipsalliance/chisel/pull/3497 so currently PR-ed against it, will be rebased on main once #3497 is merged.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Properties in package chisel3.ltl will now be clocked and disabled by default (if there is an implicit clock and disable). Default disable is not hasBeenReset of the current implicit reset (if one exists). The clock and disable can be removed by setting them to None via withClock, withReset, and withDisable APIs.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
