### PR TITLE
Fix BoringUtils for identity views

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -225,7 +225,12 @@ abstract class RawModule extends BaseModule {
   }
   private[chisel3] val stagedSecretCommands = collection.mutable.ArrayBuffer[Command]()
 
-  private[chisel3] def secretConnection(left: Data, right: Data)(implicit si: SourceInfo): Unit = {
+  private[chisel3] def secretConnection(left: Data, _right: Data)(implicit si: SourceInfo): Unit = {
+    val (right: Data, _) = chisel3.experimental.dataview
+      .reifyIdentityView(_right)
+      .getOrElse(
+        throwException(s"BoringUtils currently only support identity views, ${_right} has multiple targets.")
+      )
     val rhs = (left.probeInfo.nonEmpty, right.probeInfo.nonEmpty) match {
       case (true, true)                                 => ProbeDefine(si, left.lref, Node(right))
       case (true, false) if left.probeInfo.get.writable => ProbeDefine(si, left.lref, RWProbeExpr(Node(right)))


### PR DESCRIPTION
We should also support non-identity views, that involves creating more secret commands (e.g. materializing a wire). This is more of a patch fix that is made important because of https://github.com/chipsalliance/chisel/pull/4198 which results in a lot more identity views (the return value of `.asTypeOf`).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
