### PR TITLE
Properly handle OpaqueTypes in SRAM mask

### DIFF
--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -580,6 +580,9 @@ object SRAM {
     def assignElementMask(writeData: Data, writeMask: Bool, arg: Arg)(implicit sourceInfo: SourceInfo): Unit = {
       writeData match {
         case e: Element => Builder.pushCommand(ir.Connect(sourceInfo, arg, writeMask.ref))
+        case r: Record if r._isOpaqueType =>
+          val ("", elt) = r.elements.head
+          assignElementMask(elt, writeMask, arg)
         case r: Record =>
           r.elements.foreach { case (name, data) => assignElementMask(data, writeMask, Slot(arg, name)) }
         case v: Vec[_] =>


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix

Milestone is 7.0 because the fixed code does not exist on 6.x


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
