### PR TITLE
Make isView safe outside of Builder context

### DIFF
--- a/core/src/main/scala/chisel3/experimental/dataview/package.scala
+++ b/core/src/main/scala/chisel3/experimental/dataview/package.scala
@@ -273,7 +273,7 @@ package object dataview {
   }
 
   // Safe for all Data
-  private[chisel3] def isView(d: Data): Boolean = d._parent.contains(ViewParent)
+  private[chisel3] def isView(d: Data): Boolean = d._parent.exists(_ == ViewParent)
 
   /** Turn any [[Element]] that could be a View into a concrete Element
     *

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -275,6 +275,11 @@ trait ShiftRightWidthBehavior { self: ChiselRunners =>
 
 class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRightWidthBehavior {
 
+  // This is intentionally a val outside of any ScalaTest constructs to check that it is legal
+  // to create a literal outside of a Chisel context and *before* and Chisel contexts have been created
+  // in this thread.
+  val five = 5.U
+
   property("Bools can be created from 1 bit UInts") {
     ChiselStage.emitCHIRRTL(new GoodBoolConversion)
   }

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -276,7 +276,7 @@ trait ShiftRightWidthBehavior { self: ChiselRunners =>
 class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRightWidthBehavior {
 
   // This is intentionally a val outside of any ScalaTest constructs to check that it is legal
-  // to create a literal outside of a Chisel context and *before* and Chisel contexts have been created
+  // to create a literal outside of a Chisel context and *before* any Chisel contexts have been created
   // in this thread.
   val five = 5.U
 


### PR DESCRIPTION
Contemplating views in naming (https://github.com/chipsalliance/chisel/pull/4222) exposed a longstanding bug that I patched out recently in https://github.com/chipsalliance/chisel/pull/4147. Basically `isView` does not work outside of Builder contexts. Now it is safe.

We do have lots of tests for things like literals outside of Builder contexts, but they didn't trigger this because `ViewParent` is a `lazy val` and thus if _any_ Chisel elaboration has occurred on the same thread, then the problem doesn't manifest. Thus this "test" looks very strange, but by virtue of defining a literal assigned to a val first thing in a ScalaTest spec, it ensures no Chisel elaboration has run before when this line executes, and the naming plugin + #4222 ensures that this value is checked if it's a view.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
