### PR TITLE
Add `AnyRef` type and rework `PropertyType.getPropertyType`

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -169,7 +169,7 @@ private[chisel3] object Converter {
     case e @ DefInstance(info, id, _) =>
       Some(fir.DefInstance(convert(info), e.name, id.name))
     case e @ DefObject(info, obj) =>
-      Some(fir.DefObject(convert(info), e.name, obj.className))
+      Some(fir.DefObject(convert(info), e.name, obj.className.name))
     case e @ Stop(_, info, clock, ret) =>
       Some(fir.Stop(convert(info), ret, convert(clock, ctx, info), firrtl.Utils.one, e.name))
     case e @ Printf(_, info, clock, pable) =>

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -101,7 +101,7 @@ case class ClassType private[chisel3] (name: String) { self =>
     */
   sealed trait Type
 
-  object Type {
+  private object Type {
     implicit val classTypeProvider: ClassTypeProvider[Type] = ClassTypeProvider(name)
     implicit val propertyType = new ClassTypePropertyType[Property[ClassType] with self.Type](classTypeProvider.classType) {
       override def convert(value: Underlying, ctx: Component, info: SourceInfo): fir.Expression = Converter.convert(value, ctx, info)
@@ -109,6 +109,11 @@ case class ClassType private[chisel3] (name: String) { self =>
       override def convertUnderlying(value: Property[ClassType] with self.Type) = value.ref
     }
   }
+}
+
+object ClassType {
+  private def apply(name: String): ClassType = new ClassType(name)
+  def unsafeGetClassTypeByName(name: String): ClassType = ClassType(name)
 }
 
 sealed trait AnyClassType
@@ -134,7 +139,7 @@ object Class {
     * *WARNING*: It is the caller's resonsibility to ensure the Class exists, this is not checked automatically.
     */
   def unsafeGetReferenceType(className: String): Property[ClassType] = {
-    val cls = ClassType(className)
+    val cls = ClassType.unsafeGetClassTypeByName(className)
     Property[cls.Type]()
   }
 
@@ -144,7 +149,7 @@ object Class {
     */
   def unsafeGetDynamicObject(className: String)(implicit sourceInfo: SourceInfo): DynamicObject = {
     // Instantiate the Object.
-    val obj = new DynamicObject(ClassType(className))
+    val obj = new DynamicObject(ClassType.unsafeGetClassTypeByName(className))
 
     // Get its Property[ClassType] type.
     val classProp = obj.getReference

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -89,6 +89,7 @@ class Class extends BaseModule {
 /** Represent a Class type for referencing a Class in a Property[ClassType]
   */
 case class ClassType private[chisel3] (name: String) { self =>
+
   /** A tag type representing an instance of this ClassType
     *
     * This can be used to create a Property IOs
@@ -103,16 +104,18 @@ case class ClassType private[chisel3] (name: String) { self =>
 
   private object Type {
     implicit val classTypeProvider: ClassTypeProvider[Type] = ClassTypeProvider(name)
-    implicit val propertyType = new ClassTypePropertyType[Property[ClassType] with self.Type](classTypeProvider.classType) {
-      override def convert(value: Underlying, ctx: Component, info: SourceInfo): fir.Expression = Converter.convert(value, ctx, info)
-      type Underlying = Arg
-      override def convertUnderlying(value: Property[ClassType] with self.Type) = value.ref
-    }
+    implicit val propertyType =
+      new ClassTypePropertyType[Property[ClassType] with self.Type](classTypeProvider.classType) {
+        override def convert(value: Underlying, ctx: Component, info: SourceInfo): fir.Expression =
+          Converter.convert(value, ctx, info)
+        type Underlying = Arg
+        override def convertUnderlying(value: Property[ClassType] with self.Type) = value.ref
+      }
   }
 }
 
 object ClassType {
-  private def apply(name: String): ClassType = new ClassType(name)
+  private def apply(name:            String): ClassType = new ClassType(name)
   def unsafeGetClassTypeByName(name: String): ClassType = ClassType(name)
 }
 
@@ -124,7 +127,8 @@ object AnyClassType {
     type Type = ClassType
     override def getPropertyType(): fir.PropertyType = fir.AnyRefPropertyType
 
-    override def convert(value: Underlying, ctx: Component, info: SourceInfo): fir.Expression = Converter.convert(value, ctx, info)
+    override def convert(value: Underlying, ctx: Component, info: SourceInfo): fir.Expression =
+      Converter.convert(value, ctx, info)
     type Underlying = Arg
     override def convertUnderlying(value: Property[ClassType] with AnyClassType) = value.ref
   }

--- a/core/src/main/scala/chisel3/properties/Object.scala
+++ b/core/src/main/scala/chisel3/properties/Object.scala
@@ -6,6 +6,7 @@ import chisel3.SpecifiedDirection
 import chisel3.internal.{throwException, HasId, NamedComponent, ObjectFieldBinding}
 
 import scala.collection.immutable.HashMap
+import scala.language.existentials
 
 /** Represents an instance of a Class.
   *
@@ -14,8 +15,8 @@ import scala.collection.immutable.HashMap
   * The DynamicObject is generally unsafe, in that its getField method does not check the name, type, or direction of
   * the accessed field. It may be used with care, and a more typesafe version will be added.
   */
-class DynamicObject private[chisel3] (val className: String) extends HasId with NamedComponent {
-  private val tpe = Property.makeWithValueOpt(Some(ClassType(className)))
+class DynamicObject private[chisel3] (val className: ClassType) extends HasId with NamedComponent {
+  private val tpe = Property[className.Type]()
 
   _parent.foreach(_.addId(this))
 
@@ -29,6 +30,13 @@ class DynamicObject private[chisel3] (val className: String) extends HasId with 
     */
   def getField[T](name: String)(implicit tpe: PropertyType[T]): Property[tpe.Type] = {
     val field = Property[T]()
+    field.setRef(this, name)
+    field.bind(ObjectFieldBinding(_parent.get), SpecifiedDirection.Unspecified)
+    field
+  }
+
+  def getField[T](name: String, property: Property[T]): Property[T] = {
+    val field = property.cloneType
     field.setRef(this, name)
     field.bind(ObjectFieldBinding(_parent.get), SpecifiedDirection.Unspecified)
     field

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -219,7 +219,7 @@ private[chisel3] object PropertyType extends TuplePropertyTypeInstances with Low
   */
 sealed trait Property[T] extends Data { self =>
   sealed trait ClassType
-  object ClassType {
+  private object ClassType {
     implicit def classTypeProvider(implicit evidence: T =:= chisel3.properties.ClassType): ClassTypeProvider[ClassType] = ClassTypeProvider(getPropertyType)
     implicit def propertyType(implicit evidence: T =:= chisel3.properties.ClassType) = new ClassTypePropertyType[Property[ClassType] with self.ClassType](getPropertyType) {
       override def convert(value: Underlying, ctx: ir.Component, info: SourceInfo): fir.Expression =
@@ -314,21 +314,17 @@ sealed trait Property[T] extends Data { self =>
 
 }
 
-trait ClassTypeProvider[A] {
+private[chisel3] sealed trait ClassTypeProvider[A] {
   val classType: fir.PropertyType
 }
 
-object ClassTypeProvider {
+private[chisel3] object ClassTypeProvider {
   def apply[A](className: String) = new ClassTypeProvider[A] {
     val classType = fir.ClassPropertyType(className)
   }
   def apply[A](_classType: fir.PropertyType) = new ClassTypeProvider[A] {
     val classType = _classType
   }
-}
-
-trait Typeable[T, Lit] {
-  def convertUnderlying(l: Lit): T
 }
 
 /** Companion object for Property.

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -556,6 +556,8 @@ case class TuplePropertyType(types: Seq[PropertyType]) extends PropertyType
 
 case class ClassPropertyType(name: String) extends PropertyType
 
+case object AnyRefPropertyType extends PropertyType
+
 case object UnknownType extends Type with UseSerializer
 
 /** [[Port]] Direction */

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -422,6 +422,7 @@ object Serializer {
       }
       b += '>'
     case ClassPropertyType(name) => b ++= "Inst<"; b ++= name; b += '>'
+    case AnyRefPropertyType      => b ++= "AnyRef"
     case UnknownType             => b += '?'
     case other                   => b ++= other.serialize // Handle user-defined nodes
   }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -151,14 +151,14 @@ object Boilerplate {
               -  type Type = Tuple$Arity[${Repeated(i => s"tpe$i.Type")}]
               -  type Underlying = Tuple$Arity[${Repeated(i => s"tpe$i.Underlying")}]
               -
-              -  override def getPropertyType(value: Option[Tuple]): fir.PropertyType =
+              -  override def getPropertyType(): fir.PropertyType =
               -    fir.TuplePropertyType(Seq(
-              -      ${Repeated(i => s"tpe$i.getPropertyType(None)")}
+              -      ${Repeated(i => s"tpe$i.getPropertyType()")}
               -    ))
               -
               -  override def convert(value: Underlying, ctx: ir.Component, info: SourceInfo): fir.Expression =
               -    fir.TuplePropertyValue(Seq(
-              -      ${Repeated(i => s"tpe$i.getPropertyType(None) -> tpe$i.convert(value._$i, ctx, info)")}
+              -      ${Repeated(i => s"tpe$i.getPropertyType() -> tpe$i.convert(value._$i, ctx, info)")}
               -    ))
               -
               -  override def convertUnderlying(value: Tuple): Underlying =

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -628,8 +628,10 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
 
       // AnyRef
       val g = IO(Output(Property[AnyClassType]()))
+      val h = IO(Output(Property[Seq[AnyClassType]]()))
       g :#= objRef
       g :#= myClass.getReference
+      h :#= Property(Seq(objRef.asAnyClassType, myClass.getReference.asAnyClassType))
     })
 
     matchesAndOmits(chirrtl)(
@@ -649,8 +651,10 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
       "propassign f, obj",
 
       "output g : AnyRef",
+      "output h : List<AnyRef>",
       "propassign g, obj",
       "propassign g, myClass",
+      "propassign h, List<AnyRef>(obj, myClass)",
     )()
   }
 }

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -653,7 +653,6 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
       "object myClass of MyClass",
       "propassign b, List<Inst<MyClass>>(a, myClass)",
       "propassign c, a",
-
       "object obj of FooBar",
       "output e : Inst<FooBar>",
       "output d : Inst<FooBar>",
@@ -661,24 +660,21 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
       "propassign d, obj",
       "propassign e, obj",
       "propassign f, obj",
-
       "output g : AnyRef",
       "output h : List<AnyRef>",
       "propassign g, obj",
       "propassign g, myClass",
       "propassign h, List<AnyRef>(obj, myClass)",
-
       "output fooA : Inst<foo>",
       "output fooB : Inst<foo>",
       "object fooObj of foo",
       "propassign fooA, fooObj",
       "propassign fooB, fooObj",
-
       "output barA : Inst<bar>",
       "output barB : Inst<bar>",
       "object barObj of bar",
       "propassign barA, barObj",
-      "propassign barB, barObj",
+      "propassign barB, barObj"
     )()
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)
- API modification

this adds `AnyClassType`, which cannot be instantiated and can be used to create properties of type `AnyRef` e.g.
```scala
val io: PropertyType[ClassType] = IO(Input(Property[AnyClassType]()))
// emits "input io : AnyRef"
```

This also changes the signature of `PropertyType.getPropertyType` to take no arguments instead of `Option[T]`. Previously creating a `Property[ClassType]` that wasn't backed by a `Some(ClassType)` value would result in a None.get error during serialization. This change makes it so that it is always possible to serialize the type, and also makes it so that it is no longer possible to do `Property[ClassType]()`. Now, to create a `Property[ClassType]` you must do one of the following
```scala
// AnyRef property
val io: Property[ClassType] = IO(Input(Property[AnyClassType]()) // input io: AnyRef

// property with the type of some instance of ClassType
val cls = ClassType("foobar")
val io: Property[ClassType] = IO(Input(Property[cls.Type]())) // input io: Inst<foobar>

// property with the same type as some instance of Property[ClassType]
val ref = Class.unsafeGetReferenceType("MyClass")
val io: Property[ClassType] = IO(Input(Property[ref.ClassType]())) // input io: Inst<MyClass>
val io: Property[ClassType] = IO(Input(ref.cloneType)) // input io: Inst<MyClass>
```

This also means that you cannot create properties of arbitrary collections of `Property[ClassType]` anymore, you must cast `Property[ClassType]` properties to a specific `ClassType` using the `as` extension method
```scala
val io: Property[Seq[Property[ClassType]]] = ???

// this doesn't work anymore
io := Seq(Class.unsafeGetReferenceType("foo"), Class.unsafeGetReferenceType("bar"))

// this works
val cls = ClassType("foobar")
io := Seq(Class.unsafeGetReferenceType("foo").as(cls), Class.unsafeGetReferenceType("bar").as(cls))

// this also works
val cls = Class.unsafeGetReferenceType("foobar")
io := Seq(Class.unsafeGetReferenceType("foo").as(cls), Class.unsafeGetReferenceType("bar").as(cls))

// this also works
io := Seq(Class.unsafeGetReferenceType("foo").asAnyClassType, Class.unsafeGetReferenceType("bar").asAnyClassType)
```

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
