### PR TITLE
Make requireTypeEquivalent public and add context message

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -607,18 +607,18 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   /** Require that two things are type equivalent, and if they are not, print a helpful error message as
     * to why not.
-    * 
+    *
     * @param that the Data to compare to for type equivalence
     * @param message if they are not type equivalent, contextual message to add to the exception thrown
     */
-  def requireTypeEquivalent(that: Data, message: Option[String] = None): Unit = {
+  def requireTypeEquivalent(that: Data, message: String = ""): Unit = {
     require(
       this.typeEquivalent(that), {
         val reason = this
           .findFirstTypeMismatch(that, strictTypes = true, strictWidths = true, strictProbeInfo = true)
           .map(s => s"\nbecause $s")
           .getOrElse("")
-        s"${message.getOrElse("")}$this is not typeEquivalent to $that$reason"
+        s"$message$this is not typeEquivalent to $that$reason"
       }
     )
   }

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -607,15 +607,18 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
 
   /** Require that two things are type equivalent, and if they are not, print a helpful error message as
     * to why not.
+    * 
+    * @param that the Data to compare to for type equivalence
+    * @param message if they are not type equivalent, contextual message to add to the exception thrown
     */
-  private[chisel3] def requireTypeEquivalent(that: Data): Unit = {
+  def requireTypeEquivalent(that: Data, message: Option[String] = None): Unit = {
     require(
       this.typeEquivalent(that), {
         val reason = this
           .findFirstTypeMismatch(that, strictTypes = true, strictWidths = true, strictProbeInfo = true)
           .map(s => s"\nbecause $s")
           .getOrElse("")
-        s"$this is not typeEquivalent to $that$reason"
+        s"${message.getOrElse("")}$this is not typeEquivalent to $that$reason"
       }
     )
   }

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -611,7 +611,7 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
     * @param that the Data to compare to for type equivalence
     * @param message if they are not type equivalent, contextual message to add to the exception thrown
     */
-  def requireTypeEquivalent(that: Data, message: String = ""): Unit = {
+  private[chisel3] def requireTypeEquivalent(that: Data, message: String = ""): Unit = {
     require(
       this.typeEquivalent(that), {
         val reason = this

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -114,6 +114,20 @@ object DataMirror {
     */
   def checkTypeEquivalence(x: Data, y: Data): Boolean = x.typeEquivalent(y)
 
+  /** Require that two things are type equivalent
+    *
+    * If they are not, print a helpful error message as
+    * to why not.
+    *
+    * Requires structural, alignment, width, probe, color type equivalent
+    * @param x First Chisel type
+    * @param y Second chisel type
+    * @param message if they are not type equivalent, contextual message to add to the exception thrown
+    */
+  def requireTypeEquivalent(x: Data, y: Data, message: String = ""): Unit = {
+    x.requireTypeEquivalent(y, message)
+  }
+
   /** Check if two Chisel types have the same alignments for all matching members
     *
     * This means that for matching members in Aggregates, they must have matching member alignments relative to the parent type

--- a/src/test/scala/chisel3/TypeEquivalenceSpec.scala
+++ b/src/test/scala/chisel3/TypeEquivalenceSpec.scala
@@ -17,6 +17,14 @@ object TypeEquivalenceSpec {
     val c = if (hasC) Some(UInt(8.W)) else None
   }
 
+  class FooParent(hasC: Boolean) extends Bundle {
+    val foo = new Foo(hasC)
+  }
+
+  class FooGrandparent(hasC: Boolean) extends Bundle {
+    val bar = new FooParent(hasC)
+  }
+
   class Bar(bWidth: Int = 8) extends Bundle {
     val a = UInt(8.W)
     val b = UInt(bWidth.W)
@@ -390,11 +398,20 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
 
   behavior.of("Data.requireTypeEquivalent")
 
-  it should "have a good user message if it fails" in {
+  it should "have a good user message if it fails for wrong scala type" in {
     val result = the[IllegalArgumentException] thrownBy {
       Bool().requireTypeEquivalent(UInt(1.W), "This test should fail, because: ")
     }
     result.getMessage should include("This test should fail, because: Bool is not typeEquivalent to UInt<1>")
+  }
+
+  it should "have a good user message if it fails for mismatched bundles" in {
+    val result = the[IllegalArgumentException] thrownBy {
+      (new FooGrandparent(true)).requireTypeEquivalent(new FooGrandparent(false), "This test should fail, because: ")
+    }
+    result.getMessage should include("This test should fail, because:")
+    // Also says 'FooGrandparent$1 is not typeEquivalent to FooGrandparent$1' which isn't terribly interesting to match on
+    result.getMessage should include(".bar.foo.c: Dangling field on Left")
   }
 
 }

--- a/src/test/scala/chisel3/TypeEquivalenceSpec.scala
+++ b/src/test/scala/chisel3/TypeEquivalenceSpec.scala
@@ -388,4 +388,13 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
     )
   }
 
+  behavior.of("Data.requireTypeEquivalent")
+
+  it should "have a good user message if it fails" in {
+    val result = the[IllegalArgumentException] thrownBy {
+      Bool().requireTypeEquivalent(UInt(1.W), "This test should fail, because: ")
+    }
+    result.getMessage should include("This test should fail, because: Bool is not typeEquivalent to UInt<1>")
+  }
+
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Make Add a contextual message to Data.requireTypeEquivalent and expose a public API in DataMirror.requireTypeEquivalent, to make it easier for user code to have good error messages when requiring type equivalence between two chisel Datas

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
