### PR TITLE
Add Property expression for integer shift right.

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -330,6 +330,16 @@ sealed trait Property[T] extends Element { self =>
     */
   final def *(that: Property[T])(implicit ev: PropertyArithmeticOps[Property[T]], sourceInfo: SourceInfo): Property[T] =
     ev.mul(this, that)
+
+  /** Perform shift right as defined by FIRRTL spec section Integer Shift Right Operation.
+    */
+  final def >>(
+    that: Property[T]
+  )(
+    implicit ev: PropertyArithmeticOps[Property[T]],
+    sourceInfo:  SourceInfo
+  ): Property[T] =
+    ev.shr(this, that)
 }
 
 private[chisel3] sealed trait ClassTypeProvider[A] {
@@ -351,6 +361,7 @@ private[chisel3] object ClassTypeProvider {
 sealed trait PropertyArithmeticOps[T] {
   def add(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
   def mul(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
+  def shr(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
 }
 
 object PropertyArithmeticOps {
@@ -361,6 +372,8 @@ object PropertyArithmeticOps {
         binOp(sourceInfo, fir.IntegerAddOp, lhs, rhs)
       def mul(lhs: Property[Int], rhs: Property[Int])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.IntegerMulOp, lhs, rhs)
+      def shr(lhs: Property[Int], rhs: Property[Int])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.IntegerShrOp, lhs, rhs)
     }
 
   implicit val longArithmeticOps: PropertyArithmeticOps[Property[Long]] =
@@ -369,6 +382,8 @@ object PropertyArithmeticOps {
         binOp(sourceInfo, fir.IntegerAddOp, lhs, rhs)
       def mul(lhs: Property[Long], rhs: Property[Long])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.IntegerMulOp, lhs, rhs)
+      def shr(lhs: Property[Long], rhs: Property[Long])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.IntegerShrOp, lhs, rhs)
     }
 
   implicit val bigIntArithmeticOps: PropertyArithmeticOps[Property[BigInt]] =
@@ -377,6 +392,8 @@ object PropertyArithmeticOps {
         binOp(sourceInfo, fir.IntegerAddOp, lhs, rhs)
       def mul(lhs: Property[BigInt], rhs: Property[BigInt])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.IntegerMulOp, lhs, rhs)
+      def shr(lhs: Property[BigInt], rhs: Property[BigInt])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.IntegerShrOp, lhs, rhs)
     }
 
   // Helper function to create Property expression IR.

--- a/docs/src/explanations/properties.md
+++ b/docs/src/explanations/properties.md
@@ -147,3 +147,4 @@ on integral `Property` typed values.
 | --------- | -----------                                                                         |
 | `+`       | Perform addition as defined by FIRRTL spec section Integer Add Operation            |
 | `*`       | Perform multiplication as defined by FIRRTL spec section Integer Multiply Operation |
+| `>>`      | Perform shift right as defined by FIRRTL spec section Integer Shift Right Operation |

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -264,6 +264,7 @@ sealed abstract class PropPrimOp(name: String) {
 }
 case object IntegerAddOp extends PropPrimOp("integer_add")
 case object IntegerMulOp extends PropPrimOp("integer_mul")
+case object IntegerShrOp extends PropPrimOp("integer_shr")
 
 /** Property expressions.
   *

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -753,4 +753,19 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
       "propassign c, _c_propExpr"
     )()
   }
+
+  it should "support shift right" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val a = IO(Input(Property[BigInt]()))
+      val b = IO(Input(Property[BigInt]()))
+      val c = IO(Output(Property[BigInt]()))
+      c := a >> b
+    })
+
+    matchesAndOmits(chirrtl)(
+      "wire _c_propExpr : Integer",
+      "propassign _c_propExpr, integer_shr(a, b)",
+      "propassign c, _c_propExpr"
+    )()
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
This adds an API for integer Property shift right.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
