### PR TITLE
Add output directory support to layer declarations

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1104,7 +1104,7 @@ private[chisel3] object Builder extends LazyLogging {
           case layer.Convention.Bind => LayerConvention.Bind
           case _                     => ???
         }
-        Layer(l.sourceInfo, l.name, convention, children.map(foldLayers).toSeq)
+        Layer(l.sourceInfo, l.name, convention, l.outputDir.map(_.toString), children.map(foldLayers).toSeq)
       }
 
       val optionDefs = groupByIntoSeq(options)(opt => opt.group).map {

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -493,7 +493,7 @@ private[chisel3] object Converter {
     val convention = layer.convention match {
       case LayerConvention.Bind => fir.LayerConvention.Bind
     }
-    fir.Layer(convert(layer.sourceInfo), layer.name, convention, layer.children.map(convertLayer))
+    fir.Layer(convert(layer.sourceInfo), layer.name, convention, layer.outputDir, layer.children.map(convertLayer))
   }
 
   def convertOption(option: DefOption): fir.DefOption = {

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -377,6 +377,7 @@ private[chisel3] object ir {
     sourceInfo: SourceInfo,
     name:       String,
     convention: LayerConvention.Type,
+    outputDir:  Option[String],
     children:   Seq[Layer])
 
   case class LayerBlockBegin(sourceInfo: SourceInfo, layer: chisel3.layer.Layer) extends Command

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -435,7 +435,12 @@ object LayerConvention {
   }
 }
 
-case class Layer(info: Info, name: String, convention: LayerConvention.Type, body: Seq[Layer])
+case class Layer(
+  info:       Info,
+  name:       String,
+  convention: LayerConvention.Type,
+  outputDir:  Option[String],
+  body:       Seq[Layer])
     extends FirrtlNode
     with IsDeclaration
     with UseSerializer

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -566,7 +566,13 @@ object Serializer {
     val layers = if (circuit.layers.nonEmpty) {
       implicit val b = new StringBuilder
       def layerIt(layer: Layer)(implicit indent: Int): Unit = {
-        b ++= s"${NewLine}"; doIndent(); b ++= s"layer ${layer.name}, ${layer.convention} :"
+        b ++= s"${NewLine}"
+        doIndent()
+        b ++= s"layer ${layer.name}, ${layer.convention}"
+        for (d <- layer.outputDir) {
+          b ++= ", \"" ++ d ++ "\""
+        }
+        b ++= " :"
         s(layer.info)
         layer.body.foreach(layerIt(_)(indent + 1))
       }

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -5,9 +5,12 @@ package chiselTests
 import chisel3._
 import chisel3.probe.{define, Probe, ProbeValue}
 import chiselTests.{ChiselFlatSpec, MatchesAndOmits, Utils}
+import java.nio.file.{FileSystems, Paths}
 import _root_.circt.stage.ChiselStage
 
 class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
+
+  val sep: String = FileSystems.getDefault().getSeparator()
 
   object A extends layer.Layer(layer.Convention.Bind) {
     object B extends layer.Layer(layer.Convention.Bind)
@@ -35,11 +38,11 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
 
     val chirrtl = ChiselStage.emitCHIRRTL(new Foo, Array("--full-stacktrace"))
 
-    info("CHIRRTL emission looks coorect")
+    info("CHIRRTL emission looks correct")
     // TODO: Switch to FileCheck for this testing.  This is going to miss all sorts of ordering issues.
     matchesAndOmits(chirrtl)(
-      "layer A, bind :",
-      "layer B, bind :",
+      "layer A, bind, \"A\" :",
+      "layer B, bind, \"A" ++ sep ++ "B\" :",
       "layerblock A :",
       "wire w : UInt<1>",
       "layerblock B :",
@@ -134,4 +137,68 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )
   }
 
+  "Layers" should "emit the output directory when present" in {
+    object LayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {
+      object SublayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {}
+      object SublayerWithCustomOutputDir
+          extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOtherOutputDir"))) {}
+      object SublayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {}
+    }
+
+    object LayerWithCustomOutputDir
+        extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOutputDir"))) {
+      object SublayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {}
+      object SublayerWithCustomOutputDir
+          extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOtherOutputDir"))) {}
+      object SublayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {}
+    }
+
+    object LayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {
+      object SublayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {}
+      object SublayerWithCustomOutputDir
+          extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOtherOutputDir"))) {}
+      object SublayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {}
+    }
+
+    class Foo extends RawModule {
+      layer.block(LayerWithDefaultOutputDir) {
+        layer.block(LayerWithDefaultOutputDir.SublayerWithDefaultOutputDir) {}
+        layer.block(LayerWithDefaultOutputDir.SublayerWithCustomOutputDir) {}
+        layer.block(LayerWithDefaultOutputDir.SublayerWithNoOutputDir) {}
+      }
+
+      layer.block(LayerWithCustomOutputDir) {
+        layer.block(LayerWithCustomOutputDir.SublayerWithDefaultOutputDir) {}
+        layer.block(LayerWithCustomOutputDir.SublayerWithCustomOutputDir) {}
+        layer.block(LayerWithCustomOutputDir.SublayerWithNoOutputDir) {}
+      }
+
+      layer.block(LayerWithNoOutputDir) {
+        layer.block(LayerWithNoOutputDir.SublayerWithDefaultOutputDir) {}
+        layer.block(LayerWithNoOutputDir.SublayerWithCustomOutputDir) {}
+        layer.block(LayerWithNoOutputDir.SublayerWithNoOutputDir) {}
+      }
+    }
+
+    def decl(name: String, dirs: List[String]): String = {
+      val dirsStr = if (dirs.nonEmpty) s""", "${dirs.mkString(sep)}"""" else ""
+      s"layer $name, bind$dirsStr :"
+    }
+
+    val text = ChiselStage.emitCHIRRTL(new Foo)
+    matchesAndOmits(text)(
+      decl("LayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir")),
+      decl("SublayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir", "SublayerWithDefaultOutputDir")),
+      decl("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
+      decl("SublayerWithNoOutputDir", List()),
+      decl("LayerWithCustomOutputDir", List("myOutputDir")),
+      decl("SublayerWithDefaultOutputDir", List("myOutputDir", "SublayerWithDefaultOutputDir")),
+      decl("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
+      decl("SublayerWithNoOutputDir", List()),
+      decl("LayerWithNoOutputDir", List()),
+      decl("SublayerWithDefaultOutputDir", List("SublayerWithDefaultOutputDir")),
+      decl("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
+      decl("SublayerWithNoOutputDir", List())
+    )()
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement
- Feature


#### Desired Merge Strategy
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

Feature: Add user-specified output directories to layer declarations

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
