### PR TITLE
Don't emit nodes when calling .asBool on a Bool

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -402,7 +402,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends Element wi
   /** @group SourceInfoTransformMacro */
   def do_asSInt(implicit sourceInfo: SourceInfo): SInt
 
-  final def do_asBool(implicit sourceInfo: SourceInfo): Bool = {
+  def do_asBool(implicit sourceInfo: SourceInfo): Bool = {
     width match {
       case KnownWidth(1) => this(0)
       case _             => throwException(s"can't covert ${this.getClass.getSimpleName}$width to Bool")
@@ -1215,6 +1215,8 @@ sealed class Bool() extends UInt(1.W) with Reset {
 
   /** @group SourceInfoTransformMacro */
   def do_&&(that: Bool)(implicit sourceInfo: SourceInfo): Bool = this & that
+
+  override def do_asBool(implicit sourceInfo: SourceInfo): Bool = this
 
   /** Reinterprets this $coll as a clock */
   def asClock: Clock = macro SourceInfoTransform.noArg

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -185,10 +185,9 @@ class LTLSpec extends AnyFlatSpec with Matchers {
       val a, b = IO(Input(Bool()))
       val p0: Property = a.disable(b.asDisable)
     })
-    chirrtl should include("node _T = bits(b, 0, 0)")
     chirrtl should include("inst ltl_disable of LTLDisableIntrinsic")
     chirrtl should include("connect ltl_disable.in, a")
-    chirrtl should include("connect ltl_disable.condition, _T")
+    chirrtl should include("connect ltl_disable.condition, b")
   }
 
   it should "support simple property asserts/assumes/covers" in {
@@ -268,18 +267,16 @@ class LTLSpec extends AnyFlatSpec with Matchers {
     chirrtl should include("connect verif.property, ltl_clock.out")
 
     // with disable; emitted as `assert(disable(a, b))`
-    chirrtl should include("node x2 = bits(b, 0, 0)")
     chirrtl should include("inst ltl_disable of LTLDisableIntrinsic")
     chirrtl should include("connect ltl_disable.in, a")
-    chirrtl should include("connect ltl_disable.condition, x2")
+    chirrtl should include("connect ltl_disable.condition, b")
     chirrtl should include("inst verif_1 of VerifAssertIntrinsic")
     chirrtl should include("connect verif_1.property, ltl_disable.out")
 
     // with clock and disable; emitted as `assert(clock(disable(a, b), c))`
-    chirrtl should include("node _T = bits(b, 0, 0)")
     chirrtl should include("inst ltl_disable_1 of LTLDisableIntrinsic")
     chirrtl should include("connect ltl_disable_1.in, a")
-    chirrtl should include("connect ltl_disable_1.condition, _T")
+    chirrtl should include("connect ltl_disable_1.condition, b")
     chirrtl should include("inst ltl_clock_1 of LTLClockIntrinsic")
     chirrtl should include("connect ltl_clock_1.in, ltl_disable_1.out")
     chirrtl should include("connect ltl_clock_1.clock, c")

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -469,4 +469,20 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
         log should be("")
     }
   }
+
+  property("Calling .asBool on a Bool should be a noop") {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val a = IO(Input(Bool()))
+      val b: UInt = IO(Input(Bool()))
+      val y, z = IO(Output(Bool()))
+      val c = a.asBool
+      val d = b.asBool
+      y := c
+      z := d
+      a should be(c)
+      b should be(d)
+    })
+    chirrtl should include("connect y, a")
+    chirrtl should include("connect z, b")
+  }
 }

--- a/src/test/scala/chiselTests/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/VerificationSpec.scala
@@ -33,14 +33,14 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
     val lines = fir.split("\n").map(_.trim).toIndexedSeq
 
     // reset guard around the verification statement
-    assertContains(lines, "when _T_2 : ")
+    assertContains(lines, "when _T_1 : ")
     assertContains(lines, "cover(clock, _T, UInt<1>(0h1), \"\")")
 
-    assertContains(lines, "when _T_6 : ")
-    assertContains(lines, "assume(clock, _T_4, UInt<1>(0h1), \"\")")
+    assertContains(lines, "when _T_5 : ")
+    assertContains(lines, "assume(clock, _T_3, UInt<1>(0h1), \"\")")
 
-    assertContains(lines, "when _T_10 : ")
-    assertContains(lines, "assert(clock, _T_8, UInt<1>(0h1), \"\")")
+    assertContains(lines, "when _T_8 : ")
+    assertContains(lines, "assert(clock, _T_6, UInt<1>(0h1), \"\")")
   }
 
   property("annotation of verification constructs should work") {


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Backend code generation

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This results in a slight improvement to emitted FIRRTL quality

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
