### PR TITLE
Fix DataMirror.internal.chiselTypeClone to preserve Scala type

### DIFF
--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -191,8 +191,8 @@ object DataMirror {
   object internal {
     def isSynthesizable(target: Data): Boolean = target.isSynthesizable
     // For those odd cases where you need to care about object reference and uniqueness
-    def chiselTypeClone[T <: Data](target: Data): T = {
-      target.cloneTypeFull.asInstanceOf[T]
+    def chiselTypeClone[T <: Data](target: T): T = {
+      target.cloneTypeFull
     }
   }
 

--- a/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
@@ -111,4 +111,15 @@ class DataMirrorSpec extends ChiselFlatSpec {
   it should "not support name guesses for non-hardware" in {
     an[ExpectedHardwareException] should be thrownBy DataMirror.queryNameGuess(UInt(8.W))
   }
+
+  "chiselTypeClone" should "preserve Scala type information" in {
+    class MyModule extends Module {
+      val in = IO(Input(UInt(8.W)))
+      val out = IO(Output(DataMirror.internal.chiselTypeClone(in)))
+      // The connection checks the types
+      out :#= in
+    }
+    ChiselStage.emitCHIRRTL(new MyModule)
+  }
+
 }


### PR DESCRIPTION
See https://github.com/chipsalliance/rocket-chip/pull/3476

This has been a lingering issue, about time we fixed it.

I'm going to try backporting this but it may or may not be binary compatible.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
