### PR TITLE
Optimize truth table merge

### DIFF
--- a/src/main/scala/chisel3/util/BitPat.scala
+++ b/src/main/scala/chisel3/util/BitPat.scala
@@ -437,6 +437,18 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int)
     }
   }
 
+  /** Are any bits of this BitPat `?` */
+  private[chisel3] def hasDontCares: Boolean = width > 0 && mask != ((BigInt(1) << width) - 1)
+
+  /** Are all bits of this BitPat `0` */
+  private[chisel3] def allZeros: Boolean = value == 0 && !hasDontCares
+
+  /** Are all bits of this BitPat `1` */
+  private[chisel3] def allOnes: Boolean = !hasDontCares && value == mask
+
+  /** Are all bits of this BitPat `?` */
+  private[chisel3] def allDontCares: Boolean = mask == 0
+
   override def isEmpty: Boolean = false
 
   /** Generate raw string of a `BitPat`. */

--- a/src/test/scala/chisel3/util/BitPatSpec.scala
+++ b/src/test/scala/chisel3/util/BitPatSpec.scala
@@ -59,4 +59,63 @@ class BitPatSpec extends AnyFlatSpec with Matchers {
     BitPat(2.U) should be(new BitPat(2, 3, 2))
     BitPat(0xdeadbeefL.U) should be(new BitPat(BigInt("deadbeef", 16), BigInt("ffffffff", 16), 32))
   }
+
+  it should "support .hasDontCares" in {
+    BitPat("b?").hasDontCares should be(true)
+    BitPat("b??").hasDontCares should be(true)
+    BitPat("b0?").hasDontCares should be(true)
+    BitPat("b?1").hasDontCares should be(true)
+    BitPat("b0").hasDontCares should be(false)
+    BitPat("b10").hasDontCares should be(false)
+    BitPat("b01").hasDontCares should be(false)
+    BitPat(0xdeadbeefL.U).hasDontCares should be(false)
+    // Zero-width not supported yet
+    intercept[IllegalArgumentException] { BitPat("b").hasDontCares should be(false) }
+  }
+
+  it should "support .allZeros" in {
+    BitPat("b?").allZeros should be(false)
+    BitPat("b??").allZeros should be(false)
+    BitPat("b0?").allZeros should be(false)
+    BitPat("b?1").allZeros should be(false)
+    BitPat("b0").allZeros should be(true)
+    BitPat("b10").allZeros should be(false)
+    BitPat("b01").allZeros should be(false)
+    BitPat(0.U(128.W)).allZeros should be(true)
+    BitPat.N(23).allZeros should be(true)
+    BitPat(0xdeadbeefL.U).allZeros should be(false)
+    // Zero-width not supported yet
+    intercept[IllegalArgumentException] { BitPat("b").allZeros should be(true) }
+  }
+
+  it should "support .allOnes" in {
+    BitPat("b?").allOnes should be(false)
+    BitPat("b??").allOnes should be(false)
+    BitPat("b0?").allOnes should be(false)
+    BitPat("b?1").allOnes should be(false)
+    BitPat("b0").allOnes should be(false)
+    BitPat("b10").allOnes should be(false)
+    BitPat("b01").allOnes should be(false)
+    BitPat("b1").allOnes should be(true)
+    BitPat("b" + ("1" * 128)).allOnes should be(true)
+    BitPat.Y(23).allOnes should be(true)
+    BitPat(0xdeadbeefL.U).allOnes should be(false)
+    // Zero-width not supported yet
+    intercept[IllegalArgumentException] { BitPat("b").allOnes should be(true) }
+  }
+
+  it should "support .allDontCares" in {
+    BitPat("b?").allDontCares should be(true)
+    BitPat("b??").allDontCares should be(true)
+    BitPat("b0?").allDontCares should be(false)
+    BitPat("b?1").allDontCares should be(false)
+    BitPat("b0").allDontCares should be(false)
+    BitPat("b10").allDontCares should be(false)
+    BitPat("b1").allDontCares should be(false)
+    BitPat("b" + ("1" * 128)).allDontCares should be(false)
+    BitPat.dontCare(23).allDontCares should be(true)
+    BitPat(0xdeadbeefL.U).allDontCares should be(false)
+    // Zero-width not supported yet
+    intercept[IllegalArgumentException] { BitPat("b").allDontCares should be(true) }
+  }
 }

--- a/src/test/scala/chisel3/util/BitPatSpec.scala
+++ b/src/test/scala/chisel3/util/BitPatSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.util
+package chisel3.util
 
 import chisel3._
 import chisel3.util.BitPat

--- a/src/test/scala/chisel3/util/experimental/decode/TruthTableSpec.scala
+++ b/src/test/scala/chisel3/util/experimental/decode/TruthTableSpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.util.experimental
+package chisel3.util.experimental.decode
 
 import chisel3._
 import chisel3.util.BitPat
@@ -9,7 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class TruthTableSpec extends AnyFlatSpec {
   val table = TruthTable(
-    Map(
+    Seq(
       // BitPat("b000") -> BitPat("b0"),
       BitPat("b001") -> BitPat("b?"),
       BitPat("b010") -> BitPat("b?"),
@@ -122,5 +122,24 @@ class TruthTableSpec extends AnyFlatSpec {
                                 |?
                                 |""".stripMargin)
     )
+  }
+
+  behavior.of("TruthTable.split")
+
+  it should "not change the TruthTable when the default only uses a single value" in {
+    val result = TruthTable.split(table)
+    assert(result == Seq(table -> Seq(0)))
+    // As an optimization, it should return the same literal object
+    assert(result.head._1 eq table)
+  }
+
+  behavior.of("TruthTable.merge")
+
+  it should "not change the TruthTable when merging a single one" in {
+    val tables = Seq(table -> Seq(0))
+    val result = TruthTable.merge(tables)
+    assert(result == table)
+    // As an optimization, it should return the same literal object
+    assert(result eq table)
   }
 }


### PR DESCRIPTION
I'm collecting numbers, but it should be pretty obvious that not essentially doing a deep copy of every TruthTable both before and after running espresso minimization in the common case where the default value is uniform (i.e. all ones, all zeros, or, most commonly, all dont care) will speed things up.

To implement this, I also added some useful methods to BitPat that you can see the tests for.

Doing split and merge on the `TruthTable` from `TruthTableSpec`:
```scala
  val table = TruthTable(
    Map(
      // BitPat("b000") -> BitPat("b0"),
      BitPat("b001") -> BitPat("b?"),
      BitPat("b010") -> BitPat("b?"),
      // BitPat("b011") -> BitPat("b0"),
      BitPat("b100") -> BitPat("b1"),
      BitPat("b101") -> BitPat("b1"),
      // BitPat("b110") -> BitPat("b0"),
      BitPat("b111") -> BitPat("b1")
    ),
    BitPat("b0")
  )
```
Before this change:
```
Benchmark               Mode  Cnt  Score   Error   Units
ChiselBenchmark.Merge  thrpt   10  0.366 ± 0.003  ops/us
ChiselBenchmark.Split  thrpt   10  0.786 ± 0.006  ops/us
```
After this change:
```
Benchmark               Mode  Cnt    Score   Error   Units
ChiselBenchmark.Merge  thrpt   10  453.041 ± 1.422  ops/us
ChiselBenchmark.Split  thrpt   10   83.122 ± 0.184  ops/us
```

Also from a large real design, I measured it was spending 2 **minutes** in the little filter function in split: https://github.com/chipsalliance/chisel/blob/d584dd7aee4e8b738440386739a66b40c0d53ee6/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala#L145 (this should use a Set instead of a Seq)
With this change, it now spends 0.3ms in that function which just shows how much unnecessary splitting we were doing 🙃.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Performance improvement


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Rebase

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
