### PR TITLE
Add DedupGroupAnnotation phase

### DIFF
--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -88,7 +88,7 @@ object dedupGroup {
     * @param group The name of the dedup group to assign the module to
     * @return Unmodified signal `module`
     */
-  def apply[T <: RawModule](module: T, group: String): Unit = {
+  def apply[T <: BaseModule](module: T, group: String): Unit = {
     annotate(new ChiselAnnotation { def toFirrtl = DedupGroupAnnotation(module.toTarget, group) })
   }
 }

--- a/core/src/main/scala/chisel3/BlackBox.scala
+++ b/core/src/main/scala/chisel3/BlackBox.scala
@@ -12,8 +12,13 @@ import scala.annotation.nowarn
 
 package internal {
 
-  private[chisel3] abstract class BaseBlackBox extends BaseModule
-
+  private[chisel3] abstract class BaseBlackBox extends BaseModule {
+    // Hack to make it possible to run the AddDedupAnnotation
+    // pass. Because of naming bugs in imported definitions in D/I, it
+    // is not possible to properly name EmptyExtModule created from
+    // Defintions. See unit test SeparateElaborationSpec #4.a
+    private[chisel3] def _isImportedDefinition: Boolean = false
+  }
 }
 
 package experimental {

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -535,7 +535,7 @@ package experimental {
     }
 
     /** Legalized name of this module. */
-    final lazy val name =
+    lazy val name =
       try {
         // PseudoModules are not "true modules" and thus should share
         // their original modules names without uniquification

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -535,7 +535,7 @@ package experimental {
     }
 
     /** Legalized name of this module. */
-    lazy val name =
+    final lazy val name =
       try {
         // PseudoModules are not "true modules" and thus should share
         // their original modules names without uniquification

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -132,6 +132,7 @@ object Instance extends SourceInfoDoc {
       )
       class EmptyExtModule extends ExtModule with PseudoModule {
         override def desiredName: String = extModName
+        override private[chisel3] def _isImportedDefinition = true
         override def generateComponent(): Option[Component] = {
           require(!_closed, s"Can't generate $desiredName module more than once")
           _closed = true

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -130,9 +130,8 @@ object Instance extends SourceInfoDoc {
           "Imported Definition information not found - possibly forgot to add ImportDefinition annotation?"
         )
       )
-      class EmptyExtModule extends ExtModule {
+      class EmptyExtModule extends ExtModule with PseudoModule {
         override def desiredName: String = extModName
-        override lazy val name = definition.proto.name
         override def generateComponent(): Option[Component] = {
           require(!_closed, s"Can't generate $desiredName module more than once")
           _closed = true

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -5,7 +5,7 @@ package chisel3.experimental.hierarchy.core
 import scala.language.experimental.macros
 import chisel3._
 import chisel3.experimental.hierarchy.{InstantiableClone, ModuleClone}
-import chisel3.internal.{throwException, Builder}
+import chisel3.internal.{throwException, Builder, PseudoModule}
 import chisel3.experimental.{BaseModule, ExtModule, SourceInfo}
 import chisel3.internal.sourceinfo.InstanceTransform
 import chisel3.internal.firrtl.{Component, DefBlackBox, DefIntrinsicModule, DefModule, Port}

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -132,6 +132,7 @@ object Instance extends SourceInfoDoc {
       )
       class EmptyExtModule extends ExtModule {
         override def desiredName: String = extModName
+        override lazy val name = definition.proto.name
         override def generateComponent(): Option[Component] = {
           require(!_closed, s"Can't generate $desiredName module more than once")
           _closed = true

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -5,7 +5,7 @@ package chisel3.experimental.hierarchy.core
 import scala.language.experimental.macros
 import chisel3._
 import chisel3.experimental.hierarchy.{InstantiableClone, ModuleClone}
-import chisel3.internal.{throwException, Builder, PseudoModule}
+import chisel3.internal.{throwException, Builder}
 import chisel3.experimental.{BaseModule, ExtModule, SourceInfo}
 import chisel3.internal.sourceinfo.InstanceTransform
 import chisel3.internal.firrtl.{Component, DefBlackBox, DefIntrinsicModule, DefModule, Port}
@@ -130,7 +130,7 @@ object Instance extends SourceInfoDoc {
           "Imported Definition information not found - possibly forgot to add ImportDefinition annotation?"
         )
       )
-      class EmptyExtModule extends ExtModule with PseudoModule {
+      class EmptyExtModule extends ExtModule {
         override def desiredName: String = extModName
         override private[chisel3] def _isImportedDefinition = true
         override def generateComponent(): Option[Component] = {

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -30,10 +30,7 @@ class AddDedupGroupAnnotations extends Phase {
     val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }.toSet
 
     @nowarn("msg=class Port")
-    val annos = circuit.components.filterNot {
-      case x @ DefBlackBox(id, _, _, _, _) => id.toString contains "Instance"
-      case x                               => false
-    }.collect {
+    val annos = circuit.components.collect {
       case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id.desiredName)
     }
     annos ++ annotations

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -27,7 +27,7 @@ class AddDedupGroupAnnotations extends Phase {
       )
     }
 
-    val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }
+    val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }.toSet
 
     @nowarn("msg=class Port")
     val annos = circuit.components.filterNot {

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -30,7 +30,10 @@ class AddDedupGroupAnnotations extends Phase {
     val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }.toSet
 
     @nowarn("msg=class Port")
-    val annos = circuit.components.collect {
+    val annos = circuit.components.filter {
+      case x @ DefBlackBox(id, _, _, _, _) => !id._isImportedDefinition
+      case x                               => true
+    }.collect {
       case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id.desiredName)
     }
     annos ++ annotations

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -1,0 +1,33 @@
+package chisel3.stage.phases
+
+import firrtl.AnnotationSeq
+import firrtl.options.{Dependency, Phase}
+import firrtl.options.Viewer.view
+import firrtl.transforms.DedupGroupAnnotation
+
+import chisel3.experimental.BaseModule
+import chisel3.stage._
+import chisel3.stage.CircuitSerializationAnnotation._
+import chisel3.ChiselException
+import chisel3.experimental.dedupGroup
+
+class AddDedupGroupAnnotations extends Phase {
+  override def prerequisites = Seq.empty
+  override def optionalPrerequisites = Seq(Dependency[Convert])
+  override def optionalPrerequisiteOf = Seq.empty
+  override def invalidates(a: Phase) = false
+
+  def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    val chiselOptions = view[ChiselOptions](annotations)
+    val circuit = chiselOptions.chiselCircuit.getOrElse {
+      throw new ChiselException(
+        s"Unable to locate the elaborated circuit, did ${classOf[Elaborate].getName} run correctly"
+      )
+    }
+    val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }
+    val annos = circuit.components.collect {
+      case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id.desiredName)
+    }
+    annos ++ annotations
+  }
+}

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -4,12 +4,14 @@ import firrtl.AnnotationSeq
 import firrtl.options.{Dependency, Phase}
 import firrtl.options.Viewer.view
 import firrtl.transforms.DedupGroupAnnotation
+import scala.annotation.nowarn
 
 import chisel3.experimental.BaseModule
 import chisel3.stage._
 import chisel3.stage.CircuitSerializationAnnotation._
 import chisel3.ChiselException
 import chisel3.experimental.dedupGroup
+import chisel3.internal.firrtl.DefBlackBox
 
 class AddDedupGroupAnnotations extends Phase {
   override def prerequisites = Seq.empty
@@ -24,8 +26,14 @@ class AddDedupGroupAnnotations extends Phase {
         s"Unable to locate the elaborated circuit, did ${classOf[Elaborate].getName} run correctly"
       )
     }
+
     val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }
-    val annos = circuit.components.collect {
+
+    @nowarn("msg=class Port")
+    val annos = circuit.components.filterNot {
+      case x @ DefBlackBox(id, _, _, _, _) => id.toString contains "Instance"
+      case x                               => false
+    }.collect {
       case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id.desiredName)
     }
     annos ++ annotations

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -70,6 +70,7 @@ class ChiselStage extends Stage {
         Dependency[chisel3.stage.phases.MaybeAspectPhase],
         Dependency[chisel3.stage.phases.AddSerializationAnnotations],
         Dependency[chisel3.stage.phases.Convert],
+        Dependency[chisel3.stage.phases.AddDedupGroupAnnotations],
         Dependency[chisel3.stage.phases.MaybeInjectingPhase],
         Dependency[circt.stage.phases.AddImplicitOutputFile],
         Dependency[circt.stage.phases.Checks],

--- a/src/test/scala/chiselTests/DedupSpec.scala
+++ b/src/test/scala/chiselTests/DedupSpec.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.{annotate, dedupGroup, ChiselAnnotation}
 import firrtl.transforms.DedupGroupAnnotation
+import chisel3.experimental.hierarchy._
 
 class DedupIO extends Bundle {
   val in = Flipped(Decoupled(UInt(32.W)))
@@ -67,6 +68,22 @@ class SharedConstantValDedupTop extends Module {
   io.out := inst0.io.out + inst1.io.out
 }
 
+class SharedConstantValDedupTopDesiredName extends Module {
+  val io = IO(new Bundle {
+    val in = Input(UInt(8.W))
+    val out = Output(UInt(8.W))
+  })
+  val inst0 = Module(new SharedConstantValDedup {
+    override def desiredName = "foo"
+  })
+  val inst1 = Module(new SharedConstantValDedup {
+    override def desiredName = "bar"
+  })
+  inst0.io.in := io.in
+  inst1.io.in := io.in
+  io.out := inst0.io.out + inst1.io.out
+}
+
 class DedupSpec extends ChiselFlatSpec {
   private val ModuleRegex = """\s*module\s+(\w+)\b.*""".r
   def countModules(verilog: String): Int =
@@ -89,6 +106,13 @@ class DedupSpec extends ChiselFlatSpec {
       val top = new SharedConstantValDedupTop
       dedupGroup(top.inst0, "inst0")
       dedupGroup(top.inst1, "inst1")
+      top
+    }) === 3)
+  }
+
+  it should "work natively for desiredNames" in {
+    assert(countModules(compile {
+      val top = new SharedConstantValDedupTopDesiredName
       top
     }) === 3)
   }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -867,12 +867,20 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
         val a = IO(Input(Bool()))
         val b = IO(Output(Bool()))
 
+        // Chisel groups modules for deduping using their
+        // desiredNames. By setting the desiredName here, we can make
+        // sure that these RawModules get put in the same
+        // deduplication group
+        override def desiredName = "Bar"
+
         b := a
       }
 
       class Bar extends RawModule {
         val a = IO(Input(Bool()))
         val b = IO(Output(Bool()))
+
+        override def desiredName = "Bar"
 
         b := a
       }


### PR DESCRIPTION


### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Add `DedupGroupAnnotation` phase that generates deduplication groups based on module `desiredNames`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
