### PR TITLE
Check that Optional Groups are Correctly Nested

### DIFF
--- a/core/src/main/scala/chisel3/Group.scala
+++ b/core/src/main/scala/chisel3/Group.scala
@@ -79,6 +79,10 @@ object group {
   ): Unit = {
     Builder.pushCommand(GroupDefBegin(sourceInfo, declaration))
     addDeclarations(declaration)
+    require(
+      Builder.groupStack.head == declaration.parent,
+      s"nested group '${declaration.name}' must be wrapped in parent group '${declaration.parent.name}'"
+    )
     Builder.groupStack = declaration :: Builder.groupStack
     block
     Builder.pushCommand(GroupDefEnd(sourceInfo))

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -493,7 +493,7 @@ private[chisel3] class DynamicContext(
   var currentClock:         Option[Clock] = None
   var currentReset:         Option[Reset] = None
   var currentDisable:       Disable.Type = Disable.BeforeReset
-  var groupStack:           List[group.Declaration] = Nil
+  var groupStack:           List[group.Declaration] = group.Declaration.rootDeclaration :: Nil
   val errors = new ErrorLog(warningFilters, sourceRoots, throwOnFirstError)
   val namingStack = new NamingStack
 

--- a/src/test/scala/chiselTests/util/GroupSpec.scala
+++ b/src/test/scala/chiselTests/util/GroupSpec.scala
@@ -45,4 +45,22 @@ class GroupSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )()
   }
 
+  "Groups error checking" should "require that a nested group definition matches its declaration nesting" in {
+
+    object A extends group.Declaration(group.Convention.Bind) {
+      object B extends group.Declaration(group.Convention.Bind)
+    }
+
+    class Foo extends RawModule {
+      group(A.B) {
+        val a = Wire(Bool())
+      }
+    }
+
+    intercept[IllegalArgumentException] { ChiselStage.emitCHIRRTL(new Foo) }.getMessage() should include(
+      "nested group 'B' must be wrapped in parent group 'A'"
+    )
+
+  }
+
 }


### PR DESCRIPTION
Change the Builder to record the Root Optional Group in its Group Stack.
This is done to later enable error checking that group definitions are
nested correctly.

Add a requirement check that Optional Group definitions are nested in the
same way that their declarations are.