### PR TITLE
[binder] Truncate for aggregate connection, fix inner_sym

### DIFF
--- a/binder/includeFunctions.txt
+++ b/binder/includeFunctions.txt
@@ -40,6 +40,7 @@ mlirOperationStateAddResults
 mlirOperationStateAddAttributes
 mlirOperationStateEnableResultTypeInference
 mlirOperationGetResult
+mlirOperationSetInherentAttributeByName
 mlirRegionCreate
 mlirOperationCreate
 mlirBlockCreate

--- a/binder/src/main/scala/PanamaCIRCT.scala
+++ b/binder/src/main/scala/PanamaCIRCT.scala
@@ -124,6 +124,9 @@ class PanamaCIRCT {
     CAPI.mlirOperationGetResult(arena, operation.get, pos)
   )
 
+  def mlirOperationSetInherentAttributeByName(op: MlirOperation, name: String, attr: MlirAttribute): Unit =
+    CAPI.mlirOperationSetInherentAttributeByName(op.get, newString(name).get, attr.get)
+
   def mlirBlockCreate(args: Seq[MlirType], locs: Seq[MlirLocation]): MlirBlock = {
     assert(args.length == locs.length)
     val length = args.length

--- a/binder/src/test/scala/BinderSpec.scala
+++ b/binder/src/test/scala/BinderSpec.scala
@@ -34,6 +34,9 @@ class TruncationTest extends RawModule {
   val dest = IO(Output(UInt(8.W)))
   val src = IO(Input(UInt(16.W)))
   dest := src
+
+  val vDest = IO(Output(Vec(4, UInt(1.W))))
+  vDest := VecInit(Seq.fill(4)(1.U(2.W)))
 }
 
 // https://github.com/chipsalliance/chisel/issues/3548#issuecomment-1734346659
@@ -113,7 +116,11 @@ class BinderTest extends AnyFlatSpec with Matchers {
         .and(include("if (counterWrap)"))
         .and(include("counterWrap_c_value <=")))
 
-    firrtlString(new TruncationTest) should include("connect dest, tail(src, 8)")
+    verilogString(new TruncationTest) should include("assign dest = src[7:0]")
+      .and(include("assign vDest_0 = 1'h1"))
+      .and(include("assign vDest_1 = 1'h1"))
+      .and(include("assign vDest_2 = 1'h1"))
+      .and(include("assign vDest_3 = 1'h1"))
 
     firrtlString(new BitLengthOfNeg1Test) should include("asUInt(SInt<1>(-1))")
 


### PR DESCRIPTION
Some fixes for binder:

- Truncate for aggregate connection.

- Set `inner_sym` only when needed.