### PR TITLE
Add ModuleChoice and Groups

### DIFF
--- a/core/src/main/scala/chisel3/choice/package.scala
+++ b/core/src/main/scala/chisel3/choice/package.scala
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import chisel3.experimental.{BaseModule, SourceInfo}
+import chisel3.util.simpleClassName
+
+/** This package contains Chisel language definitions for describing configuration options and their accepted values.
+  */
+package object choice {
+
+  /** An option group declaration. Specifies a container grouping values for some design configuration parameter.
+    *
+    * @example
+    * {{{
+    * import chisel3.option.{Group, Case}
+    * object Platform extends Group {
+    *   object FPGA extends Case
+    *   object ASIC extends Case
+    * }
+    * }}}
+    */
+  abstract class Group(implicit _sourceInfo: SourceInfo) {
+    self: Singleton =>
+
+    private[chisel3] def sourceInfo: SourceInfo = _sourceInfo
+
+    private[chisel3] def name: String = simpleClassName(this.getClass())
+
+    final implicit def group: Group = this
+  }
+
+  /** An option case declaration.
+    */
+  abstract class Case(implicit val group: Group, _sourceInfo: SourceInfo) {
+    self: Singleton =>
+
+    private[chisel3] def sourceInfo: SourceInfo = _sourceInfo
+
+    private[chisel3] def name: String = simpleClassName(this.getClass())
+
+    /** A helper method to allow ModuleChoice to use the `->` syntax to specify case-module mappings.
+      *
+      * It captures a lazy reference to the module and produces a generator to avoid instantiating it.
+      *
+      * @param module Module to map to the current case.
+      */
+    def ->[T](module: => T): (Case, () => T) = (this, () => module)
+  }
+}

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -10,6 +10,7 @@ import chisel3.internal.Builder.Prefix
 
 import scala.util.Try
 import scala.annotation.{implicitNotFound, nowarn}
+import scala.collection.mutable
 
 package object internal {
 
@@ -191,4 +192,15 @@ package object internal {
     "skip",
     "node"
   )
+
+  /** Similar to Seq.groupBy except that it preserves ordering of elements within each group */
+  private[chisel3] def groupByIntoSeq[A, K](xs: Iterable[A])(f: A => K): Seq[(K, Seq[A])] = {
+    val map = mutable.LinkedHashMap.empty[K, mutable.ListBuffer[A]]
+    for (x <- xs) {
+      val key = f(x)
+      val l = map.getOrElseUpdate(key, mutable.ListBuffer.empty[A])
+      l += x
+    }
+    map.view.map({ case (k, vs) => k -> vs.toList }).toList
+  }
 }

