### PR TITLE
Fix .toString for dynamic indexing

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -96,7 +96,7 @@ private[chisel3] object ir {
 
     def earlyLocalName(id: HasId, includeRoot: Boolean): String = id.getOptionRef match {
       case Some(Index(Node(imm), Node(value))) =>
-        s"${earlyLocalName(imm, includeRoot)}[${earlyLocalName(imm, includeRoot)}]"
+        s"${earlyLocalName(imm, includeRoot)}[${earlyLocalName(value, includeRoot)}]"
       case Some(Index(Node(imm), arg)) => s"${earlyLocalName(imm, includeRoot)}[${arg.localName}]"
       case Some(Slot(Node(imm), name)) => s"${earlyLocalName(imm, includeRoot)}.$name"
       case Some(OpaqueSlot(Node(imm))) => s"${earlyLocalName(imm, includeRoot)}"

--- a/src/test/scala/chiselTests/DataPrint.scala
+++ b/src/test/scala/chiselTests/DataPrint.scala
@@ -53,6 +53,16 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
     (2.U + 2.U).toString should be("BoundDataModule.?: OpResult[UInt<2>]")
     Wire(Vec(3, UInt(2.W))).toString should be("BoundDataModule.?: Wire[UInt<2>[3]]")
 
+    val idx = IO(Input(UInt(3.W)))
+    val jdx = IO(Input(new Bundle {
+      val value = UInt(3.W)
+    }))
+    val port = IO(Input(new Bundle {
+      val vec = Vec(8, UInt(8.W))
+    }))
+    port.vec(idx).toString should be("BoundDataModule.port.vec[idx]: IO[UInt<8>]")
+    port.vec(jdx.value).toString should be("BoundDataModule.port.vec[jdx.value]: IO[UInt<8>]")
+
     class InnerModule extends Module {
       val io = IO(Output(new Bundle {
         val a = UInt(4.W)


### PR DESCRIPTION
We should turn on warnings for unused variables 🙃 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
