### PR TITLE
Don't add DedupGroupAnnotation to classes.

### DIFF
--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -11,7 +11,7 @@ import chisel3.stage._
 import chisel3.stage.CircuitSerializationAnnotation._
 import chisel3.ChiselException
 import chisel3.experimental.dedupGroup
-import chisel3.internal.firrtl.{DefBlackBox, DefIntrinsicModule}
+import chisel3.internal.firrtl.{DefBlackBox, DefClass, DefIntrinsicModule}
 
 class AddDedupGroupAnnotations extends Phase {
   override def prerequisites = Seq.empty
@@ -33,6 +33,7 @@ class AddDedupGroupAnnotations extends Phase {
     val annos = circuit.components.filter {
       case x @ DefBlackBox(id, _, _, _, _)   => !id._isImportedDefinition
       case DefIntrinsicModule(_, _, _, _, _) => false
+      case DefClass(_, _, _, _)              => false
       case x                                 => true
     }.collect {
       case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id.desiredName)

--- a/src/test/scala/chiselTests/DedupSpec.scala
+++ b/src/test/scala/chiselTests/DedupSpec.scala
@@ -5,6 +5,8 @@ package chiselTests
 import chisel3._
 import chisel3.util._
 import chisel3.experimental.{annotate, dedupGroup, ChiselAnnotation}
+import chisel3.experimental.hierarchy.Definition
+import chisel3.properties.Class
 import firrtl.transforms.DedupGroupAnnotation
 import chisel3.experimental.hierarchy._
 import chisel3.util.circt.PlusArgsValue
@@ -89,6 +91,10 @@ class ModuleWithIntrinsic extends Module {
   val plusarg = PlusArgsValue(Bool(), "plusarg=%d")
 }
 
+class ModuleWithClass extends Module {
+  val cls = Definition(new Class)
+}
+
 class DedupSpec extends ChiselFlatSpec {
   private val ModuleRegex = """\s*module\s+(\w+)\b.*""".r
   def countModules(verilog: String): Int =
@@ -141,5 +147,13 @@ class DedupSpec extends ChiselFlatSpec {
       case DedupGroupAnnotation(target, _) => target.module
     }
     dedupGroupAnnos should contain theSameElementsAs Seq("ModuleWithIntrinsic")
+  }
+
+  it should "not add DedupGroupAnnotation to classes" in {
+    val (_, annos) = getFirrtlAndAnnos(new ModuleWithClass)
+    val dedupGroupAnnos = annos.collect {
+      case DedupGroupAnnotation(target, _) => target.module
+    }
+    dedupGroupAnnos should contain theSameElementsAs Seq("ModuleWithClass")
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Class definition components cannot have any annotations.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
