### PR TITLE
Add Instanitate.definition to get Definition from cache.

### DIFF
--- a/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstantiateSpec.scala
@@ -499,4 +499,13 @@ class InstantiateSpec extends ChiselFunSpec with Utils {
     }
     assert(convert(new MyTop).modules.map(_.name).sorted == Seq("Bar", "Bar_1", "Baz", "Foo", "Foo_1", "Top").sorted)
   }
+
+  it("Instantiate.definition should work") {
+    class MyTop extends Top {
+      val def0 = Instantiate.definition(new Foo(1))
+      val inst0 = def0.toInstance
+      val inst1 = Instantiate(new Foo(1))
+    }
+    assert(convert(new MyTop).modules.map(_.name).sorted == Seq("Bar", "Bar_1", "Baz", "Foo", "Top").sorted)
+  }
 }


### PR DESCRIPTION
Dep on #4018 

This issue is designed for the use case of OM, but also apply to the future linking flow.

The type of `Class` should always be deduped at chisel elaboration time, since for each elaboration, newly generated `Class` has a different type to previous one.
Thus we need to force user to pass `Definition` from top to down though hierarchy. I think is a bad user experience. :( 
Generally, all OM `Class` are cacheable since it only containing simple value or no values. This makes cache always work.
Thus user only need to use `Instanitate.definition(new SomeOM)` to elaborate `SomeOM` or fetch `SomeOM` from builder cache if possible.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?


#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
