### PR TITLE
Layers: Add support for inline convention.

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1108,11 +1108,12 @@ private[chisel3] object Builder extends LazyLogging {
         */
       def foldLayers(l: layer.Layer): Layer = {
         val children = layerAdjacencyList(l)
-        val convention = l.convention match {
-          case layer.Convention.Bind => LayerConvention.Bind
-          case _                     => ???
+        val config = l.config match {
+          case layer.LayerConfig.Extract(_) => LayerConfig.Extract(l.outputDir.map(_.toString))
+          case layer.LayerConfig.Inline     => LayerConfig.Inline
+          case layer.LayerConfig.Root       => ???
         }
-        Layer(l.sourceInfo, l.name, convention, l.outputDir.map(_.toString), children.map(foldLayers).toSeq)
+        Layer(l.sourceInfo, l.name, config, children.map(foldLayers).toSeq)
       }
 
       val optionDefs = groupByIntoSeq(options)(opt => opt.group).map {

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -437,10 +437,11 @@ private[chisel3] object Converter {
   }
 
   def convertLayer(layer: Layer): fir.Layer = {
-    val convention = layer.convention match {
-      case LayerConvention.Bind => fir.LayerConvention.Bind
+    val config = layer.config match {
+      case LayerConfig.Extract(outputDir) => fir.LayerConfig.Extract(outputDir)
+      case LayerConfig.Inline             => fir.LayerConfig.Inline
     }
-    fir.Layer(convert(layer.sourceInfo), layer.name, convention, layer.outputDir, layer.children.map(convertLayer))
+    fir.Layer(convert(layer.sourceInfo), layer.name, config, layer.children.map(convertLayer))
   }
 
   def convertOption(option: DefOption): fir.DefOption = {

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -381,11 +381,16 @@ private[chisel3] object ir {
     case object Bind extends Type
   }
 
-  case class Layer(
+  sealed abstract class LayerConfig
+  object LayerConfig {
+    final case class Extract(outputDir: Option[String]) extends LayerConfig
+    final case object Inline extends LayerConfig
+  }
+
+  final case class Layer(
     sourceInfo: SourceInfo,
     name:       String,
-    convention: LayerConvention.Type,
-    outputDir:  Option[String],
+    config:     LayerConfig,
     children:   Seq[Layer])
 
   class LayerBlock(val sourceInfo: SourceInfo, val layer: chisel3.layer.Layer) extends Command {

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -428,22 +428,26 @@ case class ProbeRelease(info: Info, clock: Expression, cond: Expression, probe: 
     extends Statement
     with UseSerializer
 
-object LayerConvention {
-  sealed trait Type
-  case object Bind extends Type {
-    override def toString: String = "bind"
+sealed abstract class LayerConfig
+object LayerConfig {
+  final case class Extract(outputDir: Option[String]) extends LayerConfig
+  final case object Inline extends LayerConfig
+}
+
+final case class Layer(
+  info:   Info,
+  name:   String,
+  config: LayerConfig,
+  body:   Seq[Layer])
+    extends FirrtlNode
+    with IsDeclaration
+    with UseSerializer {
+  def outputDir: Option[String] = config match {
+    case LayerConfig.Extract(outputDir) => outputDir
+    case _                              => None
   }
 }
 
-case class Layer(
-  info:       Info,
-  name:       String,
-  convention: LayerConvention.Type,
-  outputDir:  Option[String],
-  body:       Seq[Layer])
-    extends FirrtlNode
-    with IsDeclaration
-    with UseSerializer
 case class LayerBlock(info: Info, layer: String, body: Statement) extends Statement with UseSerializer
 
 // option and case

--- a/src/test/scala/chisel3/TypeEquivalenceSpec.scala
+++ b/src/test/scala/chisel3/TypeEquivalenceSpec.scala
@@ -45,10 +45,10 @@ object TypeEquivalenceSpec {
     val maybeProbe = if (useProbe) Probe(Bool()) else Bool()
   }
 
-  object Red extends Layer(layer.Convention.Bind) {
+  object Red extends Layer(layer.LayerConfig.Extract()) {
     override def toString = "Red"
   }
-  object Green extends Layer(layer.Convention.Bind) {
+  object Green extends Layer(layer.LayerConfig.Extract()) {
     override def toString = "Green"
   }
 

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -14,11 +14,20 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
 
   val sep: String = FileSystems.getDefault().getSeparator()
 
-  object A extends layer.Layer(layer.Convention.Bind) {
-    object B extends layer.Layer(layer.Convention.Bind)
+  def bindLayer(name: String, dirs: List[String]): String = {
+    val dirsStr = if (dirs.nonEmpty) s""", "${dirs.mkString(sep)}"""" else ""
+    s"layer $name, bind$dirsStr :"
   }
 
-  object C extends layer.Layer(layer.Convention.Bind)
+  def inlineLayer(name: String): String = {
+    s"layer $name, inline :"
+  }
+
+  object A extends layer.Layer(layer.LayerConfig.Extract()) {
+    object B extends layer.Layer(layer.LayerConfig.Extract())
+  }
+
+  object C extends layer.Layer(layer.LayerConfig.Extract())
 
   "Layers" should "allow for creation of a layer and nested layers" in {
 
@@ -143,26 +152,26 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
   }
 
   they should "emit the output directory when present" in {
-    object LayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {
-      object SublayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {}
+    object LayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {
+      object SublayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {}
       object SublayerWithCustomOutputDir
-          extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOtherOutputDir"))) {}
-      object SublayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {}
+          extends layer.Layer(layer.LayerConfig.Extract(layer.CustomOutputDir(Paths.get("myOtherOutputDir")))) {}
+      object SublayerWithNoOutputDir extends layer.Layer(layer.LayerConfig.Extract(layer.NoOutputDir)) {}
     }
 
     object LayerWithCustomOutputDir
-        extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOutputDir"))) {
-      object SublayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {}
+        extends layer.Layer(layer.LayerConfig.Extract(layer.CustomOutputDir(Paths.get("myOutputDir")))) {
+      object SublayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {}
       object SublayerWithCustomOutputDir
-          extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOtherOutputDir"))) {}
-      object SublayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {}
+          extends layer.Layer(layer.LayerConfig.Extract(layer.CustomOutputDir(Paths.get("myOtherOutputDir")))) {}
+      object SublayerWithNoOutputDir extends layer.Layer(layer.LayerConfig.Extract(layer.NoOutputDir)) {}
     }
 
-    object LayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {
-      object SublayerWithDefaultOutputDir extends layer.Layer(layer.Convention.Bind) {}
+    object LayerWithNoOutputDir extends layer.Layer(layer.LayerConfig.Extract(layer.NoOutputDir)) {
+      object SublayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {}
       object SublayerWithCustomOutputDir
-          extends layer.Layer(layer.Convention.Bind, layer.CustomOutputDir(Paths.get("myOtherOutputDir"))) {}
-      object SublayerWithNoOutputDir extends layer.Layer(layer.Convention.Bind, layer.NoOutputDir) {}
+          extends layer.Layer(layer.LayerConfig.Extract(layer.CustomOutputDir(Paths.get("myOtherOutputDir")))) {}
+      object SublayerWithNoOutputDir extends layer.Layer(layer.LayerConfig.Extract(layer.NoOutputDir)) {}
     }
 
     class Foo extends RawModule {
@@ -192,18 +201,18 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
 
     val text = ChiselStage.emitCHIRRTL(new Foo)
     matchesAndOmits(text)(
-      decl("LayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir")),
-      decl("SublayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir", "SublayerWithDefaultOutputDir")),
-      decl("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
-      decl("SublayerWithNoOutputDir", List()),
-      decl("LayerWithCustomOutputDir", List("myOutputDir")),
-      decl("SublayerWithDefaultOutputDir", List("myOutputDir", "SublayerWithDefaultOutputDir")),
-      decl("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
-      decl("SublayerWithNoOutputDir", List()),
-      decl("LayerWithNoOutputDir", List()),
-      decl("SublayerWithDefaultOutputDir", List("SublayerWithDefaultOutputDir")),
-      decl("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
-      decl("SublayerWithNoOutputDir", List())
+      bindLayer("LayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir")),
+      bindLayer("SublayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir", "SublayerWithDefaultOutputDir")),
+      bindLayer("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
+      bindLayer("SublayerWithNoOutputDir", List()),
+      bindLayer("LayerWithCustomOutputDir", List("myOutputDir")),
+      bindLayer("SublayerWithDefaultOutputDir", List("myOutputDir", "SublayerWithDefaultOutputDir")),
+      bindLayer("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
+      bindLayer("SublayerWithNoOutputDir", List()),
+      bindLayer("LayerWithNoOutputDir", List()),
+      bindLayer("SublayerWithDefaultOutputDir", List("SublayerWithDefaultOutputDir")),
+      bindLayer("SublayerWithCustomOutputDir", List("myOtherOutputDir")),
+      bindLayer("SublayerWithNoOutputDir", List())
     )()
   }
 
@@ -237,4 +246,73 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )
   }
 
+  "Inline layers" should "generated expected FIRRTL" in {
+    object A extends layer.Layer(layer.LayerConfig.Inline) {
+      object B extends layer.Layer(layer.LayerConfig.Inline)
+    }
+
+    class Foo extends RawModule {
+      layer.block(A) {
+        layer.block(A.B) {}
+      }
+    }
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+      "layer A, inline :",
+      "layer B, inline :"
+    )()
+  }
+
+  "Inline layers" should "be ignored when choosing default output directories" in {
+    object LayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {
+      object InlineSublayer extends layer.Layer(layer.LayerConfig.Inline) {
+        object SublayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {}
+      }
+    }
+
+    object LayerWithCustomOutputDir
+        extends layer.Layer(layer.LayerConfig.Extract(layer.CustomOutputDir(Paths.get("myOutputDir")))) {
+      object InlineSublayer extends layer.Layer(layer.LayerConfig.Inline) {
+        object SublayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {}
+      }
+    }
+
+    object LayerWithNoOutputDir extends layer.Layer(layer.LayerConfig.Extract(layer.NoOutputDir)) {
+      object InlineSublayer extends layer.Layer(layer.LayerConfig.Inline) {
+        object SublayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {}
+      }
+    }
+
+    class Foo extends RawModule {
+      layer.block(LayerWithDefaultOutputDir) {
+        layer.block(LayerWithDefaultOutputDir.InlineSublayer) {
+          layer.block(LayerWithDefaultOutputDir.InlineSublayer.SublayerWithDefaultOutputDir) {}
+        }
+      }
+
+      layer.block(LayerWithCustomOutputDir) {
+        layer.block(LayerWithCustomOutputDir.InlineSublayer) {
+          layer.block(LayerWithCustomOutputDir.InlineSublayer.SublayerWithDefaultOutputDir) {}
+        }
+      }
+
+      layer.block(LayerWithNoOutputDir) {
+        layer.block(LayerWithNoOutputDir.InlineSublayer) {
+          layer.block(LayerWithNoOutputDir.InlineSublayer.SublayerWithDefaultOutputDir) {}
+        }
+      }
+    }
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+      bindLayer("LayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir")),
+      inlineLayer("InlineSublayer"),
+      bindLayer("SublayerWithDefaultOutputDir", List("LayerWithDefaultOutputDir", "SublayerWithDefaultOutputDir")),
+      bindLayer("LayerWithCustomOutputDir", List("myOutputDir")),
+      inlineLayer("InlineSublayer"),
+      bindLayer("SublayerWithDefaultOutputDir", List("myOutputDir", "SublayerWithDefaultOutputDir")),
+      bindLayer("LayerWithNoOutputDir", List()),
+      inlineLayer("InlineSublayer"),
+      bindLayer("SublayerWithDefaultOutputDir", List("SublayerWithDefaultOutputDir"))
+    )()
+  }
 }

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.layer.{Convention, Layer}
+import chisel3.layer.{Layer, LayerConfig}
 import chisel3.probe._
 import chisel3.util.Counter
 import chisel3.testers.{BasicTester, TesterDriver}
@@ -718,8 +718,8 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
   }
 
   "Layer colored probes" should "emit correct FIRRTL" in {
-    object LayerA extends Layer(Convention.Bind) {
-      object LayerB extends Layer(Convention.Bind)
+    object LayerA extends Layer(LayerConfig.Extract()) {
+      object LayerB extends Layer(LayerConfig.Extract())
     }
     class Foo extends RawModule {
       val a = IO(Output(Probe.apply(UInt(1.W), LayerA)))

--- a/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
+++ b/src/test/scala/chiselTests/reflect/DataMirrorSpec.scala
@@ -226,7 +226,7 @@ class DataMirrorSpec extends ChiselFlatSpec {
   }
 
   "getLayerColor" should "return a layer color if one exists" in {
-    object A extends layer.Layer(layer.Convention.Bind)
+    object A extends layer.Layer(layer.LayerConfig.Extract())
     class Foo extends Bundle {
       val a = Bool()
       val b = Probe(Bool())

--- a/src/test/scala/chiselTests/simulator/EphemeraSimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/EphemeraSimulatorSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 
 import chisel3._
-import chisel3.layer.{block, Convention, Layer}
+import chisel3.layer.{block, Layer, LayerConfig}
 import chisel3.ltl.AssertProperty
 import chisel3.simulator.LayerControl
 import chisel3.simulator.EphemeralSimulator._
@@ -24,7 +24,7 @@ class EphemeralSimulatorSpec extends AnyFunSpec with Matchers {
       }
     }
     describe("layer control functionality") {
-      object A extends Layer(Convention.Bind)
+      object A extends Layer(LayerConfig.Extract())
       class Foo extends Module {
         block(A) {
           chisel3.assert(false.B)

--- a/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
+++ b/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
@@ -5,7 +5,7 @@ package chiselTests.simulator
 import java.io.File
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import chisel3.layer.{Convention, Layer}
+import chisel3.layer.{Layer, LayerConfig}
 import chisel3.simulator.LayerControl
 
 class LayerControlSpec extends AnyFunSpec with Matchers {
@@ -31,9 +31,9 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
   }
   describe("LayerControl.Enable") {
     it("should return true for non-layers and filter layers properly") {
-      object A extends Layer(Convention.Bind)
-      object B extends Layer(Convention.Bind) {
-        object C extends Layer(Convention.Bind)
+      object A extends Layer(LayerConfig.Extract())
+      object B extends Layer(LayerConfig.Extract()) {
+        object C extends Layer(LayerConfig.Extract())
       }
       val layerControl = LayerControl.Enable(A, B.C)
       layerControl.filter(new File("foo")) should be(true)

--- a/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
@@ -2,7 +2,7 @@ package chiselTests.simulator
 
 import chisel3._
 import chisel3.experimental.ExtModule
-import chisel3.layer.{block, Convention, Layer}
+import chisel3.layer.{block, Convention, Layer, LayerConfig}
 import chisel3.simulator._
 import chisel3.util.{HasExtModuleInline, HasExtModulePath, HasExtModuleResource}
 import org.scalatest.funspec.AnyFunSpec
@@ -281,7 +281,7 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
     }
 
     it("has layers enabled") {
-      object AssertLayer extends Layer(Convention.Bind)
+      object AssertLayer extends Layer(LayerConfig.Extract())
       class Foo extends Module {
         val a = IO(Input(Bool()))
         block(AssertLayer) {

--- a/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests.stage
 
 import chisel3._
-import chisel3.layer.{Convention, Layer}
+import chisel3.layer.{Layer, LayerConfig}
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, DesignAnnotation, RemapLayer}
 import firrtl.options.OptionsException
 import org.scalatest.flatspec.AnyFlatSpec
@@ -27,7 +27,7 @@ class ChiselAnnotationsSpecQux extends ChiselAnnotationsSpecFoo {
 class ChiselAnnotation
 
 object ChiselAnnotationsSpec {
-  object A extends Layer(Convention.Bind)
+  object A extends Layer(LayerConfig.Extract())
 }
 
 class ChiselAnnotationsSpec extends AnyFlatSpec with Matchers {

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -20,7 +20,7 @@ object ChiselStageSpec {
 
   import chisel3._
   import chisel3.probe.{define, Probe, ProbeValue}
-  import chisel3.layer.{block, Convention, Layer}
+  import chisel3.layer.{block, Layer, LayerConfig}
 
   class FooBundle extends Bundle {
     val a = Input(Bool())
@@ -107,9 +107,9 @@ object ChiselStageSpec {
     val w = Wire(UInt(8.W))
   }
 
-  object A extends Layer(Convention.Bind)
+  object A extends Layer(LayerConfig.Extract())
 
-  object B extends Layer(Convention.Bind)
+  object B extends Layer(LayerConfig.Extract())
 
   class LayerRemappingTest extends RawModule {
     val out = IO(Output(Probe(Bool(), A)))


### PR DESCRIPTION
Add inline-layers, a kind of Layer that lowers to macro ifdefs, inline, in the resulting verilog.

- Rename the "bind layers" concept to "extract layers".
- An inline-layer, in contrast to extract-layers, do not have output directories. When determining the output directory of an extract-layer, skip over and ignore any parent 
- Deprecate the concept of a layer's convention in favour of two `Layer` configuration types: `LayerConfig.Extract` and `LayerConfig.Inline`. Update all code inspecting the convention of a layer to instead match against the configuration.
 
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Layer API has changed from convention as argument to constructing specific layer kind directly.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
