### PR TITLE
Add AffectsChiselName

### DIFF
--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -125,8 +125,7 @@ package object experimental {
     */
   trait AffectsChiselPrefix
 
-  /** If mixed in with a user-defined type, Chisel will attempt to name
-    * the thing using the naming plugin
+  /** If mixed in with a user-defined type, Chisel will attempt to name instances of the type
     */
   trait AffectsChiselName
 

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -125,6 +125,11 @@ package object experimental {
     */
   trait AffectsChiselPrefix
 
+  /** If mixed in with a user-defined type, Chisel will attempt to name
+    * the thing using the naming plugin
+    */
+  trait AffectsChiselName
+
   object BundleLiterals {
     implicit class AddBundleLiteralConstructor[T <: Record](x: T) {
       def Lit(elems: (T => (Data, Data))*)(implicit sourceInfo: SourceInfo): T = {

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -921,7 +921,8 @@ private[chisel3] object Builder extends LazyLogging {
       product.productIterator.zip(product.productElementNames).foreach {
         case (elt, fullName) =>
           val name = fullName.stripPrefix("_")
-          nameRecursively(s"${prefix}_${name}", elt, namer)
+          val prefixedName = if (name != "") s"${prefix}_${name}" else prefix
+          nameRecursively(prefixedName, elt, namer)
       }
     case disable: Disable => nameRecursively(prefix, disable.value, namer)
     case _ => // Do nothing

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -921,7 +921,7 @@ private[chisel3] object Builder extends LazyLogging {
       product.productIterator.zip(product.productElementNames).foreach {
         case (elt, fullName) =>
           val name = fullName.stripPrefix("_")
-          val prefixedName = if (name != "") s"${prefix}_${name}" else prefix
+          val prefixedName = if (name.nonEmpty) s"${prefix}_${name}" else prefix
           nameRecursively(prefixedName, elt, namer)
       }
     case disable: Disable => nameRecursively(prefix, disable.value, namer)

--- a/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
+++ b/plugin/src/main/scala/chisel3/internal/plugin/ChiselComponent.scala
@@ -93,7 +93,8 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
         tq"chisel3.MemBase[_]",
         tq"chisel3.VerificationStatement",
         tq"chisel3.properties.DynamicObject",
-        tq"chisel3.Disable"
+        tq"chisel3.Disable",
+        tq"chisel3.experimental.AffectsChiselName"
       )
     private val shouldMatchModule:   Type => Boolean = shouldMatchGen(tq"chisel3.experimental.BaseModule")
     private val shouldMatchInstance: Type => Boolean = shouldMatchGen(tq"chisel3.experimental.hierarchy.Instance[_]")

--- a/src/test/scala/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala/chiselTests/naming/NamePluginSpec.scala
@@ -5,6 +5,7 @@ package chiselTests.naming
 import chisel3._
 import chisel3.aop.Select
 import chisel3.experimental.prefix
+import chisel3.experimental.AffectsChiselName
 import chiselTests.{ChiselFlatSpec, Utils}
 import circt.stage.ChiselStage
 
@@ -451,6 +452,28 @@ class NamePluginSpec extends ChiselFlatSpec with Utils {
 
     aspectTest(() => new Test) { top: Test =>
       Select.wires(top).map(_.instanceName) should be(List("x", "y", "z"))
+    }
+  }
+
+  "AffectsChiselName" should "name the user-defined type" in {
+    case class SomeClass(d: UInt) extends AffectsChiselName
+    class Test extends Module {
+      val x = SomeClass(Wire(UInt(8.W)))
+    }
+    aspectTest(() => new Test) { top: Test =>
+      Select.wires(top).map(_.instanceName) should be(List("x_d"))
+    }
+  }
+
+  "AffectsChiselName with a user-defined Product" should "give an empty name" in {
+    case class SomeClass(d: UInt) extends AffectsChiselName {
+      override def productElementName(n: Int): String = ""
+    }
+    class Test extends Module {
+      val x = SomeClass(Wire(UInt(8.W)))
+    }
+    aspectTest(() => new Test) { top: Test =>
+      Select.wires(top).map(_.instanceName) should be(List("x"))
     }
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Adds new trait `AffectsChiselName` that adds support for naming user-defined types

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
