### PR TITLE
Remove ConnectInit

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -366,7 +366,6 @@ private[chisel3] object ir {
   case class Connect(sourceInfo: SourceInfo, loc: Arg, exp: Arg) extends Command
   case class PropAssign(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
   case class Attach(sourceInfo: SourceInfo, locs: Seq[Node]) extends Command
-  case class ConnectInit(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
   case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Definition
 
   object LayerConvention {

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -1687,7 +1687,6 @@ object PanamaCIRCTConverter {
     cmd match {
       case attach:      Attach      => visitAttach(attach)
       case connect:     Connect     => visitConnect(connect)
-      case connectInit: ConnectInit => visitConnectInit(connectInit)
       case defInvalid:  DefInvalid => visitDefInvalid(defInvalid)
       case when:        When =>
         visitWhen(
@@ -1745,10 +1744,6 @@ object PanamaCIRCTConverter {
   }
   def visitConnect(connect: Connect)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitConnect(connect)
-  }
-  def visitConnectInit(connectInit: ConnectInit)(implicit cvt: PanamaCIRCTConverter): Unit = {
-    // Not used anywhere
-    throw new Exception("unimplemented")
   }
   def visitDefInvalid(defInvalid: DefInvalid)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitDefInvalid(defInvalid)

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -1685,10 +1685,10 @@ object PanamaCIRCTConverter {
 
   private def visitCommand(parent: Component, cmd: Command)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cmd match {
-      case attach:      Attach      => visitAttach(attach)
-      case connect:     Connect     => visitConnect(connect)
-      case defInvalid:  DefInvalid => visitDefInvalid(defInvalid)
-      case when:        When =>
+      case attach:     Attach  => visitAttach(attach)
+      case connect:    Connect => visitConnect(connect)
+      case defInvalid: DefInvalid => visitDefInvalid(defInvalid)
+      case when:       When =>
         visitWhen(
           when,
           () => visitCommands(parent, when.ifRegion.result),


### PR DESCRIPTION
Remove an unused Chisel IR feature.

Commentary: this is a pretty rare deletion!  This IR features dates _to the first commit_ in the repo.