### PR TITLE
Preserve literals across .asTypeOf

### DIFF
--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -45,13 +45,8 @@ abstract class EnumType(private[chisel3] val factory: ChiselEnum, selfAnnotating
     pushOp(DefPrim(sourceInfo, Bool(), op, this.ref, other.ref))
   }
 
-  private[chisel3] override def connectFromBits(
-    that: Bits
-  )(
-    implicit sourceInfo: SourceInfo
-  ): Unit = {
-    this := factory.apply(that.asUInt)
-  }
+  override private[chisel3] def _fromUInt(that: UInt)(implicit sourceInfo: SourceInfo): Data =
+    factory.apply(that.asUInt)
 
   final def ===(that: EnumType): Bool = macro SourceInfoTransform.thatArg
   final def =/=(that: EnumType): Bool = macro SourceInfoTransform.thatArg
@@ -72,6 +67,28 @@ abstract class EnumType(private[chisel3] val factory: ChiselEnum, selfAnnotating
     compop(sourceInfo, LessEqOp, that)
   def do_>=(that: EnumType)(implicit sourceInfo: SourceInfo): Bool =
     compop(sourceInfo, GreaterEqOp, that)
+
+  // This preserves the _workaround_ for https://github.com/chipsalliance/chisel/issues/4159
+  // Note that #4159 is due to _asUIntImpl below not actually padding the UInt
+  // This override just ensures that if `that` has a known width, the result actually has that width
+  // Put another way, this is preserving a case where #4159 does **not** occur
+  // This can be deleted when Builder.useLegacyWidth is removed.
+  override def do_asTypeOf[T <: Data](that: T)(implicit sourceInfo: SourceInfo): T = {
+    that.widthOption match {
+      // Note that default case will handle literals just fine
+      case Some(w) =>
+        val _padded = this.litOption match {
+          case Some(value) =>
+            value.U(w.W)
+          case None =>
+            val _wire = Wire(UInt(w.W))
+            _wire := this.asUInt
+            _wire
+        }
+        _padded.do_asTypeOf(that)
+      case None => super.do_asTypeOf(that)
+    }
+  }
 
   override private[chisel3] def _asUIntImpl(first: Boolean)(implicit sourceInfo: SourceInfo): UInt = {
     this.litOption match {

--- a/core/src/main/scala/chisel3/Clock.scala
+++ b/core/src/main/scala/chisel3/Clock.scala
@@ -38,11 +38,6 @@ sealed class Clock(private[chisel3] val width: Width = Width(1)) extends Element
   override private[chisel3] def _asUIntImpl(first: Boolean)(implicit sourceInfo: SourceInfo): UInt = pushOp(
     DefPrim(sourceInfo, UInt(this.width), AsUIntOp, ref)
   )
-  private[chisel3] override def connectFromBits(
-    that: Bits
-  )(
-    implicit sourceInfo: SourceInfo
-  ): Unit = {
-    this := that.asBool.asClock
-  }
+
+  override private[chisel3] def _fromUInt(that: UInt)(implicit sourceInfo: SourceInfo): Data = that.asBool.asClock
 }

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -813,20 +813,14 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   /** @group SourceInfoTransformMacro */
   def do_asTypeOf[T <: Data](that: T)(implicit sourceInfo: SourceInfo): T = {
-    val thatCloned = Wire(that.cloneTypeFull)
-    thatCloned.connectFromBits(this.asUInt)
-    thatCloned.viewAsReadOnlyDeprecated(siteInfo =>
-      Warning(WarningID.AsTypeOfReadOnly, s"Return values of asTypeOf will soon be read-only")(siteInfo)
-    )
+    that._fromUInt(this.asUInt).asInstanceOf[T].viewAsReadOnly { _ =>
+      "Return values of asTypeOf are now read-only"
+    }
   }
 
-  /** Assigns this node from Bits type. Internal implementation for asTypeOf.
+  /** Return a value of this type from a UInt type. Internal implementation for asTypeOf.
     */
-  private[chisel3] def connectFromBits(
-    that: Bits
-  )(
-    implicit sourceInfo: SourceInfo
-  ): Unit
+  private[chisel3] def _fromUInt(that: UInt)(implicit sourceInfo: SourceInfo): Data
 
   /** Reinterpret cast to UInt.
     *
@@ -1213,12 +1207,9 @@ final case object DontCare extends Element with connectable.ConnectableDocs {
 
   def toPrintable: Printable = PString("DONTCARE")
 
-  private[chisel3] def connectFromBits(
-    that: Bits
-  )(
-    implicit sourceInfo: SourceInfo
-  ): Unit = {
-    Builder.error("connectFromBits: DontCare cannot be a connection sink (LHS)")
+  private[chisel3] def _fromUInt(that: UInt)(implicit sourceInfo: SourceInfo): Data = {
+    Builder.error("DontCare cannot be a connection sink (LHS)")
+    this
   }
 
   override private[chisel3] def _asUIntImpl(first: Boolean)(implicit sourceInfo: SourceInfo): UInt = {

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -2,9 +2,9 @@
 
 package chisel3.experimental
 
+import chisel3._
 import chisel3.internal._
 import chisel3.internal.binding._
-import chisel3.{ActualDirection, Bits, Data, Element, PString, Printable, RawModule, SpecifiedDirection, UInt, Width}
 
 import scala.collection.mutable
 
@@ -70,12 +70,9 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
   override private[chisel3] def _asUIntImpl(first: Boolean)(implicit sourceInfo: SourceInfo): UInt =
     throwException("Analog does not support asUInt")
 
-  private[chisel3] override def connectFromBits(
-    that: Bits
-  )(
-    implicit sourceInfo: SourceInfo
-  ): Unit = {
-    throwException("Analog does not support connectFromBits")
+  override private[chisel3] def _fromUInt(that: UInt)(implicit sourceInfo: SourceInfo): Data = {
+    Builder.error("Analog does not support fromUInt")
+    Wire(Analog(that.width))
   }
 
   def toPrintable: Printable = PString("Analog")

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -14,6 +14,8 @@ import scala.annotation.implicitNotFound
 import scala.collection.mutable
 import chisel3.ChiselException
 
+import scala.reflect.runtime.universe.{typeTag, TypeTag}
+
 package object internal {
 
   @implicitNotFound("You are trying to access a macro-only API. Please use the @public annotation instead.")
@@ -66,6 +68,40 @@ package object internal {
     val headOk = (!res.isEmpty) && (leadingDigitOk || legalStart(res.head))
     if (headOk) res else s"_$res"
   }
+
+  // Workaround for https://github.com/chipsalliance/chisel/issues/4162
+  // We can't use the .asTypeOf workaround because this is used to implement .asTypeOf
+  private[chisel3] def _padHandleBool[A <: Bits](
+    x:     A,
+    width: Int
+  )(
+    implicit sourceInfo: SourceInfo,
+    tag:                 TypeTag[A]
+  ): A = x match {
+    case b: Bool if !b.isLit && width > 1 && tag.tpe =:= typeTag[UInt].tpe =>
+      val _pad = Wire(UInt(width.W))
+      _pad := b
+      _pad.asInstanceOf[A] // This cast is safe because we know A is UInt on this path
+    case u => u.pad(width)
+  }
+
+  // Resize that to this width (if known)
+  private[chisel3] def _resizeToWidth[A <: Bits: TypeTag](
+    that:           A,
+    targetWidthOpt: Option[Int]
+  )(fromUInt:       UInt => A
+  )(
+    implicit sourceInfo: SourceInfo
+  ): A =
+    (targetWidthOpt, that.widthOption) match {
+      case (Some(targetWidth), Some(thatWidth)) =>
+        if (targetWidth == thatWidth) that
+        else if (targetWidth > thatWidth) _padHandleBool(that, targetWidth)
+        else fromUInt(that.take(targetWidth))
+      case (Some(targetWidth), None) => fromUInt(_padHandleBool(that, targetWidth).take(targetWidth))
+      case (None, Some(thatWidth))   => that
+      case (None, None)              => that
+    }
 
   /** Internal API for [[ViewParent]] */
   sealed private[chisel3] class ViewParentAPI extends RawModule() with PseudoModule {

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -236,9 +236,10 @@ sealed trait Property[T] extends Element { self =>
     Builder.error(s"${this._localErrorContext} does not support .asUInt.")
     0.U
   }
-  private[chisel3] def connectFromBits(that: Bits)(implicit sourceInfo: SourceInfo): Unit = {
-    Builder.error(s"${this._localErrorContext} cannot be driven by Bits")
+  override private[chisel3] def _fromUInt(that: UInt)(implicit sourceInfo: SourceInfo): Data = {
+    Builder.exception(s"${this._localErrorContext} cannot be driven by UInt")
   }
+
   override private[chisel3] def firrtlConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit = {
     that match {
       case pthat: Property[_] => MonoConnect.propConnect(sourceInfo, this, pthat, Builder.forcedUserModule)

--- a/docs/src/explanations/warnings.md
+++ b/docs/src/explanations/warnings.md
@@ -153,6 +153,12 @@ field's width).
 
 ### [W008] Return values of asTypeOf will soon be read-only
 
+:::warning
+
+As of Chisel 7.0.0, this is now an error
+
+:::
+
 This warning indicates that the result of a call to `.asTypeOf(_)` is being used as the destination for a connection.
 It can be fixed by instantiating a wire.
 

--- a/src/test/scala/chiselTests/AsTypeOfTester.scala
+++ b/src/test/scala/chiselTests/AsTypeOfTester.scala
@@ -477,12 +477,15 @@ class AsTypeOfSpec extends ChiselFunSpec {
   describe("Analogs") {
     describe("as the target type") {
       they("should error") {
-        val e = the[ChiselException] thrownBy ChiselStage.emitSystemVerilog(new RawModule {
-          val in = IO(Input(UInt(8.W)))
-          val out = IO(Analog(8.W))
-          out := in.asTypeOf(out)
-        })
-        e.getMessage should include("Analog does not support connectFromBits")
+        val e = the[ChiselException] thrownBy ChiselStage.emitSystemVerilog(
+          new RawModule {
+            val in = IO(Input(UInt(8.W)))
+            val out = IO(Analog(8.W))
+            out := in.asTypeOf(out)
+          },
+          Array("--throw-on-first-error")
+        )
+        e.getMessage should include("Analog does not support fromUInt")
       }
     }
     describe("as the source type") {

--- a/src/test/scala/chiselTests/ChiselEnum.scala
+++ b/src/test/scala/chiselTests/ChiselEnum.scala
@@ -414,7 +414,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
       out3 := Cat(1.U, z)
       x.getWidth should be(7)
       x.getWidth should be(EnumExample.getWidth)
-      y.widthOption should be(None)
+      y.getWidth should be(7)
       z.getWidth should be(7)
     })
     verilog should include("assign out1 = 8'h81;")
@@ -438,7 +438,7 @@ class ChiselEnumSpec extends ChiselFlatSpec with Utils {
         // The bug is that the width of x is 7 but the value of out1 is 3
         x.getWidth should be(7)
         x.getWidth should be(EnumExample.getWidth)
-        y.widthOption should be(None)
+        y.getWidth should be(7)
         z.getWidth should be(7)
       },
       args = Array("--use-legacy-width")

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -270,4 +270,15 @@ class SIntOpsSpec extends ChiselPropSpec with Utils with ShiftRightWidthBehavior
     -5.S(8.W).pad(16).litValue should be(-5)
     -5.S(8.W).pad(16).getWidth should be(16)
   }
+
+  property("Casting a SInt literal to a Bundle should maintain the literal value") {
+    class SimpleBundle extends Bundle {
+      val x = UInt(4.W)
+      val y = UInt(4.W)
+    }
+    val blit = -23.S.asTypeOf(new SimpleBundle)
+    blit.litOption should be(Some(0x29))
+    blit.x.litOption should be(Some(2))
+    blit.y.litOption should be(Some(9))
+  }
 }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -652,4 +652,15 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
     5.U(8.W).pad(16).litValue should be(5)
     5.U(8.W).pad(16).getWidth should be(16)
   }
+
+  property("Casting a UInt literal to a Bundle should maintain the literal value") {
+    class SimpleBundle extends Bundle {
+      val x = UInt(4.W)
+      val y = UInt(4.W)
+    }
+    val blit = 0xab.U.asTypeOf(new SimpleBundle)
+    blit.litOption should be(Some(0xab))
+    blit.x.litOption should be(Some(0xa))
+    blit.y.litOption should be(Some(0xb))
+  }
 }

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -311,7 +311,7 @@ class VecSpec extends ChiselPropSpec with Utils {
 
       val m = Module(new Module {
         val io = IO(Output(bundleWithZeroEntryVec))
-        val zero = 0.U.asTypeOf(bundleWithZeroEntryVec)
+        val zero = WireInit(0.U.asTypeOf(bundleWithZeroEntryVec))
         require(zero.getWidth == 1)
         io := zero
       })

--- a/src/test/scala/chiselTests/stage/WarningConfigurationSpec.scala
+++ b/src/test/scala/chiselTests/stage/WarningConfigurationSpec.scala
@@ -380,10 +380,10 @@ class WarningConfigurationSpec extends AnyFunSpec with Matchers with chiselTests
       e.getMessage should include("[W006] Cannot extract from Vec of size 0")
     }
 
-    it("should number AsTypeOfReadOnly as 8") {
-      val args = Array("--warn-conf", "id=8:e,any:s", "--throw-on-first-error")
+    it("should now error on AsTypeOfReadOnly") {
+      val args = Array("--throw-on-first-error")
       val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new AsTypeOfReadOnly, args)
-      e.getMessage should include("[W008] Return values of asTypeOf will soon be read-only")
+      e.getMessage should include("Return values of asTypeOf are now read-only")
     }
   }
 }


### PR DESCRIPTION
Built on top of https://github.com/chipsalliance/chisel/pull/4160 so should merge this one after that one (might need rebase but git seems smarter about cherry-picks these days).

This is very valuable for ChiselSim-style testing because it means that you can much more easily construct literals in tests.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Casting a literal (of any type) to another type with .asTypeOf will result in a literal of the new type. For non-literals, the FIRRTL representation will now be a little bit more efficient.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
