### PR TITLE
Change Trace API to only trace leaves

### DIFF
--- a/core/src/main/scala/chisel3/experimental/Trace.scala
+++ b/core/src/main/scala/chisel3/experimental/Trace.scala
@@ -31,9 +31,6 @@ object Trace {
   def traceName(x: Data): Unit = {
     x match {
       case aggregate: Aggregate =>
-        annotate(new ChiselAnnotation {
-          def toFirrtl: Annotation = TraceAnnotation(aggregate.toAbsoluteTarget, aggregate.toAbsoluteTarget)
-        })
         aggregate.elementsIterator.foreach(traceName)
       case element: Element =>
         annotate(new ChiselAnnotation {

--- a/src/test/scala/chiselTests/experimental/TraceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/TraceSpec.scala
@@ -340,13 +340,8 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
     val dut = annos.collectFirst { case DesignAnnotation(dut) => dut }.get.asInstanceOf[M]
     val allTargets = finalTargetMap(annos)
     allTargets(dut.a.toAbsoluteTarget) should be(Seq(refTarget("M", "a")))
-    allTargets(dut.b.toAbsoluteTarget) should be(
-      Seq(
-        refTarget("M", "b_0"),
-        refTarget("M", "b_1")
-      )
-    )
     allTargets(dut.b(0).toAbsoluteTarget) should be(Seq(refTarget("M", "b_0")))
     allTargets(dut.b(1).toAbsoluteTarget) should be(Seq(refTarget("M", "b_1")))
+    allTargets.keys should not contain (dut.b.toAbsoluteTarget)
   }
 }


### PR DESCRIPTION
Change the behavior of the Trace API to only trace leaves.  This aligns with recent changes to CIRCT which error if annotations are applied to aggregates which are then mandatorily split due to FIRRTL ABIs.  This should have no practical effect on use of the Trace API only that downstream consumers will need to work at the level of leaf types and not on aggregates.
