### PR TITLE
Add Property expressions, starting with addition.

### DIFF
--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -3,9 +3,11 @@
 package chisel3.internal
 
 import chisel3._
-import chisel3.experimental.BaseModule
-import chisel3.internal.firrtl.ir.{LitArg, PropertyLit}
+import chisel3.experimental.{BaseModule, SourceInfo}
+import chisel3.internal.firrtl.ir.{Arg, LitArg, PropertyLit}
 import chisel3.properties.Class
+
+import _root_.firrtl.ir.{PropPrimOp, PropertyType}
 
 import scala.collection.immutable.VectorMap
 
@@ -176,3 +178,16 @@ private[chisel3] case class BundleLitBinding(litMap: Map[Data, LitArg]) extends 
 private[chisel3] case class VecLitBinding(litMap: VectorMap[Data, LitArg]) extends LitBinding
 // Literal binding attached to a Property.
 private[chisel3] case object PropertyValueBinding extends UnconstrainedBinding with ReadOnlyBinding
+
+/** Binding for Property expressions.
+  *
+  * This binding is a little different, because Property expressions don't emit Nodes, so we sore all the information we
+  * need to create an in-memory Arg that captures the operation and operands.
+  *
+  * @param sourceInfo Source location where the expression was created
+  * @param enclosure BaseModule where the expression was created
+  * @param op Primitive operation for this expression
+  * @param args Arguments to this expression
+  */
+private[chisel3] case class PropExprBinding(sourceInfo: SourceInfo, enclosure: BaseModule, op: PropPrimOp, args: Arg*)
+    extends ConstrainedBinding

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -3,11 +3,9 @@
 package chisel3.internal
 
 import chisel3._
-import chisel3.experimental.{BaseModule, SourceInfo}
-import chisel3.internal.firrtl.ir.{Arg, LitArg, PropertyLit}
+import chisel3.experimental.BaseModule
+import chisel3.internal.firrtl.ir.{LitArg, PropertyLit}
 import chisel3.properties.Class
-
-import _root_.firrtl.ir.{PropPrimOp, PropertyType}
 
 import scala.collection.immutable.VectorMap
 
@@ -178,16 +176,3 @@ private[chisel3] case class BundleLitBinding(litMap: Map[Data, LitArg]) extends 
 private[chisel3] case class VecLitBinding(litMap: VectorMap[Data, LitArg]) extends LitBinding
 // Literal binding attached to a Property.
 private[chisel3] case object PropertyValueBinding extends UnconstrainedBinding with ReadOnlyBinding
-
-/** Binding for Property expressions.
-  *
-  * This binding is a little different, because Property expressions don't emit Nodes, so we sore all the information we
-  * need to create an in-memory Arg that captures the operation and operands.
-  *
-  * @param sourceInfo Source location where the expression was created
-  * @param enclosure BaseModule where the expression was created
-  * @param op Primitive operation for this expression
-  * @param args Arguments to this expression
-  */
-private[chisel3] case class PropExprBinding(sourceInfo: SourceInfo, enclosure: BaseModule, op: PropPrimOp, args: Arg*)
-    extends ConstrainedBinding

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -100,7 +100,7 @@ private[chisel3] object Converter {
       fir.RWProbeExpr(convert(probe, ctx, info))
     case e @ ProbeRead(probe) =>
       fir.ProbeRead(convert(probe, ctx, info))
-    case PropExpr(info, tpe, op, args @ _*) =>
+    case PropExpr(info, tpe, op, args) =>
       fir.PropExpr(convert(info), tpe, op, args.map(convert(_, ctx, info)))
     case other =>
       throw new InternalErrorException(s"Unexpected type in convert $other")

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -100,6 +100,8 @@ private[chisel3] object Converter {
       fir.RWProbeExpr(convert(probe, ctx, info))
     case e @ ProbeRead(probe) =>
       fir.ProbeRead(convert(probe, ctx, info))
+    case PropExpr(info, tpe, op, args @ _*) =>
+      fir.PropExpr(convert(info), tpe, op, args.map(convert(_, ctx, info)))
     case other =>
       throw new InternalErrorException(s"Unexpected type in convert $other")
   }

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -186,6 +186,15 @@ private[chisel3] object ir {
     }
   }
 
