### PR TITLE
Alignment: Don't require a Connectable base, split.

### DIFF
--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -285,7 +285,7 @@ object DataMirror {
   }
 
   // Alignment-aware collections
-  import connectable.{AlignedWithRoot, Alignment, FlippedWithRoot}
+  import connectable.{AlignedWithRoot, Alignment, ConnectableAlignment, FlippedWithRoot}
   // Implement typeclass to enable collecting over Alignment
   implicit val AlignmentMatchingZipOfChildren = new HasMatchingZipOfChildren[Alignment] {
     def matchingZipOfChildren(
@@ -293,6 +293,15 @@ object DataMirror {
       right: Option[Alignment]
     ): Seq[(Option[Alignment], Option[Alignment])] =
       Alignment.matchingZipOfChildren(left, right)
+  }
+
+  // Implement typeclass to enable collecting over ConnectableAlignment
+  implicit val ConnectableAlignmentMatchingZipOfChildren = new HasMatchingZipOfChildren[ConnectableAlignment] {
+    def matchingZipOfChildren(
+      left:  Option[ConnectableAlignment],
+      right: Option[ConnectableAlignment]
+    ): Seq[(Option[ConnectableAlignment], Option[ConnectableAlignment])] =
+      ConnectableAlignment.matchingZipOfChildren(left, right)
   }
 
   /** Collects all members of base who are aligned w.r.t. base


### PR DESCRIPTION
No non-internal existing functionality intended to be changed.

"Alignment" interface (internal) does change.

DataMirror methods implemented in terms of Alignment no longer require the Data to be hardware, allowing walking (bare) Chisel types and their alignments.

This will be used in a follow-on PR.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
  - This PR is meant to only refactor while supporting existing behavior.  New functionality will follow.
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification
- Internal or build-related (includes code refactoring/cleanup)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

DataMirror methods relating to alignment such as `collectAlignedDeep`) no longer require Data to be Hardware and may be used on bare Chisel types.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
