### PR TITLE
Support isLit for Property types.

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -246,6 +246,16 @@ sealed trait Property[T] extends Element { self =>
   }
 
   override def litOption: Option[BigInt] = None
+
+  /** Return whether this Property is a literal.
+    *
+    * Since we override litOption to always be None, we need to override this method to check the Binding.
+    */
+  override def isLit: Boolean = topBindingOpt match {
+    case Some(PropertyValueBinding) => true
+    case _                          => false
+  }
+
   def toPrintable: Printable = {
     throwException(s"Properties do not support hardware printing" + this._errorContext)
   }

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -607,4 +607,14 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
       "propassign flatModule.prop.int, Integer(1)"
     )()
   }
+
+  it should "support isLit" in {
+    ChiselStage.emitCHIRRTL(new RawModule {
+      val port = IO(Input(Property[Int]()))
+      val lit = Property(1)
+
+      port.isLit shouldBe false
+      lit.isLit shouldBe true
+    })
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Since we override litOption to always be None, we need to override isLit to check the Binding.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