+  /** Property expressions.
+    *
+    * Property expressions are conceptually similar to Nodes, but only exist as a tree of Args in-memory.
+    */
+  case class PropExpr(sourceInfo: SourceInfo, tpe: firrtlir.PropertyType, op: firrtlir.PropPrimOp, args: Arg*)
+      extends Arg {
+    def name: String = throwException("Internal Error! PropExpr has no name")
+  }
+
   case class Ref(name: String) extends Arg
 
   /** Arg for ports of Modules

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -192,6 +192,9 @@ private[chisel3] object ir {
     */
   case class PropExpr(sourceInfo: SourceInfo, tpe: firrtlir.PropertyType, op: firrtlir.PropPrimOp, args: List[Arg])
       extends Arg {
+    // PropExpr is different from other Args, because this is only used as an internal data structure, and we never name
+    // the Arg or use the name in textual FIRRTL. This is always expected to be the exp of a PropAssign, and it would be
+    // an internal error to request the name.
     def name: String = throwException("Internal Error! PropExpr has no name")
   }
 

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -190,7 +190,7 @@ private[chisel3] object ir {
     *
     * Property expressions are conceptually similar to Nodes, but only exist as a tree of Args in-memory.
     */
-  case class PropExpr(sourceInfo: SourceInfo, tpe: firrtlir.PropertyType, op: firrtlir.PropPrimOp, args: Arg*)
+  case class PropExpr(sourceInfo: SourceInfo, tpe: firrtlir.PropertyType, op: firrtlir.PropPrimOp, args: List[Arg])
       extends Arg {
     def name: String = throwException("Internal Error! PropExpr has no name")
   }

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -324,6 +324,8 @@ sealed trait Property[T] extends Element { self =>
     }
   }
 
