### PR TITLE
make FixedIOBaseModule.io public

### DIFF
--- a/src/main/scala/chisel3/FixedIOModule.scala
+++ b/src/main/scala/chisel3/FixedIOModule.scala
@@ -2,17 +2,20 @@
 
 package chisel3
 
+import chisel3.experimental.hierarchy.{instantiable, public}
 import chisel3.experimental.{BaseModule, ExtModule, Param}
 
 /** A module or external module whose IO is generated from a specific generator.
   * This module may have no additional IO created other than what is specified
   * by its `ioGenerator` abstract member.
   */
+@instantiable
 sealed trait FixedIOBaseModule[A <: Data] extends BaseModule {
 
   /** A generator of IO */
   protected def ioGenerator: A
 
+  @public
   final val io = FlatIO(ioGenerator)
   endIOCreation()
 


### PR DESCRIPTION
Since `io` inside `FixedIOBaseModule` is final, we cannot override or add `@public` Scala annotation to it. This PR add `@public` annotation to `FixedIOBaseModule.io`, making `FixedIOBaseModule` compatible w/ D/I API. 
 
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
make FixedIOModule work with D/I

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
