### PR TITLE
Remove annotations from ChiselSpec methods

### DIFF
--- a/integration-tests/src/test/scala/chiselTest/LFSRSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/LFSRSpec.scala
@@ -113,8 +113,7 @@ class LFSRSpec extends ChiselFlatSpec with Utils {
         LFSR.tapsMaxPeriod(width).foreach { taps =>
           info(s"""width $width okay using taps: ${taps.mkString(", ")}""")
           assertTesterPasses(
-            new LFSRMaxPeriod(PRNG(gen(width, taps, reduction))),
-            annotations = TesterDriver.verilatorOnly
+            new LFSRMaxPeriod(PRNG(gen(width, taps, reduction)))
           )
         }
       }

--- a/src/test/scala/chiselTests/AnalogIntegrationSpec.scala
+++ b/src/test/scala/chiselTests/AnalogIntegrationSpec.scala
@@ -135,16 +135,14 @@ class AnalogIntegrationSpec extends ChiselFlatSpec {
   it should "support simple bidirectional wires" in {
     assertTesterPasses(
       new AnalogIntegrationTester(new AnalogSmallDUT),
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
   // Use this test once Verilator supports alias
   ignore should "support arbitrary bidirectional wires" in {
     assertTesterPasses(
       new AnalogIntegrationTester(new AnalogDUT),
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 }

--- a/src/test/scala/chiselTests/AnalogSpec.scala
+++ b/src/test/scala/chiselTests/AnalogSpec.scala
@@ -179,8 +179,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         mod.io.bus <> writer.io.bus
         check(mod)
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 
@@ -246,8 +245,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         attach(writer.io.bus, mods(0).io.bus, mods(1).io.bus)
         mods.foreach(check(_))
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 
@@ -261,8 +259,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         attach(mods(1).io.bus, busWire)
         mods.foreach(check(_))
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 
@@ -278,8 +275,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         attach(busWire(0), busWire(1))
         check(mod)
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 
@@ -291,8 +287,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         attach(writer.io.bus, mods(0).bus, mods(1).bus)
         mods.foreach(check(_))
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 
@@ -306,8 +301,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         reader.io.bus <> connector.io.bus2
         check(reader)
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 
@@ -333,8 +327,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         mod.bus <> writer.io.bus
         check(mod)
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 
@@ -345,8 +338,7 @@ class AnalogSpec extends ChiselFlatSpec with Utils {
         mod.bus <> writer.io.bus
         check(mod)
       },
-      Seq("/chisel3/AnalogBlackBox.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/AnalogBlackBox.v")
     )
   }
 }

--- a/src/test/scala/chiselTests/BlackBox.scala
+++ b/src/test/scala/chiselTests/BlackBox.scala
@@ -195,28 +195,27 @@ class BlackBoxWithParamsTester extends BasicTester {
 
 class BlackBoxSpec extends ChiselFlatSpec {
   "A BlackBoxed inverter" should "work" in {
-    assertTesterPasses({ new BlackBoxTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new BlackBoxTester }, Seq("/chisel3/BlackBoxTest.v"))
   }
   "A BlackBoxed with flipped IO" should "work" in {
-    assertTesterPasses({ new BlackBoxFlipTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new BlackBoxFlipTester }, Seq("/chisel3/BlackBoxTest.v"))
   }
   "Multiple BlackBoxes" should "work" in {
-    assertTesterPasses({ new MultiBlackBoxTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new MultiBlackBoxTester }, Seq("/chisel3/BlackBoxTest.v"))
   }
   "A BlackBoxed register" should "work" in {
-    assertTesterPasses({ new BlackBoxWithClockTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new BlackBoxWithClockTester }, Seq("/chisel3/BlackBoxTest.v"))
   }
   //TODO: SFC->MFC, this test is ignored because the parameters have undesired quotes around values in verilog in MFC
   "BlackBoxes with simpler parameters" should "work" ignore {
     assertTesterPasses(
       { new SimplerBlackBoxWithParamsTester },
-      Seq("/chisel3/BlackBoxTest.v"),
-      TesterDriver.verilatorOnly
+      Seq("/chisel3/BlackBoxTest.v")
     )
   }
   //TODO: SFC->MFC, this test is ignored because the parameters have undesired quotes around values in verilog in MFC
   "BlackBoxes with parameters" should "work" ignore {
-    assertTesterPasses({ new BlackBoxWithParamsTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new BlackBoxWithParamsTester }, Seq("/chisel3/BlackBoxTest.v"))
   }
   "DataMirror.modulePorts" should "work with BlackBox" in {
     ChiselStage.emitCHIRRTL(new Module {
@@ -226,7 +225,7 @@ class BlackBoxSpec extends ChiselFlatSpec {
     })
   }
   "A BlackBox using suggestName(\"io\")" should "work (but don't do this)" in {
-    assertTesterPasses({ new BlackBoxTesterSuggestName }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new BlackBoxTesterSuggestName }, Seq("/chisel3/BlackBoxTest.v"))
   }
 
   "A BlackBox with no 'val io'" should "give a reasonable error message" in {

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -38,8 +38,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
 
   it should "connect two wires within a module" in {
     runTester(
-      new ShouldntAssertTester { val dut = Module(new BoringInverter) },
-      annotations = TesterDriver.verilatorOnly
+      new ShouldntAssertTester { val dut = Module(new BoringInverter) }
     ) should be(true)
   }
 
@@ -98,7 +97,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
   behavior.of("BoringUtils.bore")
 
   it should "connect across modules using BoringUtils.bore" in {
-    runTester(new TopTester, annotations = TesterDriver.verilatorOnly) should be(true)
+    runTester(new TopTester) should be(true)
   }
 
   // TODO: this test is not really testing anything as MFC does boring during
@@ -107,7 +106,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
   // pre-deduplicated circuit).  This is likely better handled as a test in
   // CIRCT than in Chisel.
   it should "still work even with dedup off" in {
-    runTester(new TopTesterFail, annotations = Seq(TesterDriver.VerilatorBackend))
+    runTester(new TopTesterFail)
   }
 
   class InternalBore extends RawModule {
@@ -124,7 +123,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
   }
 
   it should "work for an internal (same module) BoringUtils.bore" in {
-    runTester(new InternalBoreTester, annotations = TesterDriver.verilatorOnly) should be(true)
+    runTester(new InternalBoreTester) should be(true)
   }
 
   it should "work using new API" in {

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -38,8 +38,7 @@ trait ChiselRunners extends Assertions {
   private val timeStampFormat = new SimpleDateFormat("yyyyMMddHHmmss")
   def runTester(
     t:                    => BasicTester,
-    additionalVResources: Seq[String] = Seq(),
-    annotations:          AnnotationSeq = Seq()
+    additionalVResources: Seq[String] = Seq()
   ): Boolean = {
     val workspacePath = Seq(
       "test_run_dir",
@@ -113,17 +112,15 @@ trait ChiselRunners extends Assertions {
   }
   def assertTesterPasses(
     t:                    => BasicTester,
-    additionalVResources: Seq[String] = Seq(),
-    annotations:          AnnotationSeq = Seq()
+    additionalVResources: Seq[String] = Seq()
   ): Unit = {
-    assert(runTester(t, additionalVResources, annotations))
+    assert(runTester(t, additionalVResources))
   }
   def assertTesterFails(
     t:                    => BasicTester,
-    additionalVResources: Seq[String] = Seq(),
-    annotations:          Seq[chisel3.aop.Aspect[_]] = Seq()
+    additionalVResources: Seq[String] = Seq()
   ): Unit = {
-    assert(!runTester(t, additionalVResources, annotations))
+    assert(!runTester(t, additionalVResources))
   }
 
   def assertKnownWidth(expected: Int, args: Iterable[String] = Nil)(gen: => Data)(implicit pos: Position): Unit = {

--- a/src/test/scala/chiselTests/ExtModule.scala
+++ b/src/test/scala/chiselTests/ExtModule.scala
@@ -100,10 +100,10 @@ class ExtModuleInvalidatedTester extends Module {
 
 class ExtModuleSpec extends ChiselFlatSpec {
   "A ExtModule inverter" should "work" in {
-    assertTesterPasses({ new ExtModuleTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new ExtModuleTester }, Seq("/chisel3/BlackBoxTest.v"))
   }
   "Multiple ExtModules" should "work" in {
-    assertTesterPasses({ new MultiExtModuleTester }, Seq("/chisel3/BlackBoxTest.v"), TesterDriver.verilatorOnly)
+    assertTesterPasses({ new MultiExtModuleTester }, Seq("/chisel3/BlackBoxTest.v"))
   }
   "DataMirror.modulePorts" should "work with ExtModule" in {
     ChiselStage.emitCHIRRTL(new Module {

--- a/src/test/scala/chiselTests/MultiClockSpec.scala
+++ b/src/test/scala/chiselTests/MultiClockSpec.scala
@@ -120,7 +120,7 @@ class MultiClockSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "scope ports of memories" in {
-    assertTesterPasses(new MultiClockMemTest, annotations = TesterDriver.verilatorOnly)
+    assertTesterPasses(new MultiClockMemTest)
   }
 
   it should "return like a normal Scala block" in {

--- a/src/test/scala/chiselTests/aop/InjectionSpec.scala
+++ b/src/test/scala/chiselTests/aop/InjectionSpec.scala
@@ -133,48 +133,43 @@ class InjectionSpec extends ChiselFlatSpec with Utils {
   }
   //TODO: SFC->MFC, this test is ignored because aspects yet fully supported by CIRCT/firtool
   "Test" should "pass if pass wrong values, but correct with aspect" ignore {
-    assertTesterPasses({ new AspectTester(Seq(9, 9, 9)) }, Nil, Seq(correctValueAspect) ++ TesterDriver.verilatorOnly)
+    assertTesterPasses({ new AspectTester(Seq(9, 9, 9)) }, Nil)
   }
   "Test" should "pass if pass wrong values, then wrong aspect, then correct aspect" ignore {
     assertTesterPasses(
       new AspectTester(Seq(9, 9, 9)),
-      Nil,
-      Seq(wrongValueAspect, correctValueAspect) ++ TesterDriver.verilatorOnly
+      Nil
     )
   }
   "Test" should "fail if pass wrong values, then correct aspect, then wrong aspect" in {
-    assertTesterFails({ new AspectTester(Seq(9, 9, 9)) }, Nil, Seq(correctValueAspect, wrongValueAspect))
+    assertTesterFails({ new AspectTester(Seq(9, 9, 9)) }, Nil)
   }
 
   "Test" should "pass if the submodules in SubmoduleManipulationTester can be manipulated by manipulateSubmoduleAspect" ignore {
     assertTesterPasses(
       { new SubmoduleManipulationTester },
-      Nil,
-      Seq(manipulateSubmoduleAspect) ++ TesterDriver.verilatorOnly
+      Nil
     )
   }
 
   "Module name collisions when adding a new module" should "be resolved" ignore {
     assertTesterPasses(
       { new SubmoduleManipulationTester },
-      Nil,
-      Seq(duplicateSubmoduleAspect) ++ TesterDriver.verilatorOnly
+      Nil
     )
   }
 
   "Adding external modules" should "work" ignore {
     assertTesterPasses(
       { new SubmoduleManipulationTester },
-      Nil,
-      Seq(addingExternalModules) ++ TesterDriver.verilatorOnly
+      Nil
     )
   }
 
   "Injection into multiple submodules of the same class" should "work" ignore {
     assertTesterPasses(
       { new MultiModuleInjectionTester },
-      Nil,
-      Seq(multiModuleInjectionAspect) ++ TesterDriver.verilatorOnly
+      Nil
     )
   }
 }

--- a/src/test/scala/examples/SimpleVendingMachine.scala
+++ b/src/test/scala/examples/SimpleVendingMachine.scala
@@ -91,8 +91,7 @@ class SimpleVendingMachineSpec extends ChiselFlatSpec {
   "An Verilog implementation of a vending machine" should "work" in {
     assertTesterPasses(
       new SimpleVendingMachineTester(new VerilogVendingMachineWrapper),
-      List("/chisel3/VerilogVendingMachine.v"),
-      annotations = TesterDriver.verilatorOnly
+      List("/chisel3/VerilogVendingMachine.v")
     )
   }
 }


### PR DESCRIPTION
Remove annotations arguments to ChiselSpec methods, e.g., runTester. This argument was not actually used for anything.

Update all tests that were passing annotations to no longer pass annotations.