### PR TITLE
Add layers for colored probe types or enablelayer

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -106,7 +106,9 @@ object layer {
   /** Call this function from within a `Module` body to enable this layer globally for that module. */
   final def enable(layer: Layer): Unit = layer match {
     case Layer.Root =>
-    case _          => Builder.enabledLayers += layer
+    case _          =>
+      addLayer(layer)
+      Builder.enabledLayers += layer
   }
 
 }

--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -106,7 +106,7 @@ object layer {
   /** Call this function from within a `Module` body to enable this layer globally for that module. */
   final def enable(layer: Layer): Unit = layer match {
     case Layer.Root =>
-    case _          =>
+    case _ =>
       addLayer(layer)
       Builder.enabledLayers += layer
   }

--- a/core/src/main/scala/chisel3/probe/Probe.scala
+++ b/core/src/main/scala/chisel3/probe/Probe.scala
@@ -35,7 +35,8 @@ private[chisel3] sealed trait ProbeBase {
     // https://github.com/chipsalliance/chisel/issues/3609
 
     val ret: T = if (!data.mustClone(prevId)) data else data.cloneType.asInstanceOf[T]
-    if (color.isDefined) {
+    // Record the layer in the builder if we are in a builder context.
+    if (Builder.inContext && color.isDefined) {
       layer.addLayer(color.get)
     }
     setProbeModifier(ret, Some(ProbeInfo(writable, color)))

--- a/core/src/main/scala/chisel3/probe/Probe.scala
+++ b/core/src/main/scala/chisel3/probe/Probe.scala
@@ -35,6 +35,9 @@ private[chisel3] sealed trait ProbeBase {
     // https://github.com/chipsalliance/chisel/issues/3609
 
     val ret: T = if (!data.mustClone(prevId)) data else data.cloneType.asInstanceOf[T]
+    if (color.isDefined) {
+      layer.addLayer(color.get)
+    }
     setProbeModifier(ret, Some(ProbeInfo(writable, color)))
     ret
   }

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -84,6 +84,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     }
 
     matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+      "layer A, bind",
       "module Foo enablelayer A.B enablelayer C :"
     )()
 

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -680,6 +680,7 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
       val b = IO(Output(Probe.apply(UInt(2.W), LayerA.LayerB)))
     }
     matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+      "layer LayerA",
       "output a : Probe<UInt<1>, LayerA>",
       "output b : Probe<UInt<2>, LayerA.LayerB>"
     )()


### PR DESCRIPTION
Fix a bug where a layer definition would only be added to Builder state if it was used in a layer block.  Also add these layers to the Builder state if they are used by a layer-colored probe type or by a module's enable layer.

Fixes #3983.

#### Release Notes

Fix a bug where illegal FIRRTL (that was missing a layer) unless a layer block using that layer was provided.