### PR TITLE
Relax legality of defines, align with FIRRTL spec

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -6,6 +6,7 @@ import chisel3.experimental.{SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal.{Builder, HasId}
 import chisel3.internal.firrtl.ir.{LayerBlockBegin, LayerBlockEnd, Node}
 import chisel3.util.simpleClassName
+import scala.annotation.tailrec
 import scala.collection.mutable.LinkedHashSet
 
 /** This object contains Chisel language features for creating layers.  Layers
@@ -48,6 +49,13 @@ object layer {
       case null       => "<root>"
       case Layer.Root => name
       case _          => s"${parent.fullName}.$name"
+    }
+
+    @tailrec
+    final private[chisel3] def canWriteTo(that: Layer): Boolean = that match {
+      case null              => false
+      case _ if this == that => true
+      case _                 => this.canWriteTo(that.parent)
     }
   }
 

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -143,7 +143,7 @@ package object internal {
         color
       case _ => return
     }
-    val enabledLayers = Builder.enabledLayers ++ Builder.layerStack.headOption
+    val enabledLayers = Builder.enabledLayers.view ++ Builder.layerStack.headOption
     if (enabledLayers.exists(_.canWriteTo(destLayer))) {
       return
     }

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -143,7 +143,7 @@ package object internal {
         color
       case _ => return
     }
-    val enabledLayers = Builder.enabledLayers ++= Builder.layerStack.headOption
+    val enabledLayers = Builder.enabledLayers ++ Builder.layerStack.headOption
     if (enabledLayers.exists(_.canWriteTo(destLayer))) {
       return
     }

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -143,8 +143,11 @@ package object internal {
         color
       case _ => return
     }
-    if (!Builder.layerStack.exists(_ == destLayer))
-      Builder.error(errorMessage)
+    val enabledLayers = Builder.enabledLayers ++= Builder.layerStack.headOption
+    if (enabledLayers.exists(_.canWriteTo(destLayer))) {
+      return
+    }
+    Builder.error(errorMessage)
   }
 
   // TODO this exists in cats.Traverse, should we just use that?

--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -40,8 +40,9 @@ package object probe extends SourceInfoDoc {
     requireHasProbeTypeModifier(probeExpr, "Expected source to be a probe expression.")
     requireCompatibleDestinationProbeColor(
       sink,
-      if (Builder.layerStack.head == layer.Layer.Root) s"Cannot define '$sink' from outside a layerblock"
-      else s"Cannot define '$sink' from a layerblock associated with layer ${Builder.layerStack.head.fullName}"
+      s"""Cannot define '$sink' from colors ${(Builder.enabledLayers ++= Builder.layerStack.headOption)
+        .map(a => s"'${a.fullName}'")
+        .mkString("{", ", ", "}")} since at least one of these is NOT enabled when '$sink' is enabled"""
     )
     if (sink.probeInfo.get.writable) {
       requireHasWritableProbeTypeModifier(

--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -40,7 +40,7 @@ package object probe extends SourceInfoDoc {
     requireHasProbeTypeModifier(probeExpr, "Expected source to be a probe expression.")
     requireCompatibleDestinationProbeColor(
       sink,
-      s"""Cannot define '$sink' from colors ${(Builder.enabledLayers ++= Builder.layerStack.headOption)
+      s"""Cannot define '$sink' from colors ${(Builder.enabledLayers.view ++ Builder.layerStack.headOption)
         .map(a => s"'${a.fullName}'")
         .mkString("{", ", ", "}")} since at least one of these is NOT enabled when '$sink' is enabled"""
     )


### PR DESCRIPTION
Change the checking logic for the legality of a probe define destination to align with FIRRTL specification language introduced recently [1]. Specifically, this enforces the following sentence:

> An operation that "writes" to a probe must be in a region whose layer color is enabled when the probe's layer color is enabled.

Previously, Chisel was more restrictive and would only allow writing to a probe whose color was the same as the layer block you are currently in. However, as has been worked out in CIRCT and elsewhere, it is fine to drive a probe from any region that is enabled when the probe is also enabled.

Practically, this gets some Chisel code passing that was legal by a FIRRTL compiler, but Chisel was refusing to generate it.

CC: @rwy7

[1]: https://github.com/chipsalliance/firrtl-spec/commit/673aa08cc31883aa90eca5ceaa6bf0017f3165fa

#### Release Notes

Align Chisel's checks of define destinations with the FIRRTL specification. Previously, Chisel was too strict.