### PR TITLE
[circt] Remove deprecated dedup option

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -205,7 +205,7 @@ class CIRCT extends Phase {
 
     val cmd = // Only 1 of input or firFile will be Some
       Seq(binary, input.fold(_ => "-format=fir", _.toString)) ++
-        Seq("-warn-on-unprocessed-annotations", "-dedup") ++
+        Seq("-warn-on-unprocessed-annotations") ++
         Seq("-output-annotation-file", circtAnnotationFilename) ++
         circtOptions.firtoolOptions ++
         logLevel.toCIRCTOptions ++


### PR DESCRIPTION
Remove the deprecated -dedup option.  This was deprecated in firtool 1.57.0 and is planned to be removed soon.  This option has no effect. Deduplication always runs.

See: https://github.com/llvm/circt/pull/6191