### PR TITLE
Assume: Use plain FIRRTL assume + format string instead of printf + assume.

### DIFF
--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -326,7 +326,7 @@ object assume extends VerifPrintMacrosDoc {
     message.foreach(Printable.checkScope(_))
     when(!Module.reset.asBool) {
       val formattedMsg = formatFailureMessage("Assumption", line, cond, message)
-      Builder.pushCommand(Verification(id, Formal.Assume, sourceInfo, Module.clock.ref, cond.ref, formattedMsg)) 
+      Builder.pushCommand(Verification(id, Formal.Assume, sourceInfo, Module.clock.ref, cond.ref, formattedMsg))
     }
     id
   }

--- a/src/test/scala/chiselTests/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/VerificationSpec.scala
@@ -36,11 +36,10 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
     assertContains(lines, "when _T_1 : ")
     assertContains(lines, "cover(clock, _T, UInt<1>(0h1), \"\")")
 
-    assertContains(lines, "when _T_5 : ")
-    assertContains(lines, "assume(clock, _T_3, UInt<1>(0h1), \"\")")
+    assertContains(lines, "assume(clock, _T_3, UInt<1>(0h1), \"Assumption failed")
 
-    assertContains(lines, "when _T_8 : ")
-    assertContains(lines, "assert(clock, _T_6, UInt<1>(0h1), \"\")")
+    assertContains(lines, "when _T_7 : ")
+    assertContains(lines, "assert(clock, _T_5, UInt<1>(0h1), \"\")")
   }
 
   property("annotation of verification constructs should work") {
@@ -68,6 +67,8 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
 
     // check that verification appear in verilog output
     exactly(1, svLines) should include("cover__cov: cov")
-    exactly(1, svLines) should include("assume__assm: assume")
+    exactly(1, svLines) should include("assume__assm:")
+    exactly(1, svLines) should include("assume(io_in != 8'h2)")
+    exactly(1, svLines) should include("$error(\"Assumption failed")
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Backend Code Generation

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

chisel3.Assume now directly emits a FIRRTL `assume` with the specified format message.
Previously a `when not(predicate): printf(...)` was emitted followed by a message-less `assume`.
The resulting SystemVerilog will change, more aligned with `assert` output but specifically uses `$error(..)` instead of a printf guarded by the usual printf guards.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.


-----

Example output before/after:

Before:

```
FIRRTL version 4.0.0
circuit SimpleTest :
  public module SimpleTest : @[src/test/scala/chiselTests/VerificationSpec.scala 11:7]
    input clock : Clock @[src/test/scala/chiselTests/VerificationSpec.scala 11:7]
    input reset : UInt<1> @[src/test/scala/chiselTests/VerificationSpec.scala 11:7]
    output io : { flip in : UInt<8>, out : UInt<8>} @[src/test/scala/chiselTests/VerificationSpec.scala 12:14]

    connect io.out, io.in @[src/test/scala/chiselTests/VerificationSpec.scala 16:10]
    node _T = eq(io.in, UInt<2>(0h3)) @[src/test/scala/chiselTests/VerificationSpec.scala 18:14]
    when _T : @[src/test/scala/chiselTests/VerificationSpec.scala 18:23]
      node _T_1 = neq(io.in, UInt<2>(0h2)) @[src/test/scala/chiselTests/VerificationSpec.scala 19:18]
      node _T_2 = eq(reset, UInt<1>(0h0)) @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
      when _T_2 : @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
        node _T_3 = eq(_T_1, UInt<1>(0h0)) @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
        when _T_3 : @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
          printf(clock, UInt<1>(0h1), "Assumption failed\n    at VerificationSpec.scala:19 assume(io.in =/= 2.U)\n") : printf @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
        assume(clock, _T_1, UInt<1>(0h1), "") : assume @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
```
```systemverilog
// Generated by CIRCT firtool-1.66.0-55-gcad1b4fd1
// Standard header to adapt well known macros for prints and assertions.

// Users can define 'PRINTF_COND' to add an extra gate to prints.
`ifndef PRINTF_COND_
  `ifdef PRINTF_COND
    `define PRINTF_COND_ (`PRINTF_COND)
  `else  // PRINTF_COND
    `define PRINTF_COND_ 1
  `endif // PRINTF_COND
`endif // not def PRINTF_COND_

module SimpleTest(	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
  input        clock,	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
               reset,	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
  input  [7:0] io_in,	// src/test/scala/chiselTests/VerificationSpec.scala:12:14
  output [7:0] io_out	// src/test/scala/chiselTests/VerificationSpec.scala:12:14
);

  wire _GEN = io_in != 8'h2;	// src/test/scala/chiselTests/VerificationSpec.scala:19:18
  wire _GEN_0 = io_in == 8'h3 & ~reset;	// src/test/scala/chiselTests/VerificationSpec.scala:18:14, :19:11
  `ifndef SYNTHESIS	// src/test/scala/chiselTests/VerificationSpec.scala:19:11
    always @(posedge clock) begin	// src/test/scala/chiselTests/VerificationSpec.scala:19:11
      if ((`PRINTF_COND_) & _GEN_0 & ~_GEN)	// src/test/scala/chiselTests/VerificationSpec.scala:19:{11,18}
        $fwrite(32'h80000002,
                "Assumption failed\n    at VerificationSpec.scala:19 assume(io.in =/= 2.U)\n");	// src/test/scala/chiselTests/VerificationSpec.scala:19:11
    end // always @(posedge)
  `endif // not def SYNTHESIS
  always @(posedge clock) begin	// src/test/scala/chiselTests/VerificationSpec.scala:19:11
    if (_GEN_0)	// src/test/scala/chiselTests/VerificationSpec.scala:19:11
      assume__assume: assume(_GEN);	// src/test/scala/chiselTests/VerificationSpec.scala:19:{11,18}
  end // always @(posedge)
  assign io_out = io_in;	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
endmodule
```

After:

```
FIRRTL version 4.0.0
circuit SimpleTest :
  public module SimpleTest : @[src/test/scala/chiselTests/VerificationSpec.scala 11:7]
    input clock : Clock @[src/test/scala/chiselTests/VerificationSpec.scala 11:7]
    input reset : UInt<1> @[src/test/scala/chiselTests/VerificationSpec.scala 11:7]
    output io : { flip in : UInt<8>, out : UInt<8>} @[src/test/scala/chiselTests/VerificationSpec.scala 12:14]

    connect io.out, io.in @[src/test/scala/chiselTests/VerificationSpec.scala 16:10]
    node _T = eq(io.in, UInt<2>(0h3)) @[src/test/scala/chiselTests/VerificationSpec.scala 18:14]
    when _T : @[src/test/scala/chiselTests/VerificationSpec.scala 18:23]
      node _T_1 = neq(io.in, UInt<2>(0h2)) @[src/test/scala/chiselTests/VerificationSpec.scala 19:18]
      node _T_2 = eq(reset, UInt<1>(0h0)) @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
      when _T_2 : @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
        assume(clock, _T_1, UInt<1>(0h1), "Assumption failed\n    at VerificationSpec.scala:19 assume(io.in =/= 2.U)\n") : assume @[src/test/scala/chiselTests/VerificationSpec.scala 19:11]
```
```systemverilog
// Generated by CIRCT firtool-1.66.0-55-gcad1b4fd1
module SimpleTest(	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
  input        clock,	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
               reset,	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
  input  [7:0] io_in,	// src/test/scala/chiselTests/VerificationSpec.scala:12:14
  output [7:0] io_out	// src/test/scala/chiselTests/VerificationSpec.scala:12:14
);

  always @(posedge clock) begin	// src/test/scala/chiselTests/VerificationSpec.scala:19:11
    if (io_in == 8'h3 & ~reset)	// src/test/scala/chiselTests/VerificationSpec.scala:18:14, :19:11
      assume__assume:
        assume(io_in != 8'h2)
        else $error("Assumption failed\n    at VerificationSpec.scala:19 assume(io.in =/= 2.U)\n");	// src/test/scala/chiselTests/VerificationSpec.scala:19:{11,18}
  end // always @(posedge)
  assign io_out = io_in;	// src/test/scala/chiselTests/VerificationSpec.scala:11:7
endmodule
```

cc @fabianschuiki @uenoku 