### PR TITLE
Add source locators to all subclasses of BaseModule

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -371,6 +371,10 @@ lazy val unipublish =
     .aggregate(plugin) // Also publish the plugin when publishing this project
     .settings(name := (chisel / name).value)
     .enablePlugins(ScalaUnidocPlugin)
+    .settings(
+      // Plugin isn't part of Chisel's public API, exclude from ScalaDoc
+      ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(plugin)
+    )
     .settings(commonSettings: _*)
     .settings(publishSettings: _*)
     .settings(usePluginSettings: _*)

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -343,6 +343,12 @@ package experimental {
   abstract class BaseModule extends HasId with IsInstantiable {
     _parent.foreach(_.addId(this))
 
+    // Protected so it can be overridden by the compiler plugin
+    protected def _sourceInfo: SourceInfo = UnlocatableSourceInfo
+
+    // Accessor for Chisels internals
+    private[chisel3] final def _getSourceLocator: SourceInfo = _sourceInfo
+
     // Used with chisel3.naming.fixTraitIdentifier
     protected def _traitModuleDefinitionIdentifierProposal: Option[String] = None
 

--- a/core/src/main/scala/chisel3/internal/SourceInfoFileResolver.scala
+++ b/core/src/main/scala/chisel3/internal/SourceInfoFileResolver.scala
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.internal.sourceinfo
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+///////////////////////////////////////////////////////
+//                     WARNING!!                     //
+// This file is soft-linked into the compiler plugin //
+// so that the logic stays consistent                //
+///////////////////////////////////////////////////////
+
+/** Scala compile-time function for determine the String used to represent a source file path in SourceInfos */
+private[internal] object SourceInfoFileResolver {
+  def resolve(source: scala.reflect.internal.util.SourceFile): String = {
+    val userDir = sys.props.get("user.dir") // Figure out what to do if not provided
+    val projectRoot = sys.props.get("chisel.project.root")
+    val root = projectRoot.orElse(userDir)
+
+    val path = root.map(r => source.file.canonicalPath.stripPrefix(r)).getOrElse(source.file.name)
+    val pathNoStartingSlash = if (path(0) == '/') path.tail else path
+    pathNoStartingSlash
+  }
+}

--- a/core/src/main/scala/chisel3/internal/SourceInfoMacro.scala
+++ b/core/src/main/scala/chisel3/internal/SourceInfoMacro.scala
@@ -12,14 +12,8 @@ object SourceInfoMacro {
   def generate_source_info(c: Context): c.Tree = {
     import c.universe._
     val p = c.enclosingPosition
+    val path = SourceInfoFileResolver.resolve(p.source)
 
-    val userDir = sys.props.get("user.dir") // Figure out what to do if not provided
-    val projectRoot = sys.props.get("chisel.project.root")
-    val root = projectRoot.orElse(userDir)
-
-    val path = root.map(r => p.source.file.canonicalPath.stripPrefix(r)).getOrElse(p.source.file.name)
-    val pathNoStartingSlash = if (path(0) == '/') path.tail else path
-
-    q"_root_.chisel3.experimental.SourceLine($pathNoStartingSlash, ${p.line}, ${p.column})"
+    q"_root_.chisel3.experimental.SourceLine($path, ${p.line}, ${p.column})"
   }
 }

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -440,16 +440,16 @@ private[chisel3] object Converter {
   }
 
   def convert(component: Component, typeAliases: Seq[String]): fir.DefModule = component match {
-    case ctx @ DefModule(_, name, ports, cmds) =>
+    case ctx @ DefModule(id, name, ports, cmds) =>
       fir.Module(
-        fir.NoInfo,
+        convert(id._getSourceLocator),
         name,
         (ports ++ ctx.secretPorts).map(p => convert(p, typeAliases)),
         convert(cmds ++ ctx.secretCommands, ctx, typeAliases)
       )
     case ctx @ DefBlackBox(id, name, ports, topDir, params) =>
       fir.ExtModule(
-        fir.NoInfo,
+        convert(id._getSourceLocator),
         name,
         (ports ++ ctx.secretPorts).map(p => convert(p, typeAliases, topDir)),
         id.desiredName,
@@ -457,15 +457,15 @@ private[chisel3] object Converter {
       )
     case ctx @ DefIntrinsicModule(id, name, ports, topDir, params) =>
       fir.IntModule(
-        fir.NoInfo,
+        convert(id._getSourceLocator),
         name,
         (ports ++ ctx.secretPorts).map(p => convert(p, typeAliases, topDir)),
         id.intrinsic,
         params.keys.toList.sorted.map { name => convert(name, params(name)) }
       )
-    case ctx @ DefClass(_, name, ports, cmds) =>
+    case ctx @ DefClass(id, name, ports, cmds) =>
       fir.DefClass(
-        fir.NoInfo,
+        convert(id._getSourceLocator),
         name,
         ports.map(p => convert(p, typeAliases)),
         convert(cmds, ctx, typeAliases)

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselUtils.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselUtils.scala
@@ -22,6 +22,7 @@ private[plugin] trait ChiselOuterUtils { outerSelf: TypingTransformers =>
     val someOfDataTpe:   Type = inferType(tq"scala.Option[chisel3.Data]")
     val itStringAnyTpe:  Type = inferType(tq"scala.collection.Iterable[(String,Any)]")
     val itAnyTpe:        Type = inferType(tq"scala.collection.Iterable[Any]")
+    val sourceInfoTpe:   Type = inferType(tq"chisel3.experimental.SourceInfo")
 
     def stringFromTypeName(name: TypeName): String =
       name.toString.trim() // Remove trailing space (Scalac implementation detail)

--- a/plugin/src/main/scala/chisel3/internal/sourceinfo/SourceInfoFileResolver.scala
+++ b/plugin/src/main/scala/chisel3/internal/sourceinfo/SourceInfoFileResolver.scala
@@ -1,0 +1,1 @@
+../../../../../../../core/src/main/scala/chisel3/internal/SourceInfoFileResolver.scala

--- a/src/test/scala/chiselTests/IntrinsicModule.scala
+++ b/src/test/scala/chiselTests/IntrinsicModule.scala
@@ -30,15 +30,15 @@ class IntrinsicModuleSpec extends ChiselFlatSpec {
   (ChiselStage
     .emitCHIRRTL(new IntModuleTester)
     .split('\n')
-    .map(x => x.trim)
+    .map(_.trim.takeWhile(_ != '@'))
     should contain).allOf(
-    "intmodule IntModuleTest :",
+    "intmodule IntModuleTest : ",
     "intrinsic = TestIntrinsic",
-    "intmodule IntModuleParam :",
+    "intmodule IntModuleParam : ",
     "parameter STRING = \"one\"",
     "parameter REAL = 1.0",
     "intrinsic = OtherIntrinsic",
-    "intmodule IntModuleGenName :",
+    "intmodule IntModuleGenName : ",
     "intrinsic = someIntName"
   )
 }

--- a/src/test/scala/chiselTests/SourceLocatorSpec.scala
+++ b/src/test/scala/chiselTests/SourceLocatorSpec.scala
@@ -4,10 +4,42 @@ package chiselTests
 
 import circt.stage.ChiselStage.emitCHIRRTL
 import chisel3._
-import chisel3.experimental.SourceLine
+import chisel3.experimental.{BaseModule, ExtModule, SourceLine}
+import chisel3.experimental.hierarchy.Definition
 import firrtl.ir.FileInfo
 
+object SourceLocatorSpec {
+  val thisFile = "src/test/scala/chiselTests/SourceLocatorSpec.scala"
+
+  class RawModuleChild extends RawModule
+  class ModuleChild extends Module
+  class InheritanceModule extends ModuleChild
+  class BlackBoxChild extends BlackBox {
+    val io = IO(new Bundle {})
+  }
+  class ExtModuleChild extends ExtModule
+  class WrapperTop[T <: BaseModule](gen: => T) extends RawModule {
+    val child = Module(gen)
+  }
+  class ClassChild extends properties.Class
+  class ClassTop extends RawModule {
+    Definition(new ClassChild)
+  }
+  class Outer extends RawModule {
+    class Inner extends RawModule
+    val c = Module(new Inner)
+    val c2 = Module(new RawModule {
+      override def desiredName = "AnonymousModule"
+    })
+  }
+  class DefinitionWrapper extends RawModule {
+    Definition(new RawModuleChild)
+  }
+}
+
 class SourceLocatorSpec extends ChiselFunSpec with Utils {
+  import SourceLocatorSpec._
+
   describe("(0) Relative source paths") {
     it("(0.a): are emitted by default relative to `user-dir`") {
       class Top extends Module {
@@ -39,6 +71,42 @@ class SourceLocatorSpec extends ChiselFunSpec with Utils {
     it("(1.c): can be properly unescaped") {
       val escapedInfo = FileInfo(escaped)
       escapedInfo.unescaped should equal(filename)
+    }
+  }
+
+  describe("(2) Module source locators") {
+    it("(2.a): modules extending RawModule should have a source locator") {
+      val chirrtl = emitCHIRRTL(new RawModuleChild)
+      chirrtl should include(s"module RawModuleChild : @[$thisFile 14:9]")
+    }
+    it("(2.b): modules extending Module should have a source locator") {
+      val chirrtl = emitCHIRRTL(new ModuleChild)
+      chirrtl should include(s"module ModuleChild : @[$thisFile 15:9]")
+    }
+    it("(2.c): modules extending other user modules should have a source locator") {
+      val chirrtl = emitCHIRRTL(new InheritanceModule)
+      chirrtl should include(s"module InheritanceModule : @[$thisFile 16:9]")
+    }
+    it("(2.d): modules extending BlackBox should have a source locator") {
+      val chirrtl = emitCHIRRTL(new WrapperTop(new BlackBoxChild))
+      chirrtl should include(s"extmodule BlackBoxChild : @[$thisFile 17:9]")
+    }
+    it("(2.e): modules extending ExtModule should have a source locator") {
+      val chirrtl = emitCHIRRTL(new WrapperTop(new ExtModuleChild))
+      chirrtl should include(s"extmodule ExtModuleChild : @[$thisFile 20:9]")
+    }
+    it("(2.f): user-defined Classes should have a source locator") {
+      val chirrtl = emitCHIRRTL(new ClassTop)
+      chirrtl should include(s"class ClassChild : @[$thisFile 24:9]")
+    }
+    it("(2.g): Inner and anonymous modules should have a source locators") {
+      val chirrtl = emitCHIRRTL(new Outer)
+      chirrtl should include(s"module Inner : @[$thisFile 29:11]")
+      chirrtl should include(s"module AnonymousModule : @[$thisFile 31:25]")
+    }
+    it("(2.h): Definitions should have a source locator") {
+      val chirrtl = emitCHIRRTL(new RawModuleChild)
+      chirrtl should include(s"module RawModuleChild : @[$thisFile 14:9]")
     }
   }
 }

--- a/src/test/scala/chiselTests/util/circt/ClockGate.scala
+++ b/src/test/scala/chiselTests/util/circt/ClockGate.scala
@@ -22,8 +22,8 @@ private class ClockGateTop extends RawModule {
 class ClockGateSpec extends AnyFlatSpec with Matchers {
   it should "gate clocks" in {
     val fir = ChiselStage.emitCHIRRTL(new ClockGateTop)
-    (fir.split('\n').map(_.trim) should contain).allOf(
-      "intmodule ClockGateIntrinsic :",
+    (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain).allOf(
+      "intmodule ClockGateIntrinsic : ",
       "input in : Clock",
       "input en : UInt<1>",
       "output out : Clock",

--- a/src/test/scala/chiselTests/util/circt/IsXSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/IsXSpec.scala
@@ -34,8 +34,8 @@ class IsXSpec extends AnyFlatSpec with Matchers {
   it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new IsXTop)
     (
-      (fir.split('\n').map(_.trim) should contain).allOf(
-        "intmodule IsXIntrinsic :",
+      (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain).allOf(
+        "intmodule IsXIntrinsic : ",
         "input i : UInt<65>",
         "output found : UInt<1>",
         "intrinsic = circt_isX",

--- a/src/test/scala/chiselTests/util/circt/PlusArgsTestSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/PlusArgsTestSpec.scala
@@ -23,8 +23,8 @@ private class PlusArgsTestTop extends Module {
 class PlusArgsTestSpec extends AnyFlatSpec with Matchers {
   it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new PlusArgsTestTop)
-    (fir.split('\n').map(_.trim) should contain).allOf(
-      "intmodule PlusArgsTestIntrinsic :",
+    (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain).allOf(
+      "intmodule PlusArgsTestIntrinsic : ",
       "output found : UInt<1>",
       "intrinsic = circt_plusargs_test",
       "parameter FORMAT = \"FOO\"",

--- a/src/test/scala/chiselTests/util/circt/PlusArgsValueSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/PlusArgsValueSpec.scala
@@ -31,7 +31,7 @@ class PlusArgsValueSpec extends AnyFlatSpec with Matchers {
   it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new PlusArgsValueTop)
     (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain).inOrder(
-      "intmodule PlusArgsValueIntrinsic :",
+      "intmodule PlusArgsValueIntrinsic : ",
       "output found : UInt<1>",
       "output result : UInt<32>",
       "intrinsic = circt_plusargs_value",

--- a/src/test/scala/chiselTests/util/circt/SizeOfSpec.scala
+++ b/src/test/scala/chiselTests/util/circt/SizeOfSpec.scala
@@ -29,7 +29,7 @@ private class SizeOfTop extends Module {
 class SizeOfSpec extends AnyFlatSpec with Matchers {
   it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new SizeOfTop)
-    (fir.split('\n').map(_.trim) should contain)
-      .allOf("intmodule SizeOfIntrinsic :", "input i : UInt<65>", "output size : UInt<32>", "intrinsic = circt_sizeof")
+    (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain)
+      .allOf("intmodule SizeOfIntrinsic : ", "input i : UInt<65>", "output size : UInt<32>", "intrinsic = circt_sizeof")
   }
 }

--- a/src/test/scala/chiselTests/util/circt/Synthesis.scala
+++ b/src/test/scala/chiselTests/util/circt/Synthesis.scala
@@ -23,9 +23,9 @@ private class Mux2CellTop extends Module {
 class Mux2CellSpec extends AnyFlatSpec with Matchers {
   it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new Mux2CellTop)
-    (fir.split('\n').map(_.trim) should contain)
+    (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain)
       .allOf(
-        "intmodule Mux2CellIntrinsic :",
+        "intmodule Mux2CellIntrinsic : ",
         "input sel : UInt<1>",
         "input high : UInt<32>",
         "input low : UInt<32>",
@@ -48,9 +48,9 @@ private class Mux4CellTop extends Module {
 class Mux4CellSpec extends AnyFlatSpec with Matchers {
   it should "work for types" in {
     val fir = ChiselStage.emitCHIRRTL(new Mux4CellTop)
-    (fir.split('\n').map(_.trim) should contain)
+    (fir.split('\n').map(_.trim.takeWhile(_ != '@')) should contain)
       .allOf(
-        "intmodule Mux4CellIntrinsic :",
+        "intmodule Mux4CellIntrinsic : ",
         "input sel : UInt<2>",
         "input v3 : UInt<32>",
         "input v2 : UInt<32>",


### PR DESCRIPTION
This is implemented using the compiler plugin so that:
1. The source locator points to the first character of the class name.
2. Users don't accept implicit sourceInfos as arguments to their module classes (this would override all source locators in the body of the class).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

The source locators point to the name of the class extends Module, RawModule, BlackBox, ExtModule, or Class. They are included in the output FIRRTL.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
