### PR TITLE
Enable checkConnect for Property types in MonoConnect.

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -11,7 +11,7 @@ import chisel3.internal.Builder._
 import chisel3.internal.firrtl._
 import chisel3.experimental.{BaseModule, SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal.sourceinfo.{InstTransform}
-import chisel3.properties.Class
+import chisel3.properties.{Class, Property}
 import chisel3.reflect.DataMirror
 import _root_.firrtl.annotations.{IsModule, ModuleName, ModuleTarget}
 import _root_.firrtl.AnnotationSeq
@@ -176,6 +176,9 @@ object Module extends SourceInfoDoc {
     DataMirror
       .collectMembers(data) {
         case x: Element
+            if x.specifiedDirection == SpecifiedDirection.Unspecified || x.specifiedDirection == SpecifiedDirection.Flip =>
+          x
+        case x: Property[_]
             if x.specifiedDirection == SpecifiedDirection.Unspecified || x.specifiedDirection == SpecifiedDirection.Flip =>
           x
       }
@@ -680,11 +683,7 @@ package experimental {
     protected def _bindIoInPlace(iodef: Data)(implicit sourceInfo: SourceInfo): Unit = {
 
       // Assign any signals (Chisel or chisel3) with Unspecified/Flipped directions to Output/Input.
-      // This is only required for Data, not all Datas in general.
-      iodef match {
-        case (data: Data) => Module.assignCompatDir(data)
-        case _ => ()
-      }
+      Module.assignCompatDir(iodef)
 
       iodef.bind(PortBinding(this))
       _ports += iodef -> sourceInfo

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -411,6 +411,7 @@ private[chisel3] object MonoConnect {
     source:     Property[_],
     context:    BaseModule
   ): Unit = {
+    checkConnect(sourceInfo, sink, source, context)
     // Add the PropAssign command directly onto the correct BaseModule subclass.
     context match {
       case rm:  RawModule => rm.addCommand(PropAssign(sourceInfo, sink.lref, source.ref))
@@ -447,10 +448,10 @@ private[chisel3] object checkConnect {
     checkConnection(sourceInfo, sink, source, context_mod)
   }
 
-  def apply[T](
+  def apply(
     sourceInfo:  SourceInfo,
-    sink:        Property[T],
-    source:      Property[T],
+    sink:        Property[_],
+    source:      Property[_],
     context_mod: BaseModule
   ): Unit = {
     checkConnection(sourceInfo, sink, source, context_mod)


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Property types never actually called the helper that was factored out of MonoConnect specifically for them. Upon adding this, it turned out that they never had assignCompatDir called either, and this was leaving directions unspecified in aggregates. Both of these have probably lingered since Property types were made subclasses of Data again. This addresses both omissions, leading to earlier error checking for Property type connections.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
