### PR TITLE
Fix === for abstract Reset types

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -912,7 +912,7 @@ object Data {
         case (thiz: UInt, that: UInt) => thiz === that
         case (thiz: SInt, that: SInt) => thiz === that
         case (thiz: AsyncReset, that: AsyncReset) => thiz.asBool === that.asBool
-        case (thiz: Reset, that: Reset) => thiz === that
+        case (thiz: Reset, that: Reset) => thiz.asBool === that.asBool
         case (thiz: EnumType, that: EnumType) => thiz === that
         case (thiz: Clock, that: Clock) => thiz.asUInt === that.asUInt
         case (thiz: Vec[_], that: Vec[_]) =>

--- a/src/test/scala/chiselTests/DataEqualitySpec.scala
+++ b/src/test/scala/chiselTests/DataEqualitySpec.scala
@@ -109,6 +109,11 @@ class DataEqualitySpec extends ChiselFlatSpec with Utils {
       new EqualityTester(true.B, false.B)
     }
   }
+  it should "support abstract reset wires" in {
+    assertTesterPasses {
+      new EqualityTester(WireDefault(Reset(), true.B), WireDefault(Reset(), true.B))
+    }
+  }
 
   behavior.of("AsyncReset === AsyncReset")
   it should "pass with equal values" in {


### PR DESCRIPTION


### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, the function would infinitely recurse resulting in a stack overflow.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
