### PR TITLE
Change the width of static shift right

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -677,7 +677,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
   override def do_<<(that: UInt)(implicit sourceInfo: SourceInfo): UInt =
     binop(sourceInfo, UInt(this.width.dynamicShiftLeft(that.width)), DynamicShiftLeftOp, that)
   override def do_>>(that: Int)(implicit sourceInfo: SourceInfo): UInt =
-    binop(sourceInfo, UInt(this.width.shiftRight(that)), ShiftRightOp, validateShiftAmount(that))
+    binop(sourceInfo, UInt(this.width.unsignedShiftRight(that)), ShiftRightOp, validateShiftAmount(that))
   override def do_>>(that: BigInt)(implicit sourceInfo: SourceInfo): UInt =
     this >> castToInt(that, "Shift amount")
   override def do_>>(that: UInt)(implicit sourceInfo: SourceInfo): UInt =
@@ -990,7 +990,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
   override def do_<<(that: UInt)(implicit sourceInfo: SourceInfo): SInt =
     binop(sourceInfo, SInt(this.width.dynamicShiftLeft(that.width)), DynamicShiftLeftOp, that)
   override def do_>>(that: Int)(implicit sourceInfo: SourceInfo): SInt =
-    binop(sourceInfo, SInt(this.width.shiftRight(that)), ShiftRightOp, validateShiftAmount(that))
+    binop(sourceInfo, SInt(this.width.signedShiftRight(that)), ShiftRightOp, validateShiftAmount(that))
   override def do_>>(that: BigInt)(implicit sourceInfo: SourceInfo): SInt =
     this >> castToInt(that, "Shift amount")
   override def do_>>(that: UInt)(implicit sourceInfo: SourceInfo): SInt =

