### PR TITLE
Fix 'Malformed class name' errors in typeName and related implementations

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -16,6 +16,7 @@ import chisel3.internal.sourceinfo.{
 import chisel3.internal.firrtl.PrimOp._
 import _root_.firrtl.{ir => firrtlir}
 import chisel3.internal.{castToInt, Builder, Warning, WarningID}
+import chisel3.util.simpleClassName
 
 /** Exists to unify common interfaces of [[Bits]] and [[Reset]].
   *
@@ -54,7 +55,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   /** A non-ambiguous name of this `Bits` instance for use in generated Verilog names
     * Inserts the width directly after the typeName, e.g. UInt4, SInt1
     */
-  override def typeName: String = s"${this.getClass.getSimpleName}$width"
+  override def typeName: String = s"${simpleClassName(this.getClass)}$width"
 
   /** Tail operator
     *

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -12,6 +12,7 @@ import chisel3.internal._
 import chisel3.internal.sourceinfo._
 import chisel3.internal.firrtl._
 import chisel3.reflect.DataMirror
+import chisel3.util.simpleClassName
 
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -778,7 +779,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   def toPrintable: Printable
 
   /** A non-ambiguous name of this `Data` for use in generated Verilog names */
-  def typeName: String = this.getClass.getSimpleName
+  def typeName: String = simpleClassName(this.getClass)
 }
 
 object Data {

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -16,6 +16,7 @@ import chisel3.reflect.DataMirror
 import _root_.firrtl.annotations.{IsModule, ModuleName, ModuleTarget}
 import _root_.firrtl.AnnotationSeq
 import chisel3.internal.plugin.autoNameRecursively
+import chisel3.util.simpleClassName
 
 object Module extends SourceInfoDoc {
 
@@ -504,21 +505,7 @@ package experimental {
       *
       * @note If you want a custom or parametric name, override this method.
       */
-    def desiredName: String = {
-      /* The default module name is derived from the Java reflection derived class name. */
-      val baseName = this.getClass.getName
-
-      /* A sequence of string filters applied to the name */
-      val filters: Seq[String => String] =
-        Seq(((a: String) => raw"\$$+anon".r.replaceAllIn(a, "_Anon")) // Merge the "$$anon" name with previous name
-        )
-
-      filters
-        .foldLeft(baseName) { case (str, filter) => filter(str) } // 1. Apply filters to baseName
-        .split("\\.|\\$") // 2. Split string at '.' or '$'
-        .filterNot(_.forall(_.isDigit)) // 3. Drop purely numeric names
-        .last // 4. Use the last name
-    }
+    def desiredName: String = simpleClassName(this.getClass)
 
     /** Legalized name of this module. */
     final lazy val name =

--- a/core/src/main/scala/chisel3/experimental/HasAutoTypename.scala
+++ b/core/src/main/scala/chisel3/experimental/HasAutoTypename.scala
@@ -1,7 +1,7 @@
 package chisel3.experimental
 
 import chisel3.{Data, Record}
-import chisel3.internal.{Builder, sanitize}
+import chisel3.internal.{sanitize, Builder}
 import chisel3.util.simpleClassName
 
 /** Trait for [[Record]]s that signals the compiler plugin to generate a typeName for the

--- a/core/src/main/scala/chisel3/experimental/HasAutoTypename.scala
+++ b/core/src/main/scala/chisel3/experimental/HasAutoTypename.scala
@@ -1,7 +1,8 @@
 package chisel3.experimental
 
 import chisel3.{Data, Record}
-import chisel3.internal.{sanitize}
+import chisel3.internal.{Builder, sanitize}
+import chisel3.util.simpleClassName
 
 /** Trait for [[Record]]s that signals the compiler plugin to generate a typeName for the
   * inheriting [[Record]] based on the parameter values provided to its constructor.
@@ -37,12 +38,13 @@ trait HasAutoTypename {
 
   /** Auto generate a type name for this Bundle using the bundle arguments supplied by the compiler plugin.
     */
-  override def typeName: String = autoTypeName(getClass.getSimpleName, _typeNameConParams)
+  override def typeName: String = autoTypeName(simpleClassName(this.getClass), _typeNameConParams)
 
-  private def autoTypeName(bundleName: String, typeNameParams: Iterable[Any]): String =
+  private def autoTypeName(bundleName: String, typeNameParams: Iterable[Any]): String = {
     _typeNameConParams.foldLeft(sanitize(bundleName)) {
       case (prev, accessor) => prev + s"_${accessorString(accessor)}"
     }
+  }
 
   private def accessorString(accessor: Any): String = accessor match {
     case d: Data => d.typeName

--- a/core/src/main/scala/chisel3/util/Naming.scala
+++ b/core/src/main/scala/chisel3/util/Naming.scala
@@ -1,0 +1,23 @@
+package chisel3.util
+
+/* Generates a safe 'simple class name' from the given class, avoiding `Malformed class name` exceptions from `getClass.getSimpleName`
+ * when Java 8 is used.
+ */
+object simpleClassName {
+
+  def apply[T](clazz: Class[T]): String = {
+    /* The default class name is derived from the Java reflection derived class name. */
+    val baseName = clazz.getName
+
+    /* A sequence of string filters applied to the name */
+    val filters: Seq[String => String] =
+      Seq(((a: String) => raw"\$$+anon".r.replaceAllIn(a, "_Anon")) // Merge the "$$anon" name with previous name
+      )
+
+    filters
+      .foldLeft(baseName) { case (str, filter) => filter(str) } // 1. Apply filters to baseName
+      .split("\\.|\\$") // 2. Split string at '.' or '$'
+      .filterNot(_.forall(_.isDigit)) // 3. Drop purely numeric names
+      .last // 4. Use the last name
+  }
+}

--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -179,17 +179,13 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
 
     def generateAutoTypename(record: ClassDef, thiz: global.This, conArgsOpt: Option[List[Tree]]): Option[Tree] = {
       conArgsOpt.flatMap { conArgs =>
-        // Check if the class is an inner class within an outer concrete class (not a static object or a package)
-        val recordIsInnerClassInOuterClass =
-          !(record.symbol.outerClass.isStaticOwner || record.symbol.outerClass.isPackageClass)
         val recordIsAnon = record.symbol.isAnonOrRefinementClass
 
-        // Anonymous `Records` in any scope are forbidden, as well as inner `Records` contained in outer classes
-        if (recordIsInnerClassInOuterClass || recordIsAnon) {
-          val illegalRecordTypeStr = if (recordIsAnon) "anonymous" else "inner"
+        // Anonymous `Records` in any scope are forbidden
+        if (record.symbol.isAnonOrRefinementClass) {
           global.reporter.error(
             record.pos,
-            s"Users can not mix 'HasAutoTypename' into an $illegalRecordTypeStr Record. Pull the Record definition into its own outer class."
+            "Users can not mix 'HasAutoTypename' into an anonymous Record. Pull the Record definition into its own outer class."
           )
           None
         } else {

--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -182,7 +182,10 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
         val recordIsInnerClass = !(record.symbol.isPackageClass || record.symbol.outerClass.isStaticOwner)
         if (recordIsInnerClass) {
           val illegalRecordTypeStr = if (record.name.toString.contains("anon")) "anonymous" else "inner"
-          global.reporter.error(record.pos, s"Users can not mix 'HasAutoTypename' into an $illegalRecordTypeStr Record. Pull the Record definition into its own outer class.")
+          global.reporter.error(
+            record.pos,
+            s"Users can not mix 'HasAutoTypename' into an $illegalRecordTypeStr Record. Pull the Record definition into its own outer class."
+          )
           None
         } else {
           // Create an iterable out of all constructor argument accessors
@@ -195,9 +198,11 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
           typeNameConParamsSym.resetFlag(Flags.METHOD)
           typeNameConParamsSym.setInfo(NullaryMethodType(itAnyTpe))
 
-          Some(localTyper.typed(
-            DefDef(typeNameConParamsSym, q"scala.collection.immutable.Vector.apply[Any](..${conArgs})")
-          ))
+          Some(
+            localTyper.typed(
+              DefDef(typeNameConParamsSym, q"scala.collection.immutable.Vector.apply[Any](..${conArgs})")
+            )
+          )
         }
       }
     }

--- a/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/BundleComponent.scala
@@ -185,7 +185,7 @@ private[plugin] class BundleComponent(val global: Global, arguments: ChiselPlugi
         if (record.symbol.isAnonOrRefinementClass) {
           global.reporter.error(
             record.pos,
-            "Users can not mix 'HasAutoTypename' into an anonymous Record. Pull the Record definition into its own outer class."
+            "Users cannot mix 'HasAutoTypename' into an anonymous Record. Create a named class."
           )
           None
         } else {

--- a/src/main/scala/chisel3/util/Decoupled.scala
+++ b/src/main/scala/chisel3/util/Decoupled.scala
@@ -8,6 +8,7 @@ package chisel3.util
 import chisel3._
 import chisel3.experimental.{requireIsChiselType, Direction}
 import chisel3.reflect.DataMirror
+import chisel3.util.simpleClassName
 
 import scala.annotation.nowarn
 
@@ -40,7 +41,7 @@ abstract class ReadyValidIO[+T <: Data](gen: T) extends Bundle {
   /** A stable typeName for this `ReadyValidIO` and any of its implementations
     * using the supplied `Data` generator's `typeName`
     */
-  override def typeName = s"${this.getClass.getSimpleName}_${gen.typeName}"
+  override def typeName = s"${simpleClassName(this.getClass)}_${gen.typeName}"
 }
 
 object ReadyValidIO {

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -7,6 +7,7 @@ package chisel3.util
 
 import chisel3._
 import chisel3.experimental.prefix
+import chisel3.util.simpleClassName
 
 /** A [[Bundle]] that adds a `valid` bit to some data. This indicates that the user expects a "valid" interface between
   * a producer and a consumer. Here, the producer asserts the `valid` bit when data on the `bits` line contains valid
@@ -40,7 +41,7 @@ class Valid[+T <: Data](gen: T) extends Bundle {
   /** A non-ambiguous name of this `Valid` instance for use in generated Verilog names
     * Inserts the parameterized generator's typeName, e.g. Valid_UInt4
     */
-  override def typeName = s"${this.getClass.getSimpleName}_${gen.typeName}"
+  override def typeName = s"${simpleClassName(this.getClass)}_${gen.typeName}"
 }
 
 /** Factory for generating "valid" interfaces. A "valid" interface is a data-communicating interface between a producer
@@ -182,7 +183,7 @@ class Pipe[T <: Data](val gen: T, val latency: Int = 1) extends Module {
     * Includes the latency cycle count in the name as well as the parameterized
     * generator's `typeName`, e.g. `Pipe4_UInt4`
     */
-  override def desiredName = s"${this.getClass.getSimpleName}${latency}_${gen.typeName}"
+  override def desiredName = s"${simpleClassName(this.getClass)}${latency}_${gen.typeName}"
 
   /** Interface for [[Pipe]]s composed of a [[Valid]] input and [[Valid]] output
     * @define notAQueue


### PR DESCRIPTION
Replaces instances of `getClass.getSimpleName` in `typeName`, which is problematic in Java 8, with a common utility function (which just bundles the default `Module.desiredName` logic). Also disallows mixing `HasAutoTypename` into an anonymous Record, which is prone to generating `Malformed class name` errors.

Compiler plugin change was validated by attempting to compile anonymous `Bundle with HasAutoTypename` classes, with positive erroring.
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

Squash

#### Release Notes
- Introduce a `simpleClassName` utility object that emulates a `getClass.getSimpleName` call without throwing `Malformed class name` exceptions when Java 8 is used. `typeName` and all related implementations use this function now instead of `getClass.getSimpleName`.
- `HasAutoTypename` can no longer be mixed into an anonymous `Record`; the compiler plugin now reports this as a compilation error.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
