### PR TITLE
Support instanceName on HasId without a component by using localName.

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -317,9 +317,10 @@ private[chisel3] trait HasId extends chisel3.InstanceId {
         case (None, _: MemBase[_]) => _ref.get.localName
         case (None, _) if _ref.isDefined => {
           // Support instance names for HasIds that don't have a _parent set yet, but do have a _ref set.
-          // This allows most HasIds to be named in atModuleBodyEnd, for example.
-          // However, this is only valid if the _ref's fullName doesn't depend on the component name.
-          // Notably, this is not valid for ports of instances, and other constructs that need the _parent's name.
+          // This allows HasIds to be named in atModuleBodyEnd, for example.
+          // In this case, we directly use the localName. This is valid, because the only time names are
+          // context-dependent is on ports. If a port doesn't have a _parent set yet, the port must be within
+          // the currently elaborating module, and should be named by its localName.
           _ref.get.localName
         }
         case (None, _) =>

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -315,6 +315,13 @@ private[chisel3] trait HasId extends chisel3.InstanceId {
         case (Some(c), _) => refName(c)
         case (None, d: Data) if d.topBindingOpt == Some(CrossModuleBinding) => _ref.get.localName
         case (None, _: MemBase[_]) => _ref.get.localName
+        case (None, _) if _ref.isDefined => {
+          // Support instance names for HasIds that don't have a _parent set yet, but do have a _ref set.
+          // This allows most HasIds to be named in atModuleBodyEnd, for example.
+          // However, this is only valid if the _ref's fullName doesn't depend on the component name.
+          // Notably, this is not valid for ports of instances, and other constructs that need the _parent's name.
+          _ref.get.localName
+        }
         case (None, _) =>
           throwException(s"signalName/pathName should be called after circuit elaboration: $this, ${_parent}")
       }

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -27,10 +27,25 @@ class RelativeOuterRootModule extends RawModule {
 class RelativeCurrentModule extends RawModule {
   val wire = Wire(Bool())
 
+  val child = Module(new RawModule {
+    override def desiredName = "Child"
+    val io = IO(Output(Bool()))
+  })
+
+  val io = IO(Output(Bool()))
+
   atModuleBodyEnd {
-    val reference = wire.toRelativeTarget(Some(this))
-    val referenceOut = IO(Output(Property[Path]()))
-    referenceOut := Property(Path(reference))
+    val reference1 = wire.toRelativeTarget(Some(this))
+    val referenceOut1 = IO(Output(Property[Path]()))
+    referenceOut1 := Property(Path(reference1))
+
+    val reference2 = child.io.toRelativeTarget(Some(this))
+    val referenceOut2 = IO(Output(Property[Path]()))
+    referenceOut2 := Property(Path(reference2))
+
+    val reference3 = io.toRelativeTarget(Some(this))
+    val referenceOut3 = IO(Output(Property[Path]()))
+    referenceOut3 := Property(Path(reference3))
   }
 }
 
@@ -137,6 +152,8 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeCurrentModule)
 
     chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule>wire")
+    chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule/child:Child>io")
+    chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule>io")
   }
 
   it should "work relative to non top-level modules that have been elaborated" in {

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -24,6 +24,16 @@ class RelativeOuterRootModule extends RawModule {
   }
 }
 
+class RelativeCurrentModule extends RawModule {
+  val wire = Wire(Bool())
+
+  atModuleBodyEnd {
+    val reference = wire.toRelativeTarget(Some(this))
+    val referenceOut = IO(Output(Property[Path]()))
+    referenceOut := Property(Path(reference))
+  }
+}
+
 class RelativeOuterMiddleModule extends RawModule {
   val middle = Module(new RelativeMiddleModule())
   val reference = middle.inner.wire.toRelativeTarget(Some(middle))
@@ -121,6 +131,12 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
     chirrtl should include(
       "~RelativeOuterRootModule|RelativeOuterRootModule/middle:RelativeMiddleModule/inner:RelativeInnerModule>wire"
     )
+  }
+
+  it should "work relative to modules being elaborated for NamedComponents within the module" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RelativeCurrentModule)
+
+    chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule>wire")
   }
 
   it should "work relative to non top-level modules that have been elaborated" in {

--- a/src/test/scala/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala/chiselTests/ToTargetSpec.scala
@@ -148,7 +148,7 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
     )
   }
 
-  it should "work relative to modules being elaborated for NamedComponents within the module" in {
+  it should "work relative to modules being elaborated for HasIds within the module" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeCurrentModule)
 
     chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule>wire")


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
We have recently reworked when HasIds are named within a module so they can be named before atModuleBodyEnd executes, and then get referenced within atModuleBodyEnd. However, the component is still not set when they are referenced, so in this case use the local name.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
