### PR TITLE
Make logger annotations unserializable

### DIFF
--- a/firrtl/src/main/scala/logger/LoggerAnnotations.scala
+++ b/firrtl/src/main/scala/logger/LoggerAnnotations.scala
@@ -3,7 +3,7 @@
 package logger
 
 import firrtl.annotations.{Annotation, NoTargetAnnotation}
-import firrtl.options.{HasShellOptions, ShellOption}
+import firrtl.options.{HasShellOptions, ShellOption, Unserializable}
 
 /** An annotation associated with a Logger command line option */
 sealed trait LoggerOption { this: Annotation => }
@@ -16,6 +16,7 @@ sealed trait LoggerOption { this: Annotation => }
 case class LogLevelAnnotation(globalLogLevel: LogLevel.Value = LogLevel.None)
     extends NoTargetAnnotation
     with LoggerOption
+    with Unserializable
 
 object LogLevelAnnotation extends HasShellOptions {
 
@@ -39,6 +40,7 @@ object LogLevelAnnotation extends HasShellOptions {
 case class ClassLogLevelAnnotation(className: String, level: LogLevel.Value)
     extends NoTargetAnnotation
     with LoggerOption
+    with Unserializable
 
 object ClassLogLevelAnnotation extends HasShellOptions {
 
@@ -63,7 +65,7 @@ object ClassLogLevelAnnotation extends HasShellOptions {
   *  - maps to [[LoggerOptions.logFileName]]
   *  - enabled with `--log-file`
   */
-case class LogFileAnnotation(file: Option[String]) extends NoTargetAnnotation with LoggerOption
+case class LogFileAnnotation(file: Option[String]) extends NoTargetAnnotation with LoggerOption with Unserializable
 
 object LogFileAnnotation extends HasShellOptions {
 
@@ -81,7 +83,11 @@ object LogFileAnnotation extends HasShellOptions {
 /** Enables class names in log output
   *  - enabled with `-lcn/--log-class-names`
   */
-case object LogClassNamesAnnotation extends NoTargetAnnotation with LoggerOption with HasShellOptions {
+case object LogClassNamesAnnotation
+    extends NoTargetAnnotation
+    with LoggerOption
+    with HasShellOptions
+    with Unserializable {
 
   val options = Seq(
     new ShellOption[Unit](

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -1133,6 +1133,12 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       }
       log2 shouldNot include("Done elaborating.")
     }
+
+    it("should not emit logger annotations") {
+      import chisel3.RawModule
+      (ChiselStage.emitCHIRRTL(new RawModule {}) should not).include("LogLevelAnnotation")
+      (ChiselStage.emitCHIRRTL(new RawModule {}, Array("-ll", "info")) should not).include("LogLevelAnnotation")
+    }
   }
 
   describe("ChiselStage$ exception handling") {


### PR DESCRIPTION
Change logger annotations to mix-in the Unserializable trait so that they will not emitted by a stage.  These annotations are not intended to be seen by CIRCT and these should be stripped from the output FIRRTL text.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Change all logger annotations to be unserializable. This avoids a bug where these could be seen by CIRCT (which rightly does not understand them) and cause it to reject the FIRRTL it sees.