### PR TITLE
Support === on empty Aggregates

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -908,7 +908,8 @@ object Data {
             thiz.elementsIterator
               .zip(that.elementsIterator)
               .map { case (thisData, thatData) => thisData === thatData }
-              .reduce(_ && _)
+              .reduceOption(_ && _) // forall but that isn't defined for Bool on Seq
+              .getOrElse(true.B)
           }
         case (thiz: Record, that: Record) =>
           if (thiz._elements.size != that._elements.size) {
@@ -932,7 +933,8 @@ object Data {
                     )
                 }
             }
-              .reduce(_ && _)
+              .reduceOption(_ && _) // forall but that isn't defined for Bool on Seq
+              .getOrElse(true.B)
           }
         // This should be matching to (DontCare, DontCare) but the compiler wasn't happy with that
         case (_: DontCare.type, _: DontCare.type) => true.B

--- a/src/test/scala/chiselTests/DataEqualitySpec.scala
+++ b/src/test/scala/chiselTests/DataEqualitySpec.scala
@@ -70,6 +70,9 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
     val a = UInt(8.W)
     val b: Bundle = gen
   }
+  class MaybeEmptyBundle(x: Boolean) extends Bundle {
+    val a = Option.when(x)(UInt(8.W))
+  }
 
   behavior.of("UInt === UInt")
   it should "pass with equal values" in {
@@ -140,6 +143,14 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
       )
     }
   }
+  it should "support empty Vecs" in {
+    assertTesterPasses {
+      new EqualityTester(
+        Wire(Vec(0, UInt(8.W))),
+        Wire(Vec(0, UInt(8.W)))
+      )
+    }
+  }
   it should "fail with equal sizes, differing values" in {
     assertTesterFails {
       new EqualityTester(
@@ -165,6 +176,14 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
       new EqualityTester(
         (new MyBundle).Lit(_.a -> 42.U, _.b -> false.B, _.c -> MyEnum.sB),
         (new MyBundle).Lit(_.a -> 42.U, _.b -> false.B, _.c -> MyEnum.sB)
+      )
+    }
+  }
+  it should "support empty Bundles" in {
+    assertTesterPasses {
+      new EqualityTester(
+        (new MaybeEmptyBundle(false)).Lit(),
+        (new MaybeEmptyBundle(false)).Lit()
       )
     }
   }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.5.x`, `3.6.x`, or `5.x` depending on impact, API modification or big change: `6.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
