### PR TITLE
Micro-optimize Direction

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -399,10 +399,11 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int) extend
     val reconstructedResolvedDirection = direction match {
       case ActualDirection.Input  => SpecifiedDirection.Input
       case ActualDirection.Output => SpecifiedDirection.Output
-      case ActualDirection.Bidirectional(ActualDirection.Default) | ActualDirection.Unspecified =>
+      case ActualDirection.Bidirectional.Default | ActualDirection.Unspecified =>
         SpecifiedDirection.Unspecified
-      case ActualDirection.Bidirectional(ActualDirection.Flipped) => SpecifiedDirection.Flip
-      case ActualDirection.Empty                                  => SpecifiedDirection.Unspecified
+      case ActualDirection.Bidirectional.Flipped => SpecifiedDirection.Flip
+      case ActualDirection.Empty                 => SpecifiedDirection.Unspecified
+      case dir                                   => throwException("Unexpected directionality: $dir")
     }
     // TODO port technically isn't directly child of this data structure, but the result of some
     // muxes / demuxes. However, this does make access consistent with the top-level bindings.

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -85,31 +85,63 @@ object SpecifiedDirection {
   * a node is bound (since higher-level specifications like Input and Output
   * can override directions).
   */
-sealed abstract class ActualDirection
+sealed abstract class ActualDirection(private[chisel3] val value: Byte)
 
 object ActualDirection {
 
+  // 0 is reserved for unset, no case object added because that would be an unnecessary API breakage.
+  private[chisel3] val Unset: Byte = 0
+
   /** The object does not exist / is empty and hence has no direction
     */
-  case object Empty extends ActualDirection
+  case object Empty extends ActualDirection(1)
 
   /** Undirectioned, struct-like
     */
-  case object Unspecified extends ActualDirection
+  case object Unspecified extends ActualDirection(2)
 
   /** Output element, or container with all outputs (even if forced)
     */
-  case object Output extends ActualDirection
+  case object Output extends ActualDirection(3)
 
   /** Input element, or container with all inputs (even if forced)
     */
-  case object Input extends ActualDirection
+  case object Input extends ActualDirection(4)
 
-  sealed abstract class BidirectionalDirection
-  case object Default extends BidirectionalDirection
-  case object Flipped extends BidirectionalDirection
+  // BidirectionalDirection is effectively an extension of ActualDirection, see its use in Bidirectional below.
+  // Thus, the numbering here is a continuation of the numbering in ActualDirection.
+  // Bidirectional.Default and Bidirectional.Flipped wrap these objects.
+  sealed abstract class BidirectionalDirection(private[chisel3] val value: Byte)
+  case object Default extends BidirectionalDirection(5)
+  case object Flipped extends BidirectionalDirection(6)
 
-  case class Bidirectional(dir: BidirectionalDirection) extends ActualDirection
+  // This constructor has 2 arguments (which need to be in sync) only to distinguish it from the other constructor
+  // Once that one is removed, delete _value
+  case class Bidirectional private[chisel3] (dir: BidirectionalDirection, _value: Byte)
+      extends ActualDirection(_value) {
+    @deprecated("Use companion object factory apply method", "Chisel 6.5")
+    def this(dir: BidirectionalDirection) = this(dir, dir.value)
+  }
+  object Bidirectional {
+    val Default = new Bidirectional(ActualDirection.Default, ActualDirection.Default.value)
+    val Flipped = new Bidirectional(ActualDirection.Flipped, ActualDirection.Flipped.value)
+    def apply(dir: BidirectionalDirection): ActualDirection = dir match {
+      case ActualDirection.Default => Default
+      case ActualDirection.Flipped => Flipped
+    }
+    @deprecated("Match on Bidirectional.Default and Bidirectional.Flipped directly instead", "Chisel 6.5")
+    def unapply(dir: Bidirectional): Option[BidirectionalDirection] = Some(dir.dir)
+  }
+
+  private[chisel3] def fromByte(b: Byte): ActualDirection = b match {
+    case Empty.value                 => Empty
+    case Unspecified.value           => Unspecified
+    case Output.value                => Output
+    case Input.value                 => Input
+    case Bidirectional.Default.value => Bidirectional.Default
+    case Bidirectional.Flipped.value => Bidirectional.Flipped
+    case _                           => throwException(s"Unexpected ActualDirection value $b")
+  }
 
   def fromSpecified(direction: SpecifiedDirection): ActualDirection = direction match {
     case SpecifiedDirection.Unspecified | SpecifiedDirection.Flip => ActualDirection.Unspecified
@@ -344,12 +376,29 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
   private[chisel3] def isConst: Boolean = _isConst
   private[chisel3] def isConst_=(isConst: Boolean) = _isConst = isConst
 
+  // Both _direction and _resolvedUserDirection are saved versions of computed variables (for
+  // efficiency, avoid expensive recomputation of frequent operations).
+  // Both are only valid after binding is set.
+
   // User-specified direction, local at this node only.
   // Note that the actual direction of this node can differ from child and parent specifiedDirection.
   private var _specifiedDirection:         Byte = SpecifiedDirection.Unspecified.value
   private[chisel3] def specifiedDirection: SpecifiedDirection = SpecifiedDirection.fromByte(_specifiedDirection)
   private[chisel3] def specifiedDirection_=(direction: SpecifiedDirection) = {
     _specifiedDirection = direction.value
+  }
+
+  // Direction of this node, accounting for parents (force Input / Output) and children.
+  private var _directionVar: Byte = ActualDirection.Unset
+  private def _direction: Option[ActualDirection] =
+    Option.when(_directionVar != ActualDirection.Unset)(ActualDirection.fromByte(_directionVar))
+
+  private[chisel3] def direction: ActualDirection = _direction.get
+  private[chisel3] def direction_=(actualDirection: ActualDirection): Unit = {
+    if (_direction.isDefined) {
+      throw RebindingException(s"Attempted reassignment of resolved direction to $this")
+    }
+    _directionVar = actualDirection.value
   }
 
   /** This overwrites a relative SpecifiedDirection with an explicit one, and is used to implement
@@ -413,22 +462,6 @@ abstract class Data extends HasId with NamedComponent with SourceInfoDoc {
       case c: ConstrainedBinding => _parent.foreach(_.addId(this))
       case _ =>
     }
-  }
-
-  // Both _direction and _resolvedUserDirection are saved versions of computed variables (for
-  // efficiency, avoid expensive recomputation of frequent operations).
-  // Both are only valid after binding is set.
-
-  // Direction of this node, accounting for parents (force Input / Output) and children.
-  private var _directionVar: ActualDirection = null // using nullable var for better memory usage
-  private def _direction:    Option[ActualDirection] = Option(_directionVar)
-
-  private[chisel3] def direction: ActualDirection = _direction.get
-  private[chisel3] def direction_=(actualDirection: ActualDirection): Unit = {
-    if (_direction.isDefined) {
-      throw RebindingException(s"Attempted reassignment of resolved direction to $this")
-    }
-    _directionVar = actualDirection
   }
 
   private[chisel3] def stringAccessor(chiselType: String): String = {

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -305,9 +305,9 @@ private[chisel3] object MonoConnect {
       // See: https://github.com/freechipsproject/firrtl/issues/1703
       // Original behavior should just check if the sink direction is an Input
       val sinkCanBeInput = sink.direction match {
-        case Input            => true
-        case Bidirectional(_) => true
-        case _                => false
+        case Input => true
+        case _: Bidirectional => true
+        case _ => false
       }
       // Thus, right node better be a port node and thus have a direction
       if (!source_is_port) { false }
@@ -323,9 +323,9 @@ private[chisel3] object MonoConnect {
       // See: https://github.com/freechipsproject/firrtl/issues/1703
       // Original behavior should just check if the sink direction is an Input
       sink.direction match {
-        case Input            => true
-        case Bidirectional(_) => true
-        case _                => false
+        case Input => true
+        case _: Bidirectional => true
+        case _ => false
       }
     }
 
@@ -340,9 +340,9 @@ private[chisel3] object MonoConnect {
         // See: https://github.com/freechipsproject/firrtl/issues/1703
         // Original behavior should just check if the sink direction is an Input
         sink.direction match {
-          case Input            => true
-          case Bidirectional(_) => true // NOTE: Workaround for non-agnostified ports
-          case _                => false
+          case Input => true
+          case _: Bidirectional => true // NOTE: Workaround for non-agnostified ports
+          case _ => false
         }
       } else { false }
     }


### PR DESCRIPTION
This almost entirely API compatible, but due to `ActualDirection.Bidirectional` being a case class, this change breaks things like the copy method. This is mostly a performance improvement

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification
- Performance improvement


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Rebase (merge commit)

#### Release Notes

* Specified and actual direction information are each now stored as single bytes rather than references.
* This reduces the memory use of a typical bound UInt from 72 bytes shallow, 128 bytes retained to 64 bytes shallow, 120 bytes retained.
* The change is mostly source compatible, but ActualDirection.Bidirectional, has changed slightly to memoize its two possibilities (`Bidirectional.Default` and `Bidirectional.Flipped`). There are deprecations for the typical APIs

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
