### PR TITLE
Add Public trait to create public FIRRTL modules

### DIFF
--- a/core/src/main/scala/chisel3/Public.scala
+++ b/core/src/main/scala/chisel3/Public.scala
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import chisel3.internal.Builder
+
+/** A trait that can be mixed into a Chisel module to indicate that a module has external users.
+  *
+  * This will result in a public FIRRTL module being produced.
+  */
+trait Public { this: RawModule =>
+  isPublic = true
+}

--- a/core/src/main/scala/chisel3/Public.scala
+++ b/core/src/main/scala/chisel3/Public.scala
@@ -2,12 +2,18 @@
 
 package chisel3
 
-import chisel3.internal.Builder
-
 /** A trait that can be mixed into a Chisel module to indicate that a module has external users.
   *
   * This will result in a public FIRRTL module being produced.
   */
 trait Public { this: RawModule =>
-  isPublic = true
+
+  override private[chisel3] def _isPublic = isPublic
+
+  /** Is this module public?
+    *
+    * Users can override this if they need more control over when outputs of this Module should
+    * be considered public
+    */
+  def isPublic: Boolean = true
 }

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -114,7 +114,7 @@ abstract class RawModule extends BaseModule {
   }
 
   /** Private variable that tracks if a module is public. */
-  private[chisel3] var isPublic: Boolean = false
+  private[chisel3] def _isPublic: Boolean = false
 
   /** Finalize name for an id created during this RawModule's constructor.
     *
@@ -196,7 +196,7 @@ abstract class RawModule extends BaseModule {
     // Generate IO invalidation commands to initialize outputs as unused,
     //  unless the client wants explicit control over their generation.
     val component =
-      DefModule(this, name, isPublic, Builder.enabledLayers.toSeq, firrtlPorts, _commands.result())
+      DefModule(this, name, _isPublic, Builder.enabledLayers.toSeq, firrtlPorts, _commands.result())
 
     // Secret connections can be staged if user bored into children modules
     component.secretCommands ++= stagedSecretCommands

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -113,6 +113,9 @@ abstract class RawModule extends BaseModule {
     }
   }
 
+  /** Private variable that tracks if a module is public. */
+  private[chisel3] var isPublic: Boolean = false
+
   /** Finalize name for an id created during this RawModule's constructor.
     *
     * @param id The id to finalize.
@@ -192,7 +195,8 @@ abstract class RawModule extends BaseModule {
 
     // Generate IO invalidation commands to initialize outputs as unused,
     //  unless the client wants explicit control over their generation.
-    val component = DefModule(this, name, Builder.enabledLayers.toSeq, firrtlPorts, _commands.result())
+    val component =
+      DefModule(this, name, isPublic, Builder.enabledLayers.toSeq, firrtlPorts, _commands.result())
 
     // Secret connections can be staged if user bored into children modules
     component.secretCommands ++= stagedSecretCommands

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1067,7 +1067,14 @@ private[chisel3] object Builder extends LazyLogging {
 
       // Make the main module (the last component) public.
       components.last match {
-        case module: DefModule => components.update(components.size - 1, module.copy(isPublic = true))
+        case module: DefModule =>
+          components.update(
+            components.size - 1, {
+              val newModule = module.copy(isPublic = true)
+              newModule.secretCommands ++= module.secretCommands
+              newModule
+            }
+          )
         case _ =>
       }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1065,6 +1065,12 @@ private[chisel3] object Builder extends LazyLogging {
           )
       }
 
+      // Make the main module (the last component) public.
+      components.last match {
+        case module: DefModule => components.update(components.size - 1, module.copy(isPublic = true))
+        case _ =>
+      }
+
       (
         Circuit(
           components.last.name,

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -456,10 +456,11 @@ private[chisel3] object Converter {
   }
 
   def convert(component: Component, typeAliases: Seq[String]): fir.DefModule = component match {
-    case ctx @ DefModule(id, name, layers, ports, cmds) =>
+    case ctx @ DefModule(id, name, public, layers, ports, cmds) =>
       fir.Module(
         convert(id._getSourceLocator),
         name,
+        public,
         layers.map(_.fullName),
         (ports ++ ctx.secretPorts).map(p => convert(p, typeAliases)),
         convert(cmds ++ ctx.secretCommands, ctx, typeAliases)

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -361,6 +361,7 @@ private[chisel3] object ir {
   case class DefModule(
     id:       RawModule,
     name:     String,
+    isPublic: Boolean,
     layers:   Seq[chisel3.layer.Layer],
     ports:    Seq[Port],
     commands: Seq[Command])

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -84,7 +84,7 @@ package object internal {
     // Sigil to mark views, starts with '_' to make it a legal FIRRTL target
     override def desiredName = "_$$View$$_"
 
-    private[chisel3] val fakeComponent: Component = DefModule(this, desiredName, Nil, Nil, Nil)
+    private[chisel3] val fakeComponent: Component = DefModule(this, desiredName, false, Nil, Nil, Nil)
   }
 
   /** Special internal object representing the parent of all views

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -634,7 +634,7 @@ abstract class DefModule extends FirrtlNode with IsDeclaration {
   *
   * An instantiable hardware block
   */
