### PR TITLE
Fix boring tap of non-passive source from parent.

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -10,6 +10,7 @@ import chisel3.experimental.hierarchy.{InstanceClone, ModuleClone}
 import chisel3.properties.{DynamicObject, Property, StaticObject}
 import chisel3.internal.Builder._
 import chisel3.internal.firrtl.ir._
+import chisel3.reflect.DataMirror
 import _root_.firrtl.annotations.{IsModule, ModuleTarget}
 import scala.collection.immutable.VectorBuilder
 import scala.collection.mutable.ArrayBuffer
@@ -217,6 +218,12 @@ abstract class RawModule extends BaseModule {
         // For non-probe, directly create Nodes for lhs, skipping visibility check to support BoringUtils.drive.
         (left, right) match {
           case (_: Property[_], _: Property[_]) => PropAssign(si, Node(left), Node(right))
+          // Use `connect lhs, read(probe(rhs))` if lhs is passive version of rhs.
+          // This provides solution for this: https://github.com/chipsalliance/chisel/issues/3557
+          case (_, _)
+              if !DataMirror.checkAlignmentTypeEquivalence(left, right) &&
+                DataMirror.checkAlignmentTypeEquivalence(left, Output(chiselTypeOf(right))) =>
+            Connect(si, Node(left), ProbeRead(ProbeExpr(Node(right))))
           case (_, _) => Connect(si, Node(left), Node(right))
         }
     }

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -470,13 +470,7 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
 
     class Foo extends RawModule {
       val a = WireInit(DecoupledIO(Bool()), DontCare)
-      val dummyA = Wire(Output(chiselTypeOf(a)))
-      // FIXME we shouldn't need this intermediate wire
-      // https://github.com/chipsalliance/chisel/issues/3557
-      dummyA :#= a
-      dontTouch(a)
-
-      val bar = Module(new Bar(dummyA))
+      val bar = Module(new Bar(a))
     }
 
     val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Foo, Array("--full-stacktrace"))
@@ -486,9 +480,7 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       "input bore : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}",
       "module Foo :",
       "wire a : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}",
-      // FIXME shouldn't need intermediate wire
-      "wire dummyA : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}",
-      "connect bar.bore, dummyA"
+      "connect bar.bore, read(probe(a))"
     )()
 
     // Check that firtool also passes


### PR DESCRIPTION
Expected result is fully aligned, which is what happens when reading from a probe.

When the source is already at the LCA (from parent) there's no probe and the secret connections only support a few commands.

For lack of a way to do, e.g., `:#=` here,
use `read(probe(x))` to get the fully aligned result that's expected and bored down to the child.

This isn't ideal but fixes this using only the sorts of expressions and commands that we've already committed to supporting.

Fixes #3557.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Fix tapping mix-alignment signal from parent.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
