### PR TITLE
Fix widths for literal values in Bundle literals

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1212,20 +1212,20 @@ abstract class Record extends Aggregate {
       val duplicateNames = duplicates.map(cloneFields(_)).mkString(", ")
       throw new BundleLiteralException(s"duplicate fields $duplicateNames in Bundle literal constructor")
     }
-    // Check widths and sign extend as appropriate
+    // Check widths and sign extend as appropriate.
     val bundleLitMap = bundleLitMapping.view.map {
       case (field, value) =>
         field.width match {
-          // If width is unknown, then it is set by the literal value
+          // If width is unknown, then it is set by the literal value.
           case UnknownWidth()                 => field -> value
           case width @ KnownWidth(widthValue) =>
-            // TODO make this a warning then an error, but for older versions, just truncate
+            // TODO make this a warning then an error, but for older versions, just truncate.
             val valuex = if (widthValue < value.width.get) {
-              // Mask the value to the width of the field
+              // Mask the value to the width of the field.
               val mask = (BigInt(1) << widthValue) - 1
               value.cloneWithValue(value.num & mask).cloneWithWidth(width)
             } else if (widthValue > value.width.get) value.cloneWithWidth(width)
-            // Otherwise, ensure width is same as that of the field
+            // Otherwise, ensure width is same as that of the field.
             else value
 
             field -> valuex

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -122,7 +122,6 @@ private[chisel3] object ir {
     }
 
     /** Provides a mechanism that LitArgs can have their width adjusted
-      * to match other members of a VecLiteral
       *
       * @param newWidth the new width for this
       * @return

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -128,7 +128,7 @@ private[chisel3] object ir {
       */
     def cloneWithWidth(newWidth: Width): this.type
 
-    /** Provides a mechanism that LitArgs can have their value adjusted
+    /** Provides a mechanism that LitArgs can have their value adjusted.
       *
       * @param newWidth the new width for this
       * @return

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -121,12 +121,19 @@ private[chisel3] object ir {
       elem
     }
 
-    /** Provides a mechanism that LitArgs can have their width adjusted
+    /** Provides a mechanism that LitArgs can have their width adjusted.
       *
       * @param newWidth the new width for this
       * @return
       */
     def cloneWithWidth(newWidth: Width): this.type
+
+    /** Provides a mechanism that LitArgs can have their value adjusted
+      *
+      * @param newWidth the new width for this
+      * @return
+      */
+    def cloneWithValue(newValue: BigInt): this.type
 
     protected def minWidth: Int
     if (forcedWidth) {
@@ -149,6 +156,8 @@ private[chisel3] object ir {
       ULit(n, newWidth).asInstanceOf[this.type]
     }
 
+    def cloneWithValue(newValue: BigInt): this.type = ULit(newValue, w).asInstanceOf[this.type]
+
     require(n >= 0, s"UInt literal ${n} is negative")
   }
 
@@ -162,6 +171,8 @@ private[chisel3] object ir {
     def cloneWithWidth(newWidth: Width): this.type = {
       SLit(n, newWidth).asInstanceOf[this.type]
     }
+
+    def cloneWithValue(newValue: BigInt): this.type = SLit(newValue, w).asInstanceOf[this.type]
   }
 
   /** Literal property value.

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -344,13 +344,16 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
     exc.getMessage should include(".c")
   }
 
-  "bundle literals with too-wide literal values" should "fail" in {
-    val e = the[BundleLiteralException] thrownBy {
-      ChiselStage.emitCHIRRTL(new RawModule {
-        (new MyBundle).Lit(_.a -> 0.U(32.W))
-      })
+  "bundle literals with too-wide of literal values" should "truncate" in {
+    class SimpleBundle extends Bundle {
+      val a = UInt(4.W)
+      val b = UInt(4.W)
     }
-    e.getMessage should include("Literal value ULit(0,<32>) is too wide for field _.a with width 8")
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val lit = (new SimpleBundle).Lit(_.a -> 0xde.U, _.b -> 0xad.U)
+      val x = lit.asUInt
+    })
+    chirrtl should include("node x = cat(UInt<4>(0he), UInt<4>(0hd))")
   }
 
   "partial bundle literals" should "fail to pack" in {

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -386,7 +386,7 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
       val b = UInt(4.W)
     }
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
-      // Whether the user specifies a width or not
+      // Whether the user specifies a width or not.
       val lit = (new SimpleBundle).Lit(_.a -> 0x3.U, _.b -> 0x3.U(3.W))
       lit.a.getWidth should be(4)
       lit.b.getWidth should be(4)

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -1060,7 +1060,7 @@ class ConnectableSpec extends ChiselFunSpec with Utils {
           "connect out.valid, in.valid",
           "connect in.ready, out.ready",
           "connect out.data.b, in.data.b",
-          "connect out.data.c, UInt<1>(0h1)"
+          "connect out.data.c, UInt<2>(0h1)"
         ),
         Nil
       )
@@ -1535,11 +1535,11 @@ class ConnectableSpec extends ChiselFunSpec with Utils {
         out,
         Seq(
           """wire w0 : { foo : UInt<3>, flip bar : UInt<3>}""",
-          """connect w0.bar, UInt<1>(0h1)""",
-          """connect w0.foo, UInt<1>(0h0)""",
+          """connect w0.bar, UInt<3>(0h1)""",
+          """connect w0.foo, UInt<3>(0h0)""",
           """wire w1 : { foo : UInt<3>, flip bar : UInt<3>}""",
-          """connect w1.bar, UInt<1>(0h1)""",
-          """connect w1.foo, UInt<1>(0h0)""",
+          """connect w1.bar, UInt<3>(0h1)""",
+          """connect w1.foo, UInt<3>(0h0)""",
           """connect w1, w0"""
         ),
         Nil
@@ -1625,7 +1625,7 @@ class ConnectableSpec extends ChiselFunSpec with Utils {
       testCheck(
         out,
         Seq(
-          """connect out.data, UInt<1>(0h0)""",
+          """connect out.data, UInt<32>(0h0)""",
           """connect in.ready, out.ready""",
           """connect out.valid, in.valid"""
         ),

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -436,7 +436,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   class VecExample extends RawModule {
     val out = IO(Output(Vec(2, new SubBundle)))
-    // Note that 22.U is too wide for bar so gets truncated below
+    // Note that 22.U is too wide for bar so gets truncated below.
     val bundle = Vec(2, new SubBundle).Lit(
       0 -> (new SubBundle).Lit(_.foo -> 42.U, _.bar -> 22.U),
       1 -> (new SubBundle).Lit(_.foo -> 7.U, _.bar -> 3.U)
@@ -534,7 +534,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "Vec literals should use the width of the Vec element rather than the widths of the literals" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
-      // Whether the user specifies a width or not
+      // Whether the user specifies a width or not.
       val lit0 = (Vec(2, UInt(4.W))).Lit(0 -> 0x3.U, 1 -> 0x2.U(3.W))
       lit0(0).getWidth should be(4)
       lit0(1).getWidth should be(4)

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -436,6 +436,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   class VecExample extends RawModule {
     val out = IO(Output(Vec(2, new SubBundle)))
+    // Note that 22.U is too wide for bar so gets truncated below
     val bundle = Vec(2, new SubBundle).Lit(
       0 -> (new SubBundle).Lit(_.foo -> 42.U, _.bar -> 22.U),
       1 -> (new SubBundle).Lit(_.foo -> 7.U, _.bar -> 3.U)
@@ -445,10 +446,10 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "vec literals can contain bundles and should not be bulk connected" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new VecExample)
-    chirrtl should include("""connect out[0].bar, UInt<5>(0h16)""")
-    chirrtl should include("""connect out[0].foo, UInt<6>(0h2a)""")
-    chirrtl should include("""connect out[1].bar, UInt<2>(0h3)""")
-    chirrtl should include("""connect out[1].foo, UInt<3>(0h7)""")
+    chirrtl should include("""connect out[0].bar, UInt<4>(0h6)""")
+    chirrtl should include("""connect out[0].foo, UInt<8>(0h2a)""")
+    chirrtl should include("""connect out[1].bar, UInt<4>(0h3)""")
+    chirrtl should include("""connect out[1].foo, UInt<8>(0h7)""")
   }
 
   "vec literals can have bundle children" in {

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -530,4 +530,20 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
       lit.litOption should equal(Some(0))
     })
   }
+
+  "Vec literals should use the width of the Vec element rather than the widths of the literals" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      // Whether the user specifies a width or not
+      val lit0 = (Vec(2, UInt(4.W))).Lit(0 -> 0x3.U, 1 -> 0x2.U(3.W))
+      lit0(0).getWidth should be(4)
+      lit0(1).getWidth should be(4)
+      val uint0 = lit0.asUInt
+      val lit1 = Vec.Lit(0x3.U, 0x2.U(4.W))
+      lit1(0).getWidth should be(4)
+      lit1(1).getWidth should be(4)
+      val uint1 = lit1.asUInt
+    })
+    chirrtl should include("node uint0 = cat(UInt<4>(0h2), UInt<4>(0h3))")
+    chirrtl should include("node uint1 = cat(UInt<4>(0h2), UInt<4>(0h3))")
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, the user-specified (or unspecified minimum width) of the literal would be used in some operations like concatenation. For literal values that are too-wide, they will now truncate to the correct width. This will become a warning (then later an error) in newer major versions of Chisel.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
