### PR TITLE
Add DataMirror.getLayerColor

### DIFF
--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -61,9 +61,8 @@ object DataMirror {
     * @param x the `Data` to examine
     * @return a `Some[Layer]` if the data has a layer color, `None` otherwise
     */
-  def getLayerColor(x: Data): Option[layer.Layer] = x.probeInfo match {
-    case None                           => None
-    case Some(Data.ProbeInfo(_, color)) => color
+  def getLayerColor(x: Data): Option[layer.Layer] = x.probeInfo.collect {
+    case Data.ProbeInfo(_, Some(color)) => color
   }
 
   /** Get an early guess for the name of this [[Data]]

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -57,6 +57,15 @@ object DataMirror {
     */
   def hasProbeTypeModifier(x: Data): Boolean = x.probeInfo.nonEmpty
 
+  /** Return the optional layer color of a `Data`.
+    * @param x the `Data` to examine
+    * @return a `Some[Layer]` if the data has a layer color, `None` otherwise
+    */
+  def getLayerColor(x: Data): Option[layer.Layer] = x.probeInfo match {
+    case None                           => None
+    case Some(Data.ProbeInfo(_, color)) => color
+  }
+
   /** Get an early guess for the name of this [[Data]]
     *
     * '''Warning: it is not guaranteed that this name will end up in the output FIRRTL or Verilog.'''

--- a/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests.reflect
 
 import chisel3._
+import chisel3.probe.Probe
 import chisel3.reflect.DataMirror
 import chiselTests.ChiselFlatSpec
 import circt.stage.ChiselStage
@@ -176,6 +177,26 @@ class DataMirrorSpec extends ChiselFlatSpec {
 
     // Check ground type.
     assert(DataMirror.isFullyAligned(UInt(8.W)))
+  }
+
+  "getLayerColor" should "return a layer color if one exists" in {
+    object A extends layer.Layer(layer.Convention.Bind)
+    class Foo extends Bundle {
+      val a = Bool()
+      val b = Probe(Bool())
+      val c = Probe(Bool(), A)
+    }
+
+    val foo = new Foo
+
+    info("a non-probe returns None")
+    DataMirror.getLayerColor(foo.a) should be(None)
+
+    info("an uncolored probe returns None")
+    DataMirror.getLayerColor(foo.b) should be(None)
+
+    info("a probe colored with A returns Some(A)")
+    DataMirror.getLayerColor(foo.c) should be(Some(A))
   }
 
 }


### PR DESCRIPTION
Add a utility to reflect on the optional color of a layer.  This will be used by libraries that need to know if they need to put generated logic in a layerblock or not.

#### Release Notes

Add `DataMirror.getLayerColor` API to return the optional layer color of a `Data`.