### PR TITLE
Fix emitted FIRRTL for dynamic index of size 0 Vec

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -182,7 +182,8 @@ trait VecFactory extends SourceInfoDoc {
     implicit sourceInfo: SourceInfo
   ): UInt = {
     val w = (n - 1).bitLength
-    if (n <= 1) 0.U
+    if (n <= 1) WireInit(0.U) // Need the Wire otherwise we emit vec[0] which is illegal FIRRTL.
+    // Other cases do not need a Wire because the literal is truncated to fit.
     else if (idx.width.known && idx.width.get <= w) idx
     else if (idx.width.known) idx(w - 1, 0)
     else (idx | 0.U(w.W))(w - 1, 0)

--- a/src/test/scala/chiselTests/Vec.scala
+++ b/src/test/scala/chiselTests/Vec.scala
@@ -460,4 +460,18 @@ class VecSpec extends ChiselPropSpec with Utils {
     }))
     log should be("")
   }
+
+  property("Indexing a size 0 Vec should warn but also emit legal FIRRTL") {
+    val (log, chirrtl) = grabLog(emitCHIRRTL(new RawModule {
+      val vec = IO(Input(Vec(0, UInt(8.W))))
+      val idx = IO(Input(UInt(2.W)))
+      val out = IO(Output(UInt(8.W)))
+      out := vec(idx)
+    }))
+    log should include("Cannot extract from Vec of size 0.")
+    chirrtl should include("input vec : UInt<8>[0]")
+    chirrtl should include("wire _out_WIRE : UInt")
+    chirrtl should include("connect _out_WIRE, UInt<1>(0h0)")
+    chirrtl should include("connect out, vec[_out_WIRE]")
+  }
 }


### PR DESCRIPTION
https://github.com/chipsalliance/chisel/pull/4268 introduced a subtle bug for when dynamically indexing Vecs of size 0. This is currently deprecated but obviously we need to emit legal FIRRTL until it becomes an error.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix (but no release notes because this bug isn't released)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
