### PR TITLE
Preserve literal value across .asSInt and .zext

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -778,11 +778,27 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with Num[U
   final def zext: SInt = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
-  def do_zext(implicit sourceInfo: SourceInfo): SInt =
-    pushOp(DefPrim(sourceInfo, SInt(width + 1), ConvertOp, ref))
+  def do_zext(implicit sourceInfo: SourceInfo): SInt = this.litOption match {
+    case Some(value) => SInt.Lit(value, this.width + 1)
+    case None        => pushOp(DefPrim(sourceInfo, SInt(width + 1), ConvertOp, ref))
+  }
 
-  override def do_asSInt(implicit sourceInfo: SourceInfo): SInt =
-    pushOp(DefPrim(sourceInfo, SInt(width), AsSIntOp, ref))
+  override def do_asSInt(implicit sourceInfo: SourceInfo): SInt = this.litOption match {
+    case Some(value) =>
+      val w = this.width.get // Literals always have a known width, will be minimum legal width if not set
+      val signedValue =
+        // If width is 0, just return value (which will be 0).
+        if (w > 0 && value.testBit(w - 1)) {
+          // If the most significant bit is set, the SInt is negative and we need to adjust the value.
+          value - (BigInt(1) << w)
+        } else {
+          value
+        }
+      // Using SInt.Lit instead of .S so we can use Width argument which may be Unknown
+      SInt.Lit(signedValue, this.width.max(Width(1))) // SInt literal has width >= 1
+    case None =>
+      pushOp(DefPrim(sourceInfo, SInt(width), AsSIntOp, ref))
+  }
 
   override private[chisel3] def _asUIntImpl(first: Boolean)(implicit sourceInfo: SourceInfo): UInt = this
 

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -247,4 +247,9 @@ class SIntOpsSpec extends ChiselPropSpec with Utils with ShiftRightWidthBehavior
       }
     }
   }
+
+  property("Calling .asSInt on a SInt literal should maintain the literal value") {
+    3.S.asSInt.litValue should be(3)
+    -5.S.asSInt.litValue should be(-5)
+  }
 }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -611,4 +611,22 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
   property("Calling .asUInt on a UInt literal should maintain the literal value") {
     3.U.asUInt.litValue should be(3)
   }
+
+  property("Calling .asSInt on a UInt literal should reinterpret the literal value") {
+    5.U.asSInt.litValue should be(-3)
+    5.U(8.W).asSInt.litValue should be(5)
+    0.U.asSInt.litValue should be(0)
+    0.U.asSInt.widthOption should be(Some(1))
+    // There are no zero-width SInt literals
+    0.U(0.W).asSInt.widthOption should be(Some(1))
+  }
+
+  property("Calling .zext on a UInt literal should maintain the literal value") {
+    5.U.zext.litValue should be(5)
+    5.U.zext.getWidth should be(4)
+    5.U(8.W).zext.litValue should be(5)
+    0.U.zext.litValue should be(0)
+    0.U.zext.widthOption should be(Some(2))
+    0.U(0.W).zext.widthOption should be(Some(1))
+  }
 }


### PR DESCRIPTION
Note that `.asSInt` is only defined on `Bits`, if you want to cast to `SInt` from Bundles or Vecs you already gotta go through `UInt`.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
