### PR TITLE
Preserve literals across .asUInt

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -1023,9 +1023,22 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with Num[S
   override def do_>>(that: UInt)(implicit sourceInfo: SourceInfo): SInt =
     binop(sourceInfo, SInt(this.width), DynamicShiftRightOp, that)
 
-  override private[chisel3] def _asUIntImpl(first: Boolean)(implicit sourceInfo: SourceInfo): UInt = pushOp(
-    DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref)
-  )
+  override private[chisel3] def _asUIntImpl(first: Boolean)(implicit sourceInfo: SourceInfo): UInt =
+    this.litOption match {
+      case Some(value) =>
+        // This is a reinterpretation of raw bits
+        val posValue =
+          if (value.signum == -1) {
+            (BigInt(1) << this.width.get) + value
+          } else {
+            value
+          }
+        // Using UInt.Lit instead of .U so we can use Width argument which may be Unknown
+        UInt.Lit(posValue, this.width)
+      case None =>
+        pushOp(DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref))
+    }
+
   override def do_asSInt(implicit sourceInfo: SourceInfo): SInt = this
 
   private[chisel3] override def connectFromBits(

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -219,4 +219,32 @@ class SIntOpsSpec extends ChiselPropSpec with Utils with ShiftRightWidthBehavior
     val verilog = ChiselStage.emitSystemVerilog(new TestModule, args)
     verilog should include(" widthcheck = in[7];")
   }
+
+  property("Calling .asUInt on an SInt literal should maintain the literal value") {
+    val s0 = 3.S
+    val u0 = s0.asUInt
+    u0.litValue should be(3)
+
+    val s1 = -3.S
+    val u1 = s1.asUInt
+    u1.litValue should be(5)
+
+    val s2 = -3.S(8.W)
+    val u2 = s2.asUInt
+    u2.litValue should be(0xfd)
+
+    assertTesterPasses {
+      new BasicTester {
+        // Check that it gives the same value as the generated hardware
+        val wire0 = WireInit(s0).asUInt
+        chisel3.assert(u0.litValue.U === wire0)
+        val wire1 = WireInit(s1).asUInt
+        chisel3.assert(u1.litValue.U === wire1)
+        val wire2 = WireInit(s2).asUInt
+        chisel3.assert(u2.litValue.U === wire2)
+
+        stop()
+      }
+    }
+  }
 }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -607,4 +607,8 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
     val e = the[IllegalArgumentException] thrownBy (UInt(-8.W))
     e.getMessage should include("Widths must be non-negative, got -8")
   }
+
+  property("Calling .asUInt on a UInt literal should maintain the literal value") {
+    3.U.asUInt.litValue should be(3)
+  }
 }


### PR DESCRIPTION
Also working on supporting preserving literals across `.asTypeOf`, but this is the first step.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This is mostly useful for initial values for async reset registers and for constructing literal values in testing contexts (e.g. ChiselSim). It also should slightly reduce memory use and `.fir` size.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
