### PR TITLE
Use :<>= in VecInit methods instead of := or <>

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -661,26 +661,6 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
 
 object VecInit extends SourceInfoDoc {
 
-  /** Gets the correct connect operation (directed hardware assign or bulk connect) for element in Vec.
-    */
-  private def getConnectOpFromDirectionality[T <: Data](
-    proto: T
-  )(
-    implicit sourceInfo: SourceInfo
-  ): (T, T) => Unit = proto.direction match {
-    case ActualDirection.Input | ActualDirection.Output | ActualDirection.Unspecified =>
-      // When internal wires are involved, driver / sink must be specified explicitly, otherwise
-      // the system is unable to infer which is driver / sink
-      (x, y) => x := y
-    case ActualDirection.Bidirectional(_) =>
-      // For bidirectional, must issue a bulk connect so subelements are resolved correctly.
-      // Bulk connecting two wires may not succeed because Chisel frontend does not infer
-      // directions.
-      (x, y) => x <> y
-    case ActualDirection.Empty =>
-      (x, y) => x <> y
-  }
-
   /** Creates a new [[Vec]] composed of elements of the input Seq of [[Data]]
     * nodes.
     *
@@ -706,10 +686,9 @@ object VecInit extends SourceInfoDoc {
     elts.foreach(requireIsHardware(_, "vec element"))
 
     val vec = Wire(Vec(elts.length, cloneSupertype(elts, "Vec")))
-    val op = getConnectOpFromDirectionality(vec.head)
 
-    (vec.zip(elts)).foreach { x =>
-      op(x._1, x._2)
+    for ((lhs, rhs) <- vec.zip(elts)) {
+      lhs :<>= rhs
     }
     vec
   }
@@ -775,12 +754,11 @@ object VecInit extends SourceInfoDoc {
 
     val tpe = cloneSupertype(flatElts, "Vec.tabulate")
     val myVec = Wire(Vec(n, Vec(m, tpe)))
-    val op = getConnectOpFromDirectionality(myVec.head.head)
     for {
       (xs1D, ys1D) <- myVec.zip(elts)
-      (x, y) <- xs1D.zip(ys1D)
+      (lhs, rhs) <- xs1D.zip(ys1D)
     } {
-      op(x, y)
+      lhs :<>= rhs
     }
     myVec
   }
@@ -815,14 +793,13 @@ object VecInit extends SourceInfoDoc {
 
     val tpe = cloneSupertype(flatElts, "Vec.tabulate")
     val myVec = Wire(Vec(n, Vec(m, Vec(p, tpe))))
-    val op = getConnectOpFromDirectionality(myVec.head.head.head)
 
     for {
       (xs2D, ys2D) <- myVec.zip(elts)
       (xs1D, ys1D) <- xs2D.zip(ys2D)
-      (x, y) <- xs1D.zip(ys1D)
+      (lhs, rhs) <- xs1D.zip(ys1D)
     } {
-      op(x, y)
+      lhs :<>= rhs
     }
 
     myVec

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -285,6 +285,21 @@ class VecSpec extends ChiselPropSpec with Utils {
     }
   }
 
+  property("VecInit should work for Bundle that mixes Output and unspecified UInts") {
+    class MyBundle extends Bundle {
+      val a = Output(UInt(8.W))
+      val b = UInt(8.W)
+    }
+    val chirrtl = emitCHIRRTL(new RawModule {
+      val w = VecInit(Seq.fill(2)(0.U.asTypeOf(new MyBundle)))
+    })
+    chirrtl should include("wire w : { a : UInt<8>, b : UInt<8>}[2]")
+    chirrtl should include("connect w[0].b, UInt<8>(0h0)")
+    chirrtl should include("connect w[0].a, UInt<8>(0h0)")
+    chirrtl should include("connect w[1].b, UInt<8>(0h0)")
+    chirrtl should include("connect w[1].a, UInt<8>(0h0)")
+  }
+
   property("Infering widths on huge Vecs should not cause a stack overflow") {
     ChiselStage.emitSystemVerilog(new HugeVecTester(10000))
   }


### PR DESCRIPTION
This is a more focused fix for the issue hit by @sequencer in [[1]](https://github.com/chipsalliance/chisel/pull/4198#issuecomment-2182917012), credit to @mwachs5 for coming up with this solution.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, VecInit would try to "intelligently" select := or <> depending on if the type is bidirectional. :<>= has the desirable behavior here for both passive and bidirectional types. It also has the advantage over <> of handling internal wires.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
