### PR TITLE
Remove line contents from assertion messages

### DIFF
--- a/core/src/main/scala/chisel3/VerificationStatement.scala
+++ b/core/src/main/scala/chisel3/VerificationStatement.scala
@@ -433,11 +433,11 @@ abstract class VerificationStatement extends NamedComponent {
 /** Helper functions for common functionality required by stop, assert, assume or cover */
 private object VerificationStatement {
 
-  type SourceLineInfo = (String, Int, String)
+  type SourceLineInfo = (String, Int)
 
   def getLine(c: blackbox.Context): SourceLineInfo = {
     val p = c.enclosingPosition
-    (p.source.file.name, p.line, p.lineContent.trim): @nowarn // suppress, there's no clear replacement
+    (p.source.file.name, p.line): @nowarn // suppress, there's no clear replacement
   }
 
   def formatFailureMessage(
@@ -448,12 +448,12 @@ private object VerificationStatement {
   )(
     implicit sourceInfo: SourceInfo
   ): Printable = {
-    val (filename, line, content) = lineInfo
-    val lineMsg = s"$filename:$line $content".replaceAll("%", "%%")
+    val (filename, line) = lineInfo
+    val lineMsg = s"$filename:$line".replaceAll("%", "%%")
     message match {
       case Some(msg) =>
-        p"$kind failed: $msg\n    at $lineMsg\n"
-      case None => p"$kind failed\n    at $lineMsg\n"
+        p"$kind failed: $msg\n"
+      case None => p"$kind failed at $lineMsg\n"
     }
   }
 }

--- a/src/test/scala/chiselTests/Assert.scala
+++ b/src/test/scala/chiselTests/Assert.scala
@@ -79,7 +79,7 @@ class PrintableAssumeTester extends Module {
 
   val w = Wire(UInt(8.W))
   w := 255.U
-  assume(w === 255.U, cf"Assumption failed, Wire w =/= $w%x")
+  assume(w === 255.U, cf"wire w =/= $w%x")
 
   out := in
 }
@@ -180,7 +180,7 @@ class AssertSpec extends ChiselFlatSpec with Utils {
   they should "allow printf-style format strings in Assumes" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new PrintableAssumeTester)
     chirrtl should include(
-      """assume(w === 255.U, cf\"Assumption failed, Wire w =/= $w%%%%x\")\n", w)"""
+      """"Assumption failed: wire w =/= %x\n", w"""
     )
   }
   they should "not allow unescaped % in the message" in {

--- a/src/test/scala/chiselTests/VerificationSpec.scala
+++ b/src/test/scala/chiselTests/VerificationSpec.scala
@@ -41,7 +41,7 @@ class VerificationSpec extends ChiselPropSpec with Matchers {
     assertContains(lines, "node _T_6 = eq(reset, UInt<1>(0h0))")
     assertContains(
       lines,
-      """intrinsic(circt_chisel_ifelsefatal<format = "Assertion failed: io.in:%d is equal to io.out:%d\n    at VerificationSpec.scala:20 assert(io.out === io.in, p\"${FullName(io.in)}:${io.in} is equal to ${FullName(io.out)}:${io.out}\")\n", label = "chisel3_builtin">, clock, _T_5, _T_6, io.in, io.out)"""
+      """intrinsic(circt_chisel_ifelsefatal<format = "Assertion failed: io.in:%d is equal to io.out:%d\n", label = "chisel3_builtin">, clock, _T_5, _T_6, io.in, io.out)"""
     )
   }
 


### PR DESCRIPTION
I'm waffling on whether to call this an API Modification or a Backend code generation. It sort of toes that line. I decided to keep the `Assertion failed:` prefix (at least for now) even when there is a user-provided message just because I know that that String is often used for determining when an assertion fires. Removing that is something we should probably do (when the user provides a String), but I'll leave that as a separate change that should be marked as an API modification.

This change feels very... late lol. This feels like the sort of thing in Chisel before 3.0 yet it has lingered for a very long time. Capturing the user's line has a lot of negative consequences, like including comments. It's also very ugly.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Backend code generation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Also remove line and column when a message is provided.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
