### PR TITLE
Convert cloneType to an extension method

### DIFF
--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -41,7 +41,7 @@ abstract class EnumType(private[chisel3] val factory: ChiselEnum, selfAnnotating
     }
   }
 
-  override def cloneType: this.type = factory().asInstanceOf[this.type]
+  override protected def _cloneType: Data = factory()
 
   private[chisel3] def compop(sourceInfo: SourceInfo, op: PrimOp, other: EnumType): Bool = {
     requireIsHardware(this, "bits operated on")
@@ -386,7 +386,8 @@ private[chisel3] object EnumMacros {
 // This is an enum type that can be connected directly to UInts. It is used as a "glue" to cast non-literal UInts
 // to enums.
 private[chisel3] class UnsafeEnum(override val width: Width) extends EnumType(UnsafeEnum, selfAnnotating = false) {
-  override def cloneType: this.type = new UnsafeEnum(width).asInstanceOf[this.type]
+
+  override protected def _cloneType: Data = new UnsafeEnum(width)
 }
 private object UnsafeEnum extends ChiselEnum
 

--- a/core/src/main/scala/chisel3/Clock.scala
+++ b/core/src/main/scala/chisel3/Clock.scala
@@ -17,7 +17,7 @@ object Clock {
 sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element {
   override def toString: String = stringAccessor("Clock")
 
-  def cloneType: this.type = Clock().asInstanceOf[this.type]
+  override protected def _cloneType: Data = Clock()
 
   override def connect(that: Data)(implicit sourceInfo: SourceInfo): Unit =
     that match {

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -672,28 +672,12 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   private[chisel3] def width: Width
   private[chisel3] def firrtlConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit
 
-  /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
+  /** Private implementation of cloneType
     *
-    * cloneType must be defined for any Chisel object extending Data.
-    * It is responsible for constructing a basic copy of the object being cloned.
-    *
-    * @return a copy of the object.
+    * _cloneType must be defined for any Chisel object extending Data.
+    * It is implemented by Chisel itself or by the compiler plugin for user-defined types.
     */
-  def cloneType: this.type
-
-  /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
-    *
-    * Returns a copy of this data type, with hardware bindings (if any) removed.
-    * Directionality data and probe information is still preserved.
-    */
-  private[chisel3] def cloneTypeFull: this.type = {
-    val clone = this.cloneType // get a fresh object, without bindings
-    // Only the top-level direction needs to be fixed up, cloneType should do the rest
-    clone.specifiedDirection = specifiedDirection
-    probe.setProbeModifier(clone, probeInfo)
-    clone.isConst = isConst
-    clone
-  }
+  protected def _cloneType: Data
 
   /** The "strong connect" operator.
     *
@@ -892,6 +876,7 @@ object Data {
     *
     * @param lhs The [[Data]] hardware on the left-hand side of the equality
     */
+  // TODO fold this into DataExtensions
   implicit class DataEquality[T <: Data](lhs: T)(implicit sourceInfo: SourceInfo) {
 
     /** Dynamic recursive equality operator for generic [[Data]]
@@ -951,6 +936,33 @@ object Data {
         // Runtime types are different
         case (thiz, that) => throwException(s"Cannot compare $thiz and $that: Runtime types differ")
       }
+    }
+  }
+
+  implicit class DataExtensions[T <: Data](self: T) {
+
+    /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
+      *
+      * cloneType must be defined for any Chisel object extending Data.
+      * It is responsible for constructing a basic copy of the object being cloned.
+      *
+      * @return a copy of the object.
+      */
+    def cloneType: T = self._cloneType.asInstanceOf[T]
+
+    /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
+      *
+      * Returns a copy of this data type, with hardware bindings (if any) removed.
+      * Directionality data and probe information is still preserved.
+      */
+    private[chisel3] def cloneTypeFull: T = {
+      val clone = self.cloneType // get a fresh object, without bindings
+      // Only the top-level direction needs to be fixed up, cloneType should do the rest
+      clone.specifiedDirection = self.specifiedDirection
+      // TODO do we need to exclude probe and const from cloneTypeFull on Properties?
+      probe.setProbeModifier(clone, self.probeInfo)
+      clone.isConst = self.isConst
+      clone
     }
   }
 }
@@ -1124,7 +1136,8 @@ final case object DontCare extends Element with connectable.ConnectableDocs {
   private[chisel3] override val width: Width = UnknownWidth()
 
   bind(DontCareBinding(), SpecifiedDirection.Output)
-  override def cloneType: this.type = DontCare
+
+  override protected def _cloneType: Data = DontCare
 
   override def toString: String = "DontCare()"
 

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -353,7 +353,7 @@ package internal {
     private[chisel3] class ClonePorts(elts: (String, Data)*) extends Record {
       val elements = ListMap(elts.map { case (name, d) => name -> d.cloneTypeFull }: _*)
       def apply(field: String) = elements(field)
-      override def cloneType = (new ClonePorts(elts: _*)).asInstanceOf[this.type]
+      override protected def _cloneTypeImpl: Record = (new ClonePorts(elts: _*))
     }
 
     private[chisel3] def cloneIORecord(

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -33,7 +33,7 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
 
   override def litOption: Option[BigInt] = None
 
-  def cloneType: this.type = new Analog(width).asInstanceOf[this.type]
+  override protected def _cloneType: Data = new Analog(width)
 
   // Used to enforce single bulk connect of Analog types, multi-attach is still okay
   // Note that this really means 1 bulk connect per Module because a port can

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -114,7 +114,8 @@ package object experimental {
   object BundleLiterals {
     implicit class AddBundleLiteralConstructor[T <: Record](x: T) {
       def Lit(elems: (T => (Data, Data))*)(implicit sourceInfo: SourceInfo): T = {
-        x._makeLit(elems: _*)
+        val fs = elems.map(_.asInstanceOf[Data => (Data, Data)])
+        x._makeLit(fs: _*).asInstanceOf[T]
       }
     }
   }

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -264,18 +264,8 @@ sealed trait Property[T] extends Element { self =>
 
   /** Clone type by simply constructing a new Property[T].
     */
-  override def cloneType: this.type = new Property[T] {
+  override protected def _cloneType: Data = new Property[T] {
     val tpe = self.tpe
-  }.asInstanceOf[this.type]
-
-  /** Clone type with extra information preserved.
-    *
-    * The only extra information present on a Property type is directionality.
-    */
-  private[chisel3] override def cloneTypeFull: this.type = {
-    val clone = this.cloneType
-    clone.specifiedDirection = specifiedDirection
-    clone
   }
 
   /** Get the IR PropertyType for this Property.


### PR DESCRIPTION
This removes much of the use of this.type in Chisel which is necessary to upgrade to Scala 3.

There is still `this.type` used for other purposes:
* suggestName
* autoSeed
* LitArg
* ChiselEnum

I figure we can fix these in multiple IRs, this is the biggest one that is the most likely to cause breakages. While this is almost entirely source compatible, you may notice a few places I had to add `this.` in front of a `cloneType`. It will break any code where the user calls `cloneType` from within a `Bundle` or `Record` but leaves of the implicit `this.`. I'm not sure how big of an issue this is, we could potentially warn about it with the compiler plugin on 6.x.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification



#### Desired Merge Strategy


- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
