### PR TITLE
[website] Fix link from Warnings to Cookbook

### DIFF
--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -30,7 +30,7 @@ Please note that these examples make use of [Chisel's scala-style printing](../e
 * [How do I create an optional I/O?](#how-do-i-create-an-optional-io)
 * [How do I create I/O without a prefix?](#how-do-i-create-io-without-a-prefix)
 * [How do I minimize the number of bits used in an output vector](#how-do-i-minimize-the-number-of-bits-used-in-an-output-vector)
-* [How do I resolve "Dynamic index ... is too wide/narrow for extractee ..."?](#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee-)
+* [How do I resolve "Dynamic index ... is too wide/narrow for extractee ..."?](#dynamic-index-too-wide-narrow)
 * Predictable Naming
   * [How do I get Chisel to name signals properly in blocks like when/withClockAndReset?](#how-do-i-get-chisel-to-name-signals-properly-in-blocks-like-whenwithclockandreset)
   * [How do I get Chisel to name the results of vector reads properly?](#how-do-i-get-chisel-to-name-the-results-of-vector-reads-properly)
@@ -778,7 +778,8 @@ circt.stage.ChiselStage.emitSystemVerilog(new CountBits(4))
   .head + ");\n"
 ```
 
-### How do I resolve "Dynamic index ... is too wide/narrow for extractee ..."?
+### <a id="dynamic-index-too-wide-narrow" /> How do I resolve "Dynamic index ... is too wide/narrow for extractee ..."?
+
 
 Chisel will warn if a dynamic index is not the correctly-sized width for indexing a Vec or UInt.
 "Correctly-sized" means that the width of the index should be the log2 of the size of the indexee.

--- a/docs/src/explanations/warnings.md
+++ b/docs/src/explanations/warnings.md
@@ -121,25 +121,26 @@ See the [ChiselEnum explanation](chisel-enum#casting) for more information and h
 
 This warning occurs when dynamically indexing a `UInt` or an `SInt` with an index that is wider than necessary to address all bits in the indexee.
 It indicates that some of the high-bits of the index are ignored by the indexing operation.
-It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#dynamic-index-too-wide-narrow).
 
 ### [W003] Dynamic bit select too narrow
 
 This warning occurs when dynamically indexing a `UInt` or an `SInt` with an index that is to small to address all bits in the indexee.
 It indicates that some bits of the indexee cannot be reached by the indexing operation.
-It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#dynamic-index-too-wide-narrow).
 
 ### [W004] Dynamic index too wide
 
 This warning occurs when dynamically indexing a `Vec` with an index that is wider than necessary to address all elements of the `Vec`.
 It indicates that some of the high-bits of the index are ignored by the indexing operation.
-It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#dynamic-index-too-wide-narrow).
 
 ### [W005] Dynamic index too narrow
 
 This warning occurs when dynamically indexing a `Vec` with an index that is to small to address all elements in the `Vec`.
 It indicates that some elements of the `Vec` cannot be reached by the indexing operation.
-It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-resolve-dynamic-index--is-too-widenarrow-for-extractee).
+It can be fixed as described in the [Cookbook](../cookbooks/cookbook#dynamic-index-too-wide-narrow).
+
 
 ### [W006] Extract from Vec of size 0
 

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,13 +1,14 @@
 buildDir ?= build
 subprojects = $(buildDir)/subprojects
 docs = $(buildDir)/docs
+website_docs_dest = docs/src/main/tut/chisel3/docs
 chisel3 = ../
 
 www-docs = \
 	$(shell find $(chisel3)/docs/ -name "*.md")
 
 www-src = \
-	docs/src/main/tut/chisel3/docs \
+	$(website_docs_dest) \
 	$(shell find docs/src/main/resources) \
 	$(shell find docs/src/main/tut) \
 	$(chisel3)/README.md
@@ -28,7 +29,7 @@ all: docs/target/site/index.html
 
 # Remove the output of all build targets
 clean:
-	rm -rf docs/target docs/src/main/tut/contributors.md docs/src/main/tut/chisel3/docs
+	rm -rf docs/target docs/src/main/tut/contributors.md $(website_docs_dest)
 
 # Remove everything
 mrproper:
@@ -53,5 +54,5 @@ docs/src/main/tut/contributors.md: build.sbt
 # Build docs in subproject with a specific tag.
 # This command is brittle as it assumes chisel3 is up one dir from here in the path to where
 # we want to put the website docs.
-docs/src/main/tut/chisel3/docs: $(chisel3)/docs/ $(www-docs)
-	(cd $(chisel3) && sbt docs/mdoc && cp -r docs/generated website/docs/src/main/tut/chisel3/docs)
+$(website_docs_dest): $(chisel3)/docs/ $(www-docs)
+	(cd $(chisel3) && sbt docs/mdoc && rm -rf website/$(website_docs_dest) && cp -r docs/generated website/$(website_docs_dest))


### PR DESCRIPTION
Done by adding a named anchor to the Cookbook to make linking easier. Also fix a minor issue with the website Makefile where stale markdown files could be left around and would not be overwritten when using the common alias cp alias `cp -i`.

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Documentation or website-related



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash
#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
