### PR TITLE
Deprecate AssertPropertyLike.createIntrinsic

### DIFF
--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -8,6 +8,8 @@ import chisel3.experimental.hierarchy.{Instance, Instantiate}
 
 import chisel3.util.circt.LTLIntrinsicInstanceMethodsInternalWorkaround._
 
+import scala.annotation.nowarn
+
 /** An opaque sequence returned by an intrinsic.
   *
   * Due to the lack of opaque user-defined types in FIRRTL, the Linear Temporal
@@ -336,6 +338,7 @@ object Property {
 /** The base class for the `AssertProperty`, `AssumeProperty`, and
   * `CoverProperty` verification constructs.
   */
+@nowarn("cat=deprecation&msg=method createIntrinsic")
 sealed abstract class AssertPropertyLike {
 
   /** Assert, assume, or cover that a property holds.
@@ -412,6 +415,7 @@ sealed abstract class AssertPropertyLike {
     apply(Sequence.BoolSequence(cond), Some(clock), Some(disable), Some(label))
   }
 
+  @deprecated("This API should never have been public", "Chisel 6.4")
   def createIntrinsic(label: Option[String]): Instance[VerifAssertLikeIntrinsic]
 }
 
@@ -421,6 +425,7 @@ sealed abstract class AssertPropertyLike {
   * clock, disable_iff, and label parameters.
   */
 object AssertProperty extends AssertPropertyLike {
+  @deprecated("This API should never have been public", "Chisel 6.4")
   def createIntrinsic(label: Option[String]) = Instantiate(new VerifAssertIntrinsic(label))
 }
 
@@ -430,6 +435,7 @@ object AssertProperty extends AssertPropertyLike {
   * clock, disable_iff, and label parameters.
   */
 object AssumeProperty extends AssertPropertyLike {
+  @deprecated("This API should never have been public", "Chisel 6.4")
   def createIntrinsic(label: Option[String]) = Instantiate(new VerifAssumeIntrinsic(label))
 }
 
@@ -439,5 +445,6 @@ object AssumeProperty extends AssertPropertyLike {
   * clock, disable_iff, and label parameters.
   */
 object CoverProperty extends AssertPropertyLike {
+  @deprecated("This API should never have been public", "Chisel 6.4")
   def createIntrinsic(label: Option[String]) = Instantiate(new VerifCoverIntrinsic(label))
 }


### PR DESCRIPTION
Companion to https://github.com/chipsalliance/chisel/pull/4058

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

It should never have been a public API.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
