### PR TITLE
[Binder] Corrent `chirrtl.memoryport` position

### DIFF
--- a/binder/src/main/scala/PanamaCIRCT.scala
+++ b/binder/src/main/scala/PanamaCIRCT.scala
@@ -122,6 +122,14 @@ class PanamaCIRCT {
     CAPI.mlirBlockAppendOwnedOperation(block.get, operation.get)
   }
 
+  def mlirBlockInsertOwnedOperationAfter(block: MlirBlock, reference: MlirOperation, operation: MlirOperation) = {
+    CAPI.mlirBlockInsertOwnedOperationAfter(block.get, reference.get, operation.get)
+  }
+
+  def mlirBlockInsertOwnedOperationBefore(block: MlirBlock, reference: MlirOperation, operation: MlirOperation) = {
+    CAPI.mlirBlockInsertOwnedOperationBefore(block.get, reference.get, operation.get)
+  }
+
   def mlirRegionCreate() = MlirRegion(CAPI.mlirRegionCreate(arena))
 
   def mlirRegionAppendOwnedBlock(region: MlirRegion, block: MlirBlock) = {

--- a/common.sc
+++ b/common.sc
@@ -292,6 +292,8 @@ trait CIRCTPanamaBinderModule
     "mlirBlockCreate",
     "mlirBlockGetArgument",
     "mlirBlockAppendOwnedOperation",
+    "mlirBlockInsertOwnedOperationAfter",
+    "mlirBlockInsertOwnedOperationBefore",
     "mlirRegionAppendOwnedBlock",
     "mlirOperationStateAddOwnedRegions",
     "mlirOperationDump",


### PR DESCRIPTION
~If the current position is under a `when` context, insert `chirrtl.memoryport` before the `whenBegin`, and leave `chirrtl.memoryport.access` inside the `when` branch.~

If the current position is under a `when` context, insert `chirrtl.memoryport` before the root `whenBegin`, and leave `chirrtl.memoryport.access` inside the `when` branch.

If not, insert `chirrtl.memoryport` directly and followed by a `chirrtl.memoryport.access`.