### PR TITLE
[docs] Switch API docs hosting from javadoc.io to sonatype

### DIFF
--- a/website/docs/src/main/tut/api/chisel/5.0/index.md
+++ b/website/docs/src/main/tut/api/chisel/5.0/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: https://javadoc.io/doc/org.chipsalliance/chisel_2.13/5.0
+redirect_to: https://s01.oss.sonatype.org/service/local/repositories/releases/archive/org/chipsalliance/chisel_2.13/5.0.0/chisel_2.13-5.0.0-javadoc.jar/!/index.html
 ---

--- a/website/docs/src/main/tut/api/chisel/6.0/index.md
+++ b/website/docs/src/main/tut/api/chisel/6.0/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: https://javadoc.io/doc/org.chipsalliance/chisel_2.13/6.0
+redirect_to: https://s01.oss.sonatype.org/service/local/repositories/releases/archive/org/chipsalliance/chisel_2.13/6.0.0-M3/chisel_2.13-6.0.0-M3-javadoc.jar/!/index.html
 ---

--- a/website/docs/src/main/tut/api/chisel/latest/index.md
+++ b/website/docs/src/main/tut/api/chisel/latest/index.md
@@ -1,5 +1,5 @@
 ---
-redirect_to: https://javadoc.io/doc/org.chipsalliance/chisel_2.13
+redirect_to: https://s01.oss.sonatype.org/service/local/repositories/snapshots/archive/org/chipsalliance/chisel_2.13/6.0.0-M3+55-6dbbc73c-SNAPSHOT/chisel_2.13-6.0.0-M3+55-6dbbc73c-SNAPSHOT-javadoc.jar/!/index.html
 redirect_from:
   - /api/latest/index.html
   - /api/chisel3/latest/index.html

--- a/website/docs/src/main/tut/api/chisel3/3.5/index.md
+++ b/website/docs/src/main/tut/api/chisel3/3.5/index.md
@@ -1,5 +1,5 @@
 ---
-redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel3_2.13/3.5
+redirect_to: https://oss.sonatype.org/service/local/repositories/releases/archive/edu/berkeley/cs/chisel3_2.13/3.5.6/chisel3_2.13-3.5.6-javadoc.jar/!/index.html
 redirect_from:
   - /api/3.5/index.html
   - /api/3.5.3/index.html

--- a/website/docs/src/main/tut/api/chisel3/3.6/index.md
+++ b/website/docs/src/main/tut/api/chisel3/3.6/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel3_2.13/3.6
+redirect_to: https://oss.sonatype.org/service/local/repositories/releases/archive/edu/berkeley/cs/chisel3_2.13/3.6.0/chisel3_2.13-3.6.0-javadoc.jar/!/index.html
 ---


### PR DESCRIPTION
javadoc.io has been down for 2 days: https://github.com/maxcellent/javadoc.io/issues/180#issuecomment-1749281890


#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Documentation or website-related

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
