### PR TITLE
Add support for Vec literals of empty Vecs

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -489,7 +489,6 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
             s"are less than zero or greater or equal to than Vec length"
         )
       }
-      cloneSupertype(elementInitializers.map(_._2), s"Vec.Lit(...)")
 
       // look for literals of this vec that are wider than the vec's type
       val badLits = elementInitializers.flatMap {

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -155,11 +155,9 @@ package object experimental {
         * object `Vec` as in `Vec.Lit(1.U, 2.U)`
         */
       def Lit[T <: Data](elems: T*)(implicit sourceInfo: SourceInfo): Vec[T] = {
-        require(elems.nonEmpty, s"Lit.Vec(...) must have at least one element")
-        val indexElements = elems.zipWithIndex.map { case (element, index) => (index, element) }
-        val widestElement = elems.maxBy(_.getWidth)
-        val vec: Vec[T] = Vec.apply(indexElements.length, chiselTypeOf(widestElement))
-        vec.Lit(indexElements: _*)
+        val sampleElement = cloneSupertype(elems, s"Vec.Lit(...)")
+        val vec: Vec[T] = Vec.apply(elems.length, sampleElement)
+        vec.Lit(elems.zipWithIndex.map(_.swap): _*)
       }
     }
   }

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -360,4 +360,11 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
     val wire = """wire.*: const \{ a : UInt<8>, b : UInt<1>, c : UInt<1>\}""".r
     (chirrtl should include).regex(wire)
   }
+
+  "Empty bundle literals" should "be supported" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val lit = (new Bundle {}).Lit()
+      lit.litOption should equal(Some(0))
+    })
+  }
 }

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -115,7 +115,6 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
   }
 
   "Vec literals should only init specified fields when used to partially initialize a reg of vec" in {
-    println(ChiselStage.emitCHIRRTL(new ResetRegWithPartialVecLiteral))
     assertTesterPasses(new BasicTester {
       val m = Module(new ResetRegWithPartialVecLiteral)
       val (counter, wrapped) = Counter(true.B, 8)
@@ -514,5 +513,21 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
     })
     val wire = """wire.*: const UInt<4>\[2\]""".r
     (chirrtl should include).regex(wire)
+  }
+
+  "Empty vec literals should be supported" in {
+    ChiselStage.emitCHIRRTL(new RawModule {
+      val lit = Vec(0, UInt(8.W)).Lit()
+      lit.litOption should equal(Some(0))
+    })
+    // It should also work when the element type is a Bundle
+    class MyBundle extends Bundle {
+      val a = UInt(8.W)
+      val b = UInt(8.W)
+    }
+    ChiselStage.emitCHIRRTL(new RawModule {
+      val lit = Vec(0, new MyBundle).Lit()
+      lit.litOption should equal(Some(0))
+    })
   }
 }


### PR DESCRIPTION
Also tweak Vec.Lit code to use cloneAsSuperType rather than implementing its own version of the same concept.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->

- Bugfix
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
