### PR TITLE
Allow BoringUtils.bore to work on probes

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -224,9 +224,14 @@ object BoringUtils {
     else if (DataMirror.hasOuterFlip(source)) Flipped(chiselTypeOf(source))
     else chiselTypeOf(source)
     def purePortType = createProbe match {
-      case Some(pi) if pi.writable => RWProbe(purePortTypeBase)
-      case Some(pi)                => Probe(purePortTypeBase)
-      case None                    => purePortTypeBase
+      case Some(pi) =>
+        // If the source is already a probe, don't double wrap it in a probe.
+        purePortTypeBase.probeInfo match {
+          case Some(_)             => purePortTypeBase
+          case None if pi.writable => RWProbe(purePortTypeBase)
+          case None                => Probe(purePortTypeBase)
+        }
+      case None => purePortTypeBase
     }
     def isPort(d: Data): Boolean = d.topBindingOpt match {
       case Some(PortBinding(_)) => true

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -495,4 +495,22 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
     val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Foo)
   }
 
+  it should "allow tapping a probe" in {
+    class Bar extends RawModule {
+      val a = Wire(probe.Probe(Bool()))
+    }
+    class Foo extends RawModule {
+      val b = IO(probe.Probe(Bool()))
+      val bar = Module(new Bar)
+      probe.define(b, BoringUtils.tap(bar.a))
+    }
+
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Foo)
+
+    matchesAndOmits(chirrtl)(
+      "define bore = a",
+      "define b = bar.bore"
+    )()
+  }
+
 }

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -497,7 +497,7 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
 
   it should "allow tapping a probe" in {
     class Bar extends RawModule {
-      val a = Wire(probe.Probe(Bool()))
+      val a = IO(probe.Probe(Bool()))
     }
     class Foo extends RawModule {
       val b = IO(probe.Probe(Bool()))
@@ -508,8 +508,7 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
     val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Foo)
 
     matchesAndOmits(chirrtl)(
-      "define bore = a",
-      "define b = bar.bore"
+      "define b = bar.a"
     )()
   }
 


### PR DESCRIPTION
Extends BorginUtils.bore (and related) to work where the source is a probe.  Currently, if a user tries to do this, they will get an error about being unable to probe a probe because the old code would unconditionally wrap whatever the source was in `Probe`/`RWProbe`.  Change this to not wrap if the source is already a probe.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Allow boring from a source which is already a probe.