### PR TITLE
Support probe-define in monoconnects

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -853,7 +853,7 @@ object Data {
         (left, right) match {
           case (None, None)                            => Nil
           case (lOpt, rOpt) if isDifferent(lOpt, rOpt) => Nil
-          case (lOpt, rOpt) if isProbe(lOpt, rOpt) => Nil
+          case (lOpt, rOpt) if isProbe(lOpt, rOpt)     => Nil
           case (lOpt: Option[Vec[Data] @unchecked], rOpt: Option[Vec[Data] @unchecked]) if isVec(lOpt, rOpt) =>
             (0 until (lOpt.size.max(rOpt.size))).map { i => (lOpt.grab(i), rOpt.grab(i)) }
           case (lOpt: Option[Record @unchecked], rOpt: Option[Record @unchecked]) if isRecord(lOpt, rOpt) =>

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -829,13 +829,15 @@ object Data {
       }
       //TODO(azidar): Rewrite this to be more clear, probably not the cleanest way to express this
       private def isDifferent(l: Option[Data], r: Option[Data]): Boolean =
-        l.nonEmpty && r.nonEmpty && !isRecord(l, r) && !isVec(l, r) && !isElement(l, r)
+        l.nonEmpty && r.nonEmpty && !isRecord(l, r) && !isVec(l, r) && !isElement(l, r) && !isProbe(l, r)
       private def isRecord(l: Option[Data], r: Option[Data]): Boolean =
         l.orElse(r).map { _.isInstanceOf[Record] }.getOrElse(false)
       private def isVec(l: Option[Data], r: Option[Data]): Boolean =
         l.orElse(r).map { _.isInstanceOf[Vec[_]] }.getOrElse(false)
       private def isElement(l: Option[Data], r: Option[Data]): Boolean =
         l.orElse(r).map { _.isInstanceOf[Element] }.getOrElse(false)
+      private def isProbe(l: Option[Data], r: Option[Data]): Boolean =
+        l.orElse(r).map { x => x.isInstanceOf[Data] && DataMirror.hasProbeTypeModifier(x) }.getOrElse(false)
 
       /** Zips matching children of `left` and `right`; returns Nil if both are empty
         *
@@ -851,6 +853,7 @@ object Data {
         (left, right) match {
           case (None, None)                            => Nil
           case (lOpt, rOpt) if isDifferent(lOpt, rOpt) => Nil
+          case (lOpt, rOpt) if isProbe(lOpt, rOpt) => Nil
           case (lOpt: Option[Vec[Data] @unchecked], rOpt: Option[Vec[Data] @unchecked]) if isVec(lOpt, rOpt) =>
             (0 until (lOpt.size.max(rOpt.size))).map { i => (lOpt.grab(i), rOpt.grab(i)) }
           case (lOpt: Option[Record @unchecked], rOpt: Option[Record @unchecked]) if isRecord(lOpt, rOpt) =>

--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -184,12 +184,12 @@ private[chisel3] object Connection {
         // Recursive Case 4: non-empty orientations
         case (conAlign: NonEmptyAlignment, proAlign: NonEmptyAlignment) =>
           (conAlign.member, proAlign.member) match {
-            case (consumer: Aggregate, producer: Aggregate) =>
+            case (consumer: Aggregate, producer: Aggregate) if !hasProbeTypeModifier(consumer) && !hasProbeTypeModifier(producer) =>
               matchingZipOfChildren(Some(conAlign), Some(proAlign)).foreach {
                 case (ceo, peo) =>
                   doConnection(ceo.getOrElse(conAlign.empty), peo.getOrElse(proAlign.empty))
               }
-            case (consumer: Aggregate, DontCare) =>
+            case (consumer: Aggregate, DontCare) if !hasProbeTypeModifier(consumer) =>
               consumer.getElements.foreach {
                 case f =>
                   doConnection(
@@ -197,7 +197,7 @@ private[chisel3] object Connection {
                     deriveChildAlignment(f, conAlign).swap(DontCare)
                   )
               }
-            case (DontCare, producer: Aggregate) =>
+            case (DontCare, producer: Aggregate) if !hasProbeTypeModifier(producer)  =>
               producer.getElements.foreach {
                 case f =>
                   doConnection(

--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -207,8 +207,8 @@ private[chisel3] object Connection {
               }
             // Check that neither consumer nor producer contains probes
             case (consumer: Data, producer: Data)
-                if (hasProbeTypeModifier(consumer) || hasProbeTypeModifier(producer)) =>
-              errors = "Cannot use connectables with probe types. Exclude them prior to connection." +: errors
+                if (hasProbeTypeModifier(consumer) ^ hasProbeTypeModifier(producer)) =>
+              errors = s"mismatched probe/non-probe types in ${consumer} and ${producer}." +: errors
             case (consumer, producer) =>
               val alignment = (
                 conAlign.alignsWith(proAlign),

--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -184,7 +184,8 @@ private[chisel3] object Connection {
         // Recursive Case 4: non-empty orientations
         case (conAlign: NonEmptyAlignment, proAlign: NonEmptyAlignment) =>
           (conAlign.member, proAlign.member) match {
-            case (consumer: Aggregate, producer: Aggregate) if !hasProbeTypeModifier(consumer) && !hasProbeTypeModifier(producer) =>
+            case (consumer: Aggregate, producer: Aggregate)
+                if !hasProbeTypeModifier(consumer) && !hasProbeTypeModifier(producer) =>
               matchingZipOfChildren(Some(conAlign), Some(proAlign)).foreach {
                 case (ceo, peo) =>
                   doConnection(ceo.getOrElse(conAlign.empty), peo.getOrElse(proAlign.empty))
@@ -197,7 +198,7 @@ private[chisel3] object Connection {
                     deriveChildAlignment(f, conAlign).swap(DontCare)
                   )
               }
-            case (DontCare, producer: Aggregate) if !hasProbeTypeModifier(producer)  =>
+            case (DontCare, producer: Aggregate) if !hasProbeTypeModifier(producer) =>
               producer.getElements.foreach {
                 case f =>
                   doConnection(

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -104,7 +104,7 @@ private[chisel3] object MonoConnect {
   ): Unit = {
     (sink, source) match {
       // Two probes are connected at the root.
-      case (source_e, sink_e) if (DataMirror.hasProbeTypeModifier(source_e) && DataMirror.hasProbeTypeModifier(sink_e)) =>
+      case (sink_e, source_e) if (DataMirror.hasProbeTypeModifier(sink_e) && DataMirror.hasProbeTypeModifier(source_e)) =>
         probeDefine(sourceInfo, sink_e, source_e, context_mod)
 
       // A probe-y thing cannot be connected to a different probe-y thing.

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -425,6 +425,7 @@ private[chisel3] object MonoConnect {
     source:     Data,
     context:    BaseModule
   ): Unit = {
+    checkConnect.checkConnection(sourceInfo, sink, source, context)
     context match {
       case rm: RawModule => rm.addCommand(ProbeDefine(sourceInfo, sink.lref, source.ref))
       case _ => throwException("Internal Error! Probe connection can only occur within RawModule.")
@@ -455,7 +456,7 @@ private[chisel3] object checkConnect {
     checkConnection(sourceInfo, sink, source, context_mod)
   }
 
-  private def checkConnection(
+  def checkConnection(
     sourceInfo:  SourceInfo,
     sink:        Data,
     source:      Data,

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.experimental.{Analog, BaseModule, SourceInfo}
 import chisel3.internal.containsProbe
 import chisel3.internal.Builder.pushCommand
-import chisel3.internal.firrtl.{Connect, Converter, DefInvalid, PropAssign, ProbeDefine}
+import chisel3.internal.firrtl.{Connect, Converter, DefInvalid, ProbeDefine, PropAssign}
 import chisel3.experimental.dataview.{isView, reify, reifyToAggregate}
 import chisel3.properties.{Class, Property}
 import chisel3.reflect.DataMirror
@@ -104,7 +104,8 @@ private[chisel3] object MonoConnect {
   ): Unit = {
     (sink, source) match {
       // Two probes are connected at the root.
-      case (sink_e, source_e) if (DataMirror.hasProbeTypeModifier(sink_e) && DataMirror.hasProbeTypeModifier(source_e)) =>
+      case (sink_e, source_e)
+          if (DataMirror.hasProbeTypeModifier(sink_e) && DataMirror.hasProbeTypeModifier(source_e)) =>
         probeDefine(sourceInfo, sink_e, source_e, context_mod)
 
       // A probe-y thing cannot be connected to a different probe-y thing.
@@ -420,12 +421,12 @@ private[chisel3] object MonoConnect {
 
   def probeDefine(
     sourceInfo: SourceInfo,
-    sink: Data,
-    source: Data,
-    context: BaseModule
+    sink:       Data,
+    source:     Data,
+    context:    BaseModule
   ): Unit = {
     context match {
-      case rm:  RawModule => rm.addCommand(ProbeDefine(sourceInfo, sink.lref, source.ref))
+      case rm: RawModule => rm.addCommand(ProbeDefine(sourceInfo, sink.lref, source.ref))
       case _ => throwException("Internal Error! Probe connection can only occur within RawModule.")
     }
   }

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -205,14 +205,20 @@ object DataMirror {
   def getIntermediateAndLeafs(d: Data): Seq[Data] = collectAllMembers(d)
 
   /** Recursively collect just the leaf components of a data component's children
-    * (i.e. anything that isn't a `Record` or a `Vec`, but an `Element`)
+    * (i.e. anything that isn't a `Record` or a `Vec`, but an `Element`).
+    * Probes of aggregates are also considered leaves.
     *
     * @param d Data component to recursively collect leaf components.
     *
     * @return All `Element` components; intermediate fields/indices are not included
     */
   def collectLeafMembers(d: Data): Seq[Data] =
-    DataMirror.collectMembers(d) { case x: Element => x }.toVector
+    DataMirror
+      .collectMembers(d) {
+        case x: Element => x
+        case x if hasProbeTypeModifier(x) => x
+      }
+      .toVector
 
   /** Recursively collect all expanded member components of a data component, including
     * intermediate aggregate nodes

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -243,12 +243,12 @@ object DataMirror {
     def iterator = {
       val myItems = collector.lift(d).map { x => (x -> path) }
       val deepChildrenItems = d match {
-        case a: Record =>
+        case a: Record if (!hasProbeTypeModifier(a)) =>
           a._elements.iterator.flatMap {
             case (fieldName, fieldData) =>
               collectMembersAndPaths(fieldData, s"$path.$fieldName")(collector)
           }
-        case a: Vec[_] =>
+        case a: Vec[_] if (!hasProbeTypeModifier(a)) =>
           a.elementsIterator.zipWithIndex.flatMap {
             case (fieldData, fieldIndex) =>
               collectMembersAndPaths(fieldData, s"$path($fieldIndex)")(collector)
@@ -270,7 +270,7 @@ object DataMirror {
     def iterator = {
       val myItems = collector.lift(d)
       val deepChildrenItems = d match {
-        case a: Aggregate => a.elementsIterator.flatMap { x => collectMembers(x)(collector) }
+        case a: Aggregate if (!hasProbeTypeModifier(a)) => a.elementsIterator.flatMap { x => collectMembers(x)(collector) }
         case other => Nil
       }
       myItems.iterator ++ deepChildrenItems

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -270,7 +270,8 @@ object DataMirror {
     def iterator = {
       val myItems = collector.lift(d)
       val deepChildrenItems = d match {
-        case a: Aggregate if (!hasProbeTypeModifier(a)) => a.elementsIterator.flatMap { x => collectMembers(x)(collector) }
+        case a: Aggregate if (!hasProbeTypeModifier(a)) =>
+          a.elementsIterator.flatMap { x => collectMembers(x)(collector) }
         case other => Nil
       }
       myItems.iterator ++ deepChildrenItems

--- a/docs/src/explanations/connectable.md
+++ b/docs/src/explanations/connectable.md
@@ -43,7 +43,7 @@ section: "chisel3"
    * E.g. `IO(Decoupled(Bool)).ready` is a member of the parent `IO` component
  * "relative alignment" - whether two members of the same component or Chisel type are aligned/flipped, relative to one another
    * see section [below](#alignment-flipped-vs-aligned) for a detailed definition
- * "structural type check" - Chisel type `A` is structurally equivalent to Chisel type `B` if `A` and `B` have matching bundle field names and types (`Record` vs `Vector` vs `Element`), vector sizes, `Element` types (UInt/SInt/Bool/Clock etc))
+ * "structural type check" - Chisel type `A` is structurally equivalent to Chisel type `B` if `A` and `B` have matching bundle field names and types (`Record` vs `Vector` vs `Element`), probe modifiers (probe vs nonprobe), vector sizes, `Element` types (UInt/SInt/Bool/Clock)
    * ignores relative alignment (flippedness)
  * "alignment type check" - a Chisel type `A` matches alignment with another Chisel type `B` if every member of `A`'s relative alignment to `A` is the same as the structurally corresponding member of `B`'s relative alignment to `B`.
 

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -205,6 +205,23 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
     processChirrtl(chirrtl) should contain("connect io.out.baz, io.in.baz")
   }
 
+  ":<>= connector with probes of aggregates" should "work" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(
+      new RawModule {
+        class FooBundle extends Bundle {
+          val baz = UInt(4.W)
+        }
+        val io = IO(new Bundle {
+          val in = Input(Probe(new FooBundle))
+          val out = Output(Probe(new FooBundle))
+        })
+        io.out :<>= io.in
+      }
+    )
+    processChirrtl(chirrtl) should contain("define io.out = io.in")
+    processChirrtl(chirrtl) should not contain("out.baz")
+  }
+
   "Mismatched probe/non-probe with :<>= connector" should "fail" in {
     val exc = intercept[chisel3.ChiselException] {
       ChiselStage.emitCHIRRTL(

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -219,7 +219,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
       }
     )
     processChirrtl(chirrtl) should contain("define io.out = io.in")
-    processChirrtl(chirrtl) should not contain("out.baz")
+    processChirrtl(chirrtl) should not contain ("out.baz")
   }
 
   "Mismatched probe/non-probe with :<>= connector" should "fail" in {

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -271,6 +271,24 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
     processChirrtl(chirrtl) should contain("define io.out = io.in")
   }
 
+  ":= connector with probes but in wrong direction" should "fail" in {
+    val exc = intercept[chisel3.ChiselException] {
+      val chirrtl = ChiselStage.emitCHIRRTL(
+        new RawModule {
+          val io = IO(new Bundle {
+            val in = Input(Probe(Bool()))
+            val out = Output(Probe(Bool()))
+          })
+          io.in := io.out
+        },
+        Array("--throw-on-first-error")
+      )
+    }
+    exc.getMessage should include(
+      "Connection between sink (ProbeSpec_Anon.io.in: IO[Bool]) and source (ProbeSpec_Anon.io.out: IO[Bool]) failed @: io.in in ProbeSpec_Anon cannot be written from module ProbeSpec_Anon"
+    )
+  }
+
   ":= connector with aggregate of probe/non-probe" should "fail" in {
     val exc = intercept[chisel3.ChiselException] {
       ChiselStage.emitCHIRRTL(

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -326,7 +326,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
   }
 
   ":= connector with aggregates of probe" should "work" in {
-    var chirrtl = ChiselStage.emitCHIRRTL(
+    val chirrtl = ChiselStage.emitCHIRRTL(
       new RawModule {
         val io = IO(new Bundle {
           val in = Input(Vec(2, Probe(Bool())))

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -199,7 +199,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
           val out = Output(new FooBundle)
         })
         io.out :<>= io.in
-      },
+      }
     )
     processChirrtl(chirrtl) should contain("define io.out.bar = io.in.bar")
     processChirrtl(chirrtl) should contain("connect io.out.baz, io.in.baz")
@@ -218,7 +218,9 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
         Array("--throw-on-first-error")
       )
     }
-    exc.getMessage should include("mismatched probe/non-probe types in ProbeSpec_Anon.io.out[0]: IO[Bool] and ProbeSpec_Anon.io.in[0]: IO[Bool].")
+    exc.getMessage should include(
+      "mismatched probe/non-probe types in ProbeSpec_Anon.io.out[0]: IO[Bool] and ProbeSpec_Anon.io.in[0]: IO[Bool]."
+    )
   }
 
   ":= connector with probe/non-probe" should "fail" in {
@@ -247,7 +249,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
           val out = Output(Probe(Bool()))
         })
         io.out := io.in
-      },
+      }
     )
     processChirrtl(chirrtl) should contain("define io.out = io.in")
   }
@@ -289,17 +291,17 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
   }
 
   ":= connector with aggregates of probe" should "work" in {
-     var chirrtl = ChiselStage.emitCHIRRTL(
-        new RawModule {
-          val io = IO(new Bundle {
-            val in = Input(Vec(2, Probe(Bool())))
-            val out = Output(Vec(2, Probe(Bool())))
-          })
-          io.out := io.in
-        },
-      )
-     processChirrtl(chirrtl) should contain("define io.out[0] = io.in[0]")
-     processChirrtl(chirrtl) should contain("define io.out[1] = io.in[1]")
+    var chirrtl = ChiselStage.emitCHIRRTL(
+      new RawModule {
+        val io = IO(new Bundle {
+          val in = Input(Vec(2, Probe(Bool())))
+          val out = Output(Vec(2, Probe(Bool())))
+        })
+        io.out := io.in
+      }
+    )
+    processChirrtl(chirrtl) should contain("define io.out[0] = io.in[0]")
+    processChirrtl(chirrtl) should contain("define io.out[1] = io.in[1]")
   }
 
   "Probe define between non-connectable data types" should "fail" in {

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -225,7 +225,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
     )
   }
 
-  ":= connector with aggregate of probe" should "fail" in {
+  ":= connector with aggregate of probe/non-probe" should "fail" in {
     val exc = intercept[chisel3.ChiselException] {
       ChiselStage.emitCHIRRTL(
         new RawModule {
@@ -239,7 +239,7 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
       )
     }
     exc.getMessage should include(
-      "Connection between sink (ProbeSpec_Anon.io.out: IO[Bool[2]]) and source (ProbeSpec_Anon.io.in: IO[Bool[2]]) failed @: Sink io.out in ProbeSpec_Anon of Probed type cannot participate in a mono connection (:=)"
+      "Connection between sink (ProbeSpec_Anon.io.out: IO[Bool[2]]) and source (ProbeSpec_Anon.io.in: IO[Bool[2]]) failed @: (0)Sink io.out[0] in ProbeSpec_Anon of Probed type cannot participate in a mono connection (:=)"
     )
   }
 
@@ -259,6 +259,18 @@ class ProbeSpec extends ChiselFlatSpec with Utils {
     exc.getMessage should be(
       "Connection between left (ProbeSpec_Anon.io.out: IO[Bool[2]]) and source (ProbeSpec_Anon.io.in: IO[Bool[2]]) failed @Left of Probed type cannot participate in a bi connection (<>)"
     )
+  }
+
+  ":= connector with aggregates of probe" should "work" in {
+      println(ChiselStage.emitCHIRRTL(
+        new RawModule {
+          val io = IO(new Bundle {
+            val in = Input(Vec(2, Probe(Bool())))
+            val out = Output(Vec(2, Probe(Bool())))
+          })
+          io.out := io.in
+        },
+      ))
   }
 
   "Probe define between non-connectable data types" should "fail" in {


### PR DESCRIPTION
- Enable mono/ `:=`connects for probes, which will emit a ProbeDefine.
- Also enables the fancier connect forms
- A "Probe<Bundle>" will be connected at the root

Co-authored-by: Will Dietz <will.dietz@sifive.com>

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)
- API modification

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

- Enable mono/ `:=`connects for probes, which will emit a ProbeDefine.
- Also enables the fancier connect forms
- A "Probe<Bundle>" will be connected at the root

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
