### PR TITLE
[ci] Bump install-circt to v1.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install CIRCT
-        uses: circt/install-circt@v1.0.0
+        uses: circt/install-circt@v1.1.1
         with:
           version: ${{ env.circt }}
           github-token: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
           java-version: ${{ inputs.jvm }}
           cache: 'sbt'
       - name: Install CIRCT
-        uses: circt/install-circt@v1.0.0
+        uses: circt/install-circt@v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -95,7 +95,7 @@ jobs:
         with:
           mill-version: 0.11.5
       - name: Install CIRCT
-        uses: circt/install-circt@v1.0.0
+        uses: circt/install-circt@v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -119,7 +119,7 @@ jobs:
           java-version: '11'
           cache: 'sbt'
       - name: Install CIRCT
-        uses: circt/install-circt@v1.0.0
+        uses: circt/install-circt@v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -145,7 +145,7 @@ jobs:
           java-version: '11'
           cache: 'sbt'
       - name: Install CIRCT
-        uses: circt/install-circt@v1.0.0
+        uses: circt/install-circt@v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -200,7 +200,7 @@ jobs:
           gem install jekyll -v 4.2.0
           gem install jekyll-redirect-from
       - name: Install CIRCT
-        uses: circt/install-circt@v1.0.0
+        uses: circt/install-circt@v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}


### PR DESCRIPTION
Switch from install-circt v1.0.0 to v1.1.1.  There is no major change to
functionality other than this switches to using a shell script instead of
scripting in a GitHub composite action.  This also fixes a bug related to the
action not working in a container environment.  (This is not a problem for
Chisel.)