### PR TITLE
Fix Nested Instantiate

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -108,7 +108,6 @@ object Definition extends SourceInfoDoc {
         context.warningFilters,
         context.sourceRoots,
         Some(context.globalNamespace),
-        Builder.allDefinitions,
         context.loggerOptions,
         context.definitions,
         context.contextCache

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -5,7 +5,7 @@ package chisel3.experimental.hierarchy.core
 import scala.language.experimental.macros
 import chisel3._
 
-import scala.collection.mutable.HashMap
+import scala.collection.mutable.{ArrayBuffer, HashMap}
 import chisel3.internal.{Builder, DynamicContext}
 import chisel3.internal.sourceinfo.{DefinitionTransform, DefinitionWrapTransform}
 import chisel3.experimental.{BaseModule, SourceInfo}
@@ -109,7 +109,9 @@ object Definition extends SourceInfoDoc {
         context.sourceRoots,
         Some(context.globalNamespace),
         Builder.allDefinitions,
-        context.loggerOptions
+        context.loggerOptions,
+        context.definitions,
+        context.contextCache
       )
     }
     dynamicContext.inDefinition = true

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -122,7 +122,7 @@ object Instance extends SourceInfoDoc {
     implicit sourceInfo: SourceInfo
   ): Instance[T] = {
     // Check to see if the module is already defined internally or externally
-    val existingMod = Builder.allDefinitions.view.flatten.map(_.proto).exists {
+    val existingMod = Builder.definitions.view.map(_.proto).exists {
       case c: Class               => c == definition.proto
       case c: RawModule           => c == definition.proto
       case c: BaseBlackBox        => c.name == definition.proto.name

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -455,7 +455,9 @@ private[chisel3] class DynamicContext(
   val defaultNamespace:      Option[Namespace],
   // Definitions from other scopes in the same elaboration, use allDefinitions below
   val outerScopeDefinitions: List[Iterable[Definition[_]]],
-  val loggerOptions:         LoggerOptions) {
+  val loggerOptions:         LoggerOptions,
+  val definitions:           ArrayBuffer[Definition[_]],
+  val contextCache:          BuilderContextCache) {
   val importedDefinitionAnnos = annotationSeq.collect { case a: ImportDefinitionAnnotation[_] => a }
 
   // Map from proto module name to ext-module name
@@ -506,7 +508,6 @@ private[chisel3] class DynamicContext(
   }
 
   val components = ArrayBuffer[Component]()
-  val definitions = ArrayBuffer[Definition[_]]()
   val annotations = ArrayBuffer[ChiselAnnotation]()
   val newAnnotations = ArrayBuffer[ChiselMultiAnnotation]()
   val layers = mutable.LinkedHashSet[layer.Layer]()
@@ -520,8 +521,6 @@ private[chisel3] class DynamicContext(
 
   // Views that do not correspond to a single ReferenceTarget and thus require renaming
   val unnamedViews: ArrayBuffer[Data] = ArrayBuffer.empty
-
-  val contextCache: BuilderContextCache = BuilderContextCache.empty
 
   // Set by object Module.apply before calling class Module constructor
   // Used to distinguish between no Module() wrapping, multiple wrappings, and rewrapping

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -454,10 +454,9 @@ private[chisel3] class DynamicContext(
   val sourceRoots:           Seq[File],
   val defaultNamespace:      Option[Namespace],
   // Definitions from other scopes in the same elaboration, use allDefinitions below
-  val outerScopeDefinitions: List[Iterable[Definition[_]]],
-  val loggerOptions:         LoggerOptions,
-  val definitions:           ArrayBuffer[Definition[_]],
-  val contextCache:          BuilderContextCache) {
+  val loggerOptions: LoggerOptions,
+  val definitions:   ArrayBuffer[Definition[_]],
+  val contextCache:  BuilderContextCache) {
   val importedDefinitionAnnos = annotationSeq.collect { case a: ImportDefinitionAnnotation[_] => a }
 
   // Map from proto module name to ext-module name
@@ -594,9 +593,6 @@ private[chisel3] object Builder extends LazyLogging {
 
   def components:  ArrayBuffer[Component] = dynamicContext.components
   def definitions: ArrayBuffer[Definition[_]] = dynamicContext.definitions
-
-  /** All definitions from current elaboration, including Definitions passed as an argument to this one */
-  def allDefinitions: List[Iterable[Definition[_]]] = definitions :: dynamicContext.outerScopeDefinitions
 
   def annotations: ArrayBuffer[ChiselAnnotation] = dynamicContext.annotations
 

--- a/core/src/main/scala/chisel3/internal/BuilderContextCache.scala
+++ b/core/src/main/scala/chisel3/internal/BuilderContextCache.scala
@@ -9,7 +9,7 @@ private[chisel3] object BuilderContextCache {
   /** Users of the [[BuilderContextCache]] must use a subclass of this type as a map key */
   abstract class Key[A]
 
-  private[internal] def empty = new BuilderContextCache
+  def empty = new BuilderContextCache
 }
 
 import BuilderContextCache.Key

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -70,7 +70,6 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
           chiselOptions.warningFilters,
           chiselOptions.sourceRoots,
           None,
-          Nil, // FIXME this maybe should somehow grab definitions from earlier elaboration
           loggerOptions,
           ArrayBuffer[Definition[_]](),
           BuilderContextCache.empty

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -4,7 +4,8 @@ package chisel3.aop.injecting
 
 import chisel3.{withClockAndReset, Module, ModuleAspect, RawModule}
 import chisel3.aop._
-import chisel3.internal.{Builder, DynamicContext}
+import chisel3.experimental.hierarchy.core.Definition
+import chisel3.internal.{Builder, BuilderContextCache, DynamicContext}
 import chisel3.internal.firrtl.ir.DefModule
 import chisel3.stage.{ChiselOptions, DesignAnnotation}
 import firrtl.annotations.{Annotation, ModuleTarget}
@@ -13,6 +14,8 @@ import firrtl.{ir, _}
 
 import scala.collection.mutable
 import logger.LoggerOptions
+
+import scala.collection.mutable.ArrayBuffer
 
 /** Aspect to inject Chisel code into a module of type M
   *
@@ -68,7 +71,9 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
           chiselOptions.sourceRoots,
           None,
           Nil, // FIXME this maybe should somehow grab definitions from earlier elaboration
-          loggerOptions
+          loggerOptions,
+          ArrayBuffer[Definition[_]](),
+          BuilderContextCache.empty
         )
       // Add existing module names into the namespace. If injection logic instantiates new modules
       //  which would share the same name, they will get uniquified accordingly

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -3,8 +3,9 @@
 package chisel3.stage.phases
 
 import chisel3.Module
+import chisel3.experimental.hierarchy.core.Definition
 import chisel3.internal.ExceptionHelpers.ThrowableHelpers
-import chisel3.internal.{Builder, DynamicContext}
+import chisel3.internal.{Builder, BuilderContextCache, DynamicContext}
 import chisel3.stage.{
   ChiselCircuitAnnotation,
   ChiselGeneratorAnnotation,
@@ -16,6 +17,8 @@ import firrtl.AnnotationSeq
 import firrtl.options.{Dependency, Phase}
 import firrtl.options.Viewer.view
 import logger.LoggerOptions
+
+import scala.collection.mutable.ArrayBuffer
 
 /** Elaborate all [[chisel3.stage.ChiselGeneratorAnnotation]]s into [[chisel3.stage.ChiselCircuitAnnotation]]s.
   */
@@ -43,7 +46,9 @@ class Elaborate extends Phase {
             chiselOptions.sourceRoots,
             None,
             Nil,
-            loggerOptions
+            loggerOptions,
+            ArrayBuffer[Definition[_]](),
+            BuilderContextCache.empty
           )
         val (circuit, dut) =
           Builder.build(Module(gen()), context)

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -45,7 +45,6 @@ class Elaborate extends Phase {
             chiselOptions.warningFilters,
             chiselOptions.sourceRoots,
             None,
-            Nil,
             loggerOptions,
             ArrayBuffer[Definition[_]](),
             BuilderContextCache.empty

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
@@ -5,6 +5,7 @@ package experimental.hierarchy
 
 import chisel3._
 import chisel3.util.Valid
+import chisel3.properties._
 import chisel3.experimental.hierarchy._
 import circt.stage.ChiselStage.convert
 import chisel3.experimental.{ExtModule, IntrinsicModule}
@@ -163,6 +164,20 @@ object InstantiateSpec {
     @public val in = IO(Input(UInt(8.W)))
     @public val out = IO(Output(UInt(8.W)))
   }
+
+  @instantiable
+  class Baz extends Module
+
+  @instantiable
+  class Bar(i: Int) extends Module {
+    val baz = Instantiate(new Baz)
+  }
+  @instantiable
+  class Foo(i: Int) extends Module {
+    val bar0 = Instantiate(new Bar(0))
+    val bar1 = Instantiate(new Bar(1))
+    val bar11 = Instantiate(new Bar(1))
+  }
 }
 
 class ParameterizedReset(hasAsyncNotSyncReset: Boolean) extends Module {
@@ -170,6 +185,7 @@ class ParameterizedReset(hasAsyncNotSyncReset: Boolean) extends Module {
 }
 
 class InstantiateSpec extends ChiselFunSpec with Utils {
+
   import InstantiateSpec._
 
   describe("Module classes that take no arguments") {
@@ -474,5 +490,13 @@ class InstantiateSpec extends ChiselFunSpec with Utils {
         "Top"
       )
     )
+  }
+
+  it("Nested Instantiate should work") {
+    class MyTop extends Top {
+      val inst0 = Instantiate(new Foo(0))
+      val inst1 = Instantiate(new Foo(1))
+    }
+    assert(convert(new MyTop).modules.map(_.name).sorted == Seq("Bar", "Bar_1", "Baz", "Foo", "Foo_1", "Top").sorted)
   }
 }


### PR DESCRIPTION
When Instantiate a instantiable module, if it has other instantiable modules inside it, inner module will miss cache.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement
- Bugfix


#### Desired Merge Strategy
- Squash

#### Release Notes
Fix Nested Instantiate

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
