### PR TITLE
[svsim] Expose further verilator options for trace file name and simulation speed optimization

### DIFF
--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -78,10 +78,11 @@ package object simulator {
       elaboratedModule:              ElaboratedModule[T],
       conservativeCommandResolution: Boolean = false,
       verbose:                       Boolean = false,
+      traceEnabled:                  Boolean = false,
       executionScriptLimit:          Option[Int] = None
     )(body:                          SimulatedModule[T] => U
     ): U = {
-      simulation.run(conservativeCommandResolution, verbose, executionScriptLimit) { controller =>
+      simulation.run(conservativeCommandResolution, verbose, traceEnabled, executionScriptLimit) { controller =>
         val module = new SimulatedModule(elaboratedModule, controller)
         AnySimulatedModule.withValue(module) {
           body(module)

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -36,6 +36,10 @@ object CommonCompilationSettings {
     /** Optimize for compilation speed, which generally means disabling as many optimizations as possible.
       */
     object OptimizeForCompilationSpeed extends OptimizationStyle
+
+    /** Optimize for execution speed, which generally means enabling as many optimizations as possible.
+      */
+    object OptimizeForSimulationSpeed extends OptimizationStyle
   }
 
   sealed trait AvailableParallelism

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -162,6 +162,7 @@ final class Backend(
               commonSettings.optimizationStyle match {
                 case OptimizationStyle.Default => Seq()
                 case OptimizationStyle.OptimizeForCompilationSpeed => Seq("-O0")
+                case OptimizationStyle.OptimizeForSimulationSpeed=> Seq("-O3")
               },
               
               additionalHeaderPaths.map { path => s"-I${path}" },

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -10,7 +10,7 @@ object Backend {
   object CompilationSettings {
     sealed trait TraceStyle
     object TraceStyle {
-      case class Vcd(traceUnderscore: Boolean = false) extends TraceStyle
+      case class Vcd(traceUnderscore: Boolean = false, filename: String = "") extends TraceStyle
     }
   }
 
@@ -55,6 +55,7 @@ final class Backend(
             "--cc", // "Create C++ output"
             "--exe", // "Link to create executable"
             "--build", // "Build model executable/library after Verilation"
+            "-j", "0", // Parallelism for --build-jobs/--verilate-jobs, when 0 uses all available cores
             "-o", s"../$outputBinaryName", // "Name of final executable"
             "--top-module", topModuleName, // "Name of top-level input module"
             "--Mdir", "verilated-sources",  // "Name of output object directory"
@@ -76,7 +77,7 @@ final class Backend(
           },
 
           backendSpecificSettings.traceStyle match {
-            case Some(TraceStyle.Vcd(traceUnderscore)) => 
+            case Some(TraceStyle.Vcd(traceUnderscore, _)) =>
               if (traceUnderscore) {
                 Seq("--trace", "--trace-underscore")
               } else {
@@ -97,6 +98,8 @@ final class Backend(
           commonSettings.optimizationStyle match {
             case OptimizationStyle.Default => Seq()
             case OptimizationStyle.OptimizeForCompilationSpeed => Seq("-O1")
+            case OptimizationStyle.OptimizeForSimulationSpeed =>
+              Seq("-O3", "--x-assign", "fast", "--x-initial", "fast")
           },
 
           Seq[(String, Option[String])](
@@ -118,6 +121,8 @@ final class Backend(
               commonSettings.optimizationStyle match {
                 case OptimizationStyle.Default => Seq()
                 case OptimizationStyle.OptimizeForCompilationSpeed => Seq("-O1")
+                case OptimizationStyle.OptimizeForSimulationSpeed =>
+                  Seq("-O3", "-march=native", "-mtune=native")
               },
 
               Seq("-std=c++14"),


### PR DESCRIPTION
- Changed `TraceStyle.Vcd` to include a trace file name
- Added `OptimizationStyle.OptimizeForSimulationSpeed` and associated verilator flags to achieve simulation speed.
  - "--x-assign ast" and "--x-initial fast" flags should not really affect behaviour of most Chisel/CIRCT generated code and seem to give some performance boost, but it's open for feedback.
- added "-j 0" flag to verilator arguments to enable arallelism for uses all available CPU cores for verilate and build jobs
- added a "ShutdownHook" to kill the simulation process in case of Ctrl+C etc. Tested on macOS only, but seems to be working.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)
- API modification

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
