### PR TITLE
Add property support to SRAMInterface-based SRAM

### DIFF
--- a/core/src/main/scala/chisel3/properties/Path.scala
+++ b/core/src/main/scala/chisel3/properties/Path.scala
@@ -2,10 +2,10 @@
 
 package chisel3.properties
 
-import chisel3.{Data, MemBase}
+import chisel3.{Data, HasTarget, MemBase, SramTarget}
 import chisel3.experimental.BaseModule
 import firrtl.annotations.{InstanceTarget, IsMember, ModuleTarget, ReferenceTarget}
-import firrtl.ir.{PathPropertyLiteral}
+import firrtl.ir.PathPropertyLiteral
 
 /** Represent a Path type for referencing a hardware instance or member in a Property[Path]
   */
@@ -76,6 +76,15 @@ object Path {
     new TargetPath {
       def toTarget():   IsMember = mem.toAbsoluteTarget
       def isMemberPath: Boolean = _isMemberPath
+    }
+  }
+
+  /** Construct a Path that refers to a SRAMInterface constructed memory
+    */
+  private[chisel3] def apply(mem: SramTarget): Path = {
+    new TargetPath {
+      def toTarget():   IsMember = mem.toAbsoluteTarget
+      def isMemberPath: Boolean = false
     }
   }
 

--- a/core/src/main/scala/chisel3/properties/Path.scala
+++ b/core/src/main/scala/chisel3/properties/Path.scala
@@ -2,7 +2,7 @@
 
 package chisel3.properties
 
-import chisel3.{Data, HasTarget, MemBase}
+import chisel3.{Data, MemBase}
 import chisel3.experimental.BaseModule
 import firrtl.annotations.{InstanceTarget, IsMember, ModuleTarget, ReferenceTarget}
 import firrtl.ir.{PathPropertyLiteral}
@@ -86,17 +86,6 @@ object Path {
     val _isMemberPath = isMemberPath // avoid name shadowing below
     new TargetPath {
       def toTarget():   IsMember = target
-      def isMemberPath: Boolean = _isMemberPath
-    }
-  }
-
-  /** Construct a Path from a HasTarget
-    */
-  def apply(hasTarget: HasTarget): Path = apply(hasTarget, false)
-  def apply(hasTarget: HasTarget, isMemberPath: Boolean): Path = {
-    val _isMemberPath = isMemberPath // avoid name shadowing below
-    new TargetPath {
-      def toTarget():   IsMember = hasTarget.toAbsoluteTarget
       def isMemberPath: Boolean = _isMemberPath
     }
   }

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -85,7 +85,7 @@ class MemoryReadWritePort[T <: Data](tpe: T, addrWidth: Int, masked: Boolean) ex
   * User can access it via CIRCT API.
   */
 @instantiable
