### PR TITLE
Revert "Shift right produce at least 1 bit width result (#3752)"

### DIFF
--- a/core/src/main/scala/chisel3/Width.scala
+++ b/core/src/main/scala/chisel3/Width.scala
@@ -13,7 +13,7 @@ sealed abstract class Width {
   def max(that:              Width): Width = this.op(that, _ max _)
   def +(that:                Width): Width = this.op(that, _ + _)
   def +(that:                Int):   Width = this.op(this, (a, b) => a + that)
-  def shiftRight(that:       Int): Width = this.op(this, (a, b) => 1.max(a - that))
+  def shiftRight(that:       Int): Width = this.op(this, (a, b) => 0.max(a - that))
   def dynamicShiftLeft(that: Width): Width =
     this.op(that, (a, b) => a + (1 << b) - 1)
 

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -211,11 +211,6 @@ class UIntLitZeroWidthTester extends BasicTester {
   stop()
 }
 
-class ShiftRightResultAtLeast1BitWidth extends BasicTester {
-  assert((0.U(32.W) >> 32).getWidth == 1)
-  stop()
-}
-
 class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
 
   property("Bools can be created from 1 bit UInts") {
@@ -489,9 +484,5 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
     })
     chirrtl should include("connect y, a")
     chirrtl should include("connect z, b")
-  }
-
-  property("Shift right should be result in at least 1 bit width") {
-    assertTesterPasses(new ShiftRightResultAtLeast1BitWidth)
   }
 }


### PR DESCRIPTION
Revert changes to the width of static shift right.  Originally, Chisel would return a 0-bit value.  However, this violated the FIRRTL spec which mandated that this return a 1-bit value.  FIRRTL compilers would then clean this up, however, if a user looks at the Chisel-determined width they would get the wrong answer.

Commit 1634320ce299775307aafa4ffbffe8e18022e81f made Chisel align with FIRRTL.  After additional discussion, it was decided that the best course of action was to make FIRRTL _align with Chisel_ for UInt, but not for SInt.  Specifically, the following behaviors are what we want to move towards:

  1. The smallest width of a UInt shifted right is 0-bit
  2. The smallest width of an SInt shifted right is 1-bit

This will then be handled with changes to the FIRRTL spec and by FIRRTL compilers.  In the mean time, do not introduce incorrect behavior in Chisel and preserve things the way they were.

This reverts commit 1634320ce299775307aafa4ffbffe8e18022e81f.