### PR TITLE
Fix ActualDirection calculation from SpecifiedDirection

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1100,12 +1100,7 @@ abstract class Record extends Aggregate {
     direction = ActualDirection.fromChildren(childDirections, resolvedDirection) match {
       case Some(dir) => dir
       case None =>
-        val resolvedDirection = SpecifiedDirection.fromParent(parentDirection, specifiedDirection)
-        resolvedDirection match {
-          case SpecifiedDirection.Unspecified => ActualDirection.Bidirectional(ActualDirection.Default)
-          case SpecifiedDirection.Flip        => ActualDirection.Bidirectional(ActualDirection.Flipped)
-          case _                              => ActualDirection.Bidirectional(ActualDirection.Default)
-        }
+        throwException(s"Internal Error! Unhandled directionality of children: $childDirections for $this!")
     }
     setElementRefs()
 

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -143,10 +143,13 @@ object ActualDirection {
     case _                           => throwException(s"Unexpected ActualDirection value $b")
   }
 
+  /** Converts a `SpecifiedDirection` to an `ActualDirection`
+    *
+    * Implements the Chisel convention that Flip is Input and unspecified is Output.
+    */
   def fromSpecified(direction: SpecifiedDirection): ActualDirection = direction match {
-    case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip => ActualDirection.Unspecified
-    case SpecifiedDirection.Output                                => ActualDirection.Output
-    case SpecifiedDirection.Input                                 => ActualDirection.Input
+    case SpecifiedDirection.Output | SpecifiedDirection.Unspecified => ActualDirection.Output
+    case SpecifiedDirection.Input | SpecifiedDirection.Flip         => ActualDirection.Input
   }
 
   /** Determine the actual binding of a container given directions of its children.


### PR DESCRIPTION
In https://github.com/chipsalliance/chisel/pull/2634, we unified the Chisel 2 and Chisel 3 direction semantics, making it legal to have Records where the directionality of elements is mixed (some may be specified, some may be not). The implementation is mostly right, but there was a corner case I came across in https://github.com/chipsalliance/chisel/issues/4204.

Previously, ActualDirection.fromSpecified would return Unspecified for either Unspecified or Flipped input. This in turn resulted in Bundles mixing Unspecified and Outputs as being "bidirectional" despite the fact that they are actually unidirectional (or passive), and similarly for Bundles mixing Flipped with Input.

Now, Unspecified maps to Output and Flip maps to Input. This change makes the direction calculation more consistent albeit at the cost of marking the directions of unspecified Data as Output.

I'm backporting this to 6.x because #4204 will manifest there, but this is a pretty big change to the reported direction of Chisel Data so I don't think we should backport it to other branches.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?


#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Fixes https://github.com/chipsalliance/chisel/issues/4204.

Unspecified direction maps to Output while Flip maps to Input. Previously, ActualDirection.fromSpecified would return Unspecified for either Unspecified or Flipped input. This in turn resulted in Bundles mixing Unspecified and Outputs as being "bidirectional" despite the fact that they are actually unidirectional (or passive).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
