### PR TITLE
Add map method for Valid

### DIFF
--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -42,6 +42,18 @@ class Valid[+T <: Data](gen: T) extends Bundle {
     * Inserts the parameterized generator's typeName, e.g. Valid_UInt4
     */
   override def typeName = s"${simpleClassName(this.getClass)}_${gen.typeName}"
+
+  /** Applies the supplied functor to the bits of this interface, returning a new typed Valid interface.
+    * @param f The function to apply to this Valid's 'bits' with return type B
+    * @return a new Valid of type B
+    */
+  def map[B <: Data](f: T => B): Valid[B] = {
+    val _map_bits = f(bits)
+    val _map = Wire(Valid(chiselTypeOf(_map_bits)))
+    _map.bits := _map_bits
+    _map.valid := valid
+    _map
+  }
 }
 
 /** Factory for generating "valid" interfaces. A "valid" interface is a data-communicating interface between a producer

--- a/src/main/scala/chisel3/util/Valid.scala
+++ b/src/main/scala/chisel3/util/Valid.scala
@@ -52,7 +52,7 @@ class Valid[+T <: Data](gen: T) extends Bundle {
     val _map = Wire(Valid(chiselTypeOf(_map_bits)))
     _map.bits := _map_bits
     _map.valid := valid
-    _map
+    _map.readOnly
   }
 }
 

--- a/src/test/scala/chiselTests/ValidSpec.scala
+++ b/src/test/scala/chiselTests/ValidSpec.scala
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import circt.stage.ChiselStage
+import chisel3.util.Valid
+
+class ValidSpec extends ChiselFlatSpec {
+  "Valid.map" should "apply a function to the wrapped Data" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+      val in = IO(Flipped(Valid(UInt(8.W))))
+      val out = IO(Valid(UInt(8.W)))
+      out :#= in.map(_ + 1.U)
+    })
+
+    // Check for data assignment
+    chirrtl should include("""node _out_map_bits_T = add(in.bits, UInt<1>(0h1))""")
+    chirrtl should include("""node _out_map_bits = tail(_out_map_bits_T, 1)""")
+    chirrtl should include("""connect _out_map.bits, _out_map_bits""")
+    chirrtl should include("""connect out.bits, _out_map.bits""")
+
+    // Check for valid assignment
+    chirrtl should include("""connect _out_map.valid, in.valid""")
+    chirrtl should include("""connect out.valid, _out_map.valid""")
+  }
+
+  "Valid.map" should "apply a function to a wrapped Bundle" in {
+    class TestBundle extends Bundle {
+      val foo = UInt(8.W)
+      val bar = UInt(8.W)
+      val fizz = Bool()
+      val buzz = Bool()
+    }
+
+    // Add one to foo, subtract one from bar, set fizz to false and buzz to true
+    def func(t: TestBundle): TestBundle = {
+      val res = Wire(new TestBundle)
+
+      res.foo := t.foo + 1.U
+      res.bar := t.bar - 1.U
+      res.fizz := false.B
+      res.buzz := true.B
+
+      res
+    }
+
+    val chirrtl = ChiselStage
+      .emitCHIRRTL(new Module {
+        val in = IO(Flipped(Valid(new TestBundle)))
+        val out = IO(Valid(new TestBundle))
+        out :#= in.map(func)
+      })
+
+    // Check for data assignment
+    chirrtl should include("""wire _out_map_bits : { foo : UInt<8>, bar : UInt<8>, fizz : UInt<1>, buzz : UInt<1>}""")
+
+    chirrtl should include("""node _out_map_bits_res_foo_T = add(in.bits.foo, UInt<1>(0h1)""")
+    chirrtl should include("""node _out_map_bits_res_foo_T_1 = tail(_out_map_bits_res_foo_T, 1)""")
+    chirrtl should include("""connect _out_map_bits.foo, _out_map_bits_res_foo_T_1""")
+
+    chirrtl should include("""node _out_map_bits_res_bar_T = sub(in.bits.bar, UInt<1>(0h1)""")
+    chirrtl should include("""node _out_map_bits_res_bar_T_1 = tail(_out_map_bits_res_bar_T, 1)""")
+    chirrtl should include("""connect _out_map_bits.bar, _out_map_bits_res_bar_T_1""")
+
+    chirrtl should include("""connect _out_map_bits.fizz, UInt<1>(0h0)""")
+    chirrtl should include("""connect _out_map_bits.buzz, UInt<1>(0h1)""")
+
+    chirrtl should include("""connect _out_map.bits, _out_map_bits""")
+    for ((field, _) <- (new TestBundle).elements) {
+      chirrtl should include(s"""connect out.bits.$field, _out_map.bits.$field""")
+    }
+
+    // Check for valid assignment
+    chirrtl should include("""connect _out_map.valid, in.valid""")
+    chirrtl should include("""connect out.valid, _out_map.valid""")
+  }
+
+  "Valid.map" should "apply a function to a wrapped Bundle and return a different typed Valid" in {
+    class TestBundle extends Bundle {
+      val foo = UInt(8.W)
+      val bar = UInt(8.W)
+    }
+
+    val chirrtl = ChiselStage
+      .emitCHIRRTL(new Module {
+        val in = IO(Flipped(Valid(new TestBundle)))
+        val out = IO(Valid(UInt(8.W)))
+        out :#= in.map(bundle => bundle.foo & bundle.bar)
+      })
+
+    // Check that the _map wire wraps a UInt and not a TestBundle
+    chirrtl should include("""wire _out_map : { valid : UInt<1>, bits : UInt<8>}""")
+
+    // Check for data assignment
+    chirrtl should include("""node _out_map_bits = and(in.bits.foo, in.bits.bar)""")
+    chirrtl should include("""connect _out_map.bits, _out_map_bits""")
+    chirrtl should include("""connect out.bits, _out_map.bits""")
+
+    // Check for valid assignment
+    chirrtl should include("""connect _out_map.valid, in.valid""")
+    chirrtl should include("""connect out.valid, _out_map.valid""")
+  }
+}


### PR DESCRIPTION
Modeled after https://github.com/chipsalliance/chisel/pull/2646.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Users can now apply a function `f` to the `bits` field of a `Valid` instance with the new `Valid.map(f)` method.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
