### PR TITLE
Optimize Record._elements to not duplicate VectorMap if possible

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -1287,7 +1287,12 @@ abstract class Record extends Aggregate {
   // without having to recurse over all elements after the Record is
   // constructed. Laziness of _elements means that this check will
   // occur (only) at the first instance _elements is referenced.
-  // Also used to sanitize names and convert to more optimized VectorMap datastructure
+  // Also used to sanitize names and convert to more optimized VectorMap datastructure (if necessary)
+  // TODO We should figure out how to combine this with elements
+  // The main trick there is storing the sanitized names and making sure every Chisel API uses them
+  // Strawman proposal is to put sanitized name in the Slot refs of the children, and then replace
+  // _elements and elements with a single Array and deprecate elements as a public API
+  // This would also give an opportunity to stop storing elements in reverse order
   private[chisel3] lazy val _elements: VectorMap[String, Data] = {
     // Since elements is a map, it is impossible for two elements to have the same
     // identifier; however, Namespace sanitizes identifiers to make them legal for Firrtl/Verilog
@@ -1295,17 +1300,33 @@ abstract class Record extends Aggregate {
     // Note that OpaqueTypes cannot have sanitization (the name of the element needs to stay empty)
     //   Use an empty Namespace to indicate OpaqueType
     val namespace = Option.when(!this._isOpaqueType)(Namespace.empty)
-    elements.view.map {
-      case (name, field) =>
-        if (field.binding.isDefined) {
-          throw RebindingException(
-            s"Cannot create Record ${this.className}; element ${field} of Record must be a Chisel type, not hardware."
-          )
-        }
-        // namespace.name also sanitizes for firrtl, leave name alone for OpaqueTypes
-        val sanitizedName = namespace.map(_.name(name, leadingDigitOk = true)).getOrElse(name)
-        sanitizedName -> field
-    }.to(VectorMap) // VectorMap has O(1) lookup whereas ListMap is O(n)
+    val originalElements = elements
+    // Don't create a new map unless necessary, this is much more memory efficient in common case
+    // This is true if elements is not a VectorMap or if any names need sanitization
+    var needNewMap = !originalElements.isInstanceOf[VectorMap[_, _]]
+    val newNames =
+      elements.view.map {
+        case (name, field) =>
+          if (field.binding.isDefined) {
+            throw RebindingException(
+              s"Cannot create Record ${this.className}; element ${field} of Record must be a Chisel type, not hardware."
+            )
+          }
+          // namespace.name also sanitizes for firrtl, leave name alone for OpaqueTypes
+          val sanitizedName = namespace.map(_.name(name, leadingDigitOk = true)).getOrElse(name)
+          if (sanitizedName != name) {
+            needNewMap = true
+          }
+          sanitizedName
+      }.toArray // It's very important we eagerly evaluate this sequence.
+    if (needNewMap) {
+      newNames.view
+        .zip(originalElements)
+        .map { case (name, (_, data)) => name -> data }
+        .to(VectorMap) // VectorMap has O(1) lookup whereas ListMap is O(n)
+    } else {
+      originalElements.asInstanceOf[VectorMap[String, Data]]
+    }
   }
 
   /** Name for Pretty Printing */

--- a/src/test/scala/chiselTests/RecordSpec.scala
+++ b/src/test/scala/chiselTests/RecordSpec.scala
@@ -9,7 +9,7 @@ import chisel3.testers.BasicTester
 import chisel3.util.{Counter, Queue}
 import circt.stage.ChiselStage
 
-import scala.collection.immutable.{ListMap, SeqMap}
+import scala.collection.immutable.{ListMap, SeqMap, VectorMap}
 
 object RecordSpec {
   class MyBundle extends Bundle {
@@ -162,6 +162,16 @@ class RecordSpec extends ChiselFlatSpec with Utils {
 
   they should "support digits as names of fields" in {
     assertTesterPasses { new RecordDigitTester }
+  }
+
+  they should "sanitize the user-provided names" in {
+    class MyRecord extends Record {
+      lazy val elements = VectorMap("sanitize me" -> UInt(8.W))
+    }
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val out = IO(Output(new MyRecord))
+    })
+    chirrtl should include("output out : { sanitizeme : UInt<8>}")
   }
 
   "Bulk connect on Record" should "check that the fields match" in {


### PR DESCRIPTION
The code is a little janky, but it is a massive reduction in memory use.

For a typical Bundle with 7 UInt fields, this reduces the memory footprint from 1992 bytes to 1552 bytes (the duplicate VectorMap of only 7 elements is 440 bytes!), a 22% reduction. Combined with my other recent performance improvement PRs (#4251, #4252, #4253 but **excluding** #4242), this 1992 bytes is reduced to 1424 for a total reduction of 28.5% memory use for this typical Bundle with 7 UInt fields.

I suspect we can do better by getting rid of any Map here at all and instead just use an `Array[Data]` (where the String names of the fields are stored in the children Data themselves as they are already stored there). Whereas the VectorMap of 7 elements is 440 bytes, an Array of 7 elements is 48 bytes.

That being said, this is a much simpler change that imparts a huge benefit so is worth it in the meantime.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Performance improvement


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This reduces memory use of a typical bundle by 20%.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
