### PR TITLE
Emit Layers when using D/I

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -7,6 +7,7 @@ import chisel3._
 
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import chisel3.internal.{Builder, DynamicContext}
+import chisel3.internal.firrtl.Converter
 import chisel3.internal.sourceinfo.{DefinitionTransform, DefinitionWrapTransform}
 import chisel3.experimental.{BaseModule, SourceInfo}
 import firrtl.annotations.{IsModule, ModuleTarget, NoTargetAnnotation}
@@ -129,6 +130,7 @@ object Definition extends SourceInfoDoc {
     val (ir, module) = Builder.build(Module(proto), dynamicContext)
     Builder.components ++= ir.components
     Builder.annotations ++= ir.annotations: @nowarn // this will go away when firrtl is merged
+    Builder.layers ++= dynamicContext.layers
     module._circuit = Builder.currentModule
     module.toDefinition
   }

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -3,6 +3,8 @@
 package chiselTests
 
 import chisel3._
+import chisel3.experimental.hierarchy.core.{Definition, Instance}
+import chisel3.experimental.hierarchy.instantiable
 import chisel3.probe.{define, Probe, ProbeValue}
 import chiselTests.{ChiselFlatSpec, MatchesAndOmits, Utils}
 import java.nio.file.{FileSystems, Paths}
@@ -107,6 +109,22 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     }
 
     ChiselStage.convert(new Foo)
+  }
+
+  they should "work correctly with Definition/Instance" in {
+
+    @instantiable
+    class Bar extends Module {
+      layer.block(A) {
+      }
+    }
+
+    class Foo extends Module {
+      private val bar = Instance(Definition(new Bar))
+    }
+
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Foo)
+    matchesAndOmits(chirrtl)("layer A")()
   }
 
   "Layers error checking" should "require that a nested layer definition matches its declaration nesting" in {

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -115,8 +115,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
 
     @instantiable
     class Bar extends Module {
-      layer.block(A) {
-      }
+      layer.block(A) {}
     }
 
     class Foo extends Module {


### PR DESCRIPTION
Fix a bug in D/I where layers created by a Definition were not added to the layers of the `Builder`.  Change this by correctly copying these layers over.

Fixes #4299.

#### Release Notes

Fix bug where layers were not added to the circuit if used in a `Definition`.