### PR TITLE
Print the optional Printable passed to stop ops

### DIFF
--- a/src/test/scala/chiselTests/Stop.scala
+++ b/src/test/scala/chiselTests/Stop.scala
@@ -4,16 +4,25 @@ package chiselTests
 
 import chisel3._
 import chisel3.testers.BasicTester
+import _root_.circt.stage.ChiselStage
 
 class StopTester() extends BasicTester {
-  stop()
+  chisel3.stop()
+}
+
+class StopWithMessageTester() extends BasicTester {
+  val cycle = RegInit(0.U(4.W))
+  cycle := cycle + 1.U
+  when(cycle === 4.U) {
+    chisel3.stop(cf"cycle: $cycle")
+  }
 }
 
 class StopImmediatelyTester extends BasicTester {
   val cycle = RegInit(0.asUInt(4.W))
   cycle := cycle + 1.U
   when(cycle === 4.U) {
-    stop()
+    chisel3.stop()
   }
   assert(cycle =/= 5.U, "Simulation did not exit upon executing stop()")
 }
@@ -21,6 +30,11 @@ class StopImmediatelyTester extends BasicTester {
 class StopSpec extends ChiselFlatSpec {
   "stop()" should "stop and succeed the testbench" in {
     assertTesterPasses { new StopTester }
+  }
+
+  it should "emit an optional message with arguments" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new StopWithMessageTester)
+    chirrtl should include("\"cycle: %d\", cycle")
   }
 
   it should "end the simulation immediately" in {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- API modification
- Bugfix

#### Desired Merge Strategy

- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes

The message passed to `stop` is no longer ignored. The construct was extended to accept Printable.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
