### PR TITLE
Fix visibility for views

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -584,12 +584,15 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   private[chisel3] def isVisible: Boolean = isVisibleFromModule && visibleFromWhen.isEmpty
   private[chisel3] def isVisibleFromModule: Boolean = {
+    val topBindingOpt = this.topBindingOpt // Only call the function once
     val mod = topBindingOpt.flatMap(_.location)
     topBindingOpt match {
       case Some(tb: TopBinding) if (mod == Builder.currentModule) => true
       case Some(pb: PortBinding)
           if mod.flatMap(Builder.retrieveParent(_, Builder.currentModule.get)) == Builder.currentModule =>
         true
+      case Some(ViewBinding(target))           => target.isVisibleFromModule
+      case Some(AggregateViewBinding(mapping)) => mapping.values.forall(_.isVisibleFromModule)
       case Some(pb: SecretPortBinding) => true // Ignore secret to not require visibility
       case Some(_: UnconstrainedBinding) => true
       case _ => false

--- a/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
@@ -9,6 +9,8 @@ import chisel3.reflect.DataMirror
 import chiselTests.ChiselFlatSpec
 import circt.stage.ChiselStage
 import chisel3.util.DecoupledIO
+import chisel3.experimental.hierarchy._
+import chisel3.experimental.dataview._
 
 object DataMirrorSpec {
   import org.scalatest.matchers.should.Matchers._
@@ -16,25 +18,51 @@ object DataMirrorSpec {
     val internal = WireInit(false.B)
     DataMirror.getParent(this) should be(Some(parent))
     DataMirror.isVisible(internal) should be(true)
+    DataMirror.isVisible(internal.viewAs[Bool]) should be(true)
   }
+  @instantiable
   class Child(parent: RawModule) extends Module {
     val inst = Module(new GrandChild(this))
-    val io = IO(Input(Bool()))
+    @public val io = IO(Input(Bool()))
     val internal = WireInit(false.B)
+    lazy val underWhen = WireInit(false.B)
+    when(true.B) {
+      underWhen := true.B // trigger the lazy val
+      DataMirror.isVisible(underWhen) should be(true)
+      DataMirror.isVisible((internal, underWhen).viewAs) should be(true)
+    }
+    val mixedView = (io, underWhen).viewAs
     DataMirror.getParent(inst) should be(Some(this))
     DataMirror.getParent(this) should be(Some(parent))
     DataMirror.isVisible(io) should be(true)
+    DataMirror.isVisible(io.viewAs[Bool]) should be(true)
     DataMirror.isVisible(internal) should be(true)
+    DataMirror.isVisible(internal.viewAs[Bool]) should be(true)
     DataMirror.isVisible(inst.internal) should be(false)
+    DataMirror.isVisible(inst.internal.viewAs[Bool]) should be(false)
+    DataMirror.isVisible(underWhen) should be(false)
+    DataMirror.isVisible(underWhen.viewAs) should be(false)
+    DataMirror.isVisible(mixedView) should be(false)
+    DataMirror.isVisible(mixedView._1) should be(true)
   }
+  @instantiable
   class Parent extends Module {
-    val inst = Module(new Child(this))
-    inst.io := false.B
+    @public val io = IO(Input(Bool()))
+    @public val inst = Module(new Child(this))
+    @public val internal = WireInit(io)
+    @public val tuple = (io, internal).viewAs
+    inst.io := internal
     DataMirror.getParent(inst) should be(Some(this))
     DataMirror.getParent(this) should be(None)
     DataMirror.isVisible(inst.io) should be(true)
+    DataMirror.isVisible(inst.io.viewAs[Bool]) should be(true)
     DataMirror.isVisible(inst.internal) should be(false)
+    DataMirror.isVisible(inst.internal.viewAs[Bool]) should be(false)
     DataMirror.isVisible(inst.inst.internal) should be(false)
+    DataMirror.isVisible(inst.inst.internal.viewAs[Bool]) should be(false)
+    DataMirror.isVisible(inst.mixedView) should be(false)
+    DataMirror.isVisible(inst.mixedView._1) should be(true)
+    DataMirror.isVisible(tuple) should be(true)
   }
 }
 
@@ -88,16 +116,23 @@ class DataMirrorSpec extends ChiselFlatSpec {
     ChiselStage.emitCHIRRTL(new MyModule)
   }
 
-  it should "support getParent for normal modules" in {
+  it should "support getParent and isVisible for normal modules" in {
     ChiselStage.emitCHIRRTL(new Parent)
   }
 
-  it should "support getParent for normal modules even when used in a D/I context" in {
-    import chisel3.experimental.hierarchy._
+  it should "support getParent and isVisible for normal modules even when used in a D/I context" in {
     class Top extends Module {
       val defn = Definition(new Parent)
       val inst = Instance(defn)
       DataMirror.getParent(this) should be(None)
+      DataMirror.isVisible(inst.io) should be(true)
+      DataMirror.isVisible(inst.io.viewAs) should be(true)
+      DataMirror.isVisible(inst.inst.io) should be(false)
+      DataMirror.isVisible(inst.inst.io.viewAs) should be(false)
+      DataMirror.isVisible(inst.internal) should be(false)
+      DataMirror.isVisible(inst.internal.viewAs) should be(false)
+      DataMirror.isVisible(inst.tuple) should be(false)
+      DataMirror.isVisible(inst.tuple._1) should be(true)
     }
     ChiselStage.emitCHIRRTL(new Top)
   }


### PR DESCRIPTION
A latent issue with how Binding and lexical scope checking (aka visiblity) works in Chisel is that it is assumes a single "location" for a given Data. Aggregate Views can have multiple locations so this logic needs to be generalized. I started doing that work but it's a much larger overhaul than I was willing to commit to for a bug fix, so I ditched that idea and did something more focused. We do need to make that change eventually though.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->

- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

`DataMirror.isVisible` and other things checking visibility now work properly for views.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
