### PR TITLE
IntrinsicModule: deprecate in favor of intrinsic expressions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,8 @@ lazy val warningSuppression = Seq(
     "msg=undefined in comment for method cf in class PrintableHelper:s",
     // This is deprecated for external users but not internal use
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
-    "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s"
+    "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
+    "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s"
   ).mkString(",")
 )
 

--- a/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
+++ b/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
@@ -11,6 +11,7 @@ private[chisel3] abstract class BaseIntrinsicModule(intrinsicName: String) exten
   val intrinsic = intrinsicName
 }
 
+@deprecated("use Intrinsic and IntrinsicExpr instead, intrinsic modules are deprecated", "Chisel 7.0.0")
 abstract class IntrinsicModule(intrinsicName: String, val params: Map[String, Param] = Map.empty[String, Param])
     extends BaseIntrinsicModule(intrinsicName) {
   private[chisel3] override def generateComponent(): Option[Component] = {

--- a/docs/src/explanations/intrinsics.md
+++ b/docs/src/explanations/intrinsics.md
@@ -16,11 +16,6 @@ available is documented by an implementation.
 The `Intrinsic` and `IntrinsicExpr` can be used to create intrinsic statements
 and expressions.
 
-Modules defined as an `IntrinsicModule` will be instantiated as normal modules, 
-but the intrinsic field communicates to the compiler what functionality to use to 
-implement the module.  Implementations may not be actual modules, the module 
-nature of intrinsics is merely for instantiation purposes.
-
 ### Parameterization
 
 Parameters can be passed as an argument to the IntModule constructor.
@@ -36,28 +31,6 @@ import chisel3._
 
 ```scala mdoc:compile-only
 class Foo extends RawModule {
- val myresult = IntrinsicExpr("MyIntrinsic", UInt(32.W), "STRING" -> "test")(3.U, 5.U)
-}
-```
-
-### IntrinsicModule Example
-
-This following creates an intrinsic module for the intrinsic named
-"OtherIntrinsic".  It takes a parameter named "STRING" and has one bundle port.
-
-```scala mdoc:invisible
-import chisel3._
-```
-
-```scala mdoc:compile-only
-import chisel3.experimental.IntrinsicModule
-
-class ExampleIntrinsicModule(str: String) extends IntrinsicModule(
-  "OtherIntrinsic",
-  Map("STRING" -> str)) {
-  val foo = IO(new Bundle() {
-    val in = Input(UInt())
-    val out = Output(UInt(32.W))
-  })
+  val myresult = IntrinsicExpr("MyIntrinsic", UInt(32.W), "STRING" -> "test")(3.U, 5.U)
 }
 ```


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API deprecation

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
IntrinsicModule has been replaced by Intrinsic and IntrinsicExpr .

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