--- a/docs/src/explanations/instchoice.md
+++ b/docs/src/explanations/instchoice.md
@@ -1,0 +1,47 @@
+# Instance Choices
+
+`Instance Choice`s are instances of modules whose targets are configurable post-elaboration.
+They allow the target of an instance to be chosen from a pre-defined set after elaboration by
+enabling an option through the ABI or through specialization in the compiler.
+
+Instance choices rely on option groups to specify the available targets attached to each option:
+
+```scala mdoc:silent
+import chisel3.choice.{Case, Group}
+
+object Platform extends Group {
+  object FPGA extends Case
+  object ASIC extends Case
+}
+```
+
+The `Platform` option groups enumerates the list of platforms for which the design
+can be specialised, such as `ASIC` or `FPGA`. Specialization is not mandatory: if an
+option is left unspecified, a default variant is chosen.
+
+The modules referenced by an instance choice must all specify the same IO interface by
+deriving from `FixedIOBaseModule`. The `ModuleChoice` operator takes the default option
+and a list of case-module mappings and returns a binding to the IO of the modules.
+
+```scala mdoc:silent
+import chisel3._
+import chisel3.choice.ModuleChoice
+
+class TargetIO extends Bundle {
+  val in = Flipped(UInt(8.W))
+  val out = UInt(8.W)
+}
+
+class FPGATarget extends FixedIOExtModule[TargetIO](new TargetIO)
+
+class ASICTarget extends FixedIOExtModule[TargetIO](new TargetIO)
+
+class VerifTarget extends FixedIORawModule[TargetIO](new TargetIO)
+
+class SomeModule extends RawModule {
+  val inst = ModuleChoice(new VerifTarget)(Seq(
+    Platform.FPGA -> new FPGATarget,
+    Platform.ASIC -> new ASICTarget
+  ))
+}
+```

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -291,6 +291,16 @@ case class DefInstance(info: Info, name: String, module: String, tpe: Type = Unk
     with IsDeclaration
     with UseSerializer
 
+case class DefInstanceChoice(
+  info:    Info,
+  name:    String,
+  default: String,
+  option:  String,
+  choices: Seq[(String, String)])
+    extends Statement
+    with IsDeclaration
+    with UseSerializer
+
 case class DefObject(info: Info, name: String, cls: String) extends Statement with IsDeclaration with UseSerializer
 
 object ReadUnderWrite extends Enumeration {
@@ -407,6 +417,10 @@ case class Layer(info: Info, name: String, convention: LayerConvention.Type, bod
     with IsDeclaration
     with UseSerializer
 case class LayerBlock(info: Info, layer: String, body: Statement) extends Statement with UseSerializer
+
+// option and case
+case class DefOption(info: Info, name: String, cases: Seq[DefOptionCase])
+case class DefOptionCase(info: Info, name: String)
 
 // formal
 object Formal extends Enumeration {
@@ -658,7 +672,8 @@ case class Circuit(
   modules:     Seq[DefModule],
   main:        String,
   typeAliases: Seq[DefTypeAlias] = Seq.empty,
-  layers:      Seq[Layer] = Seq.empty)
+  layers:      Seq[Layer] = Seq.empty,
+  options:     Seq[DefOption] = Seq.empty)
     extends FirrtlNode
     with HasInfo
     with UseSerializer

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -57,6 +57,17 @@ class InstTransform(val c: Context) extends SourceInfoTransformMacro {
 }
 
 // Workaround for https://github.com/sbt/sbt/issues/3966
+object InstChoiceTransform
+// Module instantiation transform
+class InstChoiceTransform(val c: Context) extends SourceInfoTransformMacro {
+  import c.universe._
+  def apply[T: c.WeakTypeTag](default: c.Tree)(choices: c.Tree): c.Tree = {
+    val tpe = weakTypeOf[T]
+    q"$thisObj.do_apply[$tpe]($default, $choices)($implicitSourceInfo)"
+  }
+}
+
+// Workaround for https://github.com/sbt/sbt/issues/3966
 object DefinitionTransform
 // Module instantiation transform
 class DefinitionTransform(val c: Context) extends SourceInfoTransformMacro {

--- a/src/main/scala/chisel3/choice/ModuleChoice.scala
+++ b/src/main/scala/chisel3/choice/ModuleChoice.scala
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.choice
+
+import scala.language.experimental.macros
+import scala.collection.immutable.ListMap
+
+import chisel3.{Data, FixedIOBaseModule, Module, SourceInfoDoc}
+import chisel3.experimental.{BaseModule, SourceInfo}
+import chisel3.internal.{groupByIntoSeq, Builder, WireBinding}
+import chisel3.internal.Builder.pushCommand
+import chisel3.internal.firrtl.DefInstanceChoice
+import chisel3.internal.sourceinfo.InstChoiceTransform
+
+object ModuleChoice extends SourceInfoDoc {
+
+  /** A wrapper method for Module instantiation based on option choices.
+    * (necessary to help Chisel track internal state).
+    * @see [[chisel3.choice.Group]] on how to declare the options for the alternatives.
+    *
+    * Example:
+    * ```
+    * val module = ModuleChoice(new DefaultModule)(Seq(
+    *   Platform.FPGA -> new FPGATarget,
+    *   Platform.ASIC -> new ASICTarget
+    * ))
+    * ```
+    *
+    * @param default the Module to instantiate if no module is specified
+    * @param choices the mapping from cases to module generators
+    *
+    * @return the input module `m` with Chisel metadata properly set
+    *
+    * @throws java.lang.IllegalArgumentException if the cases do not belong to the same option.
+    */
+  def apply[T <: Data](
+    default: => FixedIOBaseModule[T]
+  )(choices: => Seq[(Case, () => FixedIOBaseModule[T])]
+  ): T =
+    macro InstChoiceTransform.apply[T]
+
+  /** @group SourceInfoTransformMacro */
+  def do_apply[T <: Data](
+    default: => FixedIOBaseModule[T],
+    choices: Seq[(Case, () => FixedIOBaseModule[T])]
+  )(
+    implicit sourceInfo: SourceInfo
+  ): T = {
+    val instDefaultModule = Module.evaluate(default)
+
+    val choiceModules = choices.map {
+      case (choice, module) =>
+        val instModule = Module.evaluate(module())
+        if (!instModule.io.typeEquivalent(instDefaultModule.io)) {
+          Builder.error("Error: choice module IO bundles are not type equivalent")
+        }
+        Builder.options += choice
+        (choice, instModule)
+    }
+
+    groupByIntoSeq(choiceModules.map(_._1))(opt => opt).foreach {
+      case (_, group) =>
+        if (group.size != 1) {
+          throw new IllegalArgumentException(s"Error: duplicate case '${group.head.name}'")
+        }
+    }
+
+    val groupedChoices = choices.map(_._1.group).distinct
+    if (groupedChoices.size == 0) {
+      throw new IllegalArgumentException("Error: at least one alternative must be specified")
+    }
+    if (groupedChoices.size != 1) {
+      val groupNames = groupedChoices.map(_.name).mkString(", ")
+      throw new IllegalArgumentException(s"Error: cannot mix choices from different groups: ${groupNames}")
+    }
+    val group = groupedChoices.head.name
+
+    val binding = instDefaultModule.io.cloneTypeFull
+    binding.bind(WireBinding(Builder.forcedUserModule, Builder.currentWhen))
+
+    pushCommand(
+      DefInstanceChoice(
+        sourceInfo,
+        binding,
+        instDefaultModule,
+        group,
+        choiceModules.map {
+          case (choice, instModule) =>
+            (choice.name, instModule)
+        }
+      )
+    )
+
+    binding
+  }
+}

--- a/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
@@ -3,8 +3,9 @@
 package chisel3.util.experimental.decode
 
 import chisel3.util.BitPat
+import chisel3.internal.groupByIntoSeq
+
 import scala.util.hashing.MurmurHash3
-import scala.collection.mutable
 
 sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: BitPat) {
   def inputWidth = table.head._1.getWidth
@@ -192,16 +193,5 @@ object TruthTable {
         },
       bitPat(tables.flatMap { case (table, indexes) => table.default.rawString.zip(indexes) })
     )
-  }
-
-  /** Similar to Seq.groupBy except that it preserves ordering of elements within each group */
-  private def groupByIntoSeq[A, K](xs: Iterable[A])(f: A => K): Seq[(K, Seq[A])] = {
-    val map = mutable.LinkedHashMap.empty[K, mutable.ListBuffer[A]]
-    for (x <- xs) {
-      val key = f(x)
-      val l = map.getOrElseUpdate(key, mutable.ListBuffer.empty[A])
-      l += x
-    }
-    map.view.map({ case (k, vs) => k -> vs.toList }).toList
   }
 }

--- a/src/test/scala/chiselTests/ModuleChoiceSpec.scala
+++ b/src/test/scala/chiselTests/ModuleChoiceSpec.scala
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.choice.{Case, Group, ModuleChoice}
+import chiselTests.{ChiselFlatSpec, MatchesAndOmits, Utils}
+import _root_.circt.stage.ChiselStage
+
+object Platform extends Group {
+  object FPGA extends Case
+  object ASIC extends Case
+}
+
+class TargetIO(width: Int) extends Bundle {
+  val in = Flipped(UInt(width.W))
+  val out = UInt(width.W)
+}
+
+class FPGATarget extends FixedIOExtModule[TargetIO](new TargetIO(8))
+
+class ASICTarget extends FixedIOExtModule[TargetIO](new TargetIO(8))
+
+class VerifTarget extends FixedIORawModule[TargetIO](new TargetIO(8))
+
+class ModuleChoiceSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
+  it should "emit options and cases" in {
+    class ModuleWithChoice extends Module {
+      val out = IO(UInt(8.W))
+
+      val inst =
+        ModuleChoice(new VerifTarget)(Seq(Platform.FPGA -> new FPGATarget, Platform.ASIC -> new ASICTarget))
+
+      inst.in := 42.U(8.W)
+      out := inst.out
+    }
+
+    val chirrtl = ChiselStage.emitCHIRRTL(new ModuleWithChoice, Array("--full-stacktrace"))
+
+    info("CHIRRTL emission looks correct")
+    matchesAndOmits(chirrtl)(
+      "option Platform :",
+      "FPGA",
+      "ASIC",
+      "instchoice inst of VerifTarget, Platform :",
+      "FPGA => FPGATarget",
+      "ASIC => ASICTarget"
+    )()
+  }
+
+  it should "require that all cases are part of the same option" in {
+
+    class MixedOptions extends Module {
+      object Performance extends Group {
+        object Fast extends Case
+        object Small extends Case
+      }
+
+      val out = IO(UInt(8.W))
+
+      val inst =
+        ModuleChoice(new VerifTarget)(Seq(Platform.FPGA -> new FPGATarget, Performance.Fast -> new ASICTarget))
+
+      inst.in := 42.U(8.W)
+      out := inst.out
+    }
+
+    intercept[IllegalArgumentException] { ChiselStage.emitCHIRRTL(new MixedOptions) }.getMessage() should include(
+      "cannot mix choices from different groups: Platform, Performance"
+    )
+
+  }
+
+  it should "require that at least one alternative is present" in {
+
+    class MixedOptions extends Module {
+      val out = IO(UInt(8.W))
+
+      val inst =
+        ModuleChoice(new VerifTarget)(Seq())
+
+      inst.in := 42.U(8.W)
+      out := inst.out
+    }
+
+    intercept[IllegalArgumentException] { ChiselStage.emitCHIRRTL(new MixedOptions) }.getMessage() should include(
+      "at least one alternative must be specified"
+    )
+
+  }
+
+  it should "require that all cases are distinct" in {
+
+    class MixedOptions extends Module {
+      val out = IO(UInt(8.W))
+
+      val inst =
+        ModuleChoice(new VerifTarget)(Seq(Platform.FPGA -> new FPGATarget, Platform.FPGA -> new ASICTarget))
+
+      inst.in := 42.U(8.W)
+      out := inst.out
+    }
+
+    intercept[IllegalArgumentException] { ChiselStage.emitCHIRRTL(new MixedOptions) }.getMessage() should include(
+      "duplicate case 'FPGA'"
+    )
+
+  }
+
+  it should "require that all IO bundles are type equivalent" in {
+
+    class MixedIO extends Module {
+      val out = IO(UInt(8.W))
+
+      class Target16 extends FixedIOExtModule[TargetIO](new TargetIO(16))
+
+      val inst =
+        ModuleChoice(new VerifTarget)(Seq(Platform.FPGA -> new Target16))
+
+      inst.in := 42.U(8.W)
+      out := inst.out
+    }
+
+    intercept[ChiselException] { ChiselStage.emitCHIRRTL(new MixedIO, Array("--throw-on-first-error")) }
+      .getMessage() should include(
+      "choice module IO bundles are not type equivalent"
+    )
+
+  }
+
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash

#### Release Notes

Added support for the post-generation configuration of designs. Instance choices allow multiple, option-dependent targets to be specified for a single option, picking an implementation in the downstream flow.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