-private[chisel3] class SRAMDescription extends Class {
+final class SRAMDescription extends Class {
   val depth:           Property[BigInt] = IO(Output(Property[BigInt]()))
   val width:           Property[Int] = IO(Output(Property[Int]()))
   val masked:          Property[Boolean] = IO(Output(Property[Boolean]()))
@@ -120,6 +120,9 @@ private[chisel3] class SRAMDescription extends Class {
   readwrite := readwriteIn
   maskGranularity := maskGranularityIn
   hierarchy := hierarchyIn
+}
+object SRAMDescription {
+  val definition: Definition[SRAMDescription] = Instantiate.definition(new SRAMDescription)
 }
 
 /** A IO bundle of signals connecting to the ports of a memory, as requested by
@@ -165,10 +168,10 @@ class SRAMInterface[T <: Data](
   private[chisel3] var _underlying: Option[HasTarget] = None
 
   /** Target information for annotating the underlying SRAM if it is known. */
-  def underlying:                    Option[HasTarget] = _underlying
-  private val descriptionDefinition: Definition[SRAMDescription] = Instantiate.definition(new SRAMDescription)
-  private val descriptionType:       ClassType = descriptionDefinition.getClassType
-  val description:                   Property[ClassType] = Property[descriptionType.Type]()
+  def underlying: Option[HasTarget] = _underlying
+
+  /** SRAM Description */
+  val description: Property[ClassType] = SRAMDescription.definition.getPropertyType
 }
 
 /** A memory file with which to preload an [[SRAM]]

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -601,6 +601,19 @@ object SRAM {
       assignMask(firrtlReadwritePort.wmask, memReadwritePort.mask)
     }
 
+    // Hack to ScalaDoc Bug, see [[LTLIntrinsicInstanceMethodsInternalWorkaround]]
+    implicit class SRAMDescriptionInstanceMethods(underlying: Instance[SRAMDescription]) {
+      implicit val mg: internal.MacroGenerated = new chisel3.internal.MacroGenerated {}
+      def depthIn = underlying._lookup(_.depthIn)
+      def widthIn = underlying._lookup(_.widthIn)
+      def maskedIn = underlying._lookup(_.maskedIn)
+      def readIn = underlying._lookup(_.readIn)
+      def writeIn = underlying._lookup(_.writeIn)
+      def readwriteIn = underlying._lookup(_.readwriteIn)
+      def maskGranularityIn = underlying._lookup(_.maskGranularityIn)
+      def hierarchyIn = underlying._lookup(_.hierarchyIn)
+    }
+
     // Add metadata to the SRAM.
     val descriptionInstance: Instance[SRAMDescription] = Instantiate(new SRAMDescription)
     descriptionInstance.depthIn := Property(size)

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -9,7 +9,6 @@ import circt.stage.ChiselStage
 import chisel3.properties.ClassType
 import chisel3.properties.AnyClassType
 import chisel3.util.experimental.BoringUtils
-import chisel3.util.SRAM
 
 class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
   behavior.of("Property")
@@ -191,35 +190,25 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
   }
 
   it should "support member path target types when requested" in {
-    val chirrtl = ChiselStage.emitCHIRRTL(new Module {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val propOutA = IO(Output(Property[Path]()))
       val propOutB = IO(Output(Property[Path]()))
       val propOutC = IO(Output(Property[Path]()))
-      val propOutD = IO(Output(Property[Path]()))
       override def desiredName = "Top"
-      val inst = Module(new Module {
+      val inst = Module(new RawModule {
         val data = WireInit(false.B)
         val mem = SyncReadMem(1, Bool())
-        val sram = SRAM(
-          size = 1,
-          tpe = Bool(),
-          numReadPorts = 1,
-          numWritePorts = 1,
-          numReadwritePorts = 0
-        )
         override def desiredName = "Foo"
       })
       propOutA := Property(Path(inst, true))
       propOutB := Property(Path(inst.data, true))
       propOutC := Property(Path(inst.mem, true))
-      propOutD := Property(Path(inst.sram.underlying.get, true))
     })
 
     matchesAndOmits(chirrtl)(
       """propassign propOutA, path("OMMemberInstanceTarget:~Top|Top/inst:Foo")""",
       """propassign propOutB, path("OMMemberReferenceTarget:~Top|Top/inst:Foo>data")""",
-      """propassign propOutC, path("OMMemberReferenceTarget:~Top|Top/inst:Foo>mem")""",
-      """propassign propOutD, path("OMMemberReferenceTarget:~Top|Top/inst:Foo>sram_sram")"""
+      """propassign propOutC, path("OMMemberReferenceTarget:~Top|Top/inst:Foo>mem")"""
     )()
   }
 

--- a/src/test/scala/chiselTests/util/SRAMSpec.scala
+++ b/src/test/scala/chiselTests/util/SRAMSpec.scala
@@ -36,7 +36,7 @@ class SRAMSpec extends ChiselFlatSpec {
     val chirrtl = chirrtlCircuit.serialize
     chirrtl should include("module Top :")
     chirrtl should include(
-      "wire sram : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1]}"
+      "wire sram : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1], description : Inst<SRAMDescription>}"
     )
     chirrtl should include("mem sram_sram")
     chirrtl should include("data-type => UInt<8>")
@@ -51,6 +51,10 @@ class SRAMSpec extends ChiselFlatSpec {
     chirrtl should include("connect sram.readwritePorts[0].readData, sram_sram.RW0.rdata")
     chirrtl should include("connect sram_sram.RW0.wdata, sram.readwritePorts[0].writeData")
     chirrtl should include("connect sram_sram.RW0.wmode, sram.readwritePorts[0].isWrite")
+    chirrtl should include(
+      "propassign sram_descriptionInstance.hierarchyIn, path(\"OMReferenceTarget:~Top|Top>sram_sram\")"
+    )
+    chirrtl should include("propassign sram.description, sram_descriptionInstance")
 
     val dummyAnno = annos.collectFirst { case DummyAnno(t) => (t.toString) }
     dummyAnno should be(Some("~Top|Top>sram_sram"))
@@ -77,7 +81,7 @@ class SRAMSpec extends ChiselFlatSpec {
     chirrtl should include("module Top :")
     chirrtl should include("mem carrot :")
     chirrtl should include(
-      "wire sramInterface : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1]}"
+      "wire sramInterface : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1], description : Inst<SRAMDescription>}"
     )
 
     val dummyAnno = annos.collectFirst { case DummyAnno(t) => (t.toString) }

--- a/src/test/scala/chiselTests/util/SRAMSpec.scala
+++ b/src/test/scala/chiselTests/util/SRAMSpec.scala
@@ -37,7 +37,7 @@ class SRAMSpec extends ChiselFlatSpec {
     val chirrtl = chirrtlCircuit.serialize
     chirrtl should include("module Top :")
     chirrtl should include(
-      "wire sram : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1], description : Inst<SRAMDescription>}"
+      "wire sram : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1], description : { depth : Integer, dataWidth : Integer, masked : Bool, read : Integer, write : Integer, readwrite : Integer, maskGranularity : Integer, hierarchy : Path}"
     )
     chirrtl should include("mem sram_sram")
     chirrtl should include("data-type => UInt<8>")
@@ -53,9 +53,8 @@ class SRAMSpec extends ChiselFlatSpec {
     chirrtl should include("connect sram_sram.RW0.wdata, sram.readwritePorts[0].writeData")
     chirrtl should include("connect sram_sram.RW0.wmode, sram.readwritePorts[0].isWrite")
     chirrtl should include(
-      "propassign sram_descriptionInstance.hierarchyIn, path(\"OMReferenceTarget:~Top|Top>sram_sram\")"
+      """propassign sram.description.hierarchy, path("OMReferenceTarget:~Top|Top>sram_sram")"""
     )
-    chirrtl should include("propassign sram.description, sram_descriptionInstance")
 
     val dummyAnno = annos.collectFirst { case DummyAnno(t) => (t.toString) }
     dummyAnno should be(Some("~Top|Top>sram_sram"))
@@ -82,7 +81,7 @@ class SRAMSpec extends ChiselFlatSpec {
     chirrtl should include("module Top :")
     chirrtl should include("mem carrot :")
     chirrtl should include(
-      "wire sramInterface : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1], description : Inst<SRAMDescription>}"
+      "wire sramInterface : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1], description : { depth : Integer, dataWidth : Integer, masked : Bool, read : Integer, write : Integer, readwrite : Integer, maskGranularity : Integer, hierarchy : Path}"
     )
 
     val dummyAnno = annos.collectFirst { case DummyAnno(t) => (t.toString) }
@@ -243,13 +242,11 @@ class SRAMSpec extends ChiselFlatSpec {
         numWritePorts = 0,
         numReadwritePorts = 1
       )
-      sramPath := sram.description.getField[Path]("hierarchy")
-      // or better yet
       sramPath := sram.description.hierarchy
     }
     // TODO we need a way with ChiselSim to evaluate properties
     val chirrtl = emitCHIRRTL(new Top)
-    chirrtl should include("propassign sramPath, sram_descriptionInstance.hierarchy")
-    println(chirrtl)
+    chirrtl should include("output sramPath : Path")
+    chirrtl should include("propassign sramPath, sram.description.hierarchy")
   }
 }


### PR DESCRIPTION
This PR adds Property support for `SRAMInterface`, instantiating the `SRAMOM` when using `SRAMInterface`. In our flow this is intend to replace the repl-sram and provide a unified Verilog for both synthesis tool and simulation tools.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
add property to SRAMInterface

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
