### PR TITLE
add Double property type

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -132,6 +132,14 @@ private[chisel3] object PropertyType extends LowPriorityPropertyTypeInstances {
     makeSimple[BigInt](_ => fir.IntegerPropertyType, fir.IntegerPropertyLiteral(_))
 
   @implicitAmbiguous("unable to infer Property type. Please specify it explicitly in square brackets on the LHS.")
+  implicit val doublePropertyTypeInstance =
+    makeSimple[Double](_ => fir.DecimalPropertyType, fir.DecimalPropertyLiteral(_))
+
+  @implicitAmbiguous("unable to infer Property type. Please specify it explicitly in square brackets on the LHS.")
+  implicit val bigDecimalPropertyTypeInstance =
+    makeSimple[BigDecimal](_ => fir.DecimalPropertyType, fir.DecimalPropertyLiteral(_))
+
+  @implicitAmbiguous("unable to infer Property type. Please specify it explicitly in square brackets on the LHS.")
   implicit val classPropertyTypeInstance = makeSimple[ClassType](
     value => fir.ClassPropertyType(value.get.name),
     value => fir.StringPropertyLiteral(value.name)

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -133,11 +133,7 @@ private[chisel3] object PropertyType extends LowPriorityPropertyTypeInstances {
 
   @implicitAmbiguous("unable to infer Property type. Please specify it explicitly in square brackets on the LHS.")
   implicit val doublePropertyTypeInstance =
-    makeSimple[Double](_ => fir.DecimalPropertyType, fir.DecimalPropertyLiteral(_))
-
-  @implicitAmbiguous("unable to infer Property type. Please specify it explicitly in square brackets on the LHS.")
-  implicit val bigDecimalPropertyTypeInstance =
-    makeSimple[BigDecimal](_ => fir.DecimalPropertyType, fir.DecimalPropertyLiteral(_))
+    makeSimple[Double](_ => fir.DoublePropertyType, fir.DoublePropertyLiteral(_))
 
   @implicitAmbiguous("unable to infer Property type. Please specify it explicitly in square brackets on the LHS.")
   implicit val classPropertyTypeInstance = makeSimple[ClassType](

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -237,8 +237,8 @@ case class IntegerPropertyLiteral(value: BigInt) extends Literal with UseSeriali
   val width = UnknownWidth
 }
 
-case class DecimalPropertyLiteral(value: BigDecimal) extends Expression with UseSerializer {
-  def tpe = DecimalPropertyType
+case class DoublePropertyLiteral(value: Double) extends Expression with UseSerializer {
+  def tpe = DoublePropertyType
   val width = UnknownWidth
 }
 
@@ -532,7 +532,7 @@ sealed abstract class PropertyType extends Type with UseSerializer
 
 case object IntegerPropertyType extends PropertyType
 
-case object DecimalPropertyType extends PropertyType
+case object DoublePropertyType extends PropertyType
 
 case object StringPropertyType extends PropertyType
 

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -237,6 +237,11 @@ case class IntegerPropertyLiteral(value: BigInt) extends Literal with UseSeriali
   val width = UnknownWidth
 }
 
+case class DecimalPropertyLiteral(value: BigDecimal) extends Expression with UseSerializer {
+  def tpe = DecimalPropertyType
+  val width = UnknownWidth
+}
+
 case class StringPropertyLiteral(value: String) extends Expression with UseSerializer {
   def tpe = StringPropertyType
   val width = UnknownWidth
@@ -526,6 +531,8 @@ case class AnalogType(width: Width) extends GroundType with UseSerializer
 sealed abstract class PropertyType extends Type with UseSerializer
 
 case object IntegerPropertyType extends PropertyType
+
+case object DecimalPropertyType extends PropertyType
 
 case object StringPropertyType extends PropertyType
 

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -110,8 +110,8 @@ object Serializer {
       b ++= "SInt"; s(width); b ++= "(0h"; b ++= value.toString(16); b ++= ")"
     case IntegerPropertyLiteral(value) =>
       b ++= "Integer("; b ++= value.toString(10); b ++= ")"
-    case DecimalPropertyLiteral(value) =>
-      b ++= "Decimal("; b ++= value.toString(); b ++= ")"
+    case DoublePropertyLiteral(value) =>
+      b ++= "Double("; b ++= value.toString(); b ++= ")"
     case StringPropertyLiteral(value) =>
       b ++= "String(\""; b ++= value; b ++= "\")"
     case BooleanPropertyLiteral(value) =>
@@ -388,7 +388,7 @@ object Serializer {
     case AsyncResetType            => b ++= "AsyncReset"
     case AnalogType(width)         => b ++= "Analog"; s(width)
     case IntegerPropertyType       => b ++= "Integer"
-    case DecimalPropertyType       => b ++= "Decimal"
+    case DoublePropertyType        => b ++= "Double"
     case StringPropertyType        => b ++= "String"
     case BooleanPropertyType       => b ++= "Bool"
     case SequencePropertyType(tpe) => b ++= "List<"; s(tpe, lastEmittedConst); b += '>'

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -110,6 +110,8 @@ object Serializer {
       b ++= "SInt"; s(width); b ++= "(0h"; b ++= value.toString(16); b ++= ")"
     case IntegerPropertyLiteral(value) =>
       b ++= "Integer("; b ++= value.toString(10); b ++= ")"
+    case DecimalPropertyLiteral(value) =>
+      b ++= "Decimal("; b ++= value.toString(); b ++= ")"
     case StringPropertyLiteral(value) =>
       b ++= "String(\""; b ++= value; b ++= "\")"
     case BooleanPropertyLiteral(value) =>
@@ -386,6 +388,7 @@ object Serializer {
     case AsyncResetType            => b ++= "AsyncReset"
     case AnalogType(width)         => b ++= "Analog"; s(width)
     case IntegerPropertyType       => b ++= "Integer"
+    case DecimalPropertyType       => b ++= "Decimal"
     case StringPropertyType        => b ++= "String"
     case BooleanPropertyType       => b ++= "Bool"
     case SequencePropertyType(tpe) => b ++= "List<"; s(tpe, lastEmittedConst); b += '>'

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -88,6 +88,48 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     )()
   }
 
+  it should "support Double as a Property type" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val doubleProp = IO(Input(Property[Double]()))
+    })
+
+    matchesAndOmits(chirrtl)(
+      "input doubleProp : Decimal"
+    )()
+  }
+
+  it should "support Double as a Property literal" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val propOut = IO(Output(Property[Double]()))
+      propOut := Property[Double](123.456)
+    })
+
+    matchesAndOmits(chirrtl)(
+      "propassign propOut, Decimal(123.456)"
+    )()
+  }
+
+  it should "support BigDecimal as a Property type" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val bigDecimalProp = IO(Input(Property[BigDecimal]()))
+    })
+
+    matchesAndOmits(chirrtl)(
+      "input bigDecimalProp : Decimal"
+    )()
+  }
+
+  it should "support BigDecimal as a Property literal" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val propOut = IO(Output(Property[BigDecimal]()))
+      propOut := Property[BigDecimal](123.456)
+    })
+
+    matchesAndOmits(chirrtl)(
+      "propassign propOut, Decimal(123.456)"
+    )()
+  }
+
   it should "support String as a Property type" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val stringProp = IO(Input(Property[String]()))

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -94,7 +94,7 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      "input doubleProp : Decimal"
+      "input doubleProp : Double"
     )()
   }
 
@@ -105,28 +105,7 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      "propassign propOut, Decimal(123.456)"
-    )()
-  }
-
-  it should "support BigDecimal as a Property type" in {
-    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
-      val bigDecimalProp = IO(Input(Property[BigDecimal]()))
-    })
-
-    matchesAndOmits(chirrtl)(
-      "input bigDecimalProp : Decimal"
-    )()
-  }
-
-  it should "support BigDecimal as a Property literal" in {
-    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
-      val propOut = IO(Output(Property[BigDecimal]()))
-      propOut := Property[BigDecimal](123.456)
-    })
-
-    matchesAndOmits(chirrtl)(
-      "propassign propOut, Decimal(123.456)"
+      "propassign propOut, Double(123.456)"
     )()
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)
Adds `DoublePropertyValue`, `DoublePropertyType`, and a `PropertyType[Double]` instance

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
