### PR TITLE
Some fixes related to OM

### DIFF
--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -1665,6 +1665,12 @@ object PanamaCIRCTConverter {
     cvt.mlirRootModule = circt.mlirModuleCreateParse(mlir)
     cvt
   }
+  def newWithMlirBc(mlirbc: Array[Byte]): PanamaCIRCTConverter = {
+    val circt = new PanamaCIRCT
+    implicit val cvt = new PanamaCIRCTConverter(circt, None, "")
+    cvt.mlirRootModule = circt.mlirModuleCreateParseBytes(mlirbc)
+    cvt
+  }
 
   def visitCircuit(circuit: Circuit)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitCircuit(circuit.name)

--- a/panamalib/src/PanamaCIRCT.scala
+++ b/panamalib/src/PanamaCIRCT.scala
@@ -49,7 +49,12 @@ class PanamaCIRCT {
   private def stringRefFromBytes(bytes: Array[Byte]): MlirStringRef = {
     val buffer = arena.allocate(bytes.length)
     buffer.copyFrom(MemorySegment.ofArray(bytes))
-    MlirStringRef(CAPI.mlirStringRefCreateFromCString(arena, buffer))
+
+    val stringRef = circt.MlirStringRef.allocate(arena)
+    circt.MlirStringRef.data$set(stringRef, buffer)
+    circt.MlirStringRef.length$set(stringRef, bytes.length)
+
+    MlirStringRef(stringRef)
   }
 
   private def newStringCallback(callback: String => Unit): MlirStringCallback = {

--- a/panamaom/src/PanamaCIRCTOM.scala
+++ b/panamaom/src/PanamaCIRCTOM.scala
@@ -98,7 +98,7 @@ class PanamaCIRCTOMEvaluatorValueBasePath private[chisel3] (val circt: PanamaCIR
 
 class PanamaCIRCTOMEvaluatorValuePath private[chisel3] (val circt: PanamaCIRCT, val value: OMEvaluatorValue)
     extends PanamaCIRCTOMEvaluatorValue {
-  def asString(): String = circt.omEvaluatorPathGetAsString(value)
+  override def toString: String = circt.omEvaluatorPathGetAsString(value)
 }
 
 class PanamaCIRCTOMEvaluatorValuePrimitive private[chisel3] (val circt: PanamaCIRCT, val value: OMEvaluatorValue)


### PR DESCRIPTION
- Add method for reading mlirbc in `PanamaCIRCTConverter`

- Construct `MlirStringRef` manually for `Array[Byte]`

  `Array[Byte]` may not end with `'\0'`, so constructing a `MlirStringRef` with `Array[Byte]` via `mlirStringRefCreateFromCString` can sometimes cause a crash in CIRCT.

- Fix infinite recursion for displaying `PanamaCIRCTOMEvaluatorValuePath`