### PR TITLE
remove outdated jextract in nix overlay

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -9,21 +9,6 @@ final: prev:
   })).override {
     jre = final.openjdk21;
   };
-
-  jextract = (prev.jextract.overrideAttrs (oldAttrs: rec {
-    src = final.fetchFromGitHub {
-      owner = "openjdk";
-      repo = "jextract";
-      rev = "jdk21";
-      hash = "sha256-jkUCh4oSgilszvvU7RpozFATIghaA9rJRAdUIl5jTHM=";
-    };
-
-    env = {
-      ORG_GRADLE_PROJECT_llvm_home = final.llvmPackages.libclang.lib;
-      ORG_GRADLE_PROJECT_jdk21_home = final.jdk21;
-    };
-  }));
-
 #  This script can be used for override circt for debuging.
 #  circt = prev.circt.overrideAttrs (old: rec {
 #    version = "nightly";


### PR DESCRIPTION
The `nix flake` setup, as added in #3050, overlaid `jextract` to `jdk21` branch without specifing a commit. With upstream updates, it won't build now as SHA-256 hash have changed, and with updates in `nixpkgs` it is not needed anymore.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement
- Bugfix



### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
