### PR TITLE
Add Attribute annotation back to chisel in-tree firrtl

### DIFF
--- a/firrtl/src/main/scala/firrtl/AttributeAnnotation.scala
+++ b/firrtl/src/main/scala/firrtl/AttributeAnnotation.scala
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+package firrtl
+
+import firrtl.annotations.{Named, SingleTargetAnnotation}
+
+/** Firrtl implementation for verilog attributes
+  * @param target       target component to tag with attribute
+  * @param description  Attribute string to add to target
+  */
+case class AttributeAnnotation(target: Named, description: String) extends SingleTargetAnnotation[Named] {
+  def duplicate(n: Named): AttributeAnnotation = this.copy(target = n, description = description)
+}

--- a/firrtl/src/test/scala/firrtlTests/annotationTests/AttributeAnnotationSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/annotationTests/AttributeAnnotationSpec.scala
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package firrtlTests.annotationTests
+
+import firrtl.AttributeAnnotation
+import firrtl.annotations._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class AttributeAnnotationSpec extends AnyFreeSpec with Matchers {
+  "AttributeAnnotation should be correctly parsed from a string" in {
+    val attribAnno = new AttributeAnnotation(
+      ComponentName("attrib", ModuleName("ModuleAttrib", CircuitName("CircuitAttrib"))),
+      "X_INTERFACE_INFO = \"some:interface:type:1.0 SIGNAL\""
+    )
+
+    val annoString = JsonProtocol.serializeTry(Seq(attribAnno)).get
+    val loadedAnnos = JsonProtocol.deserializeTry(annoString).get
+    attribAnno should equal(loadedAnnos.head)
+  }
+}

--- a/src/main/scala/chisel3/util/AttributeAnnotation.scala
+++ b/src/main/scala/chisel3/util/AttributeAnnotation.scala
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-
 package chisel3.utils
 
 import firrtl.AttributeAnnotation
@@ -8,8 +7,34 @@ import firrtl.annotations.Named
 import chisel3.Data
 import chisel3.experimental.{annotate, requireIsAnnotatable, ChiselAnnotation}
 
-object annotateAttribute {
-  def apply[T <: Data](target: T, annoString: String): Unit = {
+/** Helper Object for applying Attribute Annotations */
+object addAttribute {
+
+  /** Add attribute annotation to a chisel target.
+    *
+    *  == Example ==
+    *  {{{
+    *  import chisel3._
+    *  import chisel3.util.addAttribute
+    *  class AttributeExample extends Module {
+    *    val io = IO(new Bundle{
+    *      val input = Input(UInt(8))
+    *      val output = Output(UInt(8))
+    *
+    *      val reg = RegNext(io.input)
+    *
+    *      addAttribute(reg, "synthesis translate_off")
+    *
+    *      io.output := reg
+    *    }
+    *  }
+    *
+    *  }}}
+    *
+    * @param target Chisel target. Must be Reg, Wire, or RawModule type.
+    * @param annoString attribute string to add to target.
+    */
+  def apply(target: Data, annoString: String): Unit = {
     requireIsAnnotatable(target, "target must be annotatable")
     annotate(new ChiselAnnotation {
       def toFirrtl = AttributeAnnotation(target.toNamed, annoString)

--- a/src/main/scala/chisel3/util/AttributeAnnotation.scala
+++ b/src/main/scala/chisel3/util/AttributeAnnotation.scala
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.utils
+
+import firrtl.AttributeAnnotation
+import firrtl.annotations.Named
+
+import chisel3.Data
+import chisel3.experimental.{annotate, requireIsAnnotatable, ChiselAnnotation}
+
+object annotateAttribute {
+  def apply[T <: Data](target: T, annoString: String): Unit = {
+    requireIsAnnotatable(target, "target must be annotatable")
+    annotate(new ChiselAnnotation {
+      def toFirrtl = AttributeAnnotation(target.toNamed, annoString)
+    })
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [X] Did you add Scaladoc to every public function/method?
- [X] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?
- [X] Did you add appropriate documentation in `docs/src`?
- [X] Did you request a desired merge strategy?
- [X] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
Bugfix


#### Desired Merge Strategy
Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
Add AttributeAnnotation back to in-tree firrtl

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
