### PR TITLE
Bump emitted FIRRTL to 3.3.0

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -15,7 +15,7 @@ object Serializer {
   val Indent = "  "
 
   // The version supported by the serializer.
-  val version = Version(3, 2, 0)
+  val version = Version(3, 3, 0)
 
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -8,7 +8,7 @@ import firrtl.testutils._
 class ExtModuleTests extends FirrtlFlatSpec {
   "extmodule" should "serialize and re-parse equivalently" in {
     val input =
-      """|FIRRTL version 3.2.0
+      """|FIRRTL version 3.3.0
          |circuit Top :
          |  extmodule Top :
          |    input y : UInt<0>

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -977,7 +977,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
       val text = ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo(hasDontTouch = true))
       info("found a version string")
-      text should include("FIRRTL version 3.2.0")
+      text should include("FIRRTL version 3.3.0")
       info("found an Annotation")
       text should include("firrtl.transforms.DontTouchAnnotation")
       info("found a circuit")


### PR DESCRIPTION
Change the reported version of Chisel-emitted FIRRTL to 3.3.0.  Version 3.2.0 includes groups and Chisel is currently emitting things that are not in a spec version yet, e.g., property lists.