### PR TITLE
Fix literal handling for views of empty Aggregates

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -44,6 +44,15 @@ sealed abstract class Aggregate extends Data {
     }
 
     topBindingOpt match {
+      // Don't accidentally invent a literal value for a view that is empty
+      case Some(_: AggregateViewBinding) if this.getElements.isEmpty =>
+        reifySingleData(this) match {
+          case Some(target: Aggregate) => target.checkingLitOption(checkForDontCares)
+          case _ =>
+            val msg =
+              s"It should not be possible to have an empty Aggregate view that doesn't reify to a single target, but got $this"
+            Builder.exception(msg)(UnlocatableSourceInfo)
+        }
       case Some(_: BundleLitBinding | _: VecLitBinding | _: AggregateViewBinding) =>
         // Records store elements in reverse order and higher indices are more significant in Vecs
         this.getElements.foldRight(Option(BigInt(0)))(shiftAdd)

--- a/src/test/scala/chiselTests/experimental/DataView.scala
+++ b/src/test/scala/chiselTests/experimental/DataView.scala
@@ -6,6 +6,8 @@ import chisel3._
 import chisel3.experimental.conversions._
 import chisel3.experimental.dataview._
 import chisel3.experimental.{Analog, HWTuple2}
+import chisel3.experimental.BundleLiterals._
+import chisel3.experimental.VecLiterals._
 import chisel3.probe._
 import chisel3.reflect.DataMirror.internal.chiselTypeClone
 import chisel3.util.{Decoupled, DecoupledIO, Valid, ValidIO}
@@ -1117,6 +1119,38 @@ class DataViewSpec extends ChiselFlatSpec {
       val bunView = vec.viewAs[MyBundle]
       bunView.litValue should be(0xdabc)
       bunView.litOption should be(Some(0xdabc))
+    }
+    ChiselStage.emitCHIRRTL(new MyModule)
+  }
+
+  it should "NOT invent literal values for views of empty Aggregates" in {
+    class MyModule extends Module {
+      val emptyBundle = IO(Output(new Bundle {}))
+      val emptyVec = IO(Output(Vec(0, UInt(8.W))))
+
+      val bundleView = emptyBundle.viewAs[Bundle]
+      val vecView = emptyVec.viewAs[Vec[UInt]]
+
+      emptyBundle.litOption should be(None)
+      bundleView.litOption should be(None)
+      emptyVec.litOption should be(None)
+      vecView.litOption should be(None)
+    }
+    ChiselStage.emitCHIRRTL(new MyModule)
+  }
+
+  it should "support literal values for views of empty Aggregates" in {
+    class MyModule extends Module {
+      val emptyBundle = (new Bundle {}).Lit()
+      val emptyVec = Vec(0, UInt(8.W)).Lit()
+
+      val bundleView = emptyBundle.viewAs[Bundle]
+      val vecView = emptyVec.viewAs[Vec[UInt]]
+
+      emptyBundle.litOption should be(Some(0))
+      bundleView.litOption should be(Some(0))
+      emptyVec.litOption should be(Some(0))
+      vecView.litOption should be(Some(0))
     }
     ChiselStage.emitCHIRRTL(new MyModule)
   }


### PR DESCRIPTION
This requires https://github.com/chipsalliance/chisel/pull/4070 for the tests to pass

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, a view of an empty aggregate would incorrectly always have a litValue of `0`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
