### PR TITLE
[binder] Fix emission of `firrtl.invalidvalue`

### DIFF
--- a/binder/includeFunctions.txt
+++ b/binder/includeFunctions.txt
@@ -91,6 +91,7 @@ firrtlAttrGetNameKind
 firrtlAttrGetRUW
 firrtlAttrGetMemoryInit
 firrtlAttrGetMemDir
+firrtlValueFoldFlow
 
 # CHIRRTL Attribute
 chirrtlTypeGetCMemory

--- a/binder/src/main/scala/PanamaCIRCT.scala
+++ b/binder/src/main/scala/PanamaCIRCT.scala
@@ -450,6 +450,8 @@ class PanamaCIRCT {
 
   def firrtlAttrGetMemDir(dir: FIRRTLMemDir) = MlirAttribute(CAPI.firrtlAttrGetMemDir(arena, mlirCtx, dir.value))
 
+  def firrtlValueFoldFlow(value: MlirValue, flow: Int): Int = CAPI.firrtlValueFoldFlow(value.get, flow)
+
   def chirrtlTypeGetCMemory(elementType: MlirType, numElements: Long) = MlirType(
     CAPI.chirrtlTypeGetCMemory(arena, mlirCtx, elementType.get, numElements)
   )

--- a/binder/src/main/scala/PanamaCIRCTConverter.scala
+++ b/binder/src/main/scala/PanamaCIRCTConverter.scala
@@ -591,13 +591,17 @@ class PanamaCIRCTConverter extends CIRCTConverter {
     }
 
     def newNode(id: HasId, name: String, resultType: fir.Type, input: MlirValue, loc: MlirLocation): Unit = {
+      newNode(id, name, util.convert(resultType), input, loc)
+    }
+
+    def newNode(id: HasId, name: String, resultType: MlirType, input: MlirValue, loc: MlirLocation): Unit = {
       val op = util
         .OpBuilder("firrtl.node", firCtx.currentBlock, loc)
         .withNamedAttr("name", circt.mlirStringAttrGet(name))
         .withNamedAttr("nameKind", circt.firrtlAttrGetNameKind(FIRRTLNameKind.InterestingName))
         .withNamedAttr("annotations", circt.emptyArrayAttr)
         .withOperand(input)
-        .withResult(util.convert(resultType))
+        .withResult(resultType)
         // .withResult( /* ref */ )
         .build()
       firCtx.ops += ((id._id, op.op))
@@ -1433,9 +1437,15 @@ class PanamaCIRCTConverter extends CIRCTConverter {
       .OpBuilder(s"firrtl.${defPrim.op.toString}", firCtx.currentBlock, loc)
       .withNamedAttrs(attrs)
       .withOperands(operands.map(_.value))
-      .withResult(util.convert(resultType))
+      // Chisel will produce zero-width types (`{S,U}IntType(IntWidth(0))`) for zero values
+      // This causes problems for example `Cat(u32 >> 32, u32)`, we expect it produces type `UIntType(IntWidth(33))` but width 32 is calculated since the first operand of `Cat` is zero-width
+      // To easily fix this, we use the result type inferred by CIRCT instead of giving it manually from Chisel
+      //
+      // .withResult(util.convert(resultType))
+      .withResultInference(1)
       .build()
-    util.newNode(defPrim.id, name, resultType, op.results(0), loc)
+    val resultTypeInferred = circt.mlirValueGetType(op.results(0))
+    util.newNode(defPrim.id, name, resultTypeInferred, op.results(0), loc)
   }
 
   def visitDefReg(defReg: DefReg): Unit = {

--- a/binder/src/test/scala/BinderSpec.scala
+++ b/binder/src/test/scala/BinderSpec.scala
@@ -102,6 +102,13 @@ class DontCareIOTest extends Module {
   io.in := DontCare
 }
 
+class ZeroWidthTest extends Module {
+  val a = IO(Input(UInt(32.W)))
+  val b = IO(Input(SInt(32.W)))
+  val c = IO(Output(UInt(33.W)))
+  c := Cat(a >> 32, b)
+}
+
 class BinderTest extends AnyFlatSpec with Matchers {
 
   def streamString(module: => RawModule, stream: CIRCTConverter => Writable): String = Seq(
@@ -190,5 +197,8 @@ class BinderTest extends AnyFlatSpec with Matchers {
     firrtlString(new ProbeRead) should include("asClock(read(clockP))")
 
     verilogString(new DontCareIOTest) should include("assign io_in_ready = 1'h0")
+    mlirString(new ZeroWidthTest) should include(
+      "firrtl.cat %_c_T, %c_lo : (!firrtl.uint<1>, !firrtl.uint<32>) -> !firrtl.uint<33>"
+    )
   }
 }

--- a/binder/src/test/scala/BinderSpec.scala
+++ b/binder/src/test/scala/BinderSpec.scala
@@ -95,6 +95,13 @@ class ProbeRead extends RawModule {
   reset := read(resetP)
 }
 
+class DontCareIOTest extends Module {
+  val io = IO(new Bundle {
+    val in = Flipped(DecoupledIO(UInt(8.W)))
+  })
+  io.in := DontCare
+}
+
 class BinderTest extends AnyFlatSpec with Matchers {
 
   def streamString(module: => RawModule, stream: CIRCTConverter => Writable): String = Seq(
@@ -181,5 +188,7 @@ class BinderTest extends AnyFlatSpec with Matchers {
       .and(include("define b_bore = probe(a)"))
       .and(include("connect baz.b_bore, read(bar.b_bore)"))
     firrtlString(new ProbeRead) should include("asClock(read(clockP))")
+
+    verilogString(new DontCareIOTest) should include("assign io_in_ready = 1'h0")
   }
 }


### PR DESCRIPTION
Based on the merged PR in upstream CIRCT: llvm/circt#6577

Unsolved issue: #3735

CC @sequencer 