### PR TITLE
Bump to FIRRTL 4.0.0

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -15,7 +15,7 @@ object Serializer {
   val Indent = "  "
 
   // The version supported by the serializer.
-  val version = Version(3, 3, 0)
+  val version = Version(4, 0, 0)
 
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.
@@ -230,7 +230,7 @@ object Serializer {
             indent -= 1
           case LayerBlockBegin(info, layer) =>
             doIndent()
-            b ++= s"group $layer :"; s(info)
+            b ++= s"layerblock $layer :"; s(info)
             indent += 1
           case LayerBlockEnd =>
             indent -= 1
@@ -527,7 +527,7 @@ object Serializer {
     val layers = if (circuit.layers.nonEmpty) {
       implicit val b = new StringBuilder
       def layerIt(layer: Layer)(implicit indent: Int): Unit = {
-        b ++= s"${NewLine}"; doIndent(); b ++= s"declgroup ${layer.name}, ${layer.convention} :"
+        b ++= s"${NewLine}"; doIndent(); b ++= s"layer ${layer.name}, ${layer.convention} :"
         s(layer.info)
         layer.body.foreach(layerIt(_)(indent + 1))
       }

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -8,7 +8,7 @@ import firrtl.testutils._
 class ExtModuleTests extends FirrtlFlatSpec {
   "extmodule" should "serialize and re-parse equivalently" in {
     val input =
-      """|FIRRTL version 3.3.0
+      """|FIRRTL version 4.0.0
          |circuit Top :
          |  extmodule Top :
          |    input y : UInt<0>

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -38,11 +38,11 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     info("CHIRRTL emission looks coorect")
     // TODO: Switch to FileCheck for this testing.  This is going to miss all sorts of ordering issues.
     matchesAndOmits(chirrtl)(
-      "declgroup A, bind :",
-      "declgroup B, bind :",
-      "group A :",
+      "layer A, bind :",
+      "layer B, bind :",
+      "layerblock A :",
       "wire w : UInt<1>",
-      "group B :",
+      "layerblock B :",
       "wire x : UInt<1>",
       "wire y : UInt<1>"
     )()

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -1001,7 +1001,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
       val text = ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo(hasDontTouch = true))
       info("found a version string")
-      text should include("FIRRTL version 3.3.0")
+      text should include("FIRRTL version 4.0.0")
       info("found an Annotation")
       text should include("firrtl.transforms.DontTouchAnnotation")
       info("found a circuit")


### PR DESCRIPTION
Bump emission to use FIRRTL 4.0.0.  Since Chisel is now emitting layer-colored probes and the work-in-progress "enablelayer" keyword, Chisel needs to emit a version of FIRRTL that compilers will accept.

The only change to the output (other than the stated version) is "groups" are now changed to "layers".

Note: FIRRTL 4.0.0 is not finalized yet.