### PR TITLE
Optimize BitPat factory from UInt literals

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -98,8 +98,9 @@ object BitPat {
     */
   def apply(x: UInt): BitPat = {
     require(x.isLit, s"$x is not a literal, BitPat.apply(x: UInt) only accepts literals")
-    val len = if (x.isWidthKnown) x.getWidth else 0
-    apply("b" + x.litValue.toString(2).reverse.padTo(len, "0").reverse.mkString)
+    val width = x.getWidth.max(1) // BitPat doesn't support zero-width
+    val mask = (BigInt(1) << width) - 1
+    new BitPat(x.litValue, mask, width)
   }
 
   implicit class fromUIntToBitPatComparable(x: UInt) extends SourceInfoDoc {

--- a/src/test/scala/chiselTests/util/BitPatSpec.scala
+++ b/src/test/scala/chiselTests/util/BitPatSpec.scala
@@ -2,6 +2,7 @@
 
 package chiselTests.util
 
+import chisel3._
 import chisel3.util.BitPat
 import _root_.circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
@@ -48,5 +49,14 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
     b(2, 0) should be(BitPat("b???"))
     b(4, 3) should be(BitPat("b01"))
     b(6, 6) should be(BitPat("b1"))
+  }
+
+  it should "parse UInt literals correctly" in {
+    BitPat(0.U) should be(new BitPat(0, 1, 1))
+    // Note that this parses as 1-bit width, there are other APIs that don't support zero-width UInts correctly
+    BitPat(0.U(0.W)) should be(new BitPat(0, 1, 1))
+    BitPat(1.U) should be(new BitPat(1, 1, 1))
+    BitPat(2.U) should be(new BitPat(2, 3, 2))
+    BitPat(0xdeadbeefL.U) should be(new BitPat(BigInt("deadbeef", 16), BigInt("ffffffff", 16), 32))
   }
 }


### PR DESCRIPTION
Benchmarked using https://github.com/chipsalliance/chisel/pull/3987,

For `BitPat(0xdeadbeefL.U)` 72x speedup:
```
Benchmark                           Mode  Cnt   Score   Error   Units
ChiselBenchmark.BitPatFromUInt     thrpt   10  42.105 ± 1.364  ops/us
ChiselBenchmark.BitPatFromUIntOld  thrpt   10   0.582 ± 0.005  ops/us
```
For `BitPat(3.U)` 7x speedup:
```
Benchmark                           Mode  Cnt   Score   Error   Units
ChiselBenchmark.BitPatFromUInt     thrpt    3  44.501 ± 7.054  ops/us
ChiselBenchmark.BitPatFromUIntOld  thrpt   10   5.819 ± 0.049  ops/us
```
For real design, reduced amount of time in `BitPat.apply` from 116 seconds to 12.5 seconds (9x speedup)

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Performance improvement


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Speeds up conversion of UInt literals to BitPat by ~9x in practice, ~70x for large UInts.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
