### PR TITLE
Provide require message for negative widths

### DIFF
--- a/core/src/main/scala/chisel3/Width.scala
+++ b/core/src/main/scala/chisel3/Width.scala
@@ -36,7 +36,7 @@ sealed case class UnknownWidth() extends Width {
 }
 
 sealed case class KnownWidth(value: Int) extends Width {
-  require(value >= 0)
+  require(value >= 0, s"Widths must be non-negative, got $value")
   def known: Boolean = true
   def get:   Int = value
   def op(that: Width, f: (W, W) => W): Width = that match {

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -602,4 +602,9 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
       withOptFirrtl should include(line)
     }
   }
+
+  property("UInts with negative widths should have a decent error message") {
+    val e = the[IllegalArgumentException] thrownBy (UInt(-8.W))
+    e.getMessage should include("Widths must be non-negative, got -8")
+  }
 }


### PR DESCRIPTION

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Fixes #4007

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