--- a/core/src/main/scala/chisel3/Width.scala
+++ b/core/src/main/scala/chisel3/Width.scala
@@ -9,12 +9,18 @@ object Width {
 
 sealed abstract class Width {
   type W = Int
-  def min(that:              Width): Width = this.op(that, _ min _)
-  def max(that:              Width): Width = this.op(that, _ max _)
-  def +(that:                Width): Width = this.op(that, _ + _)
-  def +(that:                Int):   Width = this.op(this, (a, b) => a + that)
-  def shiftRight(that:       Int): Width = this.op(this, (a, b) => 0.max(a - that))
-  def dynamicShiftLeft(that: Width): Width =
+  def min(that: Width): Width = this.op(that, _ min _)
+  def max(that: Width): Width = this.op(that, _ max _)
+  def +(that:   Width): Width = this.op(that, _ + _)
+  def +(that:   Int):   Width = this.op(this, (a, b) => a + that)
+  @deprecated(
+    "The width of shift-right now differs by type, use unsignedShiftRight and signedShiftRight",
+    "Chisel 7.0.0"
+  )
+  def shiftRight(that:         Int): Width = this.op(this, (a, b) => 0.max(a - that))
+  def unsignedShiftRight(that: Int): Width = this.op(this, (a, b) => 0.max(a - that))
+  def signedShiftRight(that:   Int): Width = this.op(this, (a, b) => 1.max(a - that))
+  def dynamicShiftLeft(that:   Width): Width =
     this.op(that, (a, b) => a + (1 << b) - 1)
 
   def known: Boolean

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -104,6 +104,7 @@ object Definition extends SourceInfoDoc {
       new DynamicContext(
         Nil,
         context.throwOnFirstError,
+        context.legacyShiftRightWidth,
         context.warningFilters,
         context.sourceRoots,
         Some(context.globalNamespace),

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -446,11 +446,12 @@ private[chisel3] class ChiselContext() {
 }
 
 private[chisel3] class DynamicContext(
-  val annotationSeq:     AnnotationSeq,
-  val throwOnFirstError: Boolean,
-  val warningFilters:    Seq[WarningFilter],
-  val sourceRoots:       Seq[File],
-  val defaultNamespace:  Option[Namespace],
+  val annotationSeq:         AnnotationSeq,
+  val throwOnFirstError:     Boolean,
+  val legacyShiftRightWidth: Boolean,
+  val warningFilters:        Seq[WarningFilter],
+  val sourceRoots:           Seq[File],
+  val defaultNamespace:      Option[Namespace],
   // Definitions from other scopes in the same elaboration, use allDefinitions below
   val outerScopeDefinitions: List[Iterable[Definition[_]]]) {
   val importedDefinitionAnnos = annotationSeq.collect { case a: ImportDefinitionAnnotation[_] => a }
@@ -925,6 +926,8 @@ private[chisel3] object Builder extends LazyLogging {
     val "2" :: major :: _ :: Nil = chisel3.BuildInfo.scalaVersion.split("\\.").toList
     major.toInt
   }
+
+  def legacyShiftRightWidth: Boolean = dynamicContextVar.value.map(_.legacyShiftRightWidth).getOrElse(false)
 
   // Builds a RenameMap for all Views that do not correspond to a single Data
   // These Data give a fake ReferenceTarget for .toTarget and .toReferenceTarget that the returned

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -61,6 +61,7 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
         new DynamicContext(
           annotationsInAspect,
           chiselOptions.throwOnFirstError,
+          chiselOptions.legacyShiftRightWidth,
           chiselOptions.warningFilters,
           chiselOptions.sourceRoots,
           None,

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -361,3 +361,29 @@ object ChiselOutputFileAnnotation extends HasShellOptions {
   * @tparam DUT Type of the top-level Chisel design
   */
 case class DesignAnnotation[DUT <: RawModule](design: DUT) extends NoTargetAnnotation with Unserializable
+
+/** Use legacy Chisel shift-right behavior
+  *
+  * '''This should only be used for checking for unexpected semantic changes when bumping to Chisel 7.0.0'''
+  *
+  * Use as CLI option `--legacy-shift-right-width`.
+  *
+  * This behavior is inconsistent between Chisel and FIRRTL
+  * - Chisel will report the width of a UInt or SInt shifted right by a number >= its width as a 0-bit value
+  * - FIRRTL will implement the width for these UInts and SInts as 1-bit
+  */
+case object UseLegacyShiftRightWidthBehavior
+    extends NoTargetAnnotation
+    with ChiselOption
+    with HasShellOptions
+    with Unserializable {
+
+  val options = Seq(
+    new ShellOption[Unit](
+      longOption = "legacy-shift-right-width",
+      toAnnotationSeq = _ => Seq(UseLegacyShiftRightWidthBehavior),
+      helpText = "Use legacy (buggy) shift right width behavior (pre Chisel 7.0.0)"
+    )
+  )
+
+}

--- a/src/main/scala/chisel3/stage/ChiselOptions.scala
+++ b/src/main/scala/chisel3/stage/ChiselOptions.scala
@@ -7,20 +7,22 @@ import chisel3.internal.WarningFilter
 import java.io.File
 
 class ChiselOptions private[stage] (
-  val printFullStackTrace: Boolean = false,
-  val throwOnFirstError:   Boolean = false,
-  val outputFile:          Option[String] = None,
-  val chiselCircuit:       Option[Circuit] = None,
-  val sourceRoots:         Vector[File] = Vector.empty,
-  val warningFilters:      Vector[WarningFilter] = Vector.empty) {
+  val printFullStackTrace:   Boolean = false,
+  val throwOnFirstError:     Boolean = false,
+  val outputFile:            Option[String] = None,
+  val chiselCircuit:         Option[Circuit] = None,
+  val sourceRoots:           Vector[File] = Vector.empty,
+  val warningFilters:        Vector[WarningFilter] = Vector.empty,
+  val legacyShiftRightWidth: Boolean = false) {
 
   private[stage] def copy(
-    printFullStackTrace: Boolean = printFullStackTrace,
-    throwOnFirstError:   Boolean = throwOnFirstError,
-    outputFile:          Option[String] = outputFile,
-    chiselCircuit:       Option[Circuit] = chiselCircuit,
-    sourceRoots:         Vector[File] = sourceRoots,
-    warningFilters:      Vector[WarningFilter] = warningFilters
+    printFullStackTrace:   Boolean = printFullStackTrace,
+    throwOnFirstError:     Boolean = throwOnFirstError,
+    outputFile:            Option[String] = outputFile,
+    chiselCircuit:         Option[Circuit] = chiselCircuit,
+    sourceRoots:           Vector[File] = sourceRoots,
+    warningFilters:        Vector[WarningFilter] = warningFilters,
+    legacyShiftRightWidth: Boolean = legacyShiftRightWidth
   ): ChiselOptions = {
 
     new ChiselOptions(
@@ -29,7 +31,8 @@ class ChiselOptions private[stage] (
       outputFile = outputFile,
       chiselCircuit = chiselCircuit,
       sourceRoots = sourceRoots,
-      warningFilters = warningFilters
+      warningFilters = warningFilters,
+      legacyShiftRightWidth = legacyShiftRightWidth
     )
 
   }

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -29,6 +29,7 @@ package object stage {
           case SourceRootAnnotation(s)       => c.copy(sourceRoots = c.sourceRoots :+ s)
           case a: WarningConfigurationAnnotation     => c.copy(warningFilters = c.warningFilters ++ a.filters)
           case a: WarningConfigurationFileAnnotation => c.copy(warningFilters = c.warningFilters ++ a.filters)
+          case UseLegacyShiftRightWidthBehavior => c.copy(legacyShiftRightWidth = true)
         }
       }
 

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -33,6 +33,7 @@ class Elaborate extends Phase {
           new DynamicContext(
             annotations,
             chiselOptions.throwOnFirstError,
+            chiselOptions.legacyShiftRightWidth,
             chiselOptions.warningFilters,
             chiselOptions.sourceRoots,
             None,

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -10,6 +10,7 @@ import chisel3.stage.{
   PrintFullStackTraceAnnotation,
   SourceRootAnnotation,
   ThrowOnFirstErrorAnnotation,
+  UseLegacyShiftRightWidthBehavior,
   WarningConfigurationAnnotation,
   WarningConfigurationFileAnnotation,
   WarningsAsErrorsAnnotation
@@ -37,6 +38,7 @@ trait CLI { this: BareShell =>
     ChiselGeneratorAnnotation,
     PrintFullStackTraceAnnotation,
     ThrowOnFirstErrorAnnotation,
+    UseLegacyShiftRightWidthBehavior,
     WarningsAsErrorsAnnotation,
     WarningConfigurationAnnotation,
     WarningConfigurationFileAnnotation,

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -198,4 +198,51 @@ class SIntOpsSpec extends ChiselPropSpec with Utils {
     )
   }
 
+  property("Static right-shift should have a minimum width of 1") {
+    assertKnownWidth(4) {
+      val in = IO(Input(SInt(8.W)))
+      in >> 4
+    }
+    assertKnownWidth(1) {
+      val in = IO(Input(SInt(8.W)))
+      in >> 8
+    }
+    assertKnownWidth(1) {
+      val in = IO(Input(SInt(8.W)))
+      in >> 16
+    }
+    assertKnownWidth(1) {
+      val in = IO(Input(SInt(0.W)))
+      in >> 8
+    }
+    assertKnownWidth(1) {
+      val in = IO(Input(SInt(0.W)))
+      in >> 0
+    }
+    assertInferredWidth(4) {
+      val in = IO(Input(SInt(8.W)))
+      val w = WireInit(SInt(), in)
+      w >> 4
+    }
+    assertInferredWidth(1) {
+      val in = IO(Input(SInt(8.W)))
+      val w = WireInit(SInt(), in)
+      w >> 8
+    }
+    assertInferredWidth(1) {
+      val in = IO(Input(SInt(8.W)))
+      val w = WireInit(SInt(), in)
+      w >> 16
+    }
+    assertInferredWidth(1) {
+      val in = IO(Input(SInt(0.W)))
+      val w = WireInit(SInt(), in)
+      w >> 8
+    }
+    assertInferredWidth(1) {
+      val in = IO(Input(SInt(0.W)))
+      val w = WireInit(SInt(), in)
+      w >> 0
+    }
+  }
 }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -485,4 +485,52 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
     chirrtl should include("connect y, a")
     chirrtl should include("connect z, b")
   }
+
+  property("Static right-shift should have a minimum width of 0") {
+    assertKnownWidth(4) {
+      val in = IO(Input(UInt(8.W)))
+      in >> 4
+    }
+    assertKnownWidth(0) {
+      val in = IO(Input(UInt(8.W)))
+      in >> 8
+    }
+    assertKnownWidth(0) {
+      val in = IO(Input(UInt(8.W)))
+      in >> 16
+    }
+    assertKnownWidth(0) {
+      val in = IO(Input(UInt(0.W)))
+      in >> 8
+    }
+    assertKnownWidth(0) {
+      val in = IO(Input(UInt(0.W)))
+      in >> 0
+    }
+    assertInferredWidth(4) {
+      val in = IO(Input(UInt(8.W)))
+      val w = WireInit(UInt(), in)
+      w >> 4
+    }
+    assertInferredWidth(0) {
+      val in = IO(Input(UInt(8.W)))
+      val w = WireInit(UInt(), in)
+      w >> 8
+    }
+    assertInferredWidth(0) {
+      val in = IO(Input(UInt(8.W)))
+      val w = WireInit(UInt(), in)
+      w >> 16
+    }
+    assertInferredWidth(0) {
+      val in = IO(Input(UInt(0.W)))
+      val w = WireInit(UInt(), in)
+      w >> 8
+    }
+    assertInferredWidth(0) {
+      val in = IO(Input(UInt(0.W)))
+      val w = WireInit(UInt(), in)
+      w >> 0
+    }
+  }
 }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -533,4 +533,63 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils {
       w >> 0
     }
   }
+
+  property("Static right-shift should have width of 0 in Chisel and 1 in FIRRTL with --legacy-shift-right-width") {
+    val args = Array("--legacy-shift-right-width")
+    assertKnownWidth(4, args) {
+      val in = IO(Input(UInt(8.W)))
+      in >> 4
+    }
+    assertKnownWidth(0, args) {
+      val in = IO(Input(UInt(8.W)))
+      in >> 8
+    }
+    assertKnownWidth(0, args) {
+      val in = IO(Input(UInt(8.W)))
+      in >> 16
+    }
+    assertKnownWidth(0, args) {
+      val in = IO(Input(UInt(0.W)))
+      in >> 8
+    }
+    assertKnownWidth(0, args) {
+      val in = IO(Input(UInt(0.W)))
+      in >> 0
+    }
+    assertInferredWidth(1, args) {
+      val in = IO(Input(UInt(8.W)))
+      val w = WireInit(UInt(), in)
+      w >> 8
+    }
+    assertInferredWidth(4, args) {
+      val in = IO(Input(UInt(8.W)))
+      val w = WireInit(UInt(), in)
+      w >> 4
+    }
+    assertInferredWidth(1, args) {
+      val in = IO(Input(UInt(8.W)))
+      val w = WireInit(UInt(), in)
+      w >> 16
+    }
+    assertInferredWidth(1, args) {
+      val in = IO(Input(UInt(0.W)))
+      val w = WireInit(UInt(), in)
+      w >> 8
+    }
+    assertInferredWidth(1, args) {
+      val in = IO(Input(UInt(0.W)))
+      val w = WireInit(UInt(), in)
+      w >> 0
+    }
+    // Focused test to show the mismatch
+    class TestModule extends Module {
+      val in = IO(Input(UInt(8.W)))
+      val out = IO(Output(UInt()))
+      val shifted = in >> 8
+      shifted.getWidth should be(0)
+      out := shifted
+    }
+    val verilog = ChiselStage.emitSystemVerilog(new TestModule, args)
+    verilog should include("assign out = 1'h0;")
+  }
 }


### PR DESCRIPTION
This requires a recent change to CIRCT (https://github.com/llvm/circt/pull/6698).

Once firtool is released with the linked change, bumped in this repository, and this PR is merged, I think we should crack 7.0.0-M1 as it will serve as a useful milestone for dealing with this semantic change.

I also added a CLI option to emulate the old behavior: `--legacy-shift-right-width`. I'm not wedded to the name so if anyone has a better name for it, please suggest it.

Instructions on using this option will be in the release notes but we should probably also add a page to the website about migrating from Chisel 6 to Chisel 7 that calls this out.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Rebase

#### Release Notes

* A UInt shifted right by a static amount >= its width will now result
  in a 0-bit UInt
* An SInt shifted right by a static amount >= its width will now result
  in a 1-bit SInt (the sign bit)

This is a change for SInts which Chisel would treat the output as a 0-bit SInt. However, FIRRTL implemented different behavior where both UInts and SInts would result in 1-bit values (which shifted right by an amount >= the width of the input).

Users can emulate the old behavior by providing CLI option `--legacy-shift-right-width`. Users are encouraged to generate Verilog with and without this option and diff it to ensure the width change does not affect the correctness of their design. Note that this option is purely for code migration and should not be used long term--it will eventually be removed.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
