### PR TITLE
Name the targets of identity views

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -18,7 +18,7 @@ import _root_.firrtl.AnnotationSeq
 import _root_.firrtl.renamemap.MutableRenameMap
 import _root_.firrtl.util.BackendCompilationUtilities._
 import _root_.firrtl.{ir => fir}
-import chisel3.experimental.dataview.{reify, reifySingleTarget}
+import chisel3.experimental.dataview.{reify, reifyIdentityView, reifySingleTarget}
 import chisel3.internal.Builder.Prefix
 import logger.{LazyLogging, LoggerOption}
 
@@ -903,6 +903,12 @@ private[chisel3] object Builder extends LazyLogging {
         case Clone(m: experimental.hierarchy.ModuleClone[_]) => namer(m.getPorts, prefix)
         case _ =>
       }
+    case (d: Data) =>
+      // Views are often returned in lieu of the original, so name the original (as appropriate)
+      // If a view but not identity, return the view and name it since it shows up in .toString and error messages
+      // TODO recurse on targets of non-identity views, perhaps with additional prefix from the view
+      val reified = reifyIdentityView(d).fold(d)(_._1)
+      namer(reified, prefix)
     case (id: HasId) => namer(id, prefix)
     case Some(elt) => nameRecursively(prefix, elt, namer)
     case (iter: Iterable[_]) if iter.hasDefiniteSize =>

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -904,9 +904,9 @@ private[chisel3] object Builder extends LazyLogging {
         case _ =>
       }
     case (d: Data) =>
-      // Views are often returned in lieu of the original, so name the original (as appropriate)
-      // If a view but not identity, return the view and name it since it shows up in .toString and error messages
-      // TODO recurse on targets of non-identity views, perhaps with additional prefix from the view
+      // Views are often returned in lieu of the target, so name the target (as appropriate).
+      // If a view but not identity, return the view and name it since it shows up in .toString and error messages.
+      // TODO recurse on targets of non-identity views, perhaps with additional prefix from the view.
       val reified = reifyIdentityView(d).fold(d)(_._1)
       namer(reified, prefix)
     case (id: HasId) => namer(id, prefix)

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -319,9 +319,9 @@ class VecSpec extends ChiselPropSpec with Utils {
 
     })
     chirrtl should include("output io : { foo : UInt<1>, bar : UInt<1>[0]}")
-    chirrtl should include("wire _zero_WIRE : { foo : UInt<1>, bar : UInt<1>[0]}")
-    chirrtl should include("connect _zero_WIRE.foo, UInt<1>(0h0)")
-    chirrtl should include("connect io, _zero_WIRE")
+    chirrtl should include("wire zero : { foo : UInt<1>, bar : UInt<1>[0]}")
+    chirrtl should include("connect zero.foo, UInt<1>(0h0)")
+    chirrtl should include("connect io, zero")
     chirrtl should include("wire w : UInt<1>[0]")
     chirrtl should include("connect w, m.io.bar")
   }

--- a/src/test/scala/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala/chiselTests/naming/NamePluginSpec.scala
@@ -435,4 +435,22 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
       Select.wires(top).map(_.instanceName) should be(List())
     }
   }
+
+  "identity views" should "forward names to their targets" in {
+    import chisel3.experimental.dataview._
+    class Test extends Module {
+      val x = {
+        val _w = Wire(UInt(3.W))
+        _w.viewAs[UInt]
+      }
+      val y = Wire(UInt(3.W)).readOnly // readOnly is implemented with views
+
+      val z = Wire(UInt(3.W))
+      val zz = z.viewAs[UInt] // But don't accidentally override names
+    }
+
+    aspectTest(() => new Test) { top: Test =>
+      Select.wires(top).map(_.instanceName) should be(List("x", "y", "z"))
+    }
+  }
 }


### PR DESCRIPTION
I'm calling this a bugfix because it fixes an issue exacerbated by https://github.com/chipsalliance/chisel/pull/4198, but it's also sort of a feature. The crux of the motivation for this change is visible in the change to `VecSpec`. Basically, if the user returns a view in lieu of the underlying target Data, the actual Data does not currently get named. This PR fixes it by having identity views forward their naming on to the underlying target. This PR is made much more important by https://github.com/chipsalliance/chisel/pull/4198 because this now comes up quite a bit in user code, `VecSpec` showing an example.

Future work is handling non-identity views because it is reasonable to forward naming in those cases as well, but perhaps with additional prefixing based on the "local" name of the target within the view Aggregate.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
