### PR TITLE
Fix tests to avoid inferred width ports on public modules.

### DIFF
--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -154,22 +154,23 @@ trait ChiselRunners extends Assertions {
       val testPoint = gen
       assert(!testPoint.isWidthKnown, s"Asserting that width should be inferred yet width is known to Chisel!")
       // Sanity check that firrtl doesn't change the width
-      val out = IO(Output(chiselTypeOf(testPoint)))
+      val widthcheck = Wire(Output(chiselTypeOf(testPoint)))
+      dontTouch(widthcheck)
       val zero = 0.U(0.W).asTypeOf(chiselTypeOf(testPoint))
       if (DataMirror.isWire(testPoint)) {
         testPoint := zero
       }
-      out := zero
-      out := testPoint
+      widthcheck := zero
+      widthcheck := testPoint
     }
     val verilog =
       ChiselStage.emitSystemVerilog(new TestModule, args.toArray :+ "--dump-fir", Array("-disable-all-randomization"))
     expected match {
-      case 0 => assert(!verilog.contains("out"))
+      case 0 => assert(!verilog.contains("widthcheck"))
       case 1 =>
-        assert(verilog.contains(s"out"))
-        assert(!verilog.contains(s"0] out"))
-      case _ => assert(verilog.contains(s"[${expected - 1}:0] out"))
+        assert(verilog.contains(s"widthcheck"))
+        assert(!verilog.contains(s"0] widthcheck"))
+      case _ => assert(verilog.contains(s"[${expected - 1}:0] widthcheck"))
     }
   }
 

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -130,7 +130,7 @@ trait ChiselRunners extends Assertions {
     class TestModule extends Module {
       val testPoint = gen
       assert(testPoint.getWidth === expected)
-      val out = IO(Output(chiselTypeOf(testPoint)))
+      val out = IO(chiselTypeOf(testPoint))
       // Sanity check that firrtl doesn't change the width
       val zero = 0.U(0.W).asTypeOf(chiselTypeOf(testPoint))
       if (DataMirror.isWire(testPoint)) {
@@ -154,7 +154,7 @@ trait ChiselRunners extends Assertions {
       val testPoint = gen
       assert(!testPoint.isWidthKnown, s"Asserting that width should be inferred yet width is known to Chisel!")
       // Sanity check that firrtl doesn't change the width
-      val widthcheck = Wire(Output(chiselTypeOf(testPoint)))
+      val widthcheck = Wire(chiselTypeOf(testPoint))
       dontTouch(widthcheck)
       val zero = 0.U(0.W).asTypeOf(chiselTypeOf(testPoint))
       if (DataMirror.isWire(testPoint)) {

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -210,12 +210,13 @@ class SIntOpsSpec extends ChiselPropSpec with Utils with ShiftRightWidthBehavior
     // Focused test to show the mismatch
     class TestModule extends Module {
       val in = IO(Input(SInt(8.W)))
-      val out = IO(Output(SInt()))
+      val widthcheck = Wire(SInt())
       val shifted = in >> 8
       shifted.getWidth should be(0)
-      out := shifted
+      widthcheck := shifted
+      dontTouch(widthcheck)
     }
     val verilog = ChiselStage.emitSystemVerilog(new TestModule, args)
-    verilog should include("assign out = in[7];")
+    verilog should include(" widthcheck = in[7];")
   }
 }


### PR DESCRIPTION
Public modules can't have inferred widths or abstract reset, fix tests to emit spec-compliant FIRRTL 4.0.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Main module are "public" (#3813, soon mandatory) which means they cannot have inferred widths or abstract resets.  Code relying on old behavior will presently encounter an error in `firtool`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
