### PR TITLE
Fix HasTypeAlias cookbook typos

### DIFF
--- a/docs/src/cookbooks/naming.md
+++ b/docs/src/cookbooks/naming.md
@@ -153,7 +153,7 @@ The suggested pattern for `typeName`, and subsequently `desiredName`, is to fold
 
 ### Can I name my bundles in FIRRTL, so I don't generate extremely long bundle types?
 
-Yes, using the `HasTypeName` trait. FIRRTL has a construct to alias a bundle type with a type alias like so:
+Yes, using the `HasTypeAlias` trait. FIRRTL has a construct to alias a bundle type with a type alias like so:
 
 ```
 circuit Top :
@@ -163,7 +163,7 @@ circuit Top :
     //...
 ```
 
-These can be automatically emitted from Chisel by mixing `HasTypeName` into a user-defined `Record`, and implementing a field named `aliasName` with a `RecordAlias(...)` instance.
+These can be automatically emitted from Chisel by mixing `HasTypeAlias` into a user-defined `Record`, and implementing a field named `aliasName` with a `RecordAlias(...)` instance.
 
 ```scala mdoc:silent
 import chisel3.experimental.{HasTypeAlias, RecordAlias}
@@ -206,9 +206,9 @@ emitFIRRTL(new Module {
 })
 ```
 
-### I keep seeing _stripped suffixing everywhere in my FIRRTL?
+### Why do I keep seeing _stripped suffixing everywhere in my FIRRTL? I didn't specify that in my `aliasName`.
 
-The string passed to `RecordAlias` serves as a _strong hint_ for the resulting FIRRTL type alias. There are some circumstances where the structure of a `Record` can be modified and so the original type alias doesn't represent the correct type anymore. Let's look at the case of `Input(...)` and `Output(...)`, which strips any `Flipped(...)` calls within a `Record`:
+You're using an `Input(...)` or `Output(...)` in conjunction with an aliased `Record` that contains a `Flipped(...)`. These flipped values are stripped by `Input` and `Output` which fundamentally changes the type of the parent `Record`:
 
 ```scala mdoc:silent
 class StrippedBundle extends Bundle with HasTypeAlias {
@@ -224,7 +224,7 @@ emitFIRRTL(new Module {
 })
 ```
 
-A slightly different alias with the suffixed name `StrippedBundle_stripped` is generated, and importantly aliases a fundamentally different bundle type. Note how the bundle type doesn't contain a `flip flipped : UInt<8>` field!
+Note how the bundle type doesn't contain a `flip flipped : UInt<8>` field, and the alias gains a `"_stripped"` suffix! This `Bundle` type is no longer the same as the one we wrote in Chisel, so we have to distinguish it as such.
 
 By default, the suffix appended to `Record` names is `"_stripped"`. This can be defined by users with an additional string argument passed to `RecordAlias(alias, strippedSuffix)`:
 


### PR DESCRIPTION
`HasTypeName` was written instead of `HasTypeAlias` (this is not the name of the trait that was added by #3445). Also changes the wording of some of the related cookbook docs to fit the rest of the naming doc.
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Documentation or website-related


#### Desired Merge Strategy

- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
