### PR TITLE
toBigInt should round identically for Double and BigDecimal

### DIFF
--- a/core/src/main/scala/chisel3/Num.scala
+++ b/core/src/main/scala/chisel3/Num.scala
@@ -200,13 +200,22 @@ trait NumObject {
     result
   }
 
-  /**
-    * How to create a bigint from a big decimal with a specific binaryPoint (int)
-    * @param x           a BigDecimal value
-    * @param binaryPoint a binaryPoint that you would like to use
+  /** Create a bigint from a big decimal with a specific binaryPoint (Int)
+    *
+    * @param x           the BigDecimal value
+    * @param binaryPoint the binaryPoint to use
     * @return
     */
-  def toBigInt(x: BigDecimal, binaryPoint: Int, roundingMode: RoundingMode = HALF_UP): BigInt = {
+  def toBigInt(x: BigDecimal, binaryPoint: Int): BigInt = toBigInt(x, binaryPoint, HALF_UP)
+
+  /** Create a bigint from a big decimal with a specific binaryPoint (Int)
+    *
+    * @param x           the BigDecimal value
+    * @param binaryPoint the binaryPoint to use
+    * @param roundingMode the RoundingMode to use
+    * @return
+    */
+  def toBigInt(x: BigDecimal, binaryPoint: Int, roundingMode: RoundingMode): BigInt = {
     val multiplier = math.pow(2, binaryPoint)
     val result = (x * multiplier).setScale(0, roundingMode).toBigInt
     result

--- a/core/src/main/scala/chisel3/Num.scala
+++ b/core/src/main/scala/chisel3/Num.scala
@@ -5,6 +5,7 @@ package chisel3
 import chisel3.internal.sourceinfo.SourceInfoTransform
 
 import scala.language.experimental.macros
+import scala.math.BigDecimal.RoundingMode._
 import chisel3.experimental.SourceInfo
 
 // REVIEW TODO: Further discussion needed on what Num actually is.
@@ -205,9 +206,9 @@ trait NumObject {
     * @param binaryPoint a binaryPoint that you would like to use
     * @return
     */
-  def toBigInt(x: BigDecimal, binaryPoint: Int): BigInt = {
+  def toBigInt(x: BigDecimal, binaryPoint: Int, roundingMode: RoundingMode = HALF_UP): BigInt = {
     val multiplier = math.pow(2, binaryPoint)
-    val result = (x * multiplier).rounded.toBigInt
+    val result = (x * multiplier).setScale(0, roundingMode).toBigInt
     result
   }
 

--- a/core/src/main/scala/chisel3/Num.scala
+++ b/core/src/main/scala/chisel3/Num.scala
@@ -5,7 +5,7 @@ package chisel3
 import chisel3.internal.sourceinfo.SourceInfoTransform
 
 import scala.language.experimental.macros
-import scala.math.BigDecimal.RoundingMode._
+import scala.math.BigDecimal.RoundingMode.{HALF_UP, RoundingMode}
 import chisel3.experimental.SourceInfo
 
 // REVIEW TODO: Further discussion needed on what Num actually is.

--- a/src/test/scala/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala/chiselTests/LiteralExtractorSpec.scala
@@ -59,6 +59,20 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
     bigIntFromDouble should be(bigInt53)
   }
 
+  "doubles and big decimals" should "be rounded identically" in {
+
+    for (double <- Seq(1.0, 1.1, 1.5, 1.6, 2.5)) {
+
+      val bigDecimal = BigDecimal(double)
+
+      val bigIntFromDouble = Num.toBigInt(double, 0)
+      val bigIntFromBigDecimal = Num.toBigInt(bigDecimal, 0)
+
+      bigIntFromDouble should be(bigIntFromBigDecimal)
+    }
+
+  }
+
   "literals declared outside a builder context" should "compare with those inside builder context" in {
     class InsideBundle extends Bundle {
       val x = SInt(8.W)


### PR DESCRIPTION
This very minor PR fixes a bug in `Num.toBigInt(x: BigDecimal, binaryPoint: Int)`. 

The current function gives the impression to round the input BigDecimal:

```scala
val result = (x * multiplier).rounded.toBigInt
```

However:

```scala
BigDecimal(1.4).rounded.toBigInt // : BigInt = 1
BigDecimal(1.5).rounded.toBigInt // : BigInt = 1
BigDecimal(1.6).rounded.toBigInt // : BigInt = 1
```

I'm assuming this is not the intended behaviour. 

The underlying issue is with the `rounded` function which uses the BigDecimal's `MathContext`. I changed this to use `setScale(0)` instead.

I added a testcase for rounding positive numbers. I would've added a testcase for negative ones, but as far as I know there is no `RoundingMode` that replicates the rounding of Doubles there (round half to positive infinity).


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
