### PR TITLE
Add requireIsAnnotatable for better errors when annotating literals

### DIFF
--- a/core/src/main/scala/chisel3/dontTouch.scala
+++ b/core/src/main/scala/chisel3/dontTouch.scala
@@ -2,7 +2,7 @@
 
 package chisel3
 
-import chisel3.experimental.{annotate, requireIsHardware, ChiselAnnotation}
+import chisel3.experimental.{annotate, requireIsAnnotatable, ChiselAnnotation}
 import chisel3.properties.Property
 import chisel3.reflect.DataMirror
 import firrtl.transforms.DontTouchAnnotation
@@ -34,7 +34,7 @@ object dontTouch {
     * @return Unmodified signal `data`
     */
   def apply[T <: Data](data: T): T = {
-    requireIsHardware(data, "Data marked dontTouch")
+    requireIsAnnotatable(data, "Data marked dontTouch")
     data match {
       case d if DataMirror.hasProbeTypeModifier(d) => ()
       case _:   Property[_] => ()

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -62,6 +62,20 @@ package object experimental {
     }
   }
 
+  /** Require that a Data can be annotated. It must be non-literal hardware.
+    */
+  object requireIsAnnotatable {
+    def apply(node: Data, msg: String = ""): Unit = {
+      requireIsHardware(node, msg)
+      if (node.isLit) {
+        val prefix = if (msg.nonEmpty) s"$msg " else ""
+        throw ExpectedAnnotatableException(
+          s"$prefix'$node' must not be a literal."
+        )
+      }
+    }
+  }
+
   /** Requires that a node is a chisel type (not hardware, "unbound")
     */
   object requireIsChiselType {

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -398,6 +398,10 @@ package object chisel3 {
     */
   case class ExpectedHardwareException(message: String) extends BindingException(message)
 
+  /** A function expected annotatable hardware
+    */
+  case class ExpectedAnnotatableException(message: String) extends BindingException(message)
+
   /** An aggregate had a mix of specified and unspecified directionality children
     */
   case class MixedDirectionAggregateException(message: String) extends BindingException(message)

--- a/src/main/scala/chisel3/util/experimental/decode/decoder.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/decoder.scala
@@ -3,7 +3,7 @@
 package chisel3.util.experimental.decode
 
 import chisel3._
-import chisel3.experimental.{annotate, ChiselAnnotation}
+import chisel3.experimental.{annotate, requireIsAnnotatable, ChiselAnnotation}
 import chisel3.util.{pla, BitPat}
 import chisel3.util.experimental.{getAnnotations, BitSet}
 import firrtl.annotations.Annotation
@@ -30,7 +30,7 @@ object decoder extends LazyLogging {
       val (plaInput, plaOutput) =
         pla(minimizedTable.table.toSeq, BitPat(minimizedTable.default.value.U(minimizedTable.default.getWidth.W)))
 
-      assert(plaOutput.isSynthesizable, s"Using DecodeTableAnnotation on non-hardware value $plaOutput")
+      requireIsAnnotatable(plaOutput, "DecodeTableAnnotation target")
       annotate(new ChiselAnnotation {
         override def toFirrtl: Annotation =
           DecodeTableAnnotation(plaOutput.toTarget, truthTable.toString, minimizedTable.toString)

--- a/src/test/scala/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala/chiselTests/DontTouchSpec.scala
@@ -106,6 +106,14 @@ class DontTouchSpec extends ChiselFlatSpec with Utils {
       })
     }
   }
+  it should "not work on literals" in {
+    val e = the[chisel3.ExpectedAnnotatableException] thrownBy {
+      ChiselStage.emitCHIRRTL(new Module {
+        dontTouch(123.U)
+      })
+    }
+    e.getMessage should include("must not be a literal")
+  }
 
   "fields" should "be marked don't touch by default" in {
     val (_, annos) = getFirrtlAndAnnos(new HasDeadCodeLeaves())


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This gives much better error messages when accidentally dontTouching a literal

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
