### PR TITLE
Improve error messages involving views

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -7,6 +7,7 @@ import chisel3.experimental.dataview.reify
 import scala.language.experimental.macros
 import chisel3.experimental.{Analog, BaseModule}
 import chisel3.experimental.{prefix, SourceInfo, UnlocatableSourceInfo}
+import chisel3.experimental.dataview.reifySingleData
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal._
 import chisel3.internal.sourceinfo._
@@ -416,14 +417,16 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   }
 
   private[chisel3] def stringAccessor(chiselType: String): String = {
-    topBindingOpt match {
+    // Trace views to give better error messages
+    val thiz = reifySingleData(this).getOrElse(this)
+    thiz.topBindingOpt match {
       case None => chiselType
       // Handle DontCares specially as they are "literal-like" but not actually literals
       case Some(DontCareBinding()) => s"$chiselType(DontCare)"
       case Some(topBinding) =>
-        val binding: String = _bindingToString(topBinding)
-        val name = earlyName
-        val mod = parentNameOpt.map(_ + ".").getOrElse("")
+        val binding: String = thiz._bindingToString(topBinding)
+        val name = thiz.earlyName
+        val mod = thiz.parentNameOpt.map(_ + ".").getOrElse("")
 
         s"$mod$name: $binding[$chiselType]"
     }


### PR DESCRIPTION
For the reviewers benefit, the error messages in the tests before this change are:
```
Exception in thread "main" chisel3.package$ChiselException: Connection between sink (_$$View$$_.view: [SInt<8>]) and source (Top.in: IO[UInt<8>]) failed @: Sink (SInt<8>) and Source (UInt<8>) have different types.
```
and
```
[error] src/main/scala/Jack.scala 18:31: Connection between sink (_$$View$$_.view_4._2: [SInt<8>]) and source (_$$View$$_.view__view_4._2: [UInt<8>]) failed @: Sink (SInt<8>) and Source (UInt<8>) have different types.
[error]   ((fizz, buzz).viewAs: Data) :#= ((foo, bar).viewAs: Data)
[error]                               ^
[error] src/main/scala/Jack.scala 18:31: Connection between sink (_$$View$$_.view_4._1: [SInt<8>]) and source (_$$View$$_.view__view_4._1: [UInt<8>]) failed @: Sink (SInt<8>) and Source (UInt<8>) have different types.
[error]   ((fizz, buzz).viewAs: Data) :#= ((foo, bar).viewAs: Data)
[error]                               ^
[error] There were 2 error(s) during hardware elaboration.
```

With this change you get:
```
Exception in thread "main" chisel3.package$ChiselException: Connection between sink (Top.out: IO[SInt<8>]) and source (Top.in: IO[UInt<8>]) failed @: Sink (SInt<8>) and Source (UInt<8>) have different types.
```
and
```
[error] src/main/scala/Jack.scala 18:31: Connection between sink (Top.buzz: IO[SInt<8>]) and source (Top.bar: IO[UInt<8>]) failed @: Sink (SInt<8>) and Source (UInt<8>) have different types.
[error]   ((fizz, buzz).viewAs: Data) :#= ((foo, bar).viewAs: Data)
[error]                               ^
[error] src/main/scala/Jack.scala 18:31: Connection between sink (Top.fizz: IO[SInt<8>]) and source (Top.foo: IO[UInt<8>]) failed @: Sink (SInt<8>) and Source (UInt<8>) have different types.
[error]   ((fizz, buzz).viewAs: Data) :#= ((foo, bar).viewAs: Data)
[error]                               ^
[error] There were 2 error(s) during hardware elaboration.
```

### Contributor Checklist

- [NA] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This improves error messages involving views where the view maps to a single Data. The error messages on legacy connections (:= and <>) involving views that do not correspond 1-1 with a single target Data are still bad, but connectables (eg. :#=) do benefit even in that case.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
