### PR TITLE
Mark return value of .asTypeOf as "deprecated read-only"

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -815,7 +815,9 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   def do_asTypeOf[T <: Data](that: T)(implicit sourceInfo: SourceInfo): T = {
     val thatCloned = Wire(that.cloneTypeFull)
     thatCloned.connectFromBits(this.asUInt)
-    thatCloned
+    thatCloned.viewAsReadOnlyDeprecated(siteInfo =>
+      Warning(WarningID.AsTypeOfReadOnly, s"Return values of asTypeOf will soon be read-only")(siteInfo)
+    )
   }
 
   /** Assigns this node from Bits type. Internal implementation for asTypeOf.

--- a/core/src/main/scala/chisel3/internal/Warning.scala
+++ b/core/src/main/scala/chisel3/internal/Warning.scala
@@ -20,6 +20,7 @@ private[chisel3] object WarningID extends Enumeration {
   val DynamicIndexTooNarrow = Value(5)
   val ExtractFromVecSizeZero = Value(6)
   val BundleLiteralValueTooWide = Value(7)
+  val AsTypeOfReadOnly = Value(8)
 }
 import WarningID.WarningID
 

--- a/docs/src/explanations/warnings.md
+++ b/docs/src/explanations/warnings.md
@@ -150,3 +150,28 @@ This warning occurs when creating a [Bundle Literal](../appendix/experimental-fe
 field is wider than the Bundle field's width.
 It can be fixed by reducing the width of the literal (perhaps choosing a different value if it is impossible to encode the value in the
 field's width).
+
+### [W008] Return values of asTypeOf will soon be read-only
+
+This warning indicates that the result of a call to `.asTypeOf(_)` is being used as the destination for a connection.
+It can be fixed by instantiating a wire.
+
+For example, given the following:
+```scala mdoc:compile-only
+class MyBundle extends Bundle {
+  val foo = UInt(8.W)
+  val bar = UInt(8.W)
+}
+val x = 0.U.asTypeOf(new MyBundle)
+x.bar := 123.U
+```
+
+The warning can be fixed by inserting a wire:
+```scala mdoc:compile-only
+class MyBundle extends Bundle {
+  val foo = UInt(8.W)
+  val bar = UInt(8.W)
+}
+val x = WireInit(0.U.asTypeOf(new MyBundle))
+x.bar := 123.U
+```

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -319,9 +319,9 @@ class VecSpec extends ChiselPropSpec with Utils {
 
     })
     chirrtl should include("output io : { foo : UInt<1>, bar : UInt<1>[0]}")
-    chirrtl should include("wire zero : { foo : UInt<1>, bar : UInt<1>[0]}")
-    chirrtl should include("connect zero.foo, UInt<1>(0h0)")
-    chirrtl should include("connect io, zero")
+    chirrtl should include("wire _zero_WIRE : { foo : UInt<1>, bar : UInt<1>[0]}")
+    chirrtl should include("connect _zero_WIRE.foo, UInt<1>(0h0)")
+    chirrtl should include("connect io, _zero_WIRE")
     chirrtl should include("wire w : UInt<1>[0]")
     chirrtl should include("connect w, m.io.bar")
   }

--- a/src/test/scala/chiselTests/stage/WarningConfigurationSpec.scala
+++ b/src/test/scala/chiselTests/stage/WarningConfigurationSpec.scala
@@ -56,6 +56,14 @@ object WarningConfigurationSpec {
     val idx = IO(Input(UInt(8.W)))
     in(idx)
   }
+  class MyBundle extends Bundle {
+    val foo = UInt(8.W)
+  }
+  class AsTypeOfReadOnly extends RawModule {
+    val in = IO(Input(UInt(8.W)))
+    val bundle = in.asTypeOf(new MyBundle)
+    bundle.foo := 0.U
+  }
 }
 
 class WarningConfigurationSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
@@ -370,6 +378,12 @@ class WarningConfigurationSpec extends AnyFunSpec with Matchers with chiselTests
       val args = Array("--warn-conf", "id=6:e,any:s", "--throw-on-first-error")
       val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new ExtractFromVecSizeZero, args)
       e.getMessage should include("[W006] Cannot extract from Vec of size 0")
+    }
+
+    it("should number AsTypeOfReadOnly as 8") {
+      val args = Array("--warn-conf", "id=8:e,any:s", "--throw-on-first-error")
+      val e = the[Exception] thrownBy ChiselStage.emitCHIRRTL(new AsTypeOfReadOnly, args)
+      e.getMessage should include("[W008] Return values of asTypeOf will soon be read-only")
     }
   }
 }


### PR DESCRIPTION
Users will now get a deprecation warning if they connect to the result of .asTypeOf.

Marked for backporting to 6.x so that we can change this in 7.0.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, `.asTypeOf` would return a `Wire`. To get the old behavior, wrap the `.asTypeOf` call in `WireInit(...)`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
