### PR TITLE
make TruthTable in DecodeTable lazy

### DIFF
--- a/src/main/scala/chisel3/util/experimental/decode/DecoderBundle.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/DecoderBundle.scala
@@ -80,7 +80,7 @@ class DecodeTable[I <: DecodePattern](patterns: Seq[I], fields: Seq[DecodeField[
 
   def bundle: DecodeBundle = new DecodeBundle(fields)
 
-  val table: TruthTable = TruthTable(
+  lazy val table: TruthTable = TruthTable(
     patterns.map { op => op.bitPat -> fields.reverse.map(field => field.genTable(op)).reduce(_ ## _) },
     fields.reverse.map(_.default).reduce(_ ## _)
   )


### PR DESCRIPTION
This PR speeds up the intensive usage of `DecodeTable`, T1 uses it to construct the `DecodeBundle`, to avoid each table instantiating overhead(QMC or espresso calling), this PR makes it lazy to speed up.
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Performance improvement

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

make TruthTable in DecodeTable lazy to speed up decoding.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