+  final def +(that: Property[T])(implicit ev: PropertyArithmeticOps[Property[T]], sourceInfo: SourceInfo): Property[T] =
+    ev.add(this, that)
 }
 
 private[chisel3] sealed trait ClassTypeProvider[A] {
@@ -341,9 +343,30 @@ private[chisel3] object ClassTypeProvider {
 
 /** Typeclass for Property arithmetic.
   */
-trait PropertyArithmeticOps[T] {}
+trait PropertyArithmeticOps[T] {
+  def add(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
+}
 
 object PropertyArithmeticOps {
+  // Type class instances for Property arithmetic.
+  implicit val intArithmeticOps: PropertyArithmeticOps[Property[Int]] =
+    new PropertyArithmeticOps[Property[Int]] {
+      def add(lhs: Property[Int], rhs: Property[Int])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.PropPrimOp.AddOp, lhs, rhs)
+    }
+
+  implicit val longArithmeticOps: PropertyArithmeticOps[Property[Long]] =
+    new PropertyArithmeticOps[Property[Long]] {
+      def add(lhs: Property[Long], rhs: Property[Long])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.PropPrimOp.AddOp, lhs, rhs)
+    }
+
+  implicit val bigIntArithmeticOps: PropertyArithmeticOps[Property[BigInt]] =
+    new PropertyArithmeticOps[Property[BigInt]] {
+      def add(lhs: Property[BigInt], rhs: Property[BigInt])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.PropPrimOp.AddOp, lhs, rhs)
+    }
+
   // Helper function to create Property expression bindings.
   private def binOp[T: PropertyType](
     sourceInfo: SourceInfo,

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -374,12 +374,17 @@ object PropertyArithmeticOps {
     lhs:        Property[T],
     rhs:        Property[T]
   ): Property[T] = {
+    implicit val info = sourceInfo
+
     val result = Property[T]()
     val enclosure = Builder.referenceUserContainer
     result.bind(
       PropExprBinding(sourceInfo, enclosure, op, lhs.ref, rhs.ref)
     )
-    result.asInstanceOf[Property[T]]
+
+    val _wire = Wire(chiselTypeOf(result))
+    _wire := result
+    _wire.asInstanceOf[Property[T]]
   }
 }
 

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -340,6 +340,7 @@ private[chisel3] object ClassTypeProvider {
 
 /** Typeclass for Property arithmetic.
   */
+@implicitNotFound("arithmetic operations are not supported on Property type ${T}")
 trait PropertyArithmeticOps[T] {
   def add(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
 }

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -379,7 +379,7 @@ object PropertyArithmeticOps {
       case cls: Class     => result.bind(ClassBinding(cls))
       case _ => throwException("Internal Error! Property expression can only occur within RawModule or Class.")
     }
-    result.setRef(ir.PropExpr(sourceInfo, result.tpe.getPropertyType(), op, lhs.ref, rhs.ref))
+    result.setRef(ir.PropExpr(sourceInfo, result.tpe.getPropertyType(), op, List(lhs.ref, rhs.ref)))
 
     val _wire = Wire(chiselTypeOf(result))
     _wire := result

--- a/docs/src/explanations/properties.md
+++ b/docs/src/explanations/properties.md
@@ -114,3 +114,35 @@ class SequenceExample extends RawModule {
   outPort2 := Property(Seq(inPort, Property(789)))
 }
 ```
+
+### Property Expressions
+
+Expressions can be built out of `Property` values for certain `Property` types.
+This is useful for expressing design intent that is parameterized by input
+`Property` values.
+
+#### Integer Arithmetic
+
+The integral `Property` types, like `Property[Int]`, `Property[Long]` and 
+`Property[BigInt]`, can be used to build arithmetic expressions in terms of
+`Property` values.
+
+In the following example, an output `address` port of `Property[Int]` type is
+computed as the addition of an `offset` `Property[Int]` value relative to an 
+input `base` `Property[Int]` value.
+
+```scala mdoc:silent
+class IntegerArithmeticExample extends RawModule {
+  val base = IO(Input(Property[Int]()))
+  val address = IO(Output(Property[Int]()))
+  val offset = Property(1024)
+  address := base + offset
+}
+```
+
+The following table lists the possible arithmetic operators that are supported
+on integral `Property` typed values.
+
+| Operation | Description                                                |
+| --------- | -----------                                                |
+| `+`       | Perform addition as defined by FIRRTL spec section 25.1.1. |

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -260,7 +260,11 @@ case class SequencePropertyValue(tpe: Type, values: Seq[Expression]) extends Exp
 /** Property primitive operations.
   */
 sealed trait PropPrimOp
-object PropPrimOp {}
+object PropPrimOp {
+  case object AddOp extends PropPrimOp {
+    override def toString(): String = "integer_add"
+  }
+}
 
 /** Property expressions.
   *

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -259,12 +259,10 @@ case class SequencePropertyValue(tpe: Type, values: Seq[Expression]) extends Exp
 
 /** Property primitive operations.
   */
-sealed trait PropPrimOp
-object PropPrimOp {
-  case object AddOp extends PropPrimOp {
-    override def toString(): String = "integer_add"
-  }
+sealed abstract class PropPrimOp(name: String) {
+  override def toString: String = name
 }
+case object IntegerAddOp extends PropPrimOp("integer_add")
 
 /** Property expressions.
   *

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -257,6 +257,25 @@ case class PathPropertyLiteral(value: String) extends Expression with UseSeriali
 
 case class SequencePropertyValue(tpe: Type, values: Seq[Expression]) extends Expression with UseSerializer
 
+/** Property primitive operations.
+  */
+sealed trait PropPrimOp
+object PropPrimOp {}
+
+/** Property expressions.
+  *
+  * Unlike other primitives, Property expressions serialize as a tree directly in their rvalue context.
+  */
+case class PropExpr(info: Info, tpe: Type, op: PropPrimOp, args: Seq[Expression])
+    extends Expression
+    with UseSerializer {
+  override def serialize: String = {
+    val serializedOp = op.toString()
+    val serializedArgs = args.map(_.serialize).mkString("(", ", ", ")")
+    serializedOp + serializedArgs
+  }
+}
+
 case class DoPrim(op: PrimOp, args: Seq[Expression], consts: Seq[BigInt], tpe: Type)
     extends Expression
     with UseSerializer

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -644,14 +644,14 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
       "wire w : Integer",
       "propassign w, t",
       "propassign c, t",
-      "wire _d_WIRE : Integer",
-      "propassign _d_WIRE, integer_add(t, a)",
-      "propassign d, _d_WIRE",
-      "wire _e_WIRE",
-      "propassign _e_WIRE, integer_add(a, b)",
-      "wire _e_WIRE_1",
-      "propassign _e_WIRE_1, integer_add(w, _e_WIRE)",
-      "propassign e, _e_WIRE_1"
+      "wire _d_propExpr : Integer",
+      "propassign _d_propExpr, integer_add(t, a)",
+      "propassign d, _d_propExpr",
+      "wire _e_propExpr",
+      "propassign _e_propExpr, integer_add(a, b)",
+      "wire _e_propExpr_1",
+      "propassign _e_propExpr_1, integer_add(w, _e_propExpr)",
+      "propassign e, _e_propExpr_1"
     )()
   }
 
@@ -733,9 +733,9 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      "wire _c_WIRE : Integer",
-      "propassign _c_WIRE, integer_add(a, b)",
-      "propassign c, _c_WIRE"
+      "wire _c_propExpr : Integer",
+      "propassign _c_propExpr, integer_add(a, b)",
+      "propassign c, _c_propExpr"
     )()
   }
 }

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -8,6 +8,7 @@ import chiselTests.{ChiselFlatSpec, MatchesAndOmits}
 import circt.stage.ChiselStage
 import chisel3.properties.ClassType
 import chisel3.properties.AnyClassType
+import chisel3.util.experimental.BoringUtils
 
 class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
   behavior.of("Property")
@@ -638,10 +639,45 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      "propassign w, integer_add(a, b)",
+      "wire t : Integer",
+      "propassign t, integer_add(a, b)",
+      "wire w : Integer",
+      "propassign w, t",
+      "propassign c, t",
+      "wire _d_WIRE : Integer",
+      "propassign _d_WIRE, integer_add(t, a)",
+      "propassign d, _d_WIRE",
+      "wire _e_WIRE",
+      "propassign _e_WIRE, integer_add(a, b)",
+      "wire _e_WIRE_1",
+      "propassign _e_WIRE_1, integer_add(w, _e_WIRE)",
+      "propassign e, _e_WIRE_1"
+    )()
+  }
+
+  it should "support boring from expressions" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val child = Module(new RawModule {
+        val a = IO(Input(Property[Int]()))
+        val b = IO(Input(Property[Int]()))
+        val c = a + b
+      })
+
+      val a = IO(Input(Property[Int]()))
+      val b = IO(Input(Property[Int]()))
+      val c = IO(Output(Property[Int]()))
+
+      child.a := a
+      child.b := a
+      c := BoringUtils.bore(child.c)
+    })
+
+    matchesAndOmits(chirrtl)(
+      "output c_bore : Integer",
+      "wire c : Integer",
       "propassign c, integer_add(a, b)",
-      "propassign d, integer_add(integer_add(a, b), a)",
-      "propassign e, integer_add(w, integer_add(a, b))"
+      "propassign c_bore, c",
+      "propassign c, child.c_bore"
     )()
   }
 
@@ -654,7 +690,9 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     })
 
     matchesAndOmits(chirrtl)(
-      "propassign c, integer_add(a, b)"
+      "wire _c_WIRE : Integer",
+      "propassign _c_WIRE, integer_add(a, b)",
+      "propassign c, _c_WIRE"
     )()
   }
 }

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -3,7 +3,7 @@
 package chiselTests.properties
 
 import chisel3._
-import chisel3.properties.{Class, Path, Property, PropertyType}
+import chisel3.properties.{Class, DynamicObject, Path, Property, PropertyType}
 import chiselTests.{ChiselFlatSpec, MatchesAndOmits}
 import circt.stage.ChiselStage
 import chisel3.properties.ClassType
@@ -707,6 +707,21 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
       val b = Property[String]()
       a + b
     """)
+  }
+
+  it should "not support expressions in Classes, and give a nice error" in {
+    val e = the[ChiselException] thrownBy (ChiselStage.emitCHIRRTL(new RawModule {
+      DynamicObject(new Class {
+        val a = IO(Input(Property[BigInt]()))
+        val b = IO(Input(Property[BigInt]()))
+        val c = IO(Output(Property[BigInt]()))
+        c := a + b
+      })
+    }))
+
+    e.getMessage should include(
+      "Property arithmetic is currently only supported in RawModules @[src/test/scala/chiselTests/properties/PropertySpec.scala"
+    )
   }
 
   it should "support addition" in {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
This allows Properties to be used to build up expressions in terms of input Properties and literals.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
