### PR TITLE
Emit FIRRTL bulk connects even for "input" wires

### DIFF
--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -296,7 +296,7 @@ private[chisel3] object MonoConnect {
 
     // CASE: Context is same module that both sink node and source node are in
     if ((context_mod == sink_mod) && (context_mod == source_mod)) {
-      sink.direction != Input
+      !sink_is_port || sink.direction != Input
     }
 
     // CASE: Context is same module as sink node and source node is in a child module

--- a/src/test/scala/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala/chiselTests/BulkConnectSpec.scala
@@ -112,4 +112,15 @@ class BulkConnectSpec extends ChiselPropSpec {
     chirrtl should include("connect out1[0], in1[1]")
     chirrtl should include("connect out1[1], in1[0]")
   }
+
+  property("Chisel should emit FIRRTL bulk connect for \"input\" wires") {
+    class MyBundle extends Bundle {
+      val foo = Input(UInt(8.W))
+    }
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val w1, w2 = Wire(new MyBundle)
+      w2 <> w1
+    })
+    chirrtl should include("connect w2, w1")
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/chisel/issues/4218

One can question the need for this, as it's just making `<>` not error in a few more cases. The main motivation is that https://github.com/chipsalliance/chisel/pull/4205 causes some existing uses of `<>` that used to work no longer work. It's an unnecessary breakage that is fixed by this change.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
