### PR TITLE
[binder] Support constructing integers larger than 64 bits

### DIFF
--- a/circtpanamabinding/includeFunctions.txt
+++ b/circtpanamabinding/includeFunctions.txt
@@ -104,6 +104,7 @@ firrtlAttrGetNameKind
 firrtlAttrGetRUW
 firrtlAttrGetMemoryInit
 firrtlAttrGetMemDir
+firrtlAttrGetIntegerFromString
 
 # Utility API
 firrtlValueFoldFlow

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -326,10 +326,10 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       def buildBefore(ref: Op): Op = buildImpl(circt.mlirBlockInsertOwnedOperationBefore(parent, ref.op, _))
     }
 
-    def newConstantValue(resultType: fir.Type, valueType: MlirType, value: BigInt, loc: MlirLocation): MlirValue = {
+    def newConstantValue(resultType: fir.Type, valueType: MlirType, bitLen: Int, value: BigInt, loc: MlirLocation): MlirValue = {
       util
         .OpBuilder("firrtl.constant", firCtx.currentBlock, loc)
-        .withNamedAttr("value", circt.mlirIntegerAttrGet(valueType, value.toLong))
+        .withNamedAttr("value", circt.firrtlAttrGetIntegerFromString(valueType, bitLen, value.toString, 10))
         .withResult(util.convert(resultType))
         .build()
         .results(0)
@@ -492,7 +492,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
         val resultType = if (isSigned) fir.SIntType(firWidth) else fir.UIntType(firWidth)
         val valueType =
           if (isSigned) circt.mlirIntegerTypeSignedGet(valWidth) else circt.mlirIntegerTypeUnsignedGet(valWidth)
-        Reference.Value(util.newConstantValue(resultType, valueType, n, util.convert(srcInfo)), resultType)
+        Reference.Value(util.newConstantValue(resultType, valueType, valWidth, n, util.convert(srcInfo)), resultType)
       }
 
       def referToNewProperty[T, U](propLit: PropertyLit[T, U]): Reference.Value = {
@@ -1512,7 +1512,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       .withNamedAttr("name", circt.mlirStringAttrGet(Converter.getRef(printf.id, printf.sourceInfo).name))
       .withOperand( /* clock */ util.referTo(printf.clock, printf.sourceInfo).value)
       .withOperand(
-        /* cond */ util.newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, loc)
+        /* cond */ util.newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, 1, loc)
       )
       .withOperands( /* substitutions */ args.map(util.referTo(_, printf.sourceInfo).value))
       .build()
@@ -1526,7 +1526,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       .withNamedAttr("name", circt.mlirStringAttrGet(Converter.getRef(stop.id, stop.sourceInfo).name))
       .withOperand( /* clock */ util.referTo(stop.clock, stop.sourceInfo).value)
       .withOperand(
-        /* cond */ util.newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, loc)
+        /* cond */ util.newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, 1, loc)
       )
       .build()
   }
@@ -1545,7 +1545,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       .withOperand( /* clock */ util.referTo(verifi.clock, verifi.sourceInfo).value)
       .withOperand( /* predicate */ util.referTo(verifi.predicate, verifi.sourceInfo).value)
       .withOperand(
-        /* enable */ util.newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, loc)
+        /* enable */ util.newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, 1, loc)
       )
       .withOperands( /* substitutions */ args.map(util.referTo(_, verifi.sourceInfo).value))
       .build()
@@ -1579,7 +1579,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       .OpBuilder("firrtl.ref.force_initial", firCtx.currentBlock, loc)
       .withOperand(
         /* predicate */ util
-          .newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, loc)
+          .newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, 1, loc)
       )
       .withOperand( /* dest */ util.referTo(probeForceInitial.probe, probeForceInitial.sourceInfo, Some(parent)).value)
       .withOperand( /* src */ util.referTo(probeForceInitial.value, probeForceInitial.sourceInfo, Some(parent)).value)
@@ -1592,7 +1592,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       .OpBuilder("firrtl.ref.release_initial", firCtx.currentBlock, loc)
       .withOperand(
         /* predicate */ util
-          .newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, loc)
+          .newConstantValue(fir.UIntType(fir.IntWidth(1)), circt.mlirIntegerTypeUnsignedGet(1), 1, 1, loc)
       )
       .withOperand(
         /* dest */ util.referTo(probeReleaseInitial.probe, probeReleaseInitial.sourceInfo, Some(parent)).value

--- a/panamalib/src/PanamaCIRCT.scala
+++ b/panamalib/src/PanamaCIRCT.scala
@@ -500,6 +500,8 @@ class PanamaCIRCT {
 
   def firrtlAttrGetMemDir(dir: FIRRTLMemDir) = MlirAttribute(CAPI.firrtlAttrGetMemDir(arena, mlirCtx, dir.value))
 
+  def firrtlAttrGetIntegerFromString(tpe: MlirType, numBits: Int, str: String, radix: Byte) = MlirAttribute(CAPI.firrtlAttrGetIntegerFromString(arena, tpe.get, numBits, newString(str).get, radix))
+
   def firrtlValueFoldFlow(value: MlirValue, flow: Int): Int = CAPI.firrtlValueFoldFlow(value.get, flow)
 
   def firrtlImportAnnotationsFromJSONRaw(annotationsStr: String): Option[MlirAttribute] = {


### PR DESCRIPTION
Fixes #3963, upstream PR: llvm/circt#6893

This PR fixes the first problem in the issue mentioned above, for the second one, it seems to be just the style of output from CIRCT that doesn't affect the final result and there's nothing we can do about it from Chisel side.