### PR TITLE
Bump firtool-resolver to 1.3.0

### DIFF
--- a/.github/workflows/build-scala-cli-template.yml
+++ b/.github/workflows/build-scala-cli-template.yml
@@ -26,11 +26,11 @@ jobs:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       # TODO have install-circt do this
-      - name: Set FIRTOOL_PATH
+      - name: Set CHISEL_FIRTOOL_PATH
         if: steps.install-circt.outcome == 'success'
         run: |
           dir=$(dirname $(which firtool))
-          echo "FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
+          echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
       - name: Cache Scala-CLI
         uses: coursier/cache-action@v6
       - name: Setup Scala-CLI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,17 +63,17 @@ jobs:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       # TODO have install-circt do this
-      - name: Set FIRTOOL_PATH
+      - name: Set CHISEL_FIRTOOL_PATH
         if: steps.install-circt.outcome == 'success'
         run: |
           dir=$(dirname $(which firtool))
-          echo "FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
+          echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
       - name: Print firtool version
         if: steps.install-circt.outcome == 'success'
         run: |
           echo "The CIRCT version used is:" >> $GITHUB_STEP_SUMMARY
           echo \`\`\` >> $GITHUB_STEP_SUMMARY
-          $FIRTOOL_PATH/firtool -version >> $GITHUB_STEP_SUMMARY
+          $CHISEL_FIRTOOL_PATH/firtool -version >> $GITHUB_STEP_SUMMARY
           echo \`\`\` >> $GITHUB_STEP_SUMMARY
       - name: Test
         run: sbt ++${{ inputs.scala }} test
@@ -165,11 +165,11 @@ jobs:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       # TODO have install-circt do this
-      - name: Set FIRTOOL_PATH
+      - name: Set CHISEL_FIRTOOL_PATH
         if: steps.install-circt.outcome == 'success'
         run: |
           dir=$(dirname $(which firtool))
-          echo "FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
+          echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
       - name: Integration Tests
         run: sbt integrationTests/test
 
@@ -227,11 +227,11 @@ jobs:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
       # TODO have install-circt do this
-      - name: Set FIRTOOL_PATH
+      - name: Set CHISEL_FIRTOOL_PATH
         if: steps.install-circt.outcome == 'success'
         run: |
           dir=$(dirname $(which firtool))
-          echo "FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
+          echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
         # TODO: make the website building include building ScalaDoc
       - name: Build the website
         run: make -C website build

--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,7 @@ lazy val chiselSettings = Seq(
     "org.scalatest" %% "scalatest" % "3.2.16" % "test",
     "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % "test",
     "com.lihaoyi" %% "upickle" % "3.1.0",
-    "org.chipsalliance" %% "firtool-resolver" % "1.2.0"
+    "org.chipsalliance" %% "firtool-resolver" % "1.3.0"
   )
 ) ++ (
   // Tests from other projects may still run concurrently

--- a/build.sc
+++ b/build.sc
@@ -17,7 +17,7 @@ object v {
   )
   val osLib = ivy"com.lihaoyi::os-lib:0.9.1"
   val upickle = ivy"com.lihaoyi::upickle:3.1.0"
-  val firtoolResolver = ivy"org.chipsalliance::firtool-resolver:1.2.0"
+  val firtoolResolver = ivy"org.chipsalliance::firtool-resolver:1.3.0"
   val scalatest = ivy"org.scalatest::scalatest:3.2.14"
   val scalacheck = ivy"org.scalatestplus::scalacheck-1-15:3.2.11.0"
   val json4s = ivy"org.json4s::json4s-native:4.0.6"

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -369,14 +369,14 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val (log1, _) = grabLog {
         ChiselStage.emitSystemVerilog(new ChiselStageSpec.Foo)
       }
-      log1 shouldNot include("Checking FIRTOOL_PATH for firtool")
+      log1 shouldNot include("Checking CHISEL_FIRTOOL_PATH for firtool")
 
       // circt.stage.ChiselStage does not currently accept --log-level so we have to use testing
       // APIs to set the level
       val (log2, _) = grabLogLevel(LogLevel.Debug) {
         ChiselStage.emitSystemVerilog(new ChiselStageSpec.Foo)
       }
-      log2 should include("Checking FIRTOOL_PATH for firtool")
+      log2 should include("Checking CHISEL_FIRTOOL_PATH for firtool")
     }
   }
 


### PR DESCRIPTION
This would be an API modification but no Chisel has yet been released using firtool-resolver

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Dependency update


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

To override which firtool is used by Chisel, users can set environment variable `CHISEL_FIRTOOL_PATH`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
