### PR TITLE
Add a label "chisel3_builtin" to ifElseFatal intrinsic

### DIFF
--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -147,7 +147,7 @@ object assert extends VerifPrintMacrosDoc {
 
     val id = Builder.forcedUserModule // It should be safe since we push commands anyway.
     val data = format.unpackArgs
-    val inst = Module(new IfElseFatalIntrinsic()(sourceInfo, id, format, data))
+    val inst = Module(new IfElseFatalIntrinsic()(sourceInfo, id, format, "chisel3_builtin", data))
     inst.clock := clock
     inst.predicate := predicate
     inst.enable := enable

--- a/core/src/main/scala/chisel3/experimental/VerificationIntrinsics.scala
+++ b/core/src/main/scala/chisel3/experimental/VerificationIntrinsics.scala
@@ -10,10 +10,11 @@ private[chisel3] class IfElseFatalIntrinsic[T <: Data](
   implicit sourceInfo: SourceInfo,
   id:                  BaseModule,
   format:              Printable,
+  label:               String,
   data:                Seq[T])
     extends IntrinsicModule(
       "circt_chisel_ifelsefatal",
-      Map("format" -> chisel3.experimental.PrintableParam(format, id))
+      Map("format" -> chisel3.experimental.PrintableParam(format, id), "label" -> label)
     ) {
   // Because this code is in core, the Chisel compiler plugin does not run on it so we must .suggestName
   val clock = IO(Input(Clock())).suggestName("clock")

--- a/src/test/scala/chiselTests/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/VerificationSpec.scala
@@ -36,6 +36,7 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
     assertContains(lines, "intmodule IfElseFatalIntrinsic :")
     assertContains(lines, "intrinsic = circt_chisel_ifelsefatal")
     assertContains(lines, "parameter format = \"Assertion failed: io.in:%d is equal to io.out:%d")
+    assertContains(lines, "parameter label = \"chisel3_builtin\"")
 
     // reset guard around the verification statement
     assertContains(lines, "when _T_1 :")


### PR DESCRIPTION
This is a follow-up to #3825.

MFC has attached a laebl "chisel3_builtin" to every ifElseFatal assertion. Usually a label on ifElseFatal is just ignored but the label is emitted when compiled with `-emit-chisel-asserts-as-sva`. So labels on assertions converted from ifElseFatal disappear due to #3825. This PR restores labels to preserve the old behavior.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Backend code generation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Add a label "chisel3_builtin" to ifElseFatal intrinsic.
### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [x] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
