### PR TITLE
Fix bug where Definitions are incorrectly public

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -112,7 +112,7 @@ object Definition extends SourceInfoDoc {
       )
     }
     dynamicContext.inDefinition = true
-    val (ir, module) = Builder.build(Module(proto), dynamicContext, false)
+    val (ir, module) = Builder.build(Module(proto), dynamicContext)
     Builder.components ++= ir.components
     Builder.annotations ++= ir.annotations: @nowarn // this will go away when firrtl is merged
     module._circuit = Builder.currentModule

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1007,8 +1007,7 @@ private[chisel3] object Builder extends LazyLogging {
 
   private[chisel3] def build[T <: BaseModule](
     f:              => T,
-    dynamicContext: DynamicContext,
-    forceModName:   Boolean = true
+    dynamicContext: DynamicContext
   ): (Circuit, T) = {
     dynamicContextVar.withValue(Some(dynamicContext)) {
       ViewParent: Unit // Must initialize the singleton in a Builder context or weird things can happen
@@ -1017,7 +1016,7 @@ private[chisel3] object Builder extends LazyLogging {
       val mod =
         try {
           val m = f
-          if (forceModName) { // This avoids definition name index skipping with D/I
+          if (!inDefinition) { // This avoids definition name index skipping with D/I
             m.forceName(m.name, globalNamespace)
           }
           m

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1067,9 +1067,10 @@ private[chisel3] object Builder extends LazyLogging {
           )
       }
 
-      // Make the main module (the last component) public.
+      // Make the main module (the last component) public if this is not a
+      // Circuit created from a Definition.
       components.last match {
-        case module: DefModule =>
+        case module: DefModule if !inDefinition =>
           components.update(
             components.size - 1, {
               val newModule = module.copy(isPublic = true)


### PR DESCRIPTION
Drop an argument from the Builder.build method which is only used to
change behavior when building Definitions.  Instead, rely on the
`inDefinition` variable made available by the DynamicContext.

Fix a bug where a Definition's root module would be incorrectly marked
public.  Definitions currently create a separate Circuit for each
Definition.  The logic to control marking the main module public relied on
marking the last module in the circuit public.  However, this incorrectly
assumed that there was one Circuit when, in actuality, there are
multiple.  (This commit ignores questions of whether or not it should work
this way.)

Instead, use the DyanmicContext `inDefinition` variable to execute this
code path to set the main module public when the Builder is not working
with a Definition.

Fixes #3834.