### PR TITLE
Add Region to Chisel IR

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -282,11 +282,7 @@ private[chisel3] object Converter {
         )
       )
     case Region(info, region) =>
-      if (region.isEmpty) {
-        None
-      } else {
-        Some(fir.Block(convert(region, ctx, typeAliases)))
-      }
+      Some(fir.Block(convert(region, ctx, typeAliases)))
     case _ => None
   }
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -281,6 +281,12 @@ private[chisel3] object Converter {
           convert(elseRegion, ctx, typeAliases)
         )
       )
+    case Region(info, region) =>
+      if (region.isEmpty) {
+        None
+      } else {
+        Some(fir.Block(convert(region, ctx, typeAliases)))
+      }
     case _ => None
   }
 

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -328,6 +328,17 @@ private[chisel3] object ir {
       extends Definition
   case class DefObject(sourceInfo: SourceInfo, id: HasId, className: String) extends Definition
 
+  class Region extends Command {
+    override val sourceInfo = UnlocatableSourceInfo
+    val region = new VectorBuilder[Command]
+  }
+
+  object Region {
+    def unapply(region: Region): Option[(SourceInfo, Seq[Command])] = {
+      Some((region.sourceInfo, region.region.result()))
+    }
+  }
+
   class When(val sourceInfo: SourceInfo, val pred: Arg) extends Command {
     val ifRegion = new VectorBuilder[Command]
     private var _elseRegion: VectorBuilder[Command] = null


### PR DESCRIPTION
Add a Region operation to Chisel IR.  This is a command which is a container of other commands.  This is intended to provide an "insertion point" that can be added to the command buffer which can then be referenced later to add more commands.  This avoids the problem of the command buffer being append only while _not_ going fully in the direction of using a datastructure which allows arbitrary insertion (i.e., a linked list).

This is stacked on #4184.