### PR TITLE
Map Properties now support Properties as the key

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -257,7 +257,7 @@ case class PathPropertyLiteral(value: String) extends Expression with UseSeriali
 
 case class SequencePropertyValue(tpe: Type, values: Seq[Expression]) extends Expression with UseSerializer
 
-case class MapPropertyValue(tpe: Type, values: Seq[(String, Expression)]) extends Expression with UseSerializer
+case class MapPropertyValue(tpe: Type, values: Seq[(Expression, Expression)]) extends Expression with UseSerializer
 
 case class TuplePropertyValue(values: Seq[(PropertyType, Expression)]) extends Expression with UseSerializer {
   val tpe = TuplePropertyType(values.map(_._1))
@@ -550,7 +550,7 @@ case object PathPropertyType extends PropertyType
 
 case class SequencePropertyType(tpe: PropertyType) extends PropertyType
 
-case class MapPropertyType(tpe: PropertyType) extends PropertyType
+case class MapPropertyType(ktpe: PropertyType, vtpe: PropertyType) extends PropertyType
 
 case class TuplePropertyType(types: Seq[PropertyType]) extends PropertyType
 

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -128,11 +128,12 @@ object Serializer {
       }
       b += ')'
     case MapPropertyValue(tpe, values) =>
-      b ++= "Map<"; s(tpe); b ++= ">(";
+      s(tpe)
+      b += '('
       val lastIdx = values.size - 1
       values.zipWithIndex.foreach {
         case ((key, value), idx) =>
-          b ++= StringLit(key).escape; b ++= " -> "; s(value)
+          s(key); b ++= " -> "; s(value)
           if (idx != lastIdx) b ++= ", "
       }
       b += ')'
@@ -410,7 +411,7 @@ object Serializer {
     case BooleanPropertyType       => b ++= "Bool"
     case PathPropertyType          => b ++= "Path"
     case SequencePropertyType(tpe) => b ++= "List<"; s(tpe, lastEmittedConst); b += '>'
-    case MapPropertyType(tpe)      => b ++= "Map<"; s(tpe, lastEmittedConst); b += '>'
+    case MapPropertyType(k, v)     => b ++= "Map<"; s(k, lastEmittedConst); b ++= ", "; s(v, lastEmittedConst); b += '>'
     case TuplePropertyType(types) =>
       val lastIdx = types.size - 1
       b ++= "Tuple<"

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -268,7 +268,7 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     )()
   }
 
-  it should "support SeqMap[Int], VectorMap[Int], and ListMap[Int] as a Property type" in {
+  it should "support SeqMap[String, Int], VectorMap[String, Int], and ListMap[String, Int] as a Property type" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val mapProp1 = IO(Input(Property[SeqMap[String, Int]]()))
       val mapProp2 = IO(Input(Property[VectorMap[String, Int]]()))
@@ -276,9 +276,9 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      "input mapProp1 : Map<Integer>",
-      "input mapProp2 : Map<Integer>",
-      "input mapProp3 : Map<Integer>"
+      "input mapProp1 : Map<String, Integer>",
+      "input mapProp2 : Map<String, Integer>",
+      "input mapProp3 : Map<String, Integer>"
     )()
   }
 
@@ -288,7 +288,7 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      "input nestedMapProp : Map<Map<Map<Integer>>>"
+      "input nestedMapProp : Map<String, Map<String, Map<String, Integer>>>"
     )()
   }
 
@@ -296,12 +296,25 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val propOut = IO(Output(Property[SeqMap[String, BigInt]]()))
       propOut := Property(
-        SeqMap[String, BigInt]("foo" -> 123, "bar" -> 456)
-      ) // The Int => BigInt implicit conversion fails here
+        SeqMap("foo" -> 123, "bar" -> 456)
+      )
     })
 
     matchesAndOmits(chirrtl)(
-      """propassign propOut, Map<Integer>("foo" -> Integer(123), "bar" -> Integer(456))"""
+      """propassign propOut, Map<String, Integer>(String("foo") -> Integer(123), String("bar") -> Integer(456))"""
+    )()
+  }
+
+  it should "support VectorMap[BigInt, String] as Property values" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val propOut = IO(Output(Property[VectorMap[BigInt, String]]()))
+      propOut := Property(
+        VectorMap(123 -> "foo", 456 -> "bar")
+      )
+    })
+
+    matchesAndOmits(chirrtl)(
+      """propassign propOut, Map<Integer, String>(Integer(123) -> String("foo"), Integer(456) -> String("bar"))"""
     )()
   }
 
@@ -313,7 +326,7 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      """propassign propOut, Map<Integer>("foo" -> propIn, "bar" -> Integer(123))"""
+      """propassign propOut, Map<String, Integer>(String("foo") -> propIn, String("bar") -> Integer(123))"""
     )()
   }
 
@@ -377,14 +390,14 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     }
 
     matchesAndOmits(chirrtl)(
-      "output a : List<Map<List<Integer>>>",
-      "output b : List<Map<List<Integer>>>",
-      "output c : List<Map<List<Integer>>>",
-      "output d : List<Map<List<Integer>>>",
-      """propassign a, List<Map<List<Integer>>>(Map<List<Integer>>("foo" -> List<Integer>(Integer(123))))""",
-      """propassign b, List<Map<List<Integer>>>(Map<List<Integer>>("foo" -> List<Integer>(Integer(123))))""",
-      """propassign c, List<Map<List<Integer>>>(Map<List<Integer>>("foo" -> List<Integer>(Integer(123))))""",
-      """propassign d, List<Map<List<Integer>>>(Map<List<Integer>>("foo" -> List<Integer>(Integer(123))))"""
+      "output a : List<Map<String, List<Integer>>>",
+      "output b : List<Map<String, List<Integer>>>",
+      "output c : List<Map<String, List<Integer>>>",
+      "output d : List<Map<String, List<Integer>>>",
+      """propassign a, List<Map<String, List<Integer>>>(Map<String, List<Integer>>(String("foo") -> List<Integer>(Integer(123))))""",
+      """propassign b, List<Map<String, List<Integer>>>(Map<String, List<Integer>>(String("foo") -> List<Integer>(Integer(123))))""",
+      """propassign c, List<Map<String, List<Integer>>>(Map<String, List<Integer>>(String("foo") -> List<Integer>(Integer(123))))""",
+      """propassign d, List<Map<String, List<Integer>>>(Map<String, List<Integer>>(String("foo") -> List<Integer>(Integer(123))))"""
     )()
   }
 


### PR DESCRIPTION
Previously they only used Strings as keys.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
