### PR TITLE
Bump SBT to 1.9.8 and update Ubuntu runners

### DIFF
--- a/.github/workflows/backport-fixup.yml
+++ b/.github/workflows/backport-fixup.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   resolve_prs:
     name: Resolve PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # If triggering PR actually is a backport, then original_pr will be set
     outputs:
         backport_pr: ${{ steps.backport.outputs.pr }}
@@ -50,7 +50,7 @@ jobs:
 
   fixup_backport:
     name: Fixup the backport PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [resolve_prs]
     if: ${{ needs.resolve_prs.outputs.original_pr }}
 

--- a/.github/workflows/build-scala-cli-template.yml
+++ b/.github/workflows/build-scala-cli-template.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_template:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/cd-circt.yml
+++ b/.github/workflows/cd-circt.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   cd-circt:
     name: 'Check Version, Create PR'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 'circt/update-circt'
         uses: circt/update-circt@v1.0.0

--- a/.github/workflows/ci-circt-nightly.yml
+++ b/.github/workflows/ci-circt-nightly.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   determine-branch:
     name: 'Update Staging Branch and Determine Target Branch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Update Staging Branch
         uses: circt/update-staging-branch@v1.2.0
@@ -44,7 +44,7 @@ jobs:
     needs: [determine-branch]
     strategy:
       matrix:
-        system: ["ubuntu-20.04"]
+        system: ["ubuntu-22.04"]
         jvm: [8]
         scala: ["2.13.12"]
         espresso: ["2.4"]
@@ -65,7 +65,7 @@ jobs:
   check-tests:
     name: "check tests"
     needs: [ci]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
     steps:
@@ -80,7 +80,7 @@ jobs:
   # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
   all_tests_passed:
     name: "all tests passed"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() # Always run so that we never skip this check
     needs: check-tests
       # Pass only if check-tests set its output value

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: ci
     strategy:
       matrix:
-        system: ["ubuntu-20.04"]
+        system: ["ubuntu-22.04"]
         jvm: [8]
         scala: ["2.13.12"]
         espresso: ["2.4"]
@@ -34,7 +34,7 @@ jobs:
   check-tests:
     name: "check tests"
     needs: ci
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
     steps:
@@ -49,7 +49,7 @@ jobs:
   # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
   all_tests_passed:
     name: "all tests passed"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() # Always run so that we never skip this check
     needs: check-tests
       # Pass only if check-tests set its output value
@@ -68,7 +68,7 @@ jobs:
   # separate from a Scala versions build matrix to avoid duplicate publishing
   publish:
     needs: [all_tests_passed]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'push'
 
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   deploy_website:
     name: Deploy Website
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [all_tests_passed]
     # Only Deploy website on pushes to main, may change to a stable branch
     if: (github.event_name == 'push') && (github.ref_name == 'main')

--- a/.github/workflows/enable-bincompat-checking.yml
+++ b/.github/workflows/enable-bincompat-checking.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   determine_version:
     name: Determine Version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
         version: ${{ steps.dowork.outputs.version }}
 
@@ -31,7 +31,7 @@ jobs:
 
   determine_branches:
     name: Determine Branches
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [determine_version]
     outputs:
       branches: ${{ steps.determine-branches.outputs.branches }}
@@ -63,7 +63,7 @@ jobs:
 
   open_prs:
     name: Open Pull Requests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [determine_version, determine_branches]
     strategy:
       matrix:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   generate_release_notes:
     name: Generate Release Notes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check_labels:
     name: Check Labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:v1.4.25
         with:

--- a/.github/workflows/scala-cli-template.yml
+++ b/.github/workflows/scala-cli-template.yml
@@ -13,7 +13,7 @@ jobs:
   publish_template:
     name: Generate Scala CLI Template
     needs: [generate_scala_cli_template]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Download Generated CLI Template

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       system:
         description: 'The GitHub runner to use'
-        default: 'ubuntu-20.04'
+        default: 'ubuntu-22.04'
         required: true
         type: string
       jvm:
@@ -84,7 +84,7 @@ jobs:
 
   mill:
     name: compile project with mill
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
 
   doc:
     name: Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -141,7 +141,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -175,7 +175,7 @@ jobs:
 
   std:
     name: Standard Library Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         scala: ["2.13.12"]
@@ -199,7 +199,7 @@ jobs:
 
   website:
     name: Build Mdoc & Website
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.0
+sbt.version=1.9.8


### PR DESCRIPTION
It seems that some change to SBT requires bumping libc, thus bumping the ubuntu runners to 22.04 fixes this.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
