### PR TITLE
Support isProperty query in DataMirror.

### DIFF
--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.internal._
 import chisel3.internal.firrtl.ir._
 import chisel3.experimental.{requireIsHardware, BaseModule, SourceInfo}
+import chisel3.properties.Property
 import scala.reflect.ClassTag
 
 object DataMirror {
@@ -50,6 +51,15 @@ object DataMirror {
     * @return `true` if x is a Reg, `false` otherwise
     */
   def isReg(x: Data): Boolean = hasBinding[RegBinding](x)
+
+  /** Check if a given `Data` is a Property
+    * @param x the `Data` to check
+    * @return `true` if x is a Property, `false` otherwise
+    */
+  def isProperty(x: Data): Boolean = x match {
+    case _: Property[_] => true
+    case _ => false
+  }
 
   /** Check if a given `Data` is a Probe
     * @param x the `Data` to check

--- a/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
@@ -4,6 +4,7 @@ package chiselTests.reflect
 
 import chisel3._
 import chisel3.probe.Probe
+import chisel3.properties.Property
 import chisel3.reflect.DataMirror
 import chiselTests.ChiselFlatSpec
 import circt.stage.ChiselStage
@@ -123,6 +124,16 @@ class DataMirrorSpec extends ChiselFlatSpec {
 
   it should "not support name guesses for non-hardware" in {
     an[ExpectedHardwareException] should be thrownBy DataMirror.queryNameGuess(UInt(8.W))
+  }
+
+  it should "support querying if a Data is a Property" in {
+    ChiselStage.emitCHIRRTL(new RawModule {
+      val notProperty = IO(Input(Bool()))
+      val property = IO(Input(Property[Int]()))
+
+      DataMirror.isProperty(notProperty) shouldBe false
+      DataMirror.isProperty(property) shouldBe true
+    })
   }
 
   "chiselTypeClone" should "preserve Scala type information" in {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
This adds an API to DataMirror to query if a Data is a Property.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
