### PR TITLE
Move registers out of when blocks

### DIFF
--- a/core/src/main/scala/chisel3/Reg.scala
+++ b/core/src/main/scala/chisel3/Reg.scala
@@ -47,6 +47,10 @@ object Reg {
 
     reg.bind(RegBinding(Builder.forcedUserModule, Builder.currentWhen))
     pushCommand(DefReg(sourceInfo, reg, clock))
+    // Record the when depth where this register was declared.  This is used
+    // later to determine what whens need to be generated for any connects to
+    // this register.
+    Builder.forcedUserModule.regToWhenDepth(reg) = Builder.whenDepth
     reg
   }
 }

--- a/src/test/scala/chiselTests/WhenSpec.scala
+++ b/src/test/scala/chiselTests/WhenSpec.scala
@@ -145,6 +145,29 @@ class WhenSpec extends ChiselFlatSpec with Utils {
     assertTesterPasses(new WhenCondTester)
   }
 
+  "Declarations inside a when block" should "be moved outside the when block" in {
+    import chisel3.layer.{block, Convention, Layer}
+
+    val chirrtl = ChiselStage.emitCHIRRTL(
+      {
+        object Verification extends Layer(Convention.Bind)
+        new Module {
+          val cond_1, cond_2, cond_3 = IO(Input(Bool()))
+          when(cond_1) {
+            val a = Reg(Bool())
+            when(cond_2) {
+              when(cond_3) {
+                a := true.B
+              }
+            }
+          }
+        }
+      },
+      Array("--full-stacktrace")
+    )
+    println(chirrtl)
+  }
+
   "Returning in a when scope" should "give a reasonable error message" in {
     val e = the[ChiselException] thrownBy extractCause[ChiselException] {
       ChiselStage.emitCHIRRTL(new Module {


### PR DESCRIPTION
Change the way that Chisel IR creates registers to move these outside of when blocks.  This works towards a world where the only statements allowed under FIRRTL when blocks are connects.