### PR TITLE
[svsim] Better error message when verilator not on PATH

### DIFF
--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -3,7 +3,8 @@
 package svsim.verilator
 
 import svsim._
-import java.io.{BufferedReader, InputStreamReader}
+import scala.sys.process._
+import scala.collection.mutable
 
 object Backend {
   object CompilationSettings {
@@ -22,10 +23,12 @@ object Backend {
     enableAllAssertions:        Boolean = false)
 
   def initializeFromProcessEnvironment() = {
-    val process = Runtime.getRuntime().exec(Array("which", "verilator"))
-    val outputReader = new BufferedReader(new InputStreamReader(process.getInputStream()))
-    val executablePath = outputReader.lines().findFirst().get()
-    process.waitFor()
+    val output = mutable.ArrayBuffer.empty[String]
+    val exitCode = List("which", "verilator").!(ProcessLogger(output += _))
+    if (exitCode != 0) {
+      throw new Exception(s"verilator not found on the PATH!\n${output.mkString("\n")}")
+    }
+    val executablePath = output.head.trim
     new Backend(executablePath = executablePath)
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
