### PR TITLE
Fix using Definitions as arguments to Definitions

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -352,8 +352,13 @@ package experimental {
       import chisel3.experimental.hierarchy.core.{Definition, Instance}
       def toInstance: Instance[T] = new Instance(Proto(b))
       def toDefinition: Definition[T] = {
+        val result = new Definition(Proto(b))
+        // .toDefinition is sometimes called in Select APIs outside of Chisel elaboration
+        if (Builder.inContext) {
+          Builder.definitions += result
+        }
         b.toDefinitionCalled = Some(si)
-        new Definition(Proto(b))
+        result
       }
     }
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -106,7 +106,8 @@ object Definition extends SourceInfoDoc {
         context.throwOnFirstError,
         context.warningFilters,
         context.sourceRoots,
-        Some(context.globalNamespace)
+        Some(context.globalNamespace),
+        Builder.allDefinitions
       )
     }
     dynamicContext.inDefinition = true
@@ -114,7 +115,7 @@ object Definition extends SourceInfoDoc {
     Builder.components ++= ir.components
     Builder.annotations ++= ir.annotations: @nowarn // this will go away when firrtl is merged
     module._circuit = Builder.currentModule
-    new Definition(Proto(module))
+    module.toDefinition
   }
 
 }

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -62,7 +62,9 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
           annotationsInAspect,
           chiselOptions.throwOnFirstError,
           chiselOptions.warningFilters,
-          chiselOptions.sourceRoots
+          chiselOptions.sourceRoots,
+          None,
+          Nil // FIXME this maybe should somehow grab definitions from earlier elaboration
         )
       // Add existing module names into the namespace. If injection logic instantiates new modules
       //  which would share the same name, they will get uniquified accordingly

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -34,7 +34,9 @@ class Elaborate extends Phase {
             annotations,
             chiselOptions.throwOnFirstError,
             chiselOptions.warningFilters,
-            chiselOptions.sourceRoots
+            chiselOptions.sourceRoots,
+            None,
+            Nil
           )
         val (circuit, dut) =
           Builder.build(Module(gen()), context)

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -90,6 +90,34 @@ class DefinitionSpec extends ChiselFunSpec with Utils {
       chirrtl.serialize should include("module AddOneWithNested_2 :")
       chirrtl.serialize should include("module AddOneWithNested_3 :")
     }
+
+    it("(0.g): definitions should work as arguments to definitions") {
+      class Top extends Module {
+        val addOne = Definition(new AddOne)
+        val addTwo = Definition(new AddTwoDefinitionArgument(addOne))
+        val inst = Instance(addTwo)
+        inst.in := 12.U
+      }
+      val chirrtl = getFirrtlAndAnnos(new Top)._1.serialize
+      chirrtl should include("module AddOne :")
+      chirrtl shouldNot include("module AddOne_")
+      chirrtl should include("module AddTwoDefinitionArgument :")
+      chirrtl should include("module Top :")
+    }
+    it("(0.h): definitions created from Modules should work as arguments to definitions") {
+      class Top extends Module {
+        val addOne = Module(new AddOne)
+        val addTwo = Definition(new AddTwoDefinitionArgument(addOne.toDefinition))
+        val inst = Instance(addTwo)
+        inst.in := 12.U
+      }
+      val chirrtl = getFirrtlAndAnnos(new Top)._1.serialize
+      chirrtl should include("module AddOne :")
+      chirrtl shouldNot include("module AddOne_")
+      chirrtl should include("module AddTwoDefinitionArgument :")
+      chirrtl should include("module Top :")
+      chirrtl should include("inst addOne of AddOne")
+    }
   }
   describe("(1): Annotations on definitions in same chisel compilation") {
     it("(1.a): should work on a single definition, annotating the definition") {

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -93,6 +93,16 @@ object Examples {
     val out = IO(Output(UInt(width.W)))
     val addOnes = makeParameterizedOnes(width)
   }
+  @instantiable
+  class AddTwoDefinitionArgument(definition: Definition[AddOne]) extends Module {
+    @public val in = IO(Input(UInt(32.W)))
+    @public val out = IO(Output(UInt(32.W)))
+    @public val i0: Instance[AddOne] = Instance(definition)
+    @public val i1: Instance[AddOne] = Instance(definition)
+    i0.in := in
+    i1.in := i0.out
+    out := i1.out
+  }
 
   @instantiable
   class AddFour extends Module {


### PR DESCRIPTION
Chisel creates new contexts whenever you're constructing a Definition. Previously, if you had a Definition in the parent context, the actual object would not be available in the child context (because it's a new context, `Builder.components` is cleared when you go to a new context). Now, we keep track of definitions explicitly _including definitions from parent/outer scopes_. This is implemented using a nested `List` for efficiency of constructing the datastructure while still allowing for efficient iteration.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Performance improvement - but probably not measurable
- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Fixes #3708

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
