### PR TITLE
Add optional group API

### DIFF
--- a/core/src/main/scala/chisel3/Group.scala
+++ b/core/src/main/scala/chisel3/Group.scala
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import chisel3.experimental.{SourceInfo, UnlocatableSourceInfo}
+import chisel3.internal.{Builder, HasId}
+import chisel3.internal.firrtl.{GroupDefBegin, GroupDefEnd, Node}
+import chisel3.util.simpleClassName
+import scala.collection.mutable.LinkedHashSet
+
+/** This object contains Chisel language features for creating optional groups.
+  * Optional groups are collections of hardware that are not always present in
+  * the circuit.  Optional groups are intended to be used to hold verification
+  * or debug code.
+  */
+object group {
+
+  /** Enumerations of different optional group conventions.  A group convention
+    * says how a given group should be lowered to Verilog.
+    */
+  object Convention {
+    sealed trait Type
+
+    /** Internal type used as the parent of all groups. */
+    private[chisel3] case object Root extends Type
+
+    /** The group should be lowered to a SystemVerilog `bind`. */
+    case object Bind extends Type
+  }
+
+  /** A declaration of an optional group.
+    *
+    * @param convention how this optional group should be lowered
+    * @param _parent the parent group, if any
+    */
+  abstract class Declaration(val convention: Convention.Type)(implicit _parent: Declaration, _sourceInfo: SourceInfo) {
+    self: Singleton =>
+
+    /** This establishes a new implicit val for any nested groups. */
+    protected final implicit val thiz: Declaration = this
+
+    private[chisel3] def parent: Declaration = _parent
+
+    private[chisel3] def sourceInfo: SourceInfo = _sourceInfo
+
+    private[chisel3] def name: String = simpleClassName(this.getClass())
+  }
+
+  object Declaration {
+    private[chisel3] case object Root extends Declaration(Convention.Root)(null, UnlocatableSourceInfo)
+    implicit val rootDeclaration: Declaration = Root
+  }
+
+  /** Add a declaration and all of its parents to the Builder.  This lets the
+    * Builder know that this group was used and should be emitted in the FIRRTL.
+    */
+  private[chisel3] def addDeclarations(declaration: Declaration) = {
+    var currentDeclaration: Declaration = declaration
+    while (currentDeclaration != Declaration.Root && !Builder.groups.contains(currentDeclaration)) {
+      val decl = currentDeclaration
+      val parent = decl.parent
+
+      Builder.groups += decl
+      currentDeclaration = parent
+    }
+  }
+
+  /** Create a new optional group definition.
+    *
+    * @param declaration the optional group declaration this definition is associated with
+    * @param block the Chisel code that goes into the group
+    * @param sourceInfo a source locator
+    */
+  def apply[A](
+    declaration: Declaration
+  )(block:       => A
+  )(
+    implicit sourceInfo: SourceInfo
+  ): Unit = {
+    Builder.pushCommand(GroupDefBegin(sourceInfo, declaration))
+    addDeclarations(declaration)
+    Builder.groupStack = declaration :: Builder.groupStack
+    block
+    Builder.pushCommand(GroupDefEnd(sourceInfo))
+    Builder.groupStack = Builder.groupStack.tail
+  }
+
+}

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -401,6 +401,19 @@ case class ProbeRelease(info: Info, clock: Expression, cond: Expression, probe: 
     extends Statement
     with UseSerializer
 
+object GroupConvention {
+  sealed trait Type
+  case object Bind extends Type {
+    override def toString: String = "bind"
+  }
+}
+
+case class GroupDeclare(info: Info, name: String, convention: GroupConvention.Type, body: Seq[GroupDeclare])
+    extends FirrtlNode
+    with IsDeclaration
+    with UseSerializer
+case class GroupDefine(info: Info, declaration: String, body: Statement) extends Statement with UseSerializer
+
 // formal
 object Formal extends Enumeration {
   val Assert = Value("assert")
@@ -650,7 +663,12 @@ case class IntModule(
   */
 case class DefClass(info: Info, name: String, ports: Seq[Port], body: Statement) extends DefModule with UseSerializer
 
-case class Circuit(info: Info, modules: Seq[DefModule], main: String, typeAliases: Seq[DefTypeAlias] = Seq.empty)
+case class Circuit(
+  info:        Info,
+  modules:     Seq[DefModule],
+  main:        String,
+  typeAliases: Seq[DefTypeAlias] = Seq.empty,
+  groups:      Seq[GroupDeclare] = Seq.empty)
     extends FirrtlNode
     with HasInfo
     with UseSerializer

--- a/src/test/scala/chiselTests/util/GroupSpec.scala
+++ b/src/test/scala/chiselTests/util/GroupSpec.scala
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.util
+
+import chisel3._
+import chiselTests.{ChiselFlatSpec, MatchesAndOmits, Utils}
+import _root_.circt.stage.ChiselStage
+
+class GroupSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
+
+  "Groups" should "allow for creation of a group and nested groups" in {
+
+    object A extends group.Declaration(group.Convention.Bind) {
+      object B extends group.Declaration(group.Convention.Bind)
+    }
+
+    class Foo extends RawModule {
+      val a = IO(Input(Bool()))
+
+      group(A) {
+        val w = WireInit(a)
+        dontTouch(w)
+        group(A.B) {
+          val x = WireInit(w)
+          dontTouch(x)
+        }
+      }
+
+      val y = Wire(Bool())
+      y := DontCare
+    }
+
+    val chirrtl = ChiselStage.emitCHIRRTL(new Foo, Array("--full-stacktrace"))
+
+    info("CHIRRTL emission looks coorect")
+    // TODO: Switch to FileCheck for this testing.  This is going to miss all sorts of ordering issues.
+    matchesAndOmits(chirrtl)(
+      "declgroup A, bind :",
+      "declgroup B, bind :",
+      "group A :",
+      "wire w : UInt<1>",
+      "group B :",
+      "wire x : UInt<1>",
+      "wire y : UInt<1>"
+    )()
+  }
+
+}


### PR DESCRIPTION
Add optional groups.

### Example

Chisel:
```scala
object A extends group.Declaration(group.Convention.Bind) {
  object B extends group.Declaration(group.Convention.Bind)
}

class Foo extends RawModule {
  val a = IO(Input(Bool()))

  group(A) {
    val w = WireInit(a)
    dontTouch(w)
    group(A.B) {
      val x = WireInit(w)
      dontTouch(x)
    }
  }

}
```

Output FIRRTL:

```
FIRRTL version 3.2.0
circuit Foo :%[[
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~Foo|Foo>w"
  },
  {
    "class":"firrtl.transforms.DontTouchAnnotation",
    "target":"~Foo|Foo>x"
  }
]]
  declgroup A, bind :
    declgroup B, bind :
  module Foo :
    input a : UInt<1>

    group A:
      wire w : UInt<1>
      connect w, a
      group B:
        wire x : UInt<1>
        connect x, w
```

Output Verilog:

```verilog
// Generated by CIRCT firtool-1.56.1-32-g4da6a4d83
module Foo_A_B(
  input _w
);

  wire x = _w;
endmodule

module Foo_A(
  input _a
);

  wire w = _a;
  wire w_probe = w;
endmodule

module Foo(
  input a
);

endmodule


// ----- 8< ----- FILE "groups_Foo_A_B.sv" ----- 8< -----

// Generated by CIRCT firtool-1.56.1-32-g4da6a4d83
`include "groups_Foo_A.sv"
`ifndef groups_Foo_A_B
`define groups_Foo_A_B
bind Foo Foo_A_B foo_A_B (
  ._w (Foo.foo_A.w_probe)
);
`endif

// ----- 8< ----- FILE "groups_Foo_A.sv" ----- 8< -----

// Generated by CIRCT firtool-1.56.1-32-g4da6a4d83
`ifndef groups_Foo_A
`define groups_Foo_A
bind Foo Foo_A foo_A (
  ._a (a)
);
`endif
```

#### Release Notes

Add optional groups. This is a feature that can be used to add optional verification functionality, e.g., asserts or debug code, that does not affect the main design. These groups are lowered to FIRRTL Optional Groups (see: https://github.com/chipsalliance/firrtl-spec/pull/108) with the "bind" convention.
