### PR TITLE
Fix toString for PanamaCIRCTOM

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708356472,
-        "narHash": "sha256-EF9EAFuDux5wESsfsZwcut1Nq5EHG5Wu+OPPc8dpeq8=",
+        "lastModified": 1710308885,
+        "narHash": "sha256-FR+E2oHc6M58XsbbAGd8DwOFd84KaCmq05juHryr+xk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f542eeb24345af7583843cda80c509454795f826",
+        "rev": "3101f6b80999a1e38d0e800896401d7a592fd0f1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
             circt
             jextract
             lit
+            scala-cli
             llvm
           ];
         in

--- a/overlay.nix
+++ b/overlay.nix
@@ -35,5 +35,4 @@ final: prev:
       circt.llvm.lib
     ];
   };
-  scala-cli = prev.callPackage ./nix/scala-cli.nix { };
 }

--- a/panamaom/src/PanamaCIRCTOM.scala
+++ b/panamaom/src/PanamaCIRCTOM.scala
@@ -33,7 +33,7 @@ abstract class PanamaCIRCTOMEvaluatorValue {
   // Incomplete. currently for debugging purposes only
   override def toString: String = {
     this match {
-      case v: PanamaCIRCTOMEvaluatorValuePath      => s"path{${v.toString}}"
+      case v: PanamaCIRCTOMEvaluatorValuePath      => s"path{${v.asString}}"
       case v: PanamaCIRCTOMEvaluatorValueList      => s"[ ${v.elements.map(_.toString).mkString(", ")} ]"
       case v: PanamaCIRCTOMEvaluatorValuePrimitive => s"prim{${v.toString}}"
       case v: PanamaCIRCTOMEvaluatorValueObject    =>


### PR DESCRIPTION
`PanamaCIRCTOMEvaluatorValuePath` only implements `asString` method. So when calling `toString` on a generic `PanamaCIRCTOMEvaluatorValue` object, there might be an infinite recursion.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
