### PR TITLE
Fix BoringUtils.bore can not bore from a Probe

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -288,7 +288,7 @@ object BoringUtils {
     val lcaSource = drill(source, upPath.dropRight(1), upPath.dropRight(1), true)
     val sink = drill(lcaSource, downPath.reverse.tail, downPath.reverse, false)
 
-    if (createProbe.nonEmpty) {
+    if (createProbe.nonEmpty || DataMirror.hasProbeTypeModifier(purePortTypeBase)) {
       sink
     } else {
       // Creating a wire to assign the result to.  We will return this.

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -6,8 +6,8 @@ import chisel3._
 import chisel3.util.Counter
 import chisel3.testers._
 import chisel3.experimental.{BaseModule, ChiselAnnotation}
+import chisel3.probe._
 import chisel3.util.experimental.BoringUtils
-
 import firrtl.annotations.Annotation
 import firrtl.transforms.DontTouchAnnotation
 
@@ -318,6 +318,30 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
       val bar = Module(new Bar)
 
       a := BoringUtils.bore(bar.baz.a)
+    }
+
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Foo)
+    matchesAndOmits(chirrtl)()(
+      "connect a_bore, a"
+    )
+  }
+
+  it should "bore from a Probe" in {
+    class Baz extends RawModule {
+      val a = IO(Probe(Bool()))
+      define(a, ProbeValue(false.B))
+    }
+
+    class Bar extends RawModule {
+      val baz = Module(new Baz)
+    }
+
+    class Foo extends RawModule {
+      val a = IO(Output(Bool()))
+
+      val bar = Module(new Bar)
+
+      a := read(BoringUtils.bore(bar.baz.a))
     }
 
     val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Foo)


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
