### PR TITLE
Update BoringUtils test for FIRRTL 4.0

### DIFF
--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -341,8 +341,8 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       ".v_0_out (", // rwprobe target.
       ".v_1_in  (inputs_1)", // rwprobe target.
       // Ref ABI.  Names of internal signals are subject to change.
-      "`define ref_Foo_Foo_outV_0_out child.v_0_out",
-      "`define ref_Foo_Foo_outV_1_in child.v_1_in"
+      "`define ref_Foo_outV_0_out child.v_0_out",
+      "`define ref_Foo_outV_1_in child.v_1_in"
     )("v_1_out")
   }
 


### PR DESCRIPTION
Fix a BoringUtils test that was checking for the name of a define produce by CIRCT.  This was changed slightly in FIRRTL 4.0.  Align the test with the new Verilog macro name.