### PR TITLE
Partial fix for probe and Decoupled interaction + demo of workaround

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -220,7 +220,9 @@ object BoringUtils {
   private def boreOrTap[A <: Data](source: A, createProbe: Option[ProbeInfo] = None)(implicit si: SourceInfo): A = {
     import reflect.DataMirror
     def parent(d: Data): BaseModule = d.topBinding.location.get
-    def purePortTypeBase = if (DataMirror.hasOuterFlip(source)) Flipped(chiselTypeOf(source)) else chiselTypeOf(source)
+    def purePortTypeBase = if (createProbe.nonEmpty) Output(chiselTypeOf(source))
+    else if (DataMirror.hasOuterFlip(source)) Flipped(chiselTypeOf(source))
+    else chiselTypeOf(source)
     def purePortType = createProbe match {
       case Some(pi) if pi.writable => RWProbe(purePortTypeBase)
       case Some(pi)                => Probe(purePortTypeBase)

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -472,7 +472,6 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       val a = WireInit(DecoupledIO(Bool()), DontCare)
       val dummyA = Wire(Output(chiselTypeOf(a)))
       // FIXME we shouldn't need this intermediate wire
-      // https://github.com/chipsalliance/chisel/issues/3556
       // https://github.com/chipsalliance/chisel/issues/3557
       dummyA :#= a
       dontTouch(a)

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -425,4 +425,75 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
     // Check that firtool also passes
     val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Top(Definition(new Foo)))
   }
+
+  it should "work with DecoupledIO in a hierarchy" in {
+    import chisel3.util.{Decoupled, DecoupledIO}
+    class Bar() extends RawModule {
+      val decoupledThing = Wire(Decoupled(Bool()))
+      decoupledThing := DontCare
+    }
+    class Foo() extends RawModule {
+      val bar = Module(new Bar())
+    }
+    class FakeView(foo: Foo) extends RawModule {
+      val decoupledThing = Wire(DecoupledIO(Bool()))
+      decoupledThing := BoringUtils.tapAndRead(foo.bar.decoupledThing)
+    }
+    class Top() extends RawModule {
+      val foo = Module(new Foo())
+      val fakeView = Module(new FakeView(foo))
+    }
+
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top(), Array("--full-stacktrace"))
+    matchesAndOmits(chirrtl)(
+      "module Bar :",
+      "output decoupledThing_bore : Probe<{ ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}>",
+      "define decoupledThing_bore = probe(decoupledThing)",
+      "module Foo :",
+      "output decoupledThing_bore : Probe<{ ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}>",
+      "define decoupledThing_bore = bar.decoupledThing_bore",
+      "module FakeView :",
+      "input decoupledThing_bore : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}",
+      "module Top :",
+      "connect fakeView.decoupledThing_bore, read(foo.decoupledThing_bore)"
+    )()
+
+    // Check that firtool also passes
+    val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Top())
+  }
+
+  it should "work with DecoupledIO" in {
+    import chisel3.util.{Decoupled, DecoupledIO}
+    class Bar(b: DecoupledIO[Bool]) extends RawModule {
+      BoringUtils.tapAndRead(b)
+    }
+
+    class Foo extends RawModule {
+      val a = WireInit(DecoupledIO(Bool()), DontCare)
+      val dummyA = Wire(Output(chiselTypeOf(a)))
+      // FIXME we shouldn't need this intermediate wire
+      // https://github.com/chipsalliance/chisel/issues/3556
+      // https://github.com/chipsalliance/chisel/issues/3557
+      dummyA :#= a
+      dontTouch(a)
+
+      val bar = Module(new Bar(dummyA))
+    }
+
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Foo, Array("--full-stacktrace"))
+
+    matchesAndOmits(chirrtl)(
+      "module Bar :",
+      "input bore : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}",
+      "module Foo :",
+      "wire a : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}",
+      // FIXME shouldn't need intermediate wire
+      "wire dummyA : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}",
+      "connect bar.bore, dummyA"
+    )()
+
+    // Check that firtool also passes
+    val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Foo)
+  }
+
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Coerces tapAndRead to punch stripped-direction flips when punching downwards with Inward non-probe ports, Fixes #3556 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
