### PR TITLE
Add PolymorphicIOModule, PolymorphicIOBlackBox

### DIFF
--- a/core/src/main/scala/chisel3/IO.scala
+++ b/core/src/main/scala/chisel3/IO.scala
@@ -23,6 +23,7 @@ object IO {
     */
   def apply[T <: Data](iodef: => T)(implicit sourceInfo: SourceInfo): T = {
     val module = Module.currentModule.get // Impossible to fail
+    require(module.isIOCreationAllowed, "This module cannot have user-created IO")
     require(!module.isClosed, "Can't add more ports after module close")
     val prevId = Builder.idGen.value
     val data = iodef // evaluate once (passed by name)

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -392,6 +392,20 @@ package experimental {
     /** Internal check if a Module's constructor has finished executing */
     private[chisel3] def isClosed = _closed
 
+    /** Mutable state that indicates if IO is allowed to be created for this module.
+      * This can be used for advanced Chisel library APIs that want to limit
+      * what IO is allowed to be created for a module.
+      */
+    private var _isIOCreationAllowed = true
+
+    /** If true, then this module is allowed to have user-created IO. */
+    private[chisel3] def isIOCreationAllowed = _isIOCreationAllowed
+
+    /** Disallow any more IO creation for this module. */
+    private[chisel3] def disallowIOCreation(): Unit = {
+      _isIOCreationAllowed = false
+    }
+
     private[chisel3] var toDefinitionCalled:  Option[SourceInfo] = None
     private[chisel3] var modulePortsAskedFor: Option[SourceInfo] = None
 

--- a/src/main/scala/chisel3/PolymorphicIOModule.scala
+++ b/src/main/scala/chisel3/PolymorphicIOModule.scala
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import chisel3.experimental.{BaseModule, ExtModule, FlatIO, Param}
+
+/** A module or external module whose IO is generated from a specific generator.
+  * This module may have no additional IO created other than what is specified
+  * by its `ioGenerator` abstract member.
+  */
+sealed trait FixedIOBaseModule[A <: Data] extends BaseModule {
+
+  /** A generator of IO */
+  protected def ioGenerator: A
+
+  final val io = FlatIO(ioGenerator)
+  disallowIOCreation()
+
+}
+
+/** A Chisel module whose IO is determined by an IO generator.  This module
+  * cannot have additional IO created by modules that extend it.
+  *
+  * @param ioGenerator
+  */
+class FixedIORawModule[A <: Data](final val ioGenerator: A) extends RawModule with FixedIOBaseModule[A]
+
+/** A Chisel blackbox whose IO is determined by an IO generator.  This module
+  * cannot have additional IO created by modules that extend it.
+  *
+  * @param ioGenerator
+  * @param params
+  */
+class FixedIOExtModule[A <: Data](final val ioGenerator: A, params: Map[String, Param] = Map.empty[String, Param])
+    extends ExtModule(params)
+    with FixedIOBaseModule[A]


### PR DESCRIPTION
Add a `private[chisel3]` ability to block further IO creation in a
`BaseModule`.  This is intended for advanced, in-tree APIs that need to
disallow the creation of further IO by a user.  This API has mutable state
to track if more IO is allowed to be created, a method to get the
value, and a method to set the module to disallow further IO creation.
This one-way setting (h/t @jackkoenig) tries to keep this as locked down
as possible.

Add a new module hierarchy that promotes the type of the IO of that module
to a type parameter.  This module hierarchy includes:

  1. PolymorphicIOBaseModule
  2. PolymorphicIORawModule
  3. PolymorphicIOBlackBox

Both (2) and (3) inherit from (1).  These modules are all polymorphic in
their type of IO.  It follows that no more IO are allowed to be created
other than what is in the type.



#### Release Notes
Add `PolymorphicIORawModule` and `PolymorphicIOExtModule` that have a type parameter describing what their IO is.  This is intended for advanced APIs which want to have guarantees about the IO will be.  These share a common trait, `PolymorphicIOBaseModule` which can be used to allow for substitution of one for the other.