### PR TITLE
[ChiselSim] Add expose/observe methods to simulator for submodule drilling

### DIFF
--- a/src/main/scala/chisel3/simulator/Observe.scala
+++ b/src/main/scala/chisel3/simulator/Observe.scala
@@ -1,0 +1,66 @@
+package chisel3.simulator
+
+import chisel3._
+import chisel3.util.experimental._
+
+object observe {
+  def apply[T <: Data](signal: T): T = BoringUtils.bore(signal)
+}
+
+object expose {
+
+  /** The method `expose` allows one to bring to a wrapped module, signals from instantiated sub-modules so they can be
+    * tested by peek/poke. This avoid cluttering the original module with signals that would be used only by
+    * the test harness.
+    *
+    * Usage:
+    *
+    * {{{
+    * import chisel3._
+    *
+    * // This is the module and submodule to be tested
+    * class SubModule extends Module {
+    *   val reg  = Reg(UInt(6.W))
+    *   reg := 42.U
+    * }
+    *
+    * // Top module which instantiates the submodule
+    * class Top extends Module {
+    *   val submodule = Module(new SubModule)
+    * }
+    * }}}
+    *
+    * Then in your spec, test the `Top` module while exposing the signal from the submodule to the testbench:
+    * {{{
+    * import chisel3._
+    * import chisel3.simulator.EphemeralSimulator._
+    * import chisel3.simulator.expose
+    * import org.scalatest._
+    *
+    * import flatspec._
+    * import matchers._
+    *
+    * // Here we create a wrapper extending the Top module adding the exposed signals
+    * class TopWrapper extends Top {
+    *   // Expose the submodule "reg" Register
+    *   val exposed_reg  = expose(submodule.reg)
+    * }
+    *
+    * it should "expose a submodule Reg by using BoringUtils" in {
+    *   simulate(new TopWrapper) { c =>
+    *     c.exposed_reg.expect(42.U)
+    *   }
+    * }
+    * }}}
+    *
+    * @param signal
+    *   the signal to be exposed
+    * @return
+    *   a signal with the same format to be tested on Top module's spec.
+    */
+  def apply[T <: Data](signal: T): T = {
+    val ob = IO(Output(chiselTypeOf(signal)))
+    ob := BoringUtils.bore(signal)
+    ob
+  }
+}

--- a/src/test/scala/chiselTests/simulator/ObserveExposeTest.scala
+++ b/src/test/scala/chiselTests/simulator/ObserveExposeTest.scala
@@ -1,0 +1,55 @@
+package chiselTests.simulator
+
+import chisel3._
+import chisel3.simulator.EphemeralSimulator._
+import chisel3.simulator.{expose, observe}
+import org.scalatest._
+
+import flatspec._
+import matchers.should._
+
+class ObserveExposeTest extends AnyFlatSpec with Matchers {
+  behavior.of("Expose")
+
+  class SubModule extends Module {
+    val reg = Reg(UInt(6.W))
+    val wire = Wire(UInt(6.W))
+    val vec = RegInit(VecInit(Seq.fill(32)(0.S(32.W))))
+    reg := 42.U
+    wire := reg
+    vec(0) := 1.S
+    vec(10) := 10.S
+    vec(20) := -25.S
+    vec(31) := 150.S
+  }
+
+  class Top extends Module {
+    val submodule = Module(new SubModule)
+  }
+
+  class TopWrapper extends Top {
+    val exposed_reg = expose(submodule.reg)
+    val exposed_wire = expose(submodule.wire)
+    val exposed_vec = expose(submodule.vec)
+  }
+
+  it should "expose a submodule Reg by using BoringUtils" in {
+    simulate(new TopWrapper) { c =>
+      c.exposed_reg.expect(42.U)
+    }
+  }
+  it should "expose a submodule Wire by using BoringUtils" in {
+    simulate(new TopWrapper) { c =>
+      c.exposed_wire.expect(42.U)
+    }
+  }
+  it should "expose a submodule Vector by using BoringUtils" in {
+    simulate(new TopWrapper) { c =>
+      c.clock.step()
+      c.exposed_vec(0).expect(1.S)
+      c.exposed_vec(10).expect(10.S)
+      c.exposed_vec(20).expect(-25.S)
+      c.exposed_vec(31).expect(150.S)
+    }
+  }
+}


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

The method `expose` allows one to bring to a wrapped module, signals from instantiated sub-modules so they can be tested by peek/poke. This avoid cluttering the original module with signals that would be used only by the test harness.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
