### PR TITLE
Add Layer Colors to Probe Types

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -804,7 +804,7 @@ object Data {
   // Needed for the `implicit def toConnectableDefault`
   import scala.language.implicitConversions
 
-  private[chisel3] case class ProbeInfo(val writable: Boolean)
+  private[chisel3] case class ProbeInfo(val writable: Boolean, color: Option[layer.Layer])
 
   /** Provides :<=, :>=, :<>=, and :#= between consumer and producer of the same T <: Data */
   implicit class ConnectableDefault[T <: Data](consumer: T) extends connectable.ConnectableOperators[T](consumer)

--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -43,6 +43,12 @@ object layer {
     private[chisel3] def sourceInfo: SourceInfo = _sourceInfo
 
     private[chisel3] def name: String = simpleClassName(this.getClass())
+
+    private[chisel3] val fullName: String = parent match {
+      case null       => "<root>"
+      case Layer.Root => name
+      case _          => s"${parent.fullName}.$name"
+    }
   }
 
   object Layer {

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -375,9 +375,15 @@ private[chisel3] object Converter {
     // extract underlying type for probe
     case t: Data if (checkProbe && t.probeInfo.nonEmpty) =>
       if (t.probeInfo.get.writable) {
-        fir.RWProbeType(extractType(t, clearDir, info, false, checkConst, typeAliases))
+        fir.RWProbeType(
+          extractType(t, clearDir, info, false, checkConst, typeAliases),
+          t.probeInfo.get.color.map(_.fullName)
+        )
       } else {
-        fir.ProbeType(extractType(t, clearDir, info, false, checkConst, typeAliases))
+        fir.ProbeType(
+          extractType(t, clearDir, info, false, checkConst, typeAliases),
+          t.probeInfo.get.color.map(_.fullName)
+        )
       }
     // extract underlying type for const
     case t: Data if (checkConst && t.isConst) =>

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -131,6 +131,21 @@ package object internal {
     case leaf => leaf.probeInfo.nonEmpty
   }
 
+  private[chisel3] def requireCompatibleDestinationProbeColor(
+    dest:         Data,
+    errorMessage: => String = ""
+  )(
+    implicit sourceInfo: SourceInfo
+  ): Unit = {
+    val destLayer = dest.probeInfo match {
+      case Some(Data.ProbeInfo(_, Some(color))) =>
+        color
+      case _ => return
+    }
+    if (!Builder.layerStack.exists(_ == destLayer))
+      Builder.error(errorMessage)
+  }
+
   // TODO this exists in cats.Traverse, should we just use that?
   private[chisel3] implicit class ListSyntax[A](xs: List[A]) {
     def mapAccumulate[B, C](z: B)(f: (B, A) => (B, C)): (B, List[C]) = {

--- a/core/src/main/scala/chisel3/probe/Probe.scala
+++ b/core/src/main/scala/chisel3/probe/Probe.scala
@@ -14,7 +14,13 @@ import scala.language.experimental.macros
   */
 private[chisel3] sealed trait ProbeBase {
 
-  protected def apply[T <: Data](source: => T, writable: Boolean)(implicit sourceInfo: SourceInfo): T = {
+  protected def apply[T <: Data](
+    source:   => T,
+    writable: Boolean,
+    color:    Option[layer.Layer]
+  )(
+    implicit sourceInfo: SourceInfo
+  ): T = {
     val prevId = Builder.idGen.value
     // call Output() to coerce passivity
     val data = Output(source) // should only evaluate source once
@@ -29,8 +35,17 @@ private[chisel3] sealed trait ProbeBase {
     // https://github.com/chipsalliance/chisel/issues/3609
 
     val ret: T = if (!data.mustClone(prevId)) data else data.cloneType.asInstanceOf[T]
-    setProbeModifier(ret, Some(ProbeInfo(writable)))
+    setProbeModifier(ret, Some(ProbeInfo(writable, color)))
     ret
+  }
+
+  protected def apply[T <: Data](
+    source:   => T,
+    writable: Boolean
+  )(
+    implicit sourceInfo: SourceInfo
+  ): T = {
+    apply(source, writable, None)
   }
 }
 
@@ -40,8 +55,16 @@ object Probe extends ProbeBase with SourceInfoDoc {
     */
   def apply[T <: Data](source: => T): T = macro chisel3.internal.sourceinfo.ProbeTransform.sourceApply[T]
 
+  def apply[T <: Data](source: => T, color: layer.Layer): T =
+    macro chisel3.internal.sourceinfo.ProbeTransform.sourceApplyWithColor[T]
+
   /** @group SourceInfoTransformMacro */
-  def do_apply[T <: Data](source: => T)(implicit sourceInfo: SourceInfo): T = super.apply(source, false)
+  def do_apply[T <: Data](source: => T)(implicit sourceInfo: SourceInfo): T =
+    super.apply(source, false, None)
+
+  /** @group SourceInfoTransformMacro */
+  def do_apply[T <: Data](source: => T, color: Option[layer.Layer])(implicit sourceInfo: SourceInfo): T =
+    super.apply(source, false, color)
 }
 
 object RWProbe extends ProbeBase with SourceInfoDoc {

--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -38,6 +38,11 @@ package object probe extends SourceInfoDoc {
     }
     requireHasProbeTypeModifier(sink, "Expected sink to be a probe.")
     requireHasProbeTypeModifier(probeExpr, "Expected source to be a probe expression.")
+    requireCompatibleDestinationProbeColor(
+      sink,
+      if (Builder.layerStack.head == layer.Layer.Root) s"Cannot define '$sink' from outside a layerblock"
+      else s"Cannot define '$sink' from a layerblock associated with layer ${Builder.layerStack.head.fullName}"
+    )
     if (sink.probeInfo.get.writable) {
       requireHasWritableProbeTypeModifier(
         probeExpr,

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -539,8 +539,9 @@ object GroundType {
 }
 abstract class AggregateType extends Type
 
-case class ProbeType(underlying: Type) extends Type with UseSerializer
-case class RWProbeType(underlying: Type) extends Type with UseSerializer
+final case class ProbeType(underlying: Type, color: Option[String] = None) extends Type with UseSerializer
+
+final case class RWProbeType(underlying: Type, color: Option[String] = None) extends Type with UseSerializer
 
 case class ConstType(underlying: Type) extends Type with UseSerializer
 

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -387,8 +387,16 @@ object Serializer {
 
   private def s(node: Type, lastEmittedConst: Boolean)(implicit b: StringBuilder, indent: Int): Unit = node match {
     // Types
-    case ProbeType(underlying: Type) => b ++= "Probe<"; s(underlying); b += '>'
-    case RWProbeType(underlying: Type) => b ++= "RWProbe<"; s(underlying); b += '>'
+    case a: ProbeType =>
+      b ++= "Probe<"
+      s(a.underlying)
+      a.color.foreach { layer => b ++= s", $layer" }
+      b += '>'
+    case a: RWProbeType =>
+      b ++= "RWProbe<"
+      s(a.underlying)
+      a.color.foreach { layer => b ++= s", $layer" }
+      b += '>'
     case ConstType(underlying: Type) => {
       // Avoid emitting multiple consecurive 'const', which can otherwise occur for const vectors of const elements
       if (!lastEmittedConst) {

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -40,6 +40,10 @@ class ProbeTransform(val c: Context) extends SourceInfoTransformMacro {
     val tpe = weakTypeOf[T]
     q"$thisObj.do_apply[$tpe]($source)($implicitSourceInfo)"
   }
+  def sourceApplyWithColor[T: c.WeakTypeTag](source: c.Tree, color: c.Tree): c.Tree = {
+    val tpe = weakTypeOf[T]
+    q"$thisObj.do_apply[$tpe]($source, Some($color))($implicitSourceInfo)"
+  }
   def sourceRead[T: c.WeakTypeTag](source: c.Tree): c.Tree = {
     val tpe = weakTypeOf[T]
     q"$thisObj.do_read[$tpe]($source)($implicitSourceInfo)"

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -141,8 +141,8 @@ class PanamaCIRCTConverter {
         case fir.UIntType(width)                                => getWidthOrSentinel(width)
         case fir.SIntType(width)                                => getWidthOrSentinel(width)
         case fir.AnalogType(width)                              => getWidthOrSentinel(width)
-        case fir.ProbeType(underlying)                          => getWidthOrSentinel(underlying)
-        case fir.RWProbeType(underlying)                        => getWidthOrSentinel(underlying)
+        case fir.ProbeType(underlying, _)                       => getWidthOrSentinel(underlying)
+        case fir.RWProbeType(underlying, _)                     => getWidthOrSentinel(underlying)
         case _: fir.BundleType | _: fir.VectorType => -2
         case unhandled => throw new Exception(s"unhandled: $unhandled")
       }
@@ -170,15 +170,15 @@ class PanamaCIRCTConverter {
               )
             )
           )
-        case fir.ProbeType(underlying)   => circt.firrtlTypeGetRef(convert(underlying), false)
-        case fir.RWProbeType(underlying) => circt.firrtlTypeGetRef(convert(underlying), true)
-        case fir.AnyRefPropertyType      => circt.firrtlTypeGetAnyRef()
-        case fir.IntegerPropertyType     => circt.firrtlTypeGetInteger()
-        case fir.DoublePropertyType      => circt.firrtlTypeGetDouble()
-        case fir.StringPropertyType      => circt.firrtlTypeGetString()
-        case fir.BooleanPropertyType     => circt.firrtlTypeGetBoolean()
-        case fir.PathPropertyType        => circt.firrtlTypeGetPath()
-        case t: fir.SequencePropertyType => circt.firrtlTypeGetList(convert(t.tpe))
+        case fir.ProbeType(underlying, _)   => circt.firrtlTypeGetRef(convert(underlying), false)
+        case fir.RWProbeType(underlying, _) => circt.firrtlTypeGetRef(convert(underlying), true)
+        case fir.AnyRefPropertyType         => circt.firrtlTypeGetAnyRef()
+        case fir.IntegerPropertyType        => circt.firrtlTypeGetInteger()
+        case fir.DoublePropertyType         => circt.firrtlTypeGetDouble()
+        case fir.StringPropertyType         => circt.firrtlTypeGetString()
+        case fir.BooleanPropertyType        => circt.firrtlTypeGetBoolean()
+        case fir.PathPropertyType           => circt.firrtlTypeGetPath()
+        case t: fir.SequencePropertyType    => circt.firrtlTypeGetList(convert(t.tpe))
         case t: fir.ClassPropertyType =>
           circt.firrtlTypeGetClass(
             circt.mlirFlatSymbolRefAttrGet(t.name),

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -313,7 +313,9 @@ object BoringUtils {
     * Returns a probe Data type.
     */
   def tap[A <: Data](source: A)(implicit si: SourceInfo): A = {
-    val tapIntermediate = skipPrefix { boreOrTap(source, createProbe = Some(ProbeInfo(writable = false))) }
+    val tapIntermediate = skipPrefix {
+      boreOrTap(source, createProbe = Some(ProbeInfo(writable = false, color = None)))
+    }
     if (tapIntermediate.probeInfo.nonEmpty) {
       tapIntermediate
     } else {
@@ -328,7 +330,7 @@ object BoringUtils {
     * Returns a probe Data type.
     */
   def rwTap[A <: Data](source: A)(implicit si: SourceInfo): A = {
-    val tapIntermediate = skipPrefix { boreOrTap(source, createProbe = Some(ProbeInfo(writable = true))) }
+    val tapIntermediate = skipPrefix { boreOrTap(source, createProbe = Some(ProbeInfo(writable = true, color = None))) }
     if (tapIntermediate.probeInfo.nonEmpty) {
       tapIntermediate
     } else {
@@ -343,7 +345,9 @@ object BoringUtils {
     * Returns a non-probe Data type.
     */
   def tapAndRead[A <: Data](source: A)(implicit si: SourceInfo): A = {
-    val tapIntermediate = skipPrefix { boreOrTap(source, createProbe = Some(ProbeInfo(writable = false))) }
+    val tapIntermediate = skipPrefix {
+      boreOrTap(source, createProbe = Some(ProbeInfo(writable = false, color = None)))
+    }
     if (tapIntermediate.probeInfo.nonEmpty) {
       probe.read(tapIntermediate)
     } else {


### PR DESCRIPTION
This adds Layer Colors to Probe types.

This is an existing part of the FIRRTL 3.2.0 "groups" feature which is being expanded/clarified in FIRRTL 4.0.0. This enables a probe to be associated/colored with a layer.  This enables a layerblock to define probes of the same color.

This feature is used to construct simple interfaces of probes whose defines require complicated logic that does not exist inside the interface. Consider a situation where you have a simple single-cycle microprocessor. You'd like to expose a simple commit trace that is the last four instructions. However, the microprocessor does not actually record the last four instructions. It only keeps track of the current instruction. What do you do? If you put the logic outside the microprocessor, then your interface has changed. If you put the logic inside the microprocessor, you're adding junk that shouldn't be there.

Layer colored probes provide a way to hide this logic in a layer while still keeping a clean interface.

(This example is intentionally simple---a real world example is computing an in-order commit trace for an out-of-order processor where you need to assemble all the instructions committing out-of-order.)

The example below shows a realization of the basic example above:

``` scala
//> using scala "2.13.12"
//> using lib "org.chipsalliance::chisel::6.0.0-M3+191-d3177dda-SNAPSHOT"
//> using plugin "org.chipsalliance:::chisel-plugin::6.0.0-M3+191-d3177dda-SNAPSHOT"
//> using options "-unchecked", "-deprecation", "-language:reflectiveCalls", "-feature", "-Xcheckinit", "-Xfatal-warnings", "-Ywarn-dead-code", "-Ywarn-unused", "-Ymacro-annotations"

import chisel3._
import chisel3.probe.{Probe, ProbeValue, define, read}
import chisel3.layer.{Layer, Convention, block}
import circt.stage.ChiselStage

object Verification extends Layer(Convention.Bind)

class DUT extends Module {
  val a = IO(Input(UInt(32.W)))
  val b = IO(Output(UInt(32.W)))
  val trace = IO(Output(Probe(Vec(4, UInt(32.W)), Verification)))

  val pc = Reg(UInt(32.W))
  pc :<>= a
  b :<>= pc

  block(Verification) {
    val committedInstructions = Reg(Vec(4, UInt(32.W)))
    committedInstructions(0) :<>= pc
    committedInstructions(1) :<>= committedInstructions(0)
    committedInstructions(2) :<>= committedInstructions(1)
    committedInstructions(3) :<>= committedInstructions(2)

    define(trace, ProbeValue(committedInstructions))
  }

}

class TestHarness extends Module {
  val a = IO(Input(UInt(32.W)))
  val b = IO(Output(UInt(32.W)))

  val dut = Module(new DUT)
  dut.a :<>= a
  b :<>= dut.b

  block(Verification) {
    printf("The last four PC's are: %x, %x, %x, %x", read(dut.trace(0)), read(dut.trace(1)), read(dut.trace(2)), read(dut.trace(3)))
  }
}

object Main extends App {
  println(ChiselStage.emitCHIRRTL(new TestHarness))
  println(
    ChiselStage.emitSystemVerilog(
      gen = new TestHarness,
      firtoolOpts = Array("-disable-all-randomization", "-strip-debug-info")
    )
  )
}
```

Using a series of patches to enable this in CIRCT (https://github.com/llvm/circt/pull/6552, https://github.com/llvm/circt/pull/6574, and https://github.com/llvm/circt/pull/6554) based on updates to the FIRRTL spec (https://github.com/chipsalliance/firrtl-spec/pull/160), this produces the following FIRRTL and Verilog:

```
FIRRTL version 3.3.0
circuit TestHarness :
  declgroup Verification, bind :
  module DUT :
    input clock : Clock
    input reset : Reset
    input a : UInt<32>
    output b : UInt<32>
    output trace : Probe<UInt<32>[4], Verification>

    reg pc : UInt<32>, clock
    connect pc, a
    connect b, pc
    group Verification :
      reg committedInstructions : UInt<32>[4], clock
      connect committedInstructions[0], pc
      connect committedInstructions[1], committedInstructions[0]
      connect committedInstructions[2], committedInstructions[1]
      connect committedInstructions[3], committedInstructions[2]
      define trace = probe(committedInstructions)


  module TestHarness :
    input clock : Clock
    input reset : UInt<1>
    input a : UInt<32>
    output b : UInt<32>

    inst dut of DUT
    connect dut.clock, clock
    connect dut.reset, reset
    connect dut.a, a
    connect b, dut.b
    group Verification :
      node _T = eq(reset, UInt<1>(0h0))
      when _T :
        printf(clock, UInt<1>(0h1), "The last four PC's are: %x, %x, %x, %x", read(dut.trace[0]), read(dut.trace[1]), read(dut.trace[2]), read(dut.trace[3])) : printf
```

``` verilog
// Generated by CIRCT firtool-1.61.0-116-gd585c5b8a
// Standard header to adapt well known macros for prints and assertions.

// Users can define 'PRINTF_COND' to add an extra gate to prints.
`ifndef PRINTF_COND_
  `ifdef PRINTF_COND
    `define PRINTF_COND_ (`PRINTF_COND)
  `else  // PRINTF_COND
    `define PRINTF_COND_ 1
  `endif // PRINTF_COND
`endif // not def PRINTF_COND_

module DUT_Verification(
  input        _clock,
  input [31:0] _pc
);

  reg  [31:0] committedInstructions_0;
  wire [31:0] committedInstructions_0_probe = committedInstructions_0;
  reg  [31:0] committedInstructions_1;
  wire [31:0] committedInstructions_1_probe = committedInstructions_1;
  reg  [31:0] committedInstructions_2;
  wire [31:0] committedInstructions_2_probe = committedInstructions_2;
  reg  [31:0] committedInstructions_3;
  wire [31:0] committedInstructions_3_probe = committedInstructions_3;
  always
    committedInstructions_0 <= _pc;
    committedInstructions_1 <= committedInstructions_0;
    committedInstructions_2 <= committedInstructions_1;
    committedInstructions_3 <= committedInstructions_2;
  end // always
endmodule

module DUT(
  input         clock,
  input  [31:0] a,
  output [31:0] b
);

  reg [31:0] pc;
  always
    pc <= a;
  assign b = pc;
endmodule

module TestHarness_Verification(
  input        _reset,
  input [31:0] _dut_trace_0,
               _dut_trace_1,
               _dut_trace_2,
               _dut_trace_3,
  input        _clock
);

  `ifndef SYNTHESIS
    always
      if ((`PRINTF_COND_) & ~_reset)
        $fwrite(32'h80000002, "The last four PC's are: %x, %x, %x, %x", _dut_trace_0,
                _dut_trace_1, _dut_trace_2, _dut_trace_3);
    end // always
  `endif // not def SYNTHESIS
endmodule

module TestHarness(
  input         clock,
                reset,
  input  [31:0] a,
  output [31:0] b
);

  DUT dut (
    .clock (clock),
    .a     (a),
    .b     (b)
  );
endmodule


// ----- 8< ----- FILE "groups_TestHarness_Verification.sv" ----- 8< -----

// Generated by CIRCT firtool-1.61.0-116-gd585c5b8a
`ifndef groups_TestHarness_Verification
`define groups_TestHarness_Verification
bind DUT DUT_Verification dUT_Verification (
  ._clock (clock),
  ._pc    (pc)
);
bind TestHarness TestHarness_Verification testHarness_Verification (
  ._reset       (reset),
  ._dut_trace_0 (TestHarness.dut.dUT_Verification.committedInstructions_0_probe),
  ._dut_trace_1 (TestHarness.dut.dUT_Verification.committedInstructions_1_probe),
  ._dut_trace_2 (TestHarness.dut.dUT_Verification.committedInstructions_2_probe),
  ._dut_trace_3 (TestHarness.dut.dUT_Verification.committedInstructions_3_probe),
  ._clock       (clock)
);
`endif // groups_TestHarness_Verification
```

The resulting Verilog has a clean DUT (no junk!). There is collateral in a bind file that can be used to "enable" the Verification layer. This then uses Verilog hierarchical names to pass information from the bound module in the DUT (which computes all the logic that we don't want in the DUT) to a bound module in the TestHarness (which consumes this). The circuit is valid (no illegal hierarchical names) whether or not the Verification layer is enabled.