### PR TITLE
Bugfix: foo and foo_ names cause incorrect prefix calculation

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -57,7 +57,7 @@ private[chisel3] class Namespace(keywords: Set[String], separator: Char = '_') {
       i -= 1
     }
     // Will get i == 0 for all digits or _\d+ with empty prefix, those have no prefix so returning 0 is correct
-    if (i == n.size) 0 // no digits
+    if (i == n.size || i == (n.size - 1)) 0 // no digits
     else if (n(i) != separator) 0 // no _
     else i
   }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -57,7 +57,7 @@ private[chisel3] class Namespace(keywords: Set[String], separator: Char = '_') {
       i -= 1
     }
     // Will get i == 0 for all digits or _\d+ with empty prefix, those have no prefix so returning 0 is correct
-    if (i == n.size || i == (n.size - 1)) 0 // no digits
+    if (i >= (n.size - 1)) 0 // no digits
     else if (n(i) != separator) 0 // no _
     else i
   }

--- a/src/test/scala/chisel3/internal/NamespaceSpec.scala
+++ b/src/test/scala/chisel3/internal/NamespaceSpec.scala
@@ -78,4 +78,10 @@ class NamespaceSpec extends AnyFlatSpec {
     name("x") should be("x_2")
     name("x_0") should be("x_0_1")
   }
+
+  they should "support resolving collisions between <name> and <name>_" in {
+    val namespace = Namespace.empty
+    namespace.name("mouth") should be("mouth")
+    namespace.name("mouth_") should be("mouth_")
+  }
 }

--- a/src/test/scala/chisel3/internal/NamespaceSpec.scala
+++ b/src/test/scala/chisel3/internal/NamespaceSpec.scala
@@ -83,5 +83,7 @@ class NamespaceSpec extends AnyFlatSpec {
     val namespace = Namespace.empty
     namespace.name("mouth") should be("mouth")
     namespace.name("mouth_") should be("mouth_")
+    namespace.name("mouth") should be("mouth_1")
+    namespace.name("mouth_") should be("mouth__1")
   }
 }


### PR DESCRIPTION
### Problem

When naming `foo`, then `foo_`, the calculation for the prefix of `foo_` is incorrect. It should not have a prefix, but instead thinks the entire `foo_` is the prefix. When the prefix is stripped to find the index, you get a `java.lang.NumberFormatException: For input string: ""`, as it tries to convert the empty string to an `Int`.

This bugfix checks the case where a prefix is calculated, but would return an empty string if stripped.

### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).


#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Naming `foo` and then `foo_` will no longer trigger an error.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
