### PR TITLE
[CI] Fix flaky CI and remove VerilogMdocModifier from API docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Scala
         uses: VirtusLab/scala-cli-setup@v1
         with:
-          jvm: adopt:11
+          jvm: adoptium:17
           apps: sbt
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/build.sbt
+++ b/build.sbt
@@ -363,7 +363,8 @@ lazy val unipublish =
     .enablePlugins(ScalaUnidocPlugin)
     .settings(
       // Plugin isn't part of Chisel's public API, exclude from ScalaDoc
-      ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(plugin)
+      // Even though this project doesn't depend on docs, Unidoc pulls it in unless we exclude it
+      ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject -- inProjects(plugin) -- inProjects(docs)
     )
     .settings(commonSettings: _*)
     .settings(publishSettings: _*)


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Documentation or website-related
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

* Use Java 17 to build documentation in CI
* Exclude docs project from Unidoc

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
