### PR TITLE
[simulator] Enable all layers for simulation

### DIFF
--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -141,9 +141,11 @@ package object simulator {
         (abs, rel) match {
           case (abs, _) if movedFiles.contains(abs) =>
           case (abs, rel) =>
+            val dest = Paths.get(workspace.primarySourcesPath).resolve(rel)
+            dest.getParent.toFile.mkdirs
             Files.move(
               abs,
-              Paths.get(workspace.primarySourcesPath).resolve(rel)
+              dest
             )
             movedFiles += abs
         }

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -143,10 +143,7 @@ package object simulator {
           case (abs, rel) =>
             val dest = Paths.get(workspace.primarySourcesPath).resolve(rel)
             dest.getParent.toFile.mkdirs
-            Files.move(
-              abs,
-              dest
-            )
+            Files.move(abs, dest)
             movedFiles += abs
         }
       }

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -131,7 +131,7 @@ package object simulator {
         // Convert the files to an absolute version and a relative version.
         val (_abs, rel) = file match {
           case file if file.startsWith(supportArtifactsPath) =>
-            (file, file.subpath(supportArtifactsPath.getNameCount(), -1))
+            (file, file.subpath(supportArtifactsPath.getNameCount(), file.getNameCount()))
           case file => (supportArtifactsPath.resolve(file), file)
         }
         // Normalize the absolute path so it can be checked if it has already

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -167,6 +167,14 @@ package object simulator {
       moveFiles(supportArtifactsPath.resolve("filelist.f"))
       maybeMoveFiles(supportArtifactsPath.resolve("firrtl_black_box_resource_files.f"))
 
+      // Additionally, move other files which are not in the filelist, but are
+      // ABI-meaningful.
+      Files
+        .walk(supportArtifactsPath)
+        .filter(_.toFile.isFile)
+        .filter(_.getFileName.toString.startsWith("layers_"))
+        .forEach(moveFile)
+
       // Initialize Module Info
       val dut = someDut.get
       val ports = {

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -61,7 +61,8 @@ trait ChiselRunners extends Assertions {
             VerilogPreprocessorDefine("ASSERT_VERBOSE_COND", s"!${Workspace.testbenchModuleName}.reset"),
             VerilogPreprocessorDefine("PRINTF_COND", s"!${Workspace.testbenchModuleName}.reset"),
             VerilogPreprocessorDefine("STOP_COND", s"!${Workspace.testbenchModuleName}.reset")
-          )
+          ),
+          includeDirs = Some(Seq(workspace.primarySourcesPath))
         )
       },
       verilator.Backend

--- a/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/SimulatorSpec.scala
@@ -290,12 +290,12 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
       }
       intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
         new VerilatorSimulator("test_run_dir/simulator/has_layers_enabled")
-        .simulate(new Foo) { module =>
-          import PeekPokeAPI._
-          val dut = module.wrapped
-          dut.a.poke(false.B)
-          dut.clock.step(1)
-        }
+          .simulate(new Foo) { module =>
+            import PeekPokeAPI._
+            val dut = module.wrapped
+            dut.a.poke(false.B)
+            dut.clock.step(1)
+          }
           .result
       }
     }

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -11,7 +11,8 @@ case class CommonCompilationSettings(
     CommonCompilationSettings.AvailableParallelism.Default,
   defaultTimescale:  Option[CommonCompilationSettings.Timescale] = None,
   libraryExtensions: Option[Seq[String]] = None,
-  libraryPaths:      Option[Seq[String]] = None)
+  libraryPaths:      Option[Seq[String]] = None,
+  includeDirs:       Option[Seq[String]] = None)
 object CommonCompilationSettings {
   object VerilogPreprocessorDefine {
     def apply(name: String, value: String) = new VerilogPreprocessorDefine(name, Some(value))

--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -314,8 +314,9 @@ final class Workspace(
       backendSpecificSettings = backendSpecificSettings
     )
     val sourceFiles = Seq(primarySourcesPath, generatedSourcesPath)
-      .map(new File(_))
-      .flatMap(_.listFiles())
+      .flatMap(p => Files.walk(Paths.get(p)).iterator().asScala.toSeq)
+      .map(_.toFile)
+      .filter(_.isFile)
       .map { file => workingDirectory.toPath().relativize(file.toPath()).toString() }
 
     val traceFileStem = (backendSpecificSettings match {

--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -1,9 +1,10 @@
 package svsim
 
 import java.io.{BufferedReader, BufferedWriter, File, FileWriter, InputStreamReader, PrintWriter}
-import java.nio.file.Paths
+import java.nio.file.{Files, Paths}
 import java.lang.ProcessBuilder.Redirect
 import scala.annotation.meta.param
+import scala.jdk.CollectionConverters._
 
 case class ModuleInfo(
   name:  String,
@@ -410,7 +411,6 @@ final class Workspace(
     )
     def readLogLines() = {
       val sourceLocationRegex = "[\\./]*generated-sources/".r
-      import scala.collection.JavaConverters._
       new BufferedReader(new InputStreamReader(process.getInputStream()))
         .lines()
         .map(sourceLocationRegex.replaceFirstIn(_, ""))

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -151,6 +151,11 @@ final class Backend(
             case Some(paths) => paths.flatMap(Seq("-y", _))
           },
 
+          commonSettings.includeDirs match {
+            case None => Seq()
+            case Some(dirs) => dirs.map(dir => s"+incdir+$dir")
+          },
+
           backendSpecificSettings.xProp match {
             case None => Seq()
             case Some(XProp.XMerge) => Seq("-xprop=xmerge")

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -72,6 +72,11 @@ final class Backend(
             case Some(paths) => paths.flatMap(Seq("-y", _))
           },
 
+          commonSettings.includeDirs match {
+            case None => Seq()
+            case Some(dirs) => dirs.map(dir => s"+incdir+$dir")
+          },
+
           commonSettings.defaultTimescale match {
             case Some(Timescale.FromString(value)) => Seq("--timescale", value)
             case None => Seq()


### PR DESCRIPTION
Change Chisel's simulator to enable all layers that exist in the circuit.
Do this by copying over the layer bind files and including them in
compilation.

In terms of implementation, this works by copying over all files in the filelist (as before) and then copying over all ABI-specified `layers_` files. All files copied over are included in the compilation (which turns on all the layers). In order for `` `include `` directives to be properly evaluated, this adds include directories to common compilation options. These include directories map to the same option in either Verilator or VCS: `+incdir`.

#### Release Notes

Enable all layers during simulation. Previously, all layers were disabled.