### PR TITLE
Get ChiselSim working with CIRCT 1.66+

### DIFF
--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -107,24 +107,37 @@ package object simulator {
         )
       )
 
-      // Move the relevant files over to primary-sources
-      val filelist =
-        new java.io.BufferedReader(new java.io.FileReader(s"${workspace.supportArtifactsPath}/filelist.f"))
-      try {
-        filelist.lines().forEach { immutableFilename =>
-          var filename = immutableFilename
-          /// Some files are provided as absolute paths
-          if (filename.startsWith(workspace.supportArtifactsPath)) {
-            filename = filename.substring(workspace.supportArtifactsPath.length + 1)
+      // Move the files indicated by a filelist.
+      def moveFiles(filename: String) = {
+        val filelist = new java.io.BufferedReader(new java.io.FileReader(filename))
+        try {
+          filelist.lines().forEach { immutableFilename =>
+            var filename = immutableFilename
+            /// Some files are provided as absolute paths
+            if (filename.startsWith(workspace.supportArtifactsPath)) {
+              filename = filename.substring(workspace.supportArtifactsPath.length + 1)
+            }
+            java.nio.file.Files.move(
+              java.nio.file.Paths.get(s"${workspace.supportArtifactsPath}/$filename"),
+              java.nio.file.Paths.get(s"${workspace.primarySourcesPath}/$filename")
+            )
           }
-          java.nio.file.Files.move(
-            java.nio.file.Paths.get(s"${workspace.supportArtifactsPath}/$filename"),
-            java.nio.file.Paths.get(s"${workspace.primarySourcesPath}/$filename")
-          )
+        } finally {
+          filelist.close()
         }
-      } finally {
-        filelist.close()
       }
+
+      // Move a file in a filelist which may not exist.
+      def maybeMoveFiles(filename: String) = try {
+        moveFiles(filename)
+      } catch {
+        case _ @(_: java.nio.file.NoSuchFileException | _: java.io.FileNotFoundException) =>
+      }
+
+      // Move files indicated by 'filelist.f' (which must exist).  Move files
+      // indicated by a black box filelist (which may exist).
+      moveFiles(s"${workspace.supportArtifactsPath}/filelist.f")
+      maybeMoveFiles(s"${workspace.supportArtifactsPath}/firrtl_black_box_resource_files.f")
 
       // Initialize Module Info
       val dut = someDut.get


### PR DESCRIPTION
Fix an incorrect assumption in ChiselSim that a 'filelist.f' will exist that includes all modules, _including blackboxes_, in the design.  Change this to try to also copy files from the black box filelist.  This makes ChiselSim work with CIRCT 1.66 and earlier (which put everything in 'filelist.f') and CIRCT 1.66+ (which does not include blackboxes in 'filelist.f').

Note that this is intended as a temporary solution until FIRRTL has a rock solid ABI that is implemented by CIRCT where all modules can be discovered under an arbitrary public module.

See CIRCT changes here: https://github.com/llvm/circt/pull/6729

#### Release Notes

Change ChiselSim to also move blackboxes as indicated by the default black box filelist.  This fixes issues with ChiselSim and CIRCT 1.67.0 introduced in (https://github.com/llvm/circt/pull/6729). This is a backwards compatible change that has no effect on earlier versions of CIRCT.
