### PR TITLE
Make it a warning to have too-wide literal values in Bundle Literals

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1118,7 +1118,7 @@ abstract class Record extends Aggregate {
     * )
     * }}}
     */
-  private[chisel3] def _makeLit(elems: (this.type => (Data, Data))*): this.type = {
+  private[chisel3] def _makeLit(elems: (this.type => (Data, Data))*)(implicit sourceInfo: SourceInfo): this.type = {
 
     requireIsChiselType(this, "bundle literal constructor model")
     val clone = cloneType
@@ -1222,6 +1222,8 @@ abstract class Record extends Aggregate {
             // TODO make this a warning then an error, but for older versions, just truncate.
             val valuex = if (widthValue < value.width.get) {
               // Mask the value to the width of the field.
+              val msg = s"Literal value $value is too wide for field ${cloneFields(field)} with width $widthValue"
+              Builder.warning(Warning(WarningID.BundleLiteralValueTooWide, msg))
               val mask = (BigInt(1) << widthValue) - 1
               value.cloneWithValue(value.num & mask).cloneWithWidth(width)
             } else if (widthValue > value.width.get) value.cloneWithWidth(width)

--- a/core/src/main/scala/chisel3/internal/Warning.scala
+++ b/core/src/main/scala/chisel3/internal/Warning.scala
@@ -19,6 +19,7 @@ private[chisel3] object WarningID extends Enumeration {
   val DynamicIndexTooWide = Value(4)
   val DynamicIndexTooNarrow = Value(5)
   val ExtractFromVecSizeZero = Value(6)
+  val BundleLiteralValueTooWide = Value(7)
 }
 import WarningID.WarningID
 

--- a/docs/src/explanations/warnings.md
+++ b/docs/src/explanations/warnings.md
@@ -143,3 +143,10 @@ It can be fixed as described in the [Cookbook](../cookbooks/cookbook#how-do-i-re
 
 This warning occurs when indexing a `Vec` with no elements.
 It can be fixed by removing the indexing operation for the size zero `Vec` (perhaps via guarding with an `if-else` or `Option.when`).
+
+### [W007] Bundle literal value too wide
+
+This warning occurs when creating a [Bundle Literal](../appendix/experimental-features#bundle-literals) where the literal value for a
+field is wider than the Bundle field's width.
+It can be fixed by reducing the width of the literal (perhaps choosing a different value if it is impossible to encode the value in the
+field's width).

--- a/src/test/scala/chiselTests/BundleLiteralSpec.scala
+++ b/src/test/scala/chiselTests/BundleLiteralSpec.scala
@@ -344,15 +344,17 @@ class BundleLiteralSpec extends ChiselFlatSpec with Utils {
     exc.getMessage should include(".c")
   }
 
-  "bundle literals with too-wide of literal values" should "truncate" in {
+  "bundle literals with too-wide of literal values" should "warn and truncate" in {
     class SimpleBundle extends Bundle {
       val a = UInt(4.W)
       val b = UInt(4.W)
     }
-    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+    val (stdout, _, chirrtl) = grabStdOutErr(ChiselStage.emitCHIRRTL(new RawModule {
       val lit = (new SimpleBundle).Lit(_.a -> 0xde.U, _.b -> 0xad.U)
       val x = lit.asUInt
-    })
+    }))
+    stdout should include("[W007] Literal value ULit(222,) is too wide for field _.a with width 4")
+    stdout should include("[W007] Literal value ULit(173,) is too wide for field _.b with width 4")
     chirrtl should include("node x = cat(UInt<4>(0he), UInt<4>(0hd))")
   }
 

--- a/src/test/scala/chiselTests/VecLiteralSpec.scala
+++ b/src/test/scala/chiselTests/VecLiteralSpec.scala
@@ -436,9 +436,8 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   class VecExample extends RawModule {
     val out = IO(Output(Vec(2, new SubBundle)))
-    // Note that 22.U is too wide for bar so gets truncated below.
     val bundle = Vec(2, new SubBundle).Lit(
-      0 -> (new SubBundle).Lit(_.foo -> 42.U, _.bar -> 22.U),
+      0 -> (new SubBundle).Lit(_.foo -> 42.U, _.bar -> 0xd.U),
       1 -> (new SubBundle).Lit(_.foo -> 7.U, _.bar -> 3.U)
     )
     out := bundle
@@ -446,7 +445,7 @@ class VecLiteralSpec extends ChiselFreeSpec with Utils {
 
   "vec literals can contain bundles and should not be bulk connected" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new VecExample)
-    chirrtl should include("""connect out[0].bar, UInt<4>(0h6)""")
+    chirrtl should include("""connect out[0].bar, UInt<4>(0hd)""")
     chirrtl should include("""connect out[0].foo, UInt<8>(0h2a)""")
     chirrtl should include("""connect out[1].bar, UInt<4>(0h3)""")
     chirrtl should include("""connect out[1].foo, UInt<8>(0h7)""")


### PR DESCRIPTION
Follow on to https://github.com/chipsalliance/chisel/pull/4082 to make too wide of Bundle literal values be a warning (Chisel warnings are elevated to errors by many users).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- API deprecation

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
