### PR TITLE
Add more information when probe types don't match

### DIFF
--- a/core/src/main/scala/chisel3/probe/package.scala
+++ b/core/src/main/scala/chisel3/probe/package.scala
@@ -34,8 +34,14 @@ package object probe extends SourceInfoDoc {
     * @param probeExpr value to initialize the sink to
     */
   def define[T <: Data](sink: T, probeExpr: T)(implicit sourceInfo: SourceInfo): Unit = {
-    if (!sink.typeEquivalent(probeExpr, false /* we will check more more detailed probe info below */ )) {
-      Builder.error("Cannot define a probe on a non-equivalent type.")
+    val typeCheckResult = sink.findFirstTypeMismatch(
+      probeExpr,
+      strictTypes = true,
+      strictWidths = true,
+      strictProbeInfo = false /* we will check more more detailed probe info below */
+    )
+    typeCheckResult.foreach { msg =>
+      Builder.error(s"Cannot define a probe on a non-equivalent type.\n$msg")
     }
     requireHasProbeTypeModifier(sink, "Expected sink to be a probe.")
     requireNotChildOfProbe(sink, "Expected sink to be the root of a probe.")

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -382,6 +382,10 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
       )
     }
     exc.getMessage should include("Cannot define a probe on a non-equivalent type.")
+    exc.getMessage should include(
+      "Left (ProbeSpec_Anon.p: IO[UInt<4>]) and Right (ProbeSpec_Anon.Node(ProbeSpec_Anon.w: Wire[Bool]): OpResult[Bool]) have different types"
+    )
+
   }
 
   "Probe of a probe type" should "fail" in {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Add more information to the error message when attempting to `probe.define` to a mismatched chisel type.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
