### PR TITLE
Support serializing large (> 2 GiB) annotation files

### DIFF
--- a/firrtl/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
+++ b/firrtl/src/main/scala/firrtl/options/phases/WriteOutputAnnotations.scala
@@ -126,7 +126,7 @@ class WriteOutputAnnotations extends Phase {
           case None =>
           case Some(file) =>
             val pw = new PrintWriter(sopts.getBuildFileName(file, Some(".anno.json")))
-            pw.write(JsonProtocol.serialize(serializable))
+            JsonProtocol.serializeTry(serializable, pw).get // .get to throw any exceptions
             pw.close()
         }
     }

--- a/firrtl/src/test/scala/firrtl/JsonProtocolSpec.scala
+++ b/firrtl/src/test/scala/firrtl/JsonProtocolSpec.scala
@@ -80,4 +80,24 @@ class JsonProtocolSpec extends AnyFlatSpec {
     val deserAnno = JsonProtocol.deserialize(serializedAnno).head
     assert(anno == deserAnno)
   }
+
+  "JsonProtocol" should "support serializing directly to a Java Writer" in {
+    val anno = SimpleAnnotation("hello")
+    class NaiveWriter extends java.io.Writer {
+      private var contents: String = ""
+      def value:            String = contents
+      def close():          Unit = contents = ""
+      def flush():          Unit = contents = ""
+      def write(cbuff: Array[Char], off: Int, len: Int): Unit = {
+        for (i <- off until off + len) {
+          contents += cbuff(i)
+        }
+      }
+    }
+    val w = new NaiveWriter
+    JsonProtocol.serializeTry(Seq(anno), w)
+    val ser1 = w.value
+    val ser2 = JsonProtocol.serialize(Seq(anno))
+    assert(ser1 == ser2)
+  }
 }


### PR DESCRIPTION
This probably also improves performance and reduces memory since creating a large String is expensive.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
