### PR TITLE
[ci] Update `jextract` download URL

### DIFF
--- a/.github/workflows/install-jextract/action.yml
+++ b/.github/workflows/install-jextract/action.yml
@@ -20,7 +20,7 @@ runs:
       run: |
         mkdir -p jextract
         cd jextract
-        wget -q https://download.java.net/java/early_access/jextract/1/${{ inputs.file-name }}
+        wget -q https://download.java.net/java/early_access/jextract/21/1/${{ inputs.file-name }}
         tar xzf ${{ inputs.file-name }}
 
     - shell: bash


### PR DESCRIPTION
Some unexpected CI failures occurred in PR #3842, logs https://github.com/chipsalliance/chisel/actions/runs/8029630555

- Updates the `jextract` download URL, the previous one is no longer accessible.