### PR TITLE
[ci] Stop copying body over to backports in backport-fixup

### DIFF
--- a/.github/workflows/backport-fixup.yml
+++ b/.github/workflows/backport-fixup.yml
@@ -1,5 +1,7 @@
 # Fixes up Mergify-created backport PRs to include necessary labels and other
-# information for release notes generation
+# information for release notes generation.
+# This action formerly copied over the PR body but it seems Mergify does that
+# itself now.
 
 name: Backport Fixup
 
@@ -66,25 +68,3 @@ jobs:
           # Long line but the paste joining must be done right away or we run into issues with spaces in labels
           LABELS=$(gh pr view --json labels --jq '.labels | .[].name | select(. != "Backported")' $ORIG_PR | paste -sd "," -)
           gh pr edit $BP_PR --add-label "$LABELS"
-      - name: Copy over body
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          BP_PR=${{ needs.resolve_prs.outputs.backport_pr }}
-          ORIG_PR=${{ needs.resolve_prs.outputs.original_pr }}
-
-          gh pr view --json body --jq '.body' $ORIG_PR > orig_body.txt
-          gh pr view --json body --jq '.body' $BP_PR > bp_body.txt
-
-          if grep -q '# Original PR Body' bp_body.txt; then
-            # Copy BP PR body but remove original PR body from bottom
-            sed '/# Original PR Body/q' bp_body.txt > new_bp_body.txt
-            echo "" >> new_bp_body.txt
-          else
-            cp bp_body.txt new_bp_body.txt
-            echo -e "\n----\n\n# Original PR Body\n" >> new_bp_body.txt
-          fi
-
-          cat orig_body.txt >> new_bp_body.txt
-
-          gh pr edit $BP_PR --body-file new_bp_body.txt


### PR DESCRIPTION
This action formerly copied over the PR body but it seems Mergify does that itself now.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
