### PR TITLE
Changed Array to Seq in MuxLookup explantation

### DIFF
--- a/docs/src/explanations/muxes-and-input-selection.md
+++ b/docs/src/explanations/muxes-and-input-selection.md
@@ -34,7 +34,7 @@ array [ condition -> selected_input_port ].
 Chisel also provides `MuxLookup` which is an n-way indexed multiplexer:
 
 ```scala
-MuxLookup(idx, default)(Array(0.U -> a, 1.U -> b, ...))
+MuxLookup(idx, default)(Seq(0.U -> a, 1.U -> b, ...))
 ```
 
 This is the same as a `MuxCase`, where the conditions are all index based selection:


### PR DESCRIPTION
`MuxLookup(idx, default)(Array(0.U -> a, 1.U -> b, ...))` was deprecated in 3.6 and now it uses `MuxLookup(idx, default)(Seq(0.U -> a, 1.U -> b, ...))`. However explanation in documentation still uses an Array. This PR fixes this.