### PR TITLE
Add new target API to get a target relative to a specific BaseModule.

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -423,7 +423,11 @@ package experimental {
 
     // Fresh Namespace because in Firrtl, Modules namespaces are disjoint with the global namespace
     private[chisel3] val _namespace = Namespace.empty
-    private val _ids = ArrayBuffer[HasId]()
+
+    // Expose _ids in Chisel. The ids should almost always be accessed through getIds, but there is a use-case to access
+    // the ids directly in generateComponent.
+    private[chisel3] val _ids = ArrayBuffer[HasId]()
+
     private[chisel3] def addId(d: HasId): Unit = {
       if (Builder.aspectModule(this).isDefined) {
         aspectModule(this).get.addId(d)

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -617,11 +617,15 @@ package experimental {
         case (Some(_), _) if root.get == this => getTarget
         // If root was defined, and we are not there yet, recurse up.
         case (Some(definedRoot), Some(parent)) => parent.toRelativeTarget(root).instOf(this.instanceName, name)
+        // If root was defined, and we are at a ViewParent, use its absolute target.
+        case (Some(definedRoot), None) if this == ViewParent => ViewParent.absoluteTarget
         // If root was defined, and there is no parent, the root was not an ancestor.
         case (Some(definedRoot), None) =>
           throwException(s"Requested .toRelativeTarget relative to ${definedRoot.name}, but it is not an ancestor")
         // If root was not defined, and there is a parent, recurse up.
         case (None, Some(parent)) => parent.toRelativeTarget(root).instOf(this.instanceName, name)
+        // If root was not defined, and we are at a ViewParent, use its absolute target.
+        case (None, None) if this == ViewParent => ViewParent.absoluteTarget
         // If root was not defined, and there is no parent, return this.
         case (None, None) => getTarget
       }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -612,23 +612,21 @@ package experimental {
       * @note This doesn't have special handling for Views.
       */
     final def toRelativeTarget(root: Option[BaseModule]): IsModule = {
-      (root, _parent) match {
-        // If root was defined, and we are it, return this.
-        case (Some(_), _) if root.get == this => getTarget
-        // If root was defined, and we are not there yet, recurse up.
-        case (Some(definedRoot), Some(parent)) => parent.toRelativeTarget(root).instOf(this.instanceName, name)
-        // If root was defined, and we are at a ViewParent, use its absolute target.
-        case (Some(definedRoot), None) if this == ViewParent => ViewParent.absoluteTarget
-        // If root was defined, and there is no parent, the root was not an ancestor.
-        case (Some(definedRoot), None) =>
-          throwException(s"Requested .toRelativeTarget relative to ${definedRoot.name}, but it is not an ancestor")
-        // If root was not defined, and there is a parent, recurse up.
-        case (None, Some(parent)) => parent.toRelativeTarget(root).instOf(this.instanceName, name)
-        // If root was not defined, and we are at a ViewParent, use its absolute target.
-        case (None, None) if this == ViewParent => ViewParent.absoluteTarget
-        // If root was not defined, and there is no parent, return this.
-        case (None, None) => getTarget
-      }
+      // If root was defined, and we are it, return this.
+      if (root.contains(this)) getTarget
+      // If we are a ViewParent, use its absolute target.
+      else if (this == ViewParent) ViewParent.absoluteTarget
+      // Otherwise check if root and _parent are defined.
+      else
+        (root, _parent) match {
+          // If root was defined, and we are not there yet, recurse up.
+          case (_, Some(parent)) => parent.toRelativeTarget(root).instOf(this.instanceName, name)
+          // If root was defined, and there is no parent, the root was not an ancestor.
+          case (Some(definedRoot), None) =>
+            throwException(s"Requested .toRelativeTarget relative to ${definedRoot.name}, but it is not an ancestor")
+          // If root was not defined, and there is no parent, return this.
+          case (None, None) => getTarget
+        }
     }
 
     /**

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -115,8 +115,53 @@ abstract class RawModule extends BaseModule {
     }
   }
 
+  /** Finalize name for an id created during this RawModule's constructor.
+    *
+    * @param id The id to finalize.
+    */
+  private def nameId(id: HasId) = id match {
+    case id: ModuleClone[_]   => id.setRefAndPortsRef(_namespace) // special handling
+    case id: InstanceClone[_] => id.setAsInstanceRef()
+    case id: BaseModule       => id.forceName(default = id.desiredName, _namespace)
+    case id: MemBase[_]       => id.forceName(default = "MEM", _namespace)
+    case id: stop.Stop        => id.forceName(default = "stop", _namespace)
+    case id: assert.Assert    => id.forceName(default = "assert", _namespace)
+    case id: assume.Assume    => id.forceName(default = "assume", _namespace)
+    case id: cover.Cover      => id.forceName(default = "cover", _namespace)
+    case id: printf.Printf => id.forceName(default = "printf", _namespace)
+    case id: DynamicObject => {
+      // Force name of the DynamicObject, and set its Property[ClassType] type's ref to the DynamicObject.
+      // The type's ref can't be set upon instantiation, because the DynamicObject hasn't been named yet.
+      id.forceName(default = "_object", _namespace)
+      id.getReference.setRef(id.getRef)
+    }
+    case id: Data =>
+      if (id.isSynthesizable) {
+        id.topBinding match {
+          case OpBinding(_, _) =>
+            id.forceName(default = "_T", _namespace)
+          case MemoryPortBinding(_, _) =>
+            id.forceName(default = "MPORT", _namespace)
+          case PortBinding(_) =>
+            id.forceName(default = "PORT", _namespace, true, x => ModuleIO(this, x))
+          case RegBinding(_, _) =>
+            id.forceName(default = "REG", _namespace)
+          case WireBinding(_, _) =>
+            id.forceName(default = "_WIRE", _namespace)
+          // probes have their refs set eagerly
+          case _ => // don't name literals
+        }
+      } // else, don't name unbound types
+  }
+
   private[chisel3] override def generateComponent(): Option[Component] = {
     require(!_closed, "Can't generate module more than once")
+
+    // Now that elaboration is complete for this Module, we can finalize names that have been generated thus far.
+    val numInitialIds = _ids.size
+    for (id <- _ids) {
+      nameId(id)
+    }
 
     // Evaluate any atModuleBodyEnd generators.
     _atModuleBodyEnd.foreach { gen =>
@@ -128,42 +173,9 @@ abstract class RawModule extends BaseModule {
     // Check to make sure that all ports can be named
     checkPorts()
 
-    // Now that elaboration is complete for this Module, we can finalize names
-    for (id <- getIds) {
-      id match {
-        case id: ModuleClone[_]   => id.setRefAndPortsRef(_namespace) // special handling
-        case id: InstanceClone[_] => id.setAsInstanceRef()
-        case id: BaseModule       => id.forceName(default = id.desiredName, _namespace)
-        case id: MemBase[_]       => id.forceName(default = "MEM", _namespace)
-        case id: stop.Stop        => id.forceName(default = "stop", _namespace)
-        case id: assert.Assert    => id.forceName(default = "assert", _namespace)
-        case id: assume.Assume    => id.forceName(default = "assume", _namespace)
-        case id: cover.Cover      => id.forceName(default = "cover", _namespace)
-        case id: printf.Printf => id.forceName(default = "printf", _namespace)
-        case id: DynamicObject => {
-          // Force name of the DynamicObject, and set its Property[ClassType] type's ref to the DynamicObject.
-          // The type's ref can't be set upon instantiation, because the DynamicObject hasn't been named yet.
-          id.forceName(default = "_object", _namespace)
-          id.getReference.setRef(id.getRef)
-        }
-        case id: Data =>
-          if (id.isSynthesizable) {
-            id.topBinding match {
-              case OpBinding(_, _) =>
-                id.forceName(default = "_T", _namespace)
-              case MemoryPortBinding(_, _) =>
-                id.forceName(default = "MPORT", _namespace)
-              case PortBinding(_) =>
-                id.forceName(default = "PORT", _namespace, true, x => ModuleIO(this, x))
-              case RegBinding(_, _) =>
-                id.forceName(default = "REG", _namespace)
-              case WireBinding(_, _) =>
-                id.forceName(default = "_WIRE", _namespace)
-              // probes have their refs set eagerly
-              case _ => // don't name literals
-            }
-          } // else, don't name unbound types
-      }
+    // Take a second pass through any ids generated during atModuleBodyEnd blocks to finalize names for them.
+    for (id <- _ids.drop(numInitialIds)) {
+      nameId(id)
     }
 
     val firrtlPorts = getModulePortsAndLocators.map {

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -174,7 +174,7 @@ abstract class RawModule extends BaseModule {
     checkPorts()
 
     // Take a second pass through any ids generated during atModuleBodyEnd blocks to finalize names for them.
-    for (id <- _ids.drop(numInitialIds)) {
+    for (id <- _ids.view.drop(numInitialIds)) {
       nameId(id)
     }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -402,8 +402,9 @@ private[chisel3] trait NamedComponent extends HasId {
     def makeTarget(p: BaseModule) =
       p.toRelativeTarget(root).ref(localTarget.ref).copy(component = localTarget.component)
     _parent match {
-      case Some(parent) => makeTarget(parent)
-      case None         => localTarget
+      case Some(ViewParent) => makeTarget(reifyParent)
+      case Some(parent)     => makeTarget(parent)
+      case None             => localTarget
     }
   }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -387,6 +387,26 @@ private[chisel3] trait NamedComponent extends HasId {
     }
   }
 
+  /** Returns a FIRRTL ReferenceTarget that references this object, relative to an optional root.
+    *
+    * If `root` is defined, the target is a hierarchical path starting from `root`.
+    *
+    * If `root` is not defined, the target is a hierarchical path equivalent to `toAbsoluteTarget`.
+    *
+    * @note If `root` is defined, and has not finished elaboration, this must be called within `atModuleBodyEnd`.
+    * @note The NamedComponent must be a descendant of `root`, if it is defined.
+    * @note This doesn't have special handling for Views.
+    */
+  final def toRelativeTarget(root: Option[BaseModule]): ReferenceTarget = {
+    val localTarget = toTarget
+    def makeTarget(p: BaseModule) =
+      p.toRelativeTarget(root).ref(localTarget.ref).copy(component = localTarget.component)
+    _parent match {
+      case Some(parent) => makeTarget(parent)
+      case None         => localTarget
+    }
+  }
+
   private def assertValidTarget(): Unit = {
     val isVecSubaccess = getOptionRef.map {
       case Index(_, _: ULit) => true // Vec literal indexing

--- a/src/test/scala/chisel3/internal/NameCollisionSpec.scala
+++ b/src/test/scala/chisel3/internal/NameCollisionSpec.scala
@@ -64,8 +64,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "error on nameless ports being assigned default names" in {
-
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    ((the[ChiselException] thrownBy extractCause[ChiselException] {
       ChiselStage.emitCHIRRTL(
         new Module {
           // Write to an output port that isn't assigned to a val, and so doesn't get prefixed
@@ -73,6 +72,6 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
         },
         Array("--throw-on-first-error")
       )
-    }).getMessage should include("try making it a public field of the Module")
+    }).getMessage should include).regex("Assign .+ to a val, or explicitly call suggestName to seed a unique name")
   }
 }

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -10,32 +10,50 @@ class RelativeInnerModule extends RawModule {
   val wire = Wire(Bool())
 }
 
-class RelativeOuterModule extends RawModule {
+class RelativeMiddleModule extends RawModule {
   val inner = Module(new RelativeInnerModule())
+}
+
+class RelativeOuterRootModule extends RawModule {
+  val middle = Module(new RelativeMiddleModule())
 
   atModuleBodyEnd {
-    val reference = inner.wire.toRelativeTarget(Some(this))
+    val reference = middle.inner.wire.toRelativeTarget(Some(this))
     val referenceOut = IO(Output(Property[Path]()))
     referenceOut := Property(Path(reference))
   }
 }
 
-class RelativeDefaultModule extends RawModule {
+class RelativeOuterMiddleModule extends RawModule {
+  val middle = Module(new RelativeMiddleModule())
+  val reference = middle.inner.wire.toRelativeTarget(Some(middle))
+  val referenceOut = IO(Output(Property[Path]()))
+  referenceOut := Property(Path(reference))
+}
+
+class RelativeOuterLocalModule extends RawModule {
   val inner = Module(new RelativeInnerModule())
+  val reference = inner.wire.toRelativeTarget(Some(inner))
+  val referenceOut = IO(Output(Property[Path]()))
+  referenceOut := Property(Path(reference))
+}
+
+class RelativeDefaultModule extends RawModule {
+  val middle = Module(new RelativeMiddleModule())
 
   atModuleBodyEnd {
-    val reference = inner.wire.toRelativeTarget(None)
+    val reference = middle.inner.wire.toRelativeTarget(None)
     val referenceOut = IO(Output(Property[Path]()))
     referenceOut := Property(Path(reference))
   }
 }
 
 class RelativeSiblingsModule extends RawModule {
-  val inner1 = Module(new RelativeInnerModule())
-  val inner2 = Module(new RelativeInnerModule())
+  val middle1 = Module(new RelativeMiddleModule())
+  val middle2 = Module(new RelativeMiddleModule())
 
   atModuleBodyEnd {
-    val reference = inner1.wire.toRelativeTarget(Some(inner2))
+    val reference = middle1.inner.wire.toRelativeTarget(Some(middle2))
   }
 }
 
@@ -97,16 +115,32 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
 
   behavior.of(".toRelativeTarget")
 
-  it should "work with modules being elaborated within atModuleBodyEnd" in {
-    val chirrtl = ChiselStage.emitCHIRRTL(new RelativeOuterModule)
+  it should "work relative to modules being elaborated within atModuleBodyEnd" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RelativeOuterRootModule)
 
-    chirrtl should include("~RelativeOuterModule|RelativeOuterModule/inner:RelativeInnerModule>wire")
+    chirrtl should include(
+      "~RelativeOuterRootModule|RelativeOuterRootModule/middle:RelativeMiddleModule/inner:RelativeInnerModule>wire"
+    )
+  }
+
+  it should "work relative to non top-level modules that have been elaborated" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RelativeOuterMiddleModule)
+
+    chirrtl should include("~RelativeOuterMiddleModule|RelativeMiddleModule/inner:RelativeInnerModule>wire")
+  }
+
+  it should "work relative to non top-level modules for components local to the root" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RelativeOuterLocalModule)
+
+    chirrtl should include("~RelativeOuterLocalModule|RelativeInnerModule>wire")
   }
 
   it should "default to the root module in the requested hierarchy" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeDefaultModule)
 
-    chirrtl should include("~RelativeDefaultModule|RelativeDefaultModule/inner:RelativeInnerModule>wire")
+    chirrtl should include(
+      "~RelativeDefaultModule|RelativeDefaultModule/middle:RelativeMiddleModule/inner:RelativeInnerModule>wire"
+    )
   }
 
   it should "raise an exception when the requested root is not an ancestor" in {

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -114,8 +114,6 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
       ChiselStage.emitCHIRRTL(new RelativeSiblingsModule)
     }
 
-    e.getMessage should include(
-      "Requested .toRelativeTarget relative to RelativeInnerModule_1, but it is not an ancestor"
-    )
+    (e.getMessage should include).regex("Requested .toRelativeTarget relative to .+, but it is not an ancestor")
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

The first commit contains some internal refactoring of how ids get named in a RawModule, which was required for the new API. The ids generated normally are named, then any `atModuleBodyEnd` blocks are evaluated and the RawModule is closed, and finally any ids generated by `atModuleBodyEnd` blocks are named. This allows the new `toRelativeTarget` to be called within an `atModuleBodyEnd` block for the root RawModule.

The second commit actually adds the new APIs.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
The new toRelativeTarget API augments the existing toAbsoluteTarget API, to provide a mechanism to get hierarchical paths to a NamedComponent relative to a known root.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
