### PR TITLE
Make "deprecated public" binding APIs private

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -11,6 +11,7 @@ import scala.language.experimental.macros
 import chisel3.experimental.{BaseModule, BundleLiteralException, HasTypeAlias, OpaqueType, VecLiteralException}
 import chisel3.experimental.{requireIsChiselType, requireIsHardware, SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir._
 import chisel3.internal.sourceinfo.{SourceInfoTransform, VecTransform}

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -11,17 +11,8 @@ import chisel3.internal.Builder.pushOp
 import chisel3.internal.firrtl.ir.PrimOp._
 import chisel3.internal.firrtl.ir._
 import chisel3.internal.sourceinfo._
-import chisel3.internal.{
-  containsProbe,
-  throwException,
-  Binding,
-  Builder,
-  BuilderContextCache,
-  ChildBinding,
-  ConstrainedBinding,
-  Warning,
-  WarningID
-}
+import chisel3.internal.{containsProbe, throwException, Builder, BuilderContextCache, Warning, WarningID}
+import chisel3.internal.binding.{Binding, ChildBinding, ConstrainedBinding}
 
 import chisel3.experimental.EnumAnnotations._
 

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -10,6 +10,7 @@ import chisel3.experimental.{prefix, SourceInfo, UnlocatableSourceInfo}
 import chisel3.experimental.dataview.reifySingleData
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.sourceinfo._
 import chisel3.internal.firrtl.ir._
 import chisel3.properties.Property

--- a/core/src/main/scala/chisel3/Element.scala
+++ b/core/src/main/scala/chisel3/Element.scala
@@ -7,6 +7,7 @@ import chisel3.internal.firrtl.ir._
 import chisel3.experimental.SourceInfo
 import chisel3.experimental.dataview.reify
 import chisel3.internal._
+import chisel3.internal.binding._
 
 /** Element is a leaf data type: it cannot contain other [[Data]] objects. Example uses are for representing primitive
   * data types, like integers and bits.

--- a/core/src/main/scala/chisel3/Intrinsic.scala
+++ b/core/src/main/scala/chisel3/Intrinsic.scala
@@ -5,7 +5,8 @@ package chisel3
 import chisel3._
 import chisel3.experimental.{requireIsChiselType, Param, SourceInfo}
 import chisel3.internal.firrtl.ir._
-import chisel3.internal.{Builder, OpBinding}
+import chisel3.internal.Builder
+import chisel3.internal.binding.OpBinding
 import chisel3.internal.Builder.pushCommand
 
 object Intrinsic {

--- a/core/src/main/scala/chisel3/Mem.scala
+++ b/core/src/main/scala/chisel3/Mem.scala
@@ -7,6 +7,7 @@ import scala.language.experimental.macros
 import firrtl.{ir => fir}
 
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir._
 import chisel3.internal.sourceinfo.{MemTransform, SourceInfoTransform}

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -7,6 +7,7 @@ import scala.collection.mutable.{ArrayBuffer, HashMap, LinkedHashSet}
 import scala.language.experimental.macros
 
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.Builder._
 import chisel3.internal.firrtl.ir._
 import chisel3.experimental.{requireIsChiselType, BaseModule, SourceInfo, UnlocatableSourceInfo}
@@ -833,7 +834,7 @@ package experimental {
       require(!isFullyClosed, "Cannot create secret ports if module is fully closed")
 
       Module.assignCompatDir(iodef)
-      iodef.bind(internal.SecretPortBinding(this), iodef.specifiedDirection)
+      iodef.bind(SecretPortBinding(this), iodef.specifiedDirection)
       iodef
     }
 

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -6,6 +6,7 @@ import scala.util.Try
 import scala.language.experimental.macros
 import chisel3.experimental.{BaseModule, SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.experimental.hierarchy.{InstanceClone, ModuleClone}
 import chisel3.properties.{DynamicObject, Property, StaticObject}
 import chisel3.internal.Builder._

--- a/core/src/main/scala/chisel3/Reg.scala
+++ b/core/src/main/scala/chisel3/Reg.scala
@@ -5,6 +5,7 @@ package chisel3
 import scala.language.experimental.macros
 
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir._
 import chisel3.experimental.{requireIsChiselType, requireIsHardware, SourceInfo}

--- a/core/src/main/scala/chisel3/connectable/Alignment.scala
+++ b/core/src/main/scala/chisel3/connectable/Alignment.scala
@@ -5,7 +5,7 @@ package chisel3.connectable
 import chisel3.{Aggregate, Data, DontCare, SpecifiedDirection}
 import chisel3.experimental.Analog
 import chisel3.reflect.DataMirror
-import chisel3.internal.{ChildBinding, TopBinding}
+import chisel3.internal.binding.{ChildBinding, TopBinding}
 
 // Represent aligned or flipped relative to an original root.
 // Used for walking types and their alignment, accounting for coercion.

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -3,6 +3,7 @@
 package chisel3.experimental
 
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.{ActualDirection, Bits, Data, Element, PString, Printable, RawModule, SpecifiedDirection, UInt, Width}
 
 import scala.collection.mutable

--- a/core/src/main/scala/chisel3/experimental/OpaqueType.scala
+++ b/core/src/main/scala/chisel3/experimental/OpaqueType.scala
@@ -3,7 +3,8 @@
 package chisel3.experimental
 
 import chisel3._
-import chisel3.internal.{Builder, ChildBinding}
+import chisel3.internal.Builder
+import chisel3.internal.binding.ChildBinding
 import chisel3.internal.firrtl.ir.Arg
 
 /** Indicates if this Record represents an "Opaque Type"

--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -4,6 +4,7 @@ package chisel3.experimental
 
 import chisel3._
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.properties.Property
 
 import scala.annotation.{implicitNotFound, tailrec}

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -10,7 +10,8 @@ import scala.collection.mutable.HashMap
 import chisel3._
 import chisel3.experimental.dataview.{isView, reify, reifySingleData}
 import chisel3.internal.firrtl.ir.{Arg, ILit, Index, ModuleIO, Slot, ULit}
-import chisel3.internal.{throwException, AggregateViewBinding, Builder, ChildBinding, ViewBinding, ViewParent}
+import chisel3.internal.{throwException, Builder, ViewParent}
+import chisel3.internal.binding.{AggregateViewBinding, ChildBinding, CrossModuleBinding, ViewBinding}
 
 /** Represents lookup typeclass to determine how a value accessed from an original IsInstantiable
   *   should be tweaked to return the Instance's version
@@ -71,7 +72,7 @@ object Lookupable {
           case Clone(m: BaseModule) =>
             val newChild = data.cloneTypeFull
             newChild.setRef(data.getRef, true)
-            newChild.bind(internal.CrossModuleBinding)
+            newChild.bind(CrossModuleBinding)
             newChild.setAllParents(Some(m))
             newChild
           case _ => throw new InternalErrorException("Match error: newParent=$newParent")

--- a/core/src/main/scala/chisel3/internal/BiConnect.scala
+++ b/core/src/main/scala/chisel3/internal/BiConnect.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental.dataview.{isView, reify, reifyToAggregate}
 import chisel3.experimental.{attach, Analog, BaseModule, SourceInfo}
 import chisel3.properties.Property
+import chisel3.internal.binding._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir.{Connect, DefInvalid}
 import chisel3.internal.firrtl.Converter

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -9,179 +9,184 @@ import chisel3.properties.Class
 
 import scala.collection.immutable.VectorMap
 
-// Element only direction used for the Binding system only.
-private[chisel3] sealed abstract class BindingDirection
-private[chisel3] object BindingDirection {
+private[chisel3] object binding {
 
-  /** Internal type or wire
-    */
-  case object Internal extends BindingDirection
+  // Element only direction used for the Binding system only.
+  private[chisel3] sealed abstract class BindingDirection
+  private[chisel3] object BindingDirection {
 
-  /** Module port with output direction
-    */
-  case object Output extends BindingDirection
+    /** Internal type or wire
+      */
+    case object Internal extends BindingDirection
 
-  /** Module port with input direction
-    */
-  case object Input extends BindingDirection
+    /** Module port with output direction
+      */
+    case object Output extends BindingDirection
 
-  /** Determine the BindingDirection of an Element given its top binding and resolved direction.
-    */
-  def from(binding: TopBinding, direction: ActualDirection): BindingDirection = {
-    binding match {
-      case _: PortBinding | _: SecretPortBinding =>
-        direction match {
-          case ActualDirection.Output => Output
-          case ActualDirection.Input  => Input
-          case dir                    => throw new RuntimeException(s"Unexpected port element direction '$dir'")
-        }
-      case _ => Internal
+    /** Module port with input direction
+      */
+    case object Input extends BindingDirection
+
+    /** Determine the BindingDirection of an Element given its top binding and resolved direction.
+      */
+    def from(binding: TopBinding, direction: ActualDirection): BindingDirection = {
+      binding match {
+        case _: PortBinding | _: SecretPortBinding =>
+          direction match {
+            case ActualDirection.Output => Output
+            case ActualDirection.Input  => Input
+            case dir                    => throw new RuntimeException(s"Unexpected port element direction '$dir'")
+          }
+        case _ => Internal
+      }
     }
   }
-}
 
-// Location refers to 'where' in the Module hierarchy this lives
-@deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
-sealed trait Binding {
-  def location: Option[BaseModule]
-}
-// Top-level binding representing hardware, not a pointer to another binding (like ChildBinding)
-@deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
-sealed trait TopBinding extends Binding
+  // Location refers to 'where' in the Module hierarchy this lives
+  @deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
+  sealed trait Binding {
+    def location: Option[BaseModule]
+  }
+  // Top-level binding representing hardware, not a pointer to another binding (like ChildBinding)
+  @deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
+  sealed trait TopBinding extends Binding
 
-// Constrained-ness refers to whether 'bound by Module boundaries'
-// An unconstrained binding, like a literal, can be read by everyone
-@deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
-sealed trait UnconstrainedBinding extends TopBinding {
-  def location: Option[BaseModule] = None
-}
-// A constrained binding can only be read/written by specific modules
-// Location will track where this Module is, and the bound object can be referenced in FIRRTL
-@deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
-sealed trait ConstrainedBinding extends TopBinding {
-  def enclosure: BaseModule
-  def location: Option[BaseModule] = {
-    // If an aspect is present, return the aspect module. Otherwise, return the enclosure module
-    // This allows aspect modules to pretend to be enclosed modules for connectivity checking,
-    // inside vs outside instance checking, etc.
-    Builder.aspectModule(enclosure) match {
-      case None         => Some(enclosure)
-      case Some(aspect) => Some(aspect)
+  // Constrained-ness refers to whether 'bound by Module boundaries'
+  // An unconstrained binding, like a literal, can be read by everyone
+  @deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
+  sealed trait UnconstrainedBinding extends TopBinding {
+    def location: Option[BaseModule] = None
+  }
+  // A constrained binding can only be read/written by specific modules
+  // Location will track where this Module is, and the bound object can be referenced in FIRRTL
+  @deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
+  sealed trait ConstrainedBinding extends TopBinding {
+    def enclosure: BaseModule
+    def location: Option[BaseModule] = {
+      // If an aspect is present, return the aspect module. Otherwise, return the enclosure module
+      // This allows aspect modules to pretend to be enclosed modules for connectivity checking,
+      // inside vs outside instance checking, etc.
+      Builder.aspectModule(enclosure) match {
+        case None         => Some(enclosure)
+        case Some(aspect) => Some(aspect)
+      }
     }
   }
-}
 
-// A binding representing a data that cannot be (re)assigned to.
-@deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
-sealed trait ReadOnlyBinding extends TopBinding
+  // A binding representing a data that cannot be (re)assigned to.
+  @deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
+  sealed trait ReadOnlyBinding extends TopBinding
 
-// A component that can potentially be declared inside a 'when'
-@deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
-sealed trait ConditionalDeclarable extends TopBinding {
-  def visibility: Option[WhenContext]
-}
-
-// TODO(twigg): Ops between unenclosed nodes can also be unenclosed
-// However, Chisel currently binds all op results to a module
-private[chisel3] case class PortBinding(enclosure: BaseModule) extends ConstrainedBinding
-
-// Added to handle BoringUtils in Chisel
-private[chisel3] case class SecretPortBinding(enclosure: BaseModule) extends ConstrainedBinding
-
-private[chisel3] case class OpBinding(enclosure: RawModule, visibility: Option[WhenContext])
-    extends ConstrainedBinding
-    with ReadOnlyBinding
-    with ConditionalDeclarable
-private[chisel3] case class MemoryPortBinding(enclosure: RawModule, visibility: Option[WhenContext])
-    extends ConstrainedBinding
-    with ConditionalDeclarable
-private[chisel3] case class SramPortBinding(enclosure: RawModule, visibility: Option[WhenContext])
-    extends ConstrainedBinding
-    with ConditionalDeclarable
-private[chisel3] case class RegBinding(enclosure: RawModule, visibility: Option[WhenContext])
-    extends ConstrainedBinding
-    with ConditionalDeclarable
-private[chisel3] case class WireBinding(enclosure: RawModule, visibility: Option[WhenContext])
-    extends ConstrainedBinding
-    with ConditionalDeclarable
-
-private[chisel3] case class ClassBinding(enclosure: Class) extends ConstrainedBinding with ReadOnlyBinding
-
-private[chisel3] case class ObjectFieldBinding(enclosure: BaseModule) extends ConstrainedBinding
-
-private[chisel3] case class ChildBinding(parent: Data) extends Binding {
-  def location: Option[BaseModule] = parent.topBinding.location
-}
-
-/** Special binding for Vec.sample_element */
-private[chisel3] case class SampleElementBinding[T <: Data](parent: Vec[T]) extends Binding {
-  def location = parent.topBinding.location
-}
-
-/** Special binding for Mem types */
-private[chisel3] case class MemTypeBinding[T <: Data](parent: MemBase[T]) extends Binding {
-  def location: Option[BaseModule] = parent._parent
-}
-
-/** Special binding for Firrtl memory (SRAM) types */
-private[chisel3] case class FirrtlMemTypeBinding(parent: SramTarget) extends Binding {
-  def location: Option[BaseModule] = parent._parent
-}
-
-// A DontCare element has a specific Binding, somewhat like a literal.
-// It is a source (RHS). It may only be connected/applied to sinks.
-private[chisel3] case class DontCareBinding() extends UnconstrainedBinding
-
-// Views currently only support 1:1 Element-level mappings
-private[chisel3] case class ViewBinding(target: Element) extends Binding with ConditionalDeclarable {
-  def location: Option[BaseModule] = target.binding.flatMap(_.location)
-  def visibility: Option[WhenContext] = target.binding.flatMap {
-    case c: ConditionalDeclarable => c.visibility
-    case _ => None
+  // A component that can potentially be declared inside a 'when'
+  @deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
+  sealed trait ConditionalDeclarable extends TopBinding {
+    def visibility: Option[WhenContext]
   }
-}
 
-/** Binding for Aggregate Views
-  * @param childMap Mapping from children of this view to their respective targets
-  * @param target Optional Data this Aggregate views if the view is total and the target is a Data
-  * @note For any Elements in the childMap, both key and value must be Elements
-  * @note The types of key and value need not match for the top Data in a total view of type
-  *       Aggregate
-  */
-private[chisel3] case class AggregateViewBinding(childMap: Map[Data, Data]) extends Binding with ConditionalDeclarable {
-  // Helper lookup function since types of Elements always match
-  def lookup(key: Element): Option[Element] = childMap.get(key).map(_.asInstanceOf[Element])
+  // TODO(twigg): Ops between unenclosed nodes can also be unenclosed
+  // However, Chisel currently binds all op results to a module
+  private[chisel3] case class PortBinding(enclosure: BaseModule) extends ConstrainedBinding
 
-  // FIXME Technically an AggregateViewBinding can have multiple locations and visibilities
-  // Fixing this requires an overhaul to this code so for now we just do the best we can
-  // Return a location if there is a unique one for all targets, None otherwise
-  lazy val location: Option[BaseModule] = {
-    val locations = childMap.values.view.flatMap(_.binding.toSeq.flatMap(_.location)).toVector.distinct
-    if (locations.size == 1) Some(locations.head)
-    else None
+  // Added to handle BoringUtils in Chisel
+  private[chisel3] case class SecretPortBinding(enclosure: BaseModule) extends ConstrainedBinding
+
+  private[chisel3] case class OpBinding(enclosure: RawModule, visibility: Option[WhenContext])
+      extends ConstrainedBinding
+      with ReadOnlyBinding
+      with ConditionalDeclarable
+  private[chisel3] case class MemoryPortBinding(enclosure: RawModule, visibility: Option[WhenContext])
+      extends ConstrainedBinding
+      with ConditionalDeclarable
+  private[chisel3] case class SramPortBinding(enclosure: RawModule, visibility: Option[WhenContext])
+      extends ConstrainedBinding
+      with ConditionalDeclarable
+  private[chisel3] case class RegBinding(enclosure: RawModule, visibility: Option[WhenContext])
+      extends ConstrainedBinding
+      with ConditionalDeclarable
+  private[chisel3] case class WireBinding(enclosure: RawModule, visibility: Option[WhenContext])
+      extends ConstrainedBinding
+      with ConditionalDeclarable
+
+  private[chisel3] case class ClassBinding(enclosure: Class) extends ConstrainedBinding with ReadOnlyBinding
+
+  private[chisel3] case class ObjectFieldBinding(enclosure: BaseModule) extends ConstrainedBinding
+
+  private[chisel3] case class ChildBinding(parent: Data) extends Binding {
+    def location: Option[BaseModule] = parent.topBinding.location
   }
-  lazy val visibility: Option[WhenContext] = {
-    val contexts = childMap.values.view
-      .flatMap(_.binding.toSeq.collect { case c: ConditionalDeclarable => c.visibility }.flatten)
-      .toVector
-      .distinct
-    if (contexts.size == 1) Some(contexts.head)
-    else None
+
+  /** Special binding for Vec.sample_element */
+  private[chisel3] case class SampleElementBinding[T <: Data](parent: Vec[T]) extends Binding {
+    def location = parent.topBinding.location
   }
-}
 
-/** Binding for Data's returned from accessing an Instance/Definition members, if not readable/writable port */
-private[chisel3] case object CrossModuleBinding extends TopBinding {
-  def location = None
-}
+  /** Special binding for Mem types */
+  private[chisel3] case class MemTypeBinding[T <: Data](parent: MemBase[T]) extends Binding {
+    def location: Option[BaseModule] = parent._parent
+  }
 
-@deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
-sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
-// Literal binding attached to a element that is not part of a Bundle.
-private[chisel3] case class ElementLitBinding(litArg: LitArg) extends LitBinding
-// Literal binding attached to the root of a Bundle, containing literal values of its children.
-private[chisel3] case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
-// Literal binding attached to the root of a Vec, containing literal values of its children.
-private[chisel3] case class VecLitBinding(litMap: VectorMap[Data, LitArg]) extends LitBinding
-// Literal binding attached to a Property.
-private[chisel3] case object PropertyValueBinding extends UnconstrainedBinding with ReadOnlyBinding
+  /** Special binding for Firrtl memory (SRAM) types */
+  private[chisel3] case class FirrtlMemTypeBinding(parent: SramTarget) extends Binding {
+    def location: Option[BaseModule] = parent._parent
+  }
+
+  // A DontCare element has a specific Binding, somewhat like a literal.
+  // It is a source (RHS). It may only be connected/applied to sinks.
+  private[chisel3] case class DontCareBinding() extends UnconstrainedBinding
+
+  // Views currently only support 1:1 Element-level mappings
+  private[chisel3] case class ViewBinding(target: Element) extends Binding with ConditionalDeclarable {
+    def location: Option[BaseModule] = target.binding.flatMap(_.location)
+    def visibility: Option[WhenContext] = target.binding.flatMap {
+      case c: ConditionalDeclarable => c.visibility
+      case _ => None
+    }
+  }
+
+  /** Binding for Aggregate Views
+    * @param childMap Mapping from children of this view to their respective targets
+    * @param target Optional Data this Aggregate views if the view is total and the target is a Data
+    * @note For any Elements in the childMap, both key and value must be Elements
+    * @note The types of key and value need not match for the top Data in a total view of type
+    *       Aggregate
+    */
+  private[chisel3] case class AggregateViewBinding(childMap: Map[Data, Data])
+      extends Binding
+      with ConditionalDeclarable {
+    // Helper lookup function since types of Elements always match
+    def lookup(key: Element): Option[Element] = childMap.get(key).map(_.asInstanceOf[Element])
+
+    // FIXME Technically an AggregateViewBinding can have multiple locations and visibilities
+    // Fixing this requires an overhaul to this code so for now we just do the best we can
+    // Return a location if there is a unique one for all targets, None otherwise
+    lazy val location: Option[BaseModule] = {
+      val locations = childMap.values.view.flatMap(_.binding.toSeq.flatMap(_.location)).toVector.distinct
+      if (locations.size == 1) Some(locations.head)
+      else None
+    }
+    lazy val visibility: Option[WhenContext] = {
+      val contexts = childMap.values.view
+        .flatMap(_.binding.toSeq.collect { case c: ConditionalDeclarable => c.visibility }.flatten)
+        .toVector
+        .distinct
+      if (contexts.size == 1) Some(contexts.head)
+      else None
+    }
+  }
+
+  /** Binding for Data's returned from accessing an Instance/Definition members, if not readable/writable port */
+  private[chisel3] case object CrossModuleBinding extends TopBinding {
+    def location = None
+  }
+
+  @deprecated(deprecatedPublicAPIMsg, "Chisel 6.0")
+  sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding
+  // Literal binding attached to a element that is not part of a Bundle.
+  private[chisel3] case class ElementLitBinding(litArg: LitArg) extends LitBinding
+  // Literal binding attached to the root of a Bundle, containing literal values of its children.
+  private[chisel3] case class BundleLitBinding(litMap: Map[Data, LitArg]) extends LitBinding
+  // Literal binding attached to the root of a Vec, containing literal values of its children.
+  private[chisel3] case class VecLitBinding(litMap: VectorMap[Data, LitArg]) extends LitBinding
+  // Literal binding attached to a Property.
+  private[chisel3] case object PropertyValueBinding extends UnconstrainedBinding with ReadOnlyBinding
+}

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -8,6 +8,7 @@ import chisel3._
 import chisel3.experimental._
 import chisel3.experimental.hierarchy.core.{Clone, Definition, Hierarchy, ImportDefinitionAnnotation, Instance}
 import chisel3.properties.Class
+import chisel3.internal.binding._
 import chisel3.internal.firrtl.ir._
 import chisel3.internal.firrtl.Converter
 import chisel3.internal.naming._

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -5,7 +5,7 @@ package chisel3.internal
 import _root_.firrtl.ir.ClassPropertyType
 import chisel3._
 import chisel3.experimental.{Analog, BaseModule, SourceInfo}
-import chisel3.internal.containsProbe
+import chisel3.internal.binding._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir.{Connect, DefInvalid, ProbeDefine, PropAssign}
 import chisel3.internal.firrtl.Converter

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -5,6 +5,7 @@ package chisel3.internal.firrtl
 import firrtl.{ir => fir}
 import chisel3._
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.experimental._
 import chisel3.properties.{Property, PropertyType => PropertyTypeclass, Class, DynamicObject}
 import _root_.firrtl.{ir => firrtlir}

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -5,6 +5,7 @@ package chisel3
 import firrtl.annotations.{IsModule, ModuleTarget}
 import chisel3.experimental.{BaseModule, SourceInfo, UnlocatableSourceInfo}
 import chisel3.reflect.DataMirror.hasProbeTypeModifier
+import chisel3.internal.binding._
 import chisel3.internal.firrtl.ir.{Component, DefModule}
 import chisel3.internal.Builder.Prefix
 

--- a/core/src/main/scala/chisel3/probe/ProbeValue.scala
+++ b/core/src/main/scala/chisel3/probe/ProbeValue.scala
@@ -3,7 +3,8 @@
 package chisel3.probe
 
 import chisel3.{Data, SourceInfoDoc}
-import chisel3.internal.{Builder, OpBinding}
+import chisel3.internal.Builder
+import chisel3.internal.binding.OpBinding
 import chisel3.internal.firrtl.ir.{ProbeExpr, RWProbeExpr}
 import chisel3.experimental.{requireIsHardware, SourceInfo}
 

--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -4,6 +4,7 @@ package chisel3
 
 import chisel3._
 import chisel3.internal._
+import chisel3.internal.binding.OpBinding
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir._
 import chisel3.Data.ProbeInfo

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -6,7 +6,8 @@ import firrtl.{ir => fir}
 import chisel3.{Data, RawModule, SpecifiedDirection}
 import chisel3.experimental.{BaseModule, SourceInfo}
 import chisel3.experimental.hierarchy.{Definition, Instance, ModuleClone}
-import chisel3.internal.{throwException, Builder, ClassBinding, OpBinding}
+import chisel3.internal.{throwException, Builder}
+import chisel3.internal.binding.{ClassBinding, OpBinding}
 import chisel3.internal.firrtl.ir.{Arg, Command, Component, DefClass, DefObject, ModuleIO, Port, PropAssign}
 import chisel3.internal.firrtl.Converter
 

--- a/core/src/main/scala/chisel3/properties/Object.scala
+++ b/core/src/main/scala/chisel3/properties/Object.scala
@@ -8,7 +8,8 @@ import chisel3.{Module, RawModule, SpecifiedDirection}
 import chisel3.experimental.{BaseModule, SourceInfo}
 import chisel3.internal.firrtl.ir.{DefClass, DefObject}
 import chisel3.internal.sourceinfo.InstTransform
-import chisel3.internal.{throwException, Builder, HasId, NamedComponent, ObjectFieldBinding}
+import chisel3.internal.{throwException, Builder, HasId, NamedComponent}
+import chisel3.internal.binding.ObjectFieldBinding
 
 import scala.collection.immutable.HashMap
 import scala.language.existentials

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -6,6 +6,7 @@ package properties
 import firrtl.{ir => fir}
 import firrtl.annotations.{InstanceTarget, IsMember, ModuleTarget, ReferenceTarget, Target}
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.firrtl.{ir, Converter}
 import chisel3.internal.sourceinfo.SourceInfoTransform
 import chisel3.experimental.{prefix, requireIsHardware, Analog, SourceInfo}

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -4,6 +4,7 @@ package chisel3.reflect
 
 import chisel3._
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.firrtl.ir._
 import chisel3.experimental.{requireIsHardware, BaseModule, SourceInfo}
 import chisel3.experimental.hierarchy.Instance

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -12,6 +12,7 @@ import firrtl.{ir => fir}
 import chisel3.{Data => ChiselData, _}
 import chisel3.experimental._
 import chisel3.internal._
+import chisel3.internal.binding._
 import chisel3.internal.firrtl.ir._
 import chisel3.internal.firrtl.Converter
 import chisel3.assert.{Assert => VerifAssert}

--- a/src/main/scala/chisel3/choice/ModuleChoice.scala
+++ b/src/main/scala/chisel3/choice/ModuleChoice.scala
@@ -7,7 +7,8 @@ import scala.collection.immutable.ListMap
 
 import chisel3.{Data, FixedIOBaseModule, Module, SourceInfoDoc}
 import chisel3.experimental.{BaseModule, SourceInfo}
-import chisel3.internal.{groupByIntoSeq, Builder, WireBinding}
+import chisel3.internal.{groupByIntoSeq, Builder}
+import chisel3.internal.binding.WireBinding
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir.DefInstanceChoice
 import chisel3.internal.sourceinfo.InstChoiceTransform

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -2,7 +2,8 @@ package chisel3.util
 
 import chisel3._
 
-import chisel3.internal.{Builder, FirrtlMemTypeBinding, NamedComponent, SramPortBinding}
+import chisel3.internal.{Builder, NamedComponent}
+import chisel3.internal.binding.{FirrtlMemTypeBinding, SramPortBinding}
 import chisel3.internal.plugin.autoNameRecursively
 import chisel3.experimental.SourceInfo
 import chisel3.internal.sourceinfo.{MemTransform, SourceInfoTransform}

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -7,7 +7,8 @@ import chisel3.probe.{Probe, RWProbe}
 import chisel3.reflect.DataMirror
 import chisel3.Data.ProbeInfo
 import chisel3.experimental.{annotate, requireIsHardware, skipPrefix, BaseModule, ChiselAnnotation, SourceInfo}
-import chisel3.internal.{Builder, BuilderContextCache, NamedComponent, Namespace, PortBinding}
+import chisel3.internal.{Builder, BuilderContextCache, NamedComponent, Namespace}
+import chisel3.internal.binding.{CrossModuleBinding, PortBinding}
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
 import firrtl.passes.wiring.{SinkAnnotation, SourceAnnotation}
 import firrtl.annotations.{ComponentName, ModuleName}
@@ -288,7 +289,7 @@ object BoringUtils {
     source.topBindingOpt match {
       case None =>
         Builder.error(s"Cannot bore from ${source._errorContext}")
-      case Some(internal.CrossModuleBinding) =>
+      case Some(CrossModuleBinding) =>
         Builder.error(
           s"Cannot bore across a Definition/Instance boundary:${thisModule._errorContext} cannot access ${source}"
         )


### PR DESCRIPTION
This is done by adding a new package private object "binding" within
which all bindings live. This required changing imports in lots of files
but it makes it much easier to not accidentally create a public binding
in the future.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Merge

#### Release Notes

These `chisel3.internal` APIs should never have been public in the first place.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
