### PR TITLE
[firrtl] Emit commas for smem/cmem

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -339,7 +339,7 @@ object Serializer {
       if (seq) b ++= "smem " else b ++= "cmem "
       b ++= legalize(name); b ++= " : "; s(tpe); b ++= " ["; b ++= size.toString(); b += ']'
       if (readUnderWrite != ReadUnderWrite.Undefined) { // undefined is the default
-        b += ' '; b ++= readUnderWrite.toString
+        b ++= ", "; b ++= readUnderWrite.toString
       }
       s(info)
     case firrtl.CDefMPort(info, name, _, mem, exps, direction) =>

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -207,8 +207,10 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
 
   it should "serialize read-under-write behavior for smems correctly" in {
     (SMemTestCircuit.circuit(ReadUnderWrite.Undefined).serialize should not).include("undefined")
-    SMemTestCircuit.circuit(ReadUnderWrite.New).serialize should include("new")
-    SMemTestCircuit.circuit(ReadUnderWrite.Old).serialize should include("old")
+    val smemNew = SMemTestCircuit.circuit(ReadUnderWrite.New).serialize
+    smemNew should include(", new")
+    val smemOld = SMemTestCircuit.circuit(ReadUnderWrite.Old).serialize
+    smemOld should include(", old")
   }
 
   it should "support emitting Probe/RWProbe types and related expressions/statements" in {


### PR DESCRIPTION
Fix a bug where smem/cmem did not emit commas which are now mandatory in the FIRRTL spec.

h/t @dtzSiFive for identifying the problem/fix