### PR TITLE
Add ChiselStage.emitCHIRRTLFile

### DIFF
--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -91,6 +91,21 @@ object ChiselStage {
     circuitAnno.get.emitLazily(inFileAnnos).mkString
   }
 
+  /** Elaborates a Chisel circuit and emits it to a file
+    *
+    * @param gen  a call-by-name Chisel module
+    * @param args additional command line arguments to pass to Chisel
+    */
+  def emitCHIRRTLFile(
+    gen:  => RawModule,
+    args: Array[String] = Array.empty
+  ): AnnotationSeq = {
+    (new circt.stage.ChiselStage).execute(
+      Array("--target", "chirrtl") ++ args,
+      Seq(ChiselGeneratorAnnotation(() => gen))
+    )
+  }
+
   /** Return a CHIRRTL circuit for a Chisel module
     *
     * @param gen a call-by-name Chisel module
@@ -186,7 +201,7 @@ object ChiselStage {
     gen:         => RawModule,
     args:        Array[String] = Array.empty,
     firtoolOpts: Array[String] = Array.empty
-  ) =
+  ): AnnotationSeq =
     (new circt.stage.ChiselStage).execute(
       Array("--target", "systemverilog") ++ args,
       Seq(ChiselGeneratorAnnotation(() => gen)) ++ firtoolOpts.map(FirtoolOption(_))

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -2,7 +2,7 @@
 
 package circtTests.stage
 
-import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.stage.{ChiselGeneratorAnnotation, CircuitSerializationAnnotation}
 import chisel3.experimental.SourceLine
 
 import circt.stage.{ChiselStage, FirtoolOption, PreserveAggregate}
@@ -1058,6 +1058,30 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       info("found a circuit")
       text should include("circuit Foo")
 
+    }
+
+    it("should emit CHIRRTL files") {
+      val targetDir = new File("test_run_dir/ChiselStageSpec/emitCHIRRTLFile")
+
+      val args: Array[String] = Array(
+        "--target-dir",
+        targetDir.toString
+      )
+
+      // Should we be returning the CircuitSerializationAnnotation? It's consistent with emitSystemVerilogFile to do so.
+      ChiselStage
+        .emitCHIRRTLFile(
+          new ChiselStageSpec.Bar,
+          args
+        )
+        .collectFirst {
+          case CircuitSerializationAnnotation(_, filename, _) => filename
+        }
+        .get should be("Bar")
+
+      val expectedOutput = new File(targetDir, "Bar.fir")
+      expectedOutput should (exist)
+      info(s"'$expectedOutput' exists")
     }
 
     it("should emit FIRRTL dialect") {


### PR DESCRIPTION


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Emits a file without returning the serialized object which is more memory efficient and supports > 2 GiB of serialized FIRRTL text.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
