### PR TITLE
Rework When IR to be Region-based

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -87,9 +87,25 @@ abstract class RawModule extends BaseModule {
   // Perhaps this should be an ArrayBuffer (or ArrayBuilder), but DefModule is public and has Seq[Command]
   // so our best option is to share a single Seq datastructure with that
   private val _commands = new VectorBuilder[Command]()
+
+  /** The current region to which commands will be added. */
+  private var _currentRegion = _commands
+
+  private[chisel3] def changeRegion(newRegion: VectorBuilder[Command]): Unit = {
+    _currentRegion = newRegion
+  }
+
+  private[chisel3] def withRegion[A](newRegion: VectorBuilder[Command])(thunk: => A): A = {
+    var oldRegion = _currentRegion
+    changeRegion(newRegion)
+    val result = thunk
+    changeRegion(oldRegion)
+    result
+  }
+
   private[chisel3] def addCommand(c: Command): Unit = {
     require(!_closed, "Can't write to module after module close")
-    _commands += c
+    _currentRegion += c
   }
   protected def getCommands: Seq[Command] = {
     require(_closed, "Can't get commands before module close")

--- a/core/src/main/scala/chisel3/When.scala
+++ b/core/src/main/scala/chisel3/When.scala
@@ -68,7 +68,7 @@ private object Scope {
     override def toString: String = "if"
   }
 
-  /** Indicatest that the `WhenContext` is in the "else" clause. */
+  /** Indicates that the `WhenContext` is in the "else" clause. */
   object Else extends Type {
     override def toString: String = "else"
   }

--- a/core/src/main/scala/chisel3/When.scala
+++ b/core/src/main/scala/chisel3/When.scala
@@ -164,12 +164,8 @@ final class WhenContext private[chisel3] (
   Builder.pushWhen(this)
   scope = Some(Scope.If)
   try {
-    Builder.currentModule match {
-      case Some(module: RawModule) =>
-        module.withRegion(ifRegion) {
-          block
-        }
-      case _ => ???
+    Builder.forcedUserModule.withRegion(ifRegion) {
+      block
     }
   } catch {
     case _: scala.runtime.NonLocalReturnControl[_] =>

--- a/core/src/main/scala/chisel3/When.scala
+++ b/core/src/main/scala/chisel3/When.scala
@@ -3,6 +3,7 @@
 package chisel3
 
 import scala.language.experimental.macros
+import scala.collection.immutable.VectorBuilder
 import chisel3.internal._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir._
@@ -34,7 +35,7 @@ object when {
   )(
     implicit sourceInfo: SourceInfo
   ): WhenContext = {
-    new WhenContext(sourceInfo, Some(() => cond), block, 0, Nil)
+    new WhenContext(sourceInfo, () => cond, block, 0, Nil)
   }
 
   /** Returns the current `when` condition
@@ -60,6 +61,20 @@ object when {
   }
 }
 
+private object Scope {
+  sealed trait Type
+
+  /** Indicates that the `WhenContext` is in the "if" clause. */
+  object If extends Type {
+    override def toString: String = "if"
+  }
+
+  /** Indicatest that the `WhenContext` is in the "else" clause. */
+  object Else extends Type {
+    override def toString: String = "else"
+  }
+}
+
 /**  A WhenContext may represent a when, and elsewhen, or an
   *  otherwise. Since FIRRTL does not have an "elsif" statement,
   *  alternatives must be mapped to nested if-else statements inside
@@ -72,13 +87,22 @@ object when {
   */
 final class WhenContext private[chisel3] (
   _sourceInfo: SourceInfo,
-  cond:        Option[() => Bool],
+  cond:        () => Bool,
   block:       => Any,
   firrtlDepth: Int,
   // For capturing conditions from prior whens or elsewhens
   altConds: List[() => Bool]) {
 
-  private var scopeOpen = false
+  /** Commands that occur under the "if" leg of this when statement. */
+  val ifRegion = new VectorBuilder[Command]()
+
+  /** Commands that occurr under the "else" leg of this when statement. */
+  val elseRegion = new VectorBuilder[Command]()
+
+  /** Indicate if the `WhenContext` is "closed" (`None`) or if this is writing to
+    * the "if" or "else" region.
+    */
+  private var scope: Option[Scope.Type] = None
 
   private[chisel3] def sourceInfo: SourceInfo = _sourceInfo
 
@@ -88,9 +112,11 @@ final class WhenContext private[chisel3] (
     val alt = altConds.foldRight(true.B) {
       case (c, acc) => acc & !c()
     }
-    cond
-      .map(alt && _())
-      .getOrElse(alt)
+    scope match {
+      case Some(Scope.If)   => alt && cond()
+      case Some(Scope.Else) => alt && !cond()
+      case None             => alt
+    }
   }
 
   /** This block of logic gets executed if above conditions have been
@@ -105,7 +131,9 @@ final class WhenContext private[chisel3] (
   )(
     implicit sourceInfo: SourceInfo
   ): WhenContext = {
-    new WhenContext(sourceInfo, Some(() => elseCond), block, firrtlDepth + 1, cond ++: altConds)
+    Builder.forcedUserModule.withRegion(elseRegion) {
+      new WhenContext(sourceInfo, () => elseCond, block, firrtlDepth + 1, cond :: altConds)
+    }
   }
 
   /** This block of logic gets executed only if the above conditions
@@ -115,20 +143,34 @@ final class WhenContext private[chisel3] (
     * assignment of the Bool node of the predicate in the correct
     * place.
     */
-  def otherwise(block: => Any)(implicit sourceInfo: SourceInfo): Unit =
-    new WhenContext(sourceInfo, None, block, firrtlDepth + 1, cond ++: altConds)
+  def otherwise(block: => Any)(implicit sourceInfo: SourceInfo): Unit = {
+    Builder.pushWhen(this)
+    scope = Some(Scope.Else)
+    Builder.forcedUserModule.withRegion(elseRegion) {
+      block
+    }
+    scope = None
+    Builder.popWhen()
+  }
 
-  def active: Boolean = scopeOpen
+  def active: Boolean = scope.isDefined
 
   /*
    *
    */
-  if (firrtlDepth > 0) { pushCommand(AltBegin(sourceInfo)) }
-  cond.foreach(c => pushCommand(WhenBegin(sourceInfo, c().ref)))
+  // if (firrtlDepth > 0) { pushCommand(AltBegin(sourceInfo)) }
+  // cond.foreach(c => pushCommand(WhenBegin(sourceInfo, c().ref)))
+  pushCommand(When(sourceInfo, cond().ref, ifRegion, elseRegion))
   Builder.pushWhen(this)
+  scope = Some(Scope.If)
   try {
-    scopeOpen = true
-    block
+    Builder.currentModule match {
+      case Some(module: RawModule) =>
+        module.withRegion(ifRegion) {
+          block
+        }
+      case _ => ???
+    }
   } catch {
     case _: scala.runtime.NonLocalReturnControl[_] =>
       throwException(
@@ -136,8 +178,8 @@ final class WhenContext private[chisel3] (
           " Perhaps you meant to use Mux or a Wire as a return value?"
       )
   }
-  scopeOpen = false
+  scope = None
   Builder.popWhen()
-  cond.foreach(_ => pushCommand(WhenEnd(sourceInfo, firrtlDepth)))
-  if (cond.isEmpty) { pushCommand(OtherwiseEnd(sourceInfo, firrtlDepth)) }
+  // cond.foreach(_ => pushCommand(WhenEnd(sourceInfo, firrtlDepth)))
+  // if (cond.isEmpty) { pushCommand(OtherwiseEnd(sourceInfo, firrtlDepth)) }
 }

--- a/core/src/main/scala/chisel3/When.scala
+++ b/core/src/main/scala/chisel3/When.scala
@@ -3,7 +3,6 @@
 package chisel3
 
 import scala.language.experimental.macros
-import scala.collection.immutable.VectorBuilder
 import chisel3.internal._
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir._
@@ -153,7 +152,7 @@ final class WhenContext private[chisel3] (
   // Create the `When` operation and run the `block` thunk inside the
   // `ifRegion`.  Any commands that this thunk creates will be put inside this
   // block.
-  private val whenCommand = pushCommand(When(sourceInfo, cond().ref))
+  private val whenCommand = pushCommand(new When(sourceInfo, cond().ref))
   Builder.pushWhen(this)
   scope = Some(Scope.If)
   try {

--- a/core/src/main/scala/chisel3/internal/CIRCTConverter.scala
+++ b/core/src/main/scala/chisel3/internal/CIRCTConverter.scala
@@ -28,8 +28,6 @@ abstract class CIRCTConverter {
 
   def visitDefIntrinsicModule(defIntrinsicModule: DefIntrinsicModule): Unit
 
-  def visitAltBegin(altBegin: AltBegin): Unit
-
   def visitAttach(attach: Attach): Unit
 
   def visitConnect(connect: Connect): Unit
@@ -38,11 +36,7 @@ abstract class CIRCTConverter {
 
   def visitDefInvalid(defInvalid: DefInvalid): Unit
 
-  def visitOtherwiseEnd(otherwiseEnd: OtherwiseEnd): Unit
-
-  def visitWhenBegin(whenBegin: WhenBegin): Unit
-
-  def visitWhenEnd(whenEnd: WhenEnd): Unit
+  def visitWhen(when: When): Unit
 
   def visitDefSeqMemory(defSeqMemory: DefSeqMemory): Unit
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -272,25 +272,20 @@ private[chisel3] object Converter {
         tpe
       )
       Some(fir.DefNode(convert(info), i.name, expr))
+    case When(info, pred, ifRegion, elseRegion) =>
+      Some(
+        fir.Conditionally(
+          convert(info),
+          convert(pred, ctx, info),
+          convert(ifRegion.result(), ctx, typeAliases),
+          convert(elseRegion.result(), ctx, typeAliases)
+        )
+      )
     case _ => None
   }
 
   /** Trait used for tracking when or layer regions. */
   private sealed trait RegionFrame
-
-  /** Internal datastructure to help translate Chisel's flat Command structure to FIRRTL's AST
-    *
-    * In particular, when scoping is translated from flat with begin end to a nested datastructure
-    *
-    * @param when Current when Statement, holds info, condition, and consequence as they are
-    *        available
-    * @param outer Already converted Statements that precede the current when block in the scope in
-    *        which the when is defined (ie. 1 level up from the scope inside the when)
-    * @param alt Indicates if currently processing commands in the alternate (else) of the when scope
-    */
-  // TODO we should probably have a different structure in the IR to close elses
-  private case class WhenFrame(when: fir.Conditionally, outer: VectorBuilder[fir.Statement], alt: Boolean)
-      extends RegionFrame
 
   /** Internal datastructure to help convert layer blocks to FIRRTL. */
   private case class LayerBlockFrame(layer: fir.LayerBlock, outer: VectorBuilder[fir.Statement]) extends RegionFrame
@@ -327,45 +322,6 @@ private[chisel3] object Converter {
         // Please see WhenFrame for more details
         case None =>
           cmd match {
-            case WhenBegin(info, pred) =>
-              val when = fir.Conditionally(convert(info), convert(pred, ctx, info), fir.EmptyStmt, fir.EmptyStmt)
-              val frame = WhenFrame(when, stmts, false)
-              stmts = new VectorBuilder[fir.Statement]
-              scope = frame :: scope
-            case WhenEnd(info, depth, _) =>
-              val frame = scope.head.asInstanceOf[WhenFrame]
-              val when =
-                if (frame.alt) frame.when.copy(alt = fir.Block(stmts.result()))
-                else frame.when.copy(conseq = fir.Block(stmts.result()))
-              // Check if this when has an else
-              cmdsIt.headOption match {
-                case Some(AltBegin(_)) =>
-                  assert(!frame.alt, "Internal Error! Unexpected when structure!") // Only 1 else per when
-                  scope = frame.copy(when = when, alt = true) :: scope.tail
-                  cmdsIt.next() // Consume the AltBegin
-                  stmts = new VectorBuilder[fir.Statement]
-                case _ => // Not followed by otherwise
-                  // If depth > 0 then we need to close multiple When scopes so we add a new WhenEnd
-                  // If we're nested we need to add more WhenEnds to ensure each When scope gets
-                  // properly closed
-                  if (depth > 0) {
-                    nextCmd = WhenEnd(info, depth - 1, false)
-                  }
-                  stmts = frame.outer
-                  stmts += when
-                  scope = scope.tail
-              }
-            case OtherwiseEnd(info, depth) =>
-              val frame = scope.head.asInstanceOf[WhenFrame]
-              val when = frame.when.copy(alt = fir.Block(stmts.result()))
-              // TODO For some reason depth == 1 indicates the last closing otherwise whereas
-              //  depth == 0 indicates last closing when
-              if (depth > 1) {
-                nextCmd = OtherwiseEnd(info, depth - 1)
-              }
-              stmts = frame.outer
-              stmts += when
-              scope = scope.tail
             case LayerBlockBegin(info, layer) =>
               val block = fir.LayerBlock(convert(info), layer.name, fir.EmptyStmt)
               val frame = LayerBlockFrame(block, stmts)

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -277,8 +277,8 @@ private[chisel3] object Converter {
         fir.Conditionally(
           convert(info),
           convert(pred, ctx, info),
-          convert(ifRegion.result(), ctx, typeAliases),
-          convert(elseRegion.result(), ctx, typeAliases)
+          convert(ifRegion, ctx, typeAliases),
+          convert(elseRegion, ctx, typeAliases)
         )
       )
     case _ => None

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -330,8 +330,8 @@ private[chisel3] object ir {
   case class When(
     sourceInfo: SourceInfo,
     pred:       Arg,
-    ifRegion:   VectorBuilder[Command],
-    elseRegion: VectorBuilder[Command])
+    ifRegion:   VectorBuilder[Command] = new VectorBuilder[Command],
+    elseRegion: VectorBuilder[Command] = new VectorBuilder[Command])
       extends Command
 
   case class Connect(sourceInfo: SourceInfo, loc: Arg, exp: Arg) extends Command

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -11,7 +11,7 @@ import _root_.firrtl.{ir => firrtlir}
 import _root_.firrtl.{PrimOps, RenameMap}
 import _root_.firrtl.annotations.Annotation
 
-import scala.collection.immutable.NumericRange
+import scala.collection.immutable.{NumericRange, VectorBuilder}
 import scala.math.BigDecimal.RoundingMode
 import scala.annotation.nowarn
 import scala.collection.mutable
@@ -326,10 +326,14 @@ private[chisel3] object ir {
     choices:    Seq[(String, BaseModule)])
       extends Definition
   case class DefObject(sourceInfo: SourceInfo, id: HasId, className: String) extends Definition
-  case class WhenBegin(sourceInfo: SourceInfo, pred: Arg) extends Command
-  case class WhenEnd(sourceInfo: SourceInfo, firrtlDepth: Int, hasAlt: Boolean = false) extends Command
-  case class AltBegin(sourceInfo: SourceInfo) extends Command
-  case class OtherwiseEnd(sourceInfo: SourceInfo, firrtlDepth: Int) extends Command
+
+  case class When(
+    sourceInfo: SourceInfo,
+    pred:       Arg,
+    ifRegion:   VectorBuilder[Command],
+    elseRegion: VectorBuilder[Command])
+      extends Command
+
   case class Connect(sourceInfo: SourceInfo, loc: Arg, exp: Arg) extends Command
   case class PropAssign(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
   case class Attach(sourceInfo: SourceInfo, locs: Seq[Node]) extends Command

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -329,19 +329,24 @@ private[chisel3] object ir {
 
   class When(val sourceInfo: SourceInfo, val pred: Arg) extends Command {
     val ifRegion = new VectorBuilder[Command]
-    private var _elseRegion: Option[VectorBuilder[Command]] = None
+    private var _elseRegion: VectorBuilder[Command] = null
     def elseRegion: VectorBuilder[Command] = {
-      if (_elseRegion.isEmpty) {
-        _elseRegion = Some(new VectorBuilder[Command])
+      if (_elseRegion == null) {
+        _elseRegion = new VectorBuilder[Command]
       }
-      _elseRegion.get
+      _elseRegion
     }
   }
 
   object When {
     def unapply(when: When): Option[(SourceInfo, Arg, Seq[Command], Seq[Command])] = {
       Some(
-        (when.sourceInfo, when.pred, when.ifRegion.result(), when._elseRegion.map(_.result()).getOrElse(Seq.empty))
+        (
+          when.sourceInfo,
+          when.pred,
+          when.ifRegion.result(),
+          Option(when._elseRegion).fold(Seq.empty[Command])(_.result())
+        )
       )
     }
   }

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -109,8 +109,7 @@ class FirContext {
 
   def enterWhen(whenOp: Op): Unit = whenStack.push(WhenContext(whenOp, currentBlock, false))
   def enterAlt(): Unit = whenStack.top.inAlt = true
-  def leaveOtherwise(depth: Int): Unit = (1 to depth).foreach(_ => whenStack.pop)
-  def leaveWhen(depth:      Int, hasAlt: Boolean): Unit = if (!hasAlt) (0 to depth).foreach(_ => whenStack.pop)
+  def leaveWhen(): Unit = whenStack.pop
 
   def circuitBlock: MlirBlock = opCircuit.region(0).block(0)
   def findModuleBlock(name: String): MlirBlock = opModules.find(_._1 == name).get._2.region(0).block(0)
@@ -1020,7 +1019,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
     util.emitInvalidate(dest, loc)
   }
 
-  def visitWhen(when: When): Unit = {
+  def visitWhen(when: When, visitIfRegion: () => Unit, visitElseRegion: Option[() => Unit]): Unit = {
     val loc = util.convert(when.sourceInfo)
     val cond = util.referTo(when.pred, when.sourceInfo)
 
@@ -1031,7 +1030,13 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       .withOperand( /* condition */ cond.value)
       .build()
 
-    ???
+    firCtx.enterWhen(op)
+    visitIfRegion()
+    if (visitElseRegion.nonEmpty) {
+      firCtx.enterAlt()
+      visitElseRegion.get()
+    }
+    firCtx.leaveWhen()
   }
 
   def visitDefInstance(defInstance: DefInstance): Unit = {
@@ -1673,6 +1678,42 @@ object PanamaCIRCTConverter {
     cvt
   }
 
+  private def visitCommands(parent: Component, cmds: Seq[Command])(implicit cvt: PanamaCIRCTConverter): Unit = {
+    cmds.foreach(visitCommand(parent, _))
+  }
+
+  private def visitCommand(parent: Component, cmd: Command)(implicit cvt: PanamaCIRCTConverter): Unit = {
+    cmd match {
+      case attach:              Attach                    => visitAttach(attach)
+      case connect:             Connect                   => visitConnect(connect)
+      case connectInit:         ConnectInit               => visitConnectInit(connectInit)
+      case defInvalid:          DefInvalid                => visitDefInvalid(defInvalid)
+      case when:                When                      => visitWhen(when, () => visitCommands(parent, when.ifRegion.result), if (when.elseRegion.nonEmpty) { Some(() => visitCommands(parent, when.elseRegion.result)) } else { None })
+      case defInstance:         DefInstance               => visitDefInstance(defInstance)
+      case defMemPort:          DefMemPort[ChiselData]    => visitDefMemPort(defMemPort)
+      case defMemory:           DefMemory                 => visitDefMemory(defMemory)
+      case defPrim:             DefPrim[ChiselData]       => visitDefPrim(defPrim)
+      case defReg:              DefReg                    => visitDefReg(defReg)
+      case defRegInit:          DefRegInit                => visitDefRegInit(defRegInit)
+      case defSeqMemory:        DefSeqMemory              => visitDefSeqMemory(defSeqMemory)
+      case defWire:             DefWire                   => visitDefWire(defWire)
+      case printf:              Printf                    => visitPrintf(parent, printf)
+      case stop:                Stop                      => visitStop(stop)
+      case assert:              Verification[VerifAssert] => visitVerfiAssert(parent, assert)
+      case assume:              Verification[VerifAssume] => visitVerfiAssume(parent, assume)
+      case cover:               Verification[VerifCover]  => visitVerfiCover(parent, cover)
+      case printf:              Verification[VerifPrintf] => visitVerfiPrintf(printf)
+      case stop:                Verification[VerifStop]   => visitVerfiStop(stop)
+      case probeDefine:         ProbeDefine               => visitProbeDefine(parent, probeDefine)
+      case probeForceInitial:   ProbeForceInitial         => visitProbeForceInitial(parent, probeForceInitial)
+      case probeReleaseInitial: ProbeReleaseInitial       => visitProbeReleaseInitial(parent, probeReleaseInitial)
+      case probeForce:          ProbeForce                => visitProbeForce(parent, probeForce)
+      case probeRelease:        ProbeRelease              => visitProbeRelease(parent, probeRelease)
+      case propAssign:          PropAssign                => visitPropAssign(parent, propAssign)
+      case unhandled => throw new Exception(s"unhandled op: $unhandled")
+    }
+  }
+
   def visitCircuit(circuit: Circuit)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitCircuit(circuit.name)
     circuit.components.foreach {
@@ -1687,43 +1728,7 @@ object PanamaCIRCTConverter {
   def visitDefModule(defModule: DefModule)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitDefModule(defModule)
     val commands = defModule.commands ++ defModule.secretCommands
-    // Workaround for https://github.com/chipsalliance/chisel/issues/3435, peeking the next command
-    commands.zip(commands.map(Some(_)).drop(1) :+ None).foreach {
-      case (cmd, nextCmd) =>
-        cmd match {
-          // Command
-          case attach:  Attach  => visitAttach(attach)
-          case connect: Connect => visitConnect(connect)
-          // case partialConnect: PartialConnect => {} // TODO
-          case connectInit: ConnectInit => visitConnectInit(connectInit)
-          case defInvalid:  DefInvalid  => visitDefInvalid(defInvalid)
-          case when:        When        => visitWhen(when)
-
-          // Definition
-          case defInstance:         DefInstance               => visitDefInstance(defInstance)
-          case defMemPort:          DefMemPort[ChiselData]    => visitDefMemPort(defMemPort)
-          case defMemory:           DefMemory                 => visitDefMemory(defMemory)
-          case defPrim:             DefPrim[ChiselData]       => visitDefPrim(defPrim)
-          case defReg:              DefReg                    => visitDefReg(defReg)
-          case defRegInit:          DefRegInit                => visitDefRegInit(defRegInit)
-          case defSeqMemory:        DefSeqMemory              => visitDefSeqMemory(defSeqMemory)
-          case defWire:             DefWire                   => visitDefWire(defWire)
-          case printf:              Printf                    => visitPrintf(defModule, printf)
-          case stop:                Stop                      => visitStop(stop)
-          case assert:              Verification[VerifAssert] => visitVerfiAssert(defModule, assert)
-          case assume:              Verification[VerifAssume] => visitVerfiAssume(defModule, assume)
-          case cover:               Verification[VerifCover]  => visitVerfiCover(defModule, cover)
-          case printf:              Verification[VerifPrintf] => visitVerfiPrintf(printf)
-          case stop:                Verification[VerifStop]   => visitVerfiStop(stop)
-          case probeDefine:         ProbeDefine               => visitProbeDefine(defModule, probeDefine)
-          case probeForceInitial:   ProbeForceInitial         => visitProbeForceInitial(defModule, probeForceInitial)
-          case probeReleaseInitial: ProbeReleaseInitial       => visitProbeReleaseInitial(defModule, probeReleaseInitial)
-          case probeForce:          ProbeForce                => visitProbeForce(defModule, probeForce)
-          case probeRelease:        ProbeRelease              => visitProbeRelease(defModule, probeRelease)
-          case propAssign:          PropAssign                => visitPropAssign(defModule, propAssign)
-          case unhandled => throw new Exception(s"unhandled op: $unhandled")
-        }
-    }
+    commands.foreach(visitCommand(defModule, _))
   }
   def visitDefIntrinsicModule(defIntrinsicModule: DefIntrinsicModule)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitDefIntrinsicModule(defIntrinsicModule)
@@ -1741,8 +1746,8 @@ object PanamaCIRCTConverter {
   def visitDefInvalid(defInvalid: DefInvalid)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitDefInvalid(defInvalid)
   }
-  def visitWhen(when: When)(implicit cvt: PanamaCIRCTConverter): Unit = {
-    cvt.visitWhen(when)
+  def visitWhen(when: When, visitIfRegion: () => Unit, visitElseRegion: Option[() => Unit])(implicit cvt: PanamaCIRCTConverter): Unit = {
+    cvt.visitWhen(when, visitIfRegion, visitElseRegion)
   }
   def visitDefInstance(defInstance: DefInstance)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitDefInstance(defInstance)

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -1692,12 +1692,12 @@ object PanamaCIRCTConverter {
       case (cmd, nextCmd) =>
         cmd match {
           // Command
-          case attach:   Attach   => visitAttach(attach)
-          case connect:  Connect  => visitConnect(connect)
+          case attach:  Attach  => visitAttach(attach)
+          case connect: Connect => visitConnect(connect)
           // case partialConnect: PartialConnect => {} // TODO
-          case connectInit:  ConnectInit  => visitConnectInit(connectInit)
-          case defInvalid:   DefInvalid   => visitDefInvalid(defInvalid)
-          case when:         When         => visitWhen(when)
+          case connectInit: ConnectInit => visitConnectInit(connectInit)
+          case defInvalid:  DefInvalid  => visitDefInvalid(defInvalid)
+          case when:        When        => visitWhen(when)
 
           // Definition
           case defInstance:         DefInstance               => visitDefInstance(defInstance)

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -42,7 +42,7 @@ object Select {
             Seq(f(cmd))
           else
             Seq.empty
-        head ++ collect(ifRegion.result())(f) ++ collect(elseRegion.result())(f)
+        head ++ collect(ifRegion)(f) ++ collect(elseRegion)(f)
       case cmd if f.isDefinedAt(cmd) => Some(f(cmd))
       case _                         => None
     }
@@ -539,8 +539,8 @@ object Select {
           case l: LitArg if l.num == BigInt(0) => When(false.B)
           case _ => ???
         }
-        searchCommands(ifRegion.result(), pred +: preds, processCommand)
-        searchCommands(elseRegion.result(), pred.not +: preds, processCommand)
+        searchCommands(ifRegion, pred +: preds, processCommand)
+        searchCommands(elseRegion, pred.not +: preds, processCommand)
       case cmd => processCommand(cmd, preds)
     }
 

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -537,7 +537,7 @@ object Select {
           case Node(pred: Bool) => When(pred)
           case l: LitArg if l.num == BigInt(1) => When(true.B)
           case l: LitArg if l.num == BigInt(0) => When(false.B)
-          case _ => ???
+          case _ => sys.error(s"Something went horribly wrong! I was expecting $cond to be a lit or a bool!")
         }
         searchCommands(ifRegion, pred +: preds, processCommand)
         searchCommands(elseRegion, pred.not +: preds, processCommand)


### PR DESCRIPTION
Change the internal representation of `When` in Chisel to be region based as opposed to token-based.  Concretely, change `WhenContext` to not push token commands indicating when the region starts/stops, has an alternative, etc.  Instead, use a single object that has an "if" and an "else" region where commands can be pushed.

CC: @sequencer, @SpriteOvO: I didn't fixup the bindings here.