### PR TITLE
Suppress exception throwing in Data.toString

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -424,7 +424,9 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   private[chisel3] def stringAccessor(chiselType: String): String = {
     // Trace views to give better error messages
-    val thiz = reifySingleData(this).getOrElse(this)
+    // Reifying involves checking against ViewParent which requires being in a Builder context
+    // Since we're just printing a String, suppress such errors and use this object
+    val thiz = Try(reifySingleData(this)).toOption.flatten.getOrElse(this)
     thiz.topBindingOpt match {
       case None => chiselType
       // Handle DontCares specially as they are "literal-like" but not actually literals

--- a/src/test/scala/chiselTests/DataPrint.scala
+++ b/src/test/scala/chiselTests/DataPrint.scala
@@ -89,23 +89,19 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
   }
 
   "Literals" should "have a meaningful string representation" in {
-    ChiselStage.emitCHIRRTL {
-      new RawModule {
-        3.U.toString should be("UInt<2>(3)")
-        3.U(5.W).toString should be("UInt<5>(3)")
-        -1.S.toString should be("SInt<1>(-1)")
-        false.B.toString should be("Bool(false)")
-        true.B.toString should be("Bool(true)")
-        Vec(3, UInt(4.W)).toString should be("UInt<4>[3]")
-        EnumTest.sNone.toString should be("EnumTest(0=sNone)")
-        EnumTest.sTwo.toString should be("EnumTest(2=sTwo)")
-        EnumTest(1.U).toString should be("EnumTest(1=sOne)")
-        (new BundleTest).Lit(_.a -> 2.U, _.b -> false.B).toString should be("BundleTest(a=UInt<8>(2), b=Bool(false))")
-        (new PartialBundleTest).Lit().toString should be(
-          "PartialBundleTest(a=UInt<8>(DontCare), b=Bool(DontCare), c=SInt<8>(DontCare), f=EnumTest(DontCare))"
-        )
-        DontCare.toString should be("DontCare()")
-      }
-    }
+    3.U.toString should be("UInt<2>(3)")
+    3.U(5.W).toString should be("UInt<5>(3)")
+    -1.S.toString should be("SInt<1>(-1)")
+    false.B.toString should be("Bool(false)")
+    true.B.toString should be("Bool(true)")
+    Vec(3, UInt(4.W)).toString should be("UInt<4>[3]")
+    EnumTest.sNone.toString should be("EnumTest(0=sNone)")
+    EnumTest.sTwo.toString should be("EnumTest(2=sTwo)")
+    EnumTest(1.U).toString should be("EnumTest(1=sOne)")
+    (new BundleTest).Lit(_.a -> 2.U, _.b -> false.B).toString should be("BundleTest(a=UInt<8>(2), b=Bool(false))")
+    (new PartialBundleTest).Lit().toString should be(
+      "PartialBundleTest(a=UInt<8>(DontCare), b=Bool(DontCare), c=SInt<8>(DontCare), f=EnumTest(DontCare))"
+    )
+    DontCare.toString should be("DontCare()")
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This makes `.toString` behavior better outside of Chisel elaboration contexts.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
