### PR TITLE
Error when calling define targeting a child of a probe

### DIFF
--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -150,6 +150,23 @@ package object internal {
     Builder.error(errorMessage)
   }
 
+  private[chisel3] def requireNotChildOfProbe(
+    probe:        Data,
+    errorMessage: => String = ""
+  )(
+    implicit sourceInfo: SourceInfo
+  ): Unit = {
+    probe.binding match {
+      case Some(ChildBinding(parent)) =>
+        if (parent.probeInfo.nonEmpty) {
+          val providedMsg = errorMessage // only evaluate by-name argument once
+          val msg = if (providedMsg.isEmpty) "Expected a root of a probe." else providedMsg
+          Builder.error(msg)
+        }
+      case _ => ()
+    }
+  }
+
   // TODO this exists in cats.Traverse, should we just use that?
   private[chisel3] implicit class ListSyntax[A](xs: List[A]) {
     def mapAccumulate[B, C](z: B)(f: (B, A) => (B, C)): (B, List[C]) = {

--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -37,6 +37,7 @@ package object probe extends SourceInfoDoc {
       Builder.error("Cannot define a probe on a non-equivalent type.")
     }
     requireHasProbeTypeModifier(sink, "Expected sink to be a probe.")
+    requireNotChildOfProbe(sink, "Expected sink to be the root of a probe.")
     requireHasProbeTypeModifier(probeExpr, "Expected source to be a probe expression.")
     requireCompatibleDestinationProbeColor(
       sink,

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -613,6 +613,22 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
     exc.getMessage should include("Probe width unknown.")
   }
 
+  it should "error trying to define a child of an Aggregate probe" in {
+    val exc = intercept[chisel3.ChiselException] {
+      ChiselStage.emitSystemVerilog(
+        new RawModule {
+          val in = IO(Input(UInt(16.W)))
+          val p = IO(Output(Probe(new Bundle {
+            val a = UInt(16.W)
+          })))
+          define(p.a, ProbeValue(in))
+        },
+        Array("--throw-on-first-error")
+      )
+    }
+    exc.getMessage should include("Expected sink to be the root of a probe.")
+  }
+
   "Probe force/release reg example" should "work in simulator" in {
     // Simple example forcing a register and checking basic behavior.
 


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This is already an error caught in firtool, now Chisel will error earlier.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
