### PR TITLE
Allow properties on ExtModule IO

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -435,9 +435,9 @@ package experimental {
     private val _ports = new ArrayBuffer[(BaseType, SourceInfo)]()
 
     // getPorts unfortunately already used for tester compatibility
-    protected[chisel3] def getModulePorts: Seq[Data] = {
+    protected[chisel3] def getModulePorts: Seq[BaseType] = {
       require(_closed, "Can't get ports before module close")
-      _ports.iterator.collect { case (d: Data, _) => d }.toSeq
+      _ports.iterator.collect { case (d: BaseType, _) => d }.toSeq
     }
 
     // gets Ports along with there source locators

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -130,6 +130,23 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     )()
   }
 
+  it should "support Properties on an ExtModule" in {
+    // See: https://github.com/chipsalliance/chisel/issues/3509
+    class Bar extends experimental.ExtModule {
+      val a = IO(Output(Property[Int]()))
+    }
+
+    class Foo extends RawModule {
+      val bar = Module(new Bar)
+    }
+
+    val chirrtl = ChiselStage.emitCHIRRTL(new Foo)
+    info(chirrtl)
+    matchesAndOmits(chirrtl)(
+      "output a : Integer"
+    )()
+  }
+
   it should "support connecting Property types of the same type" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val propIn = IO(Input(Property[Int]()))

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -141,7 +141,6 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     }
 
     val chirrtl = ChiselStage.emitCHIRRTL(new Foo)
-    info(chirrtl)
     matchesAndOmits(chirrtl)(
       "output a : Integer"
     )()


### PR DESCRIPTION
Fix ExtModules to not silently drop Property IO.

This is half of #3509.

#### Release Notes

Fix bug where Property types on ExtModules would be silently dropped.