### PR TITLE
Add unit test demonstrating BoringUtils.tap with D/I

### DIFF
--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -404,8 +404,13 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       probe.define(tapTarget, BoringUtils.rwTap(internalWire))
     }
     class Top(fooDef: Definition[Foo]) extends RawModule {
-      val fooInst = Instance(fooDef)
-      probe.forceInitial(fooInst.tapTarget, true.B)
+      val fooInstA = Instance(fooDef)
+      val fooInstB = Instance(fooDef)
+
+      probe.forceInitial(fooInstA.tapTarget, true.B)
+
+      val outProbe = IO(probe.RWProbe(Bool()))
+      probe.define(outProbe, fooInstB.tapTarget)
     }
     val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top(Definition(new Foo)), Array("--full-stacktrace"))
     matchesAndOmits(chirrtl)(
@@ -413,7 +418,8 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       "output tapTarget : RWProbe<UInt<1>>",
       "define tapTarget = rwprobe(internalWire)",
       "module Top :",
-      "force_initial(fooInst.tapTarget, UInt<1>(0h1))"
+      "force_initial(fooInstA.tapTarget, UInt<1>(0h1))",
+      "define outProbe = fooInstB.tapTarget"
     )()
 
     // Check that firtool also passes

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -408,7 +408,6 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       probe.forceInitial(fooInst.tapTarget, true.B)
     }
     val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top(Definition(new Foo)), Array("--full-stacktrace"))
-    // println(chirrtl)
     matchesAndOmits(chirrtl)(
       "module Foo :",
       "output tapTarget : RWProbe<UInt<1>>",


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Documentation or website-related


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