-case class Module(info: Info, name: String, layers: Seq[String], ports: Seq[Port], body: Statement)
+case class Module(info: Info, name: String, public: Boolean, layers: Seq[String], ports: Seq[Port], body: Statement)
     extends DefModule
     with UseSerializer
 

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -447,10 +447,13 @@ object Serializer {
   }
 
   private def sIt(node: DefModule)(implicit indent: Int): Iterator[String] = node match {
-    case Module(info, name, layers, ports, body) =>
+    case Module(info, name, public, layers, ports, body) =>
       val start = {
         implicit val b = new StringBuilder
-        doIndent(0); b ++= "module "; b ++= legalize(name);
+        doIndent(0);
+        if (public)
+          b ++= "public "
+        b ++= "module "; b ++= legalize(name);
         layers.foreach(l => b ++= s" enablelayer $l")
         b ++= " :"; s(info)
         ports.foreach { p => newLineAndIndent(1); s(p) }

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -43,6 +43,7 @@ object SerializerSpec {
     Module(
       NoInfo,
       "test",
+      false,
       Seq.empty,
       Seq(Port(NoInfo, "in", Input, UIntType(IntWidth(8))), Port(NoInfo, "out", Output, UIntType(IntWidth(8)))),
       Block(
@@ -100,6 +101,7 @@ object SMemTestCircuit {
         Module(
           NoInfo,
           "Example",
+          false,
           Seq.empty,
           Seq.empty,
           Block(
@@ -290,7 +292,7 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
     Serializer.serialize(Circuit(NoInfo, Seq.empty[DefModule], "42_Circuit")) should include("circuit `42_Circuit`")
 
     info("modules okay!")
-    Serializer.serialize(Module(NoInfo, "42_module", Seq.empty, Seq.empty, Block(Seq.empty))) should include(
+    Serializer.serialize(Module(NoInfo, "42_module", false, Seq.empty, Seq.empty, Block(Seq.empty))) should include(
       "module `42_module`"
     )
     // TODO: an external module with a numeric defname should probably be rejected

--- a/firrtl/src/test/scala/firrtlTests/stage/FirrtlOptionsViewSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/stage/FirrtlOptionsViewSpec.scala
@@ -20,6 +20,7 @@ class FirrtlOptionsViewSpec extends AnyFlatSpec with Matchers {
       ir.Module(
         ir.NoInfo,
         main,
+        false,
         Seq.empty,
         Seq.empty,
         ir.Block(

--- a/src/main/scala/chisel3/aop/injecting/InjectingPhase.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingPhase.scala
@@ -38,7 +38,7 @@ class InjectingPhase extends Phase {
               m.copy(body = ir.Block(m.body +: addStmtMap(m.name)))
             case m: _root_.firrtl.ir.ExtModule if addStmtMap.contains(m.name) =>
               logger.debug(s"Injecting to ${m.name} with statement: \n${ir.Block(addStmtMap(m.name)).serialize}")
-              ir.Module(m.info, m.name, Nil, m.ports, ir.Block(addStmtMap(m.name)))
+              ir.Module(m.info, m.name, false, Nil, m.ports, ir.Block(addStmtMap(m.name)))
             case other: ir.DefModule => other
           }
         }

--- a/src/test/scala/chiselTests/PublicModuleSpec.scala
+++ b/src/test/scala/chiselTests/PublicModuleSpec.scala
@@ -34,10 +34,9 @@ class PublicModuleSpec extends ChiselFlatSpec with MatchesAndOmits {
     matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
       "module Baz",
       "public module Bar",
-      "module Foo"
-    )(
-      "public module Baz",
       "public module Foo"
+    )(
+      "public module Baz"
     )
 
   }

--- a/src/test/scala/chiselTests/PublicModuleSpec.scala
+++ b/src/test/scala/chiselTests/PublicModuleSpec.scala
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.probe.{Probe, ProbeValue, define}
+import circt.stage.ChiselStage
+
+class PublicModuleSpec extends ChiselFlatSpec with MatchesAndOmits {
+
+  class Baz extends RawModule
+
+  class Bar extends RawModule with Public {
+    val a = IO(Output(Probe(Bool())))
+    val baz = Module(new Baz)
+
+    val b = WireInit(Bool(), true.B)
+    dontTouch(b)
+
+    define(a, ProbeValue(b))
+  }
+
+  class Foo extends RawModule {
+    val a = IO(Output(Probe(Bool())))
+    val bar = Module(new Bar)
+    define(a, bar.a)
+  }
+
+  "The main module" should "be marked public" in {
+
+    println(ChiselStage.emitCHIRRTL(new Foo))
+    println(ChiselStage.emitSystemVerilog(new Foo))
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+      "module Baz",
+      "public module Bar",
+      "module Foo"
+    )(
+      "public module Baz",
+      "public module Foo"
+    )
+
+  }
+
+}

--- a/src/test/scala/chiselTests/PublicModuleSpec.scala
+++ b/src/test/scala/chiselTests/PublicModuleSpec.scala
@@ -22,18 +22,24 @@ class PublicModuleSpec extends ChiselFlatSpec with MatchesAndOmits {
     val bar = Module(new Bar)
   }
 
-  "The main module" should "be marked public" in {
+  val chirrtl = ChiselStage.emitCHIRRTL(new Foo)
 
-    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
-      "module Qux",
-      "module Baz",
-      "public module Bar",
-      "public module Foo"
-    )(
-      "public module Qux",
-      "public module Baz"
-    )
+  "the main module" should "be implicitly public" in {
+    chirrtl should include("public module Foo")
+  }
 
+  "non-main modules" should "be implicitly private" in {
+    matchesAndOmits(chirrtl)("module Qux")("public module Qux")
+  }
+
+  behavior.of("the Public trait")
+
+  it should "cause a module that mixes it in to be public" in {
+    chirrtl should include("public module Bar")
+  }
+
+  it should "allow making a module that mixes it in private via an override" in {
+    matchesAndOmits(chirrtl)("module Baz")("public module Baz")
   }
 
 }

--- a/src/test/scala/chiselTests/PublicModuleSpec.scala
+++ b/src/test/scala/chiselTests/PublicModuleSpec.scala
@@ -28,9 +28,6 @@ class PublicModuleSpec extends ChiselFlatSpec with MatchesAndOmits {
 
   "The main module" should "be marked public" in {
 
-    println(ChiselStage.emitCHIRRTL(new Foo))
-    println(ChiselStage.emitSystemVerilog(new Foo))
-
     matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
       "module Baz",
       "public module Bar",

--- a/src/test/scala/chiselTests/PublicModuleSpec.scala
+++ b/src/test/scala/chiselTests/PublicModuleSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.probe.{Probe, ProbeValue, define}
+import chisel3.probe.{define, Probe, ProbeValue}
 import circt.stage.ChiselStage
 
 class PublicModuleSpec extends ChiselFlatSpec with MatchesAndOmits {

--- a/src/test/scala/circtTests/stage/phases/AddImplicitOutputFileSpec.scala
+++ b/src/test/scala/circtTests/stage/phases/AddImplicitOutputFileSpec.scala
@@ -19,6 +19,7 @@ class AddImplicitOutputFileSpec extends AnyFlatSpec with Matchers {
       ir.Module(
         ir.NoInfo,
         "foo",
+        false,
         Seq.empty,
         Seq.empty,
         ir.Block(


### PR DESCRIPTION
Add a new trait, `Public`, which can be used to emit FIRRTL modules which have the public keyword.  This is a weak form of "public modules" that we want to support for FIRRTL 4.0.0.  This does not allow for multiple, disjoint instance graphs to be contained in a circuit, nor does it remove the "main module" from the circuit.  However, it provides a mechanism for plucking modules out of a circuit later and working with them.

This is self-typed on `RawModule` to prevent mix-in to an external module.

For the included test Chisel:

```scala
class Baz extends RawModule

class Bar extends RawModule with Public {
  val baz = Module(new Baz)
}

class Foo extends RawModule {
  val bar = Module(new Bar)
}
```

This produces the following FIRRTL. Note the `public` keyword:

```
FIRRTL version 4.0.0
circuit Foo :
  module Baz :

    skip

  public module Bar :

    inst baz of Baz

  public module Foo :

    inst bar of Bar
```

And Verilog. Note that `Bar` is not eliminated because it is public while `Baz` is:

```verilog
// Generated by CIRCT firtool-1.65.0
module Bar();
endmodule

module Foo();
  Bar bar ();
endmodule
```

### Release Notes

Add `Public` keyword to create public FIRRTL modules.