### PR TITLE
Remove unnecessary overrides of lref and ref in Property

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -266,6 +266,8 @@ sealed trait Property[T] extends Element { self =>
 
   override def typeName: String = s"Property[${tpe.getPropertyType().serialize}]"
 
+  override def toString: String = stringAccessor("Property")
+
   /** Bind this node to the in-memory graph.
     */
   private[chisel3] override def bind(target: Binding, parentDirection: SpecifiedDirection): Unit = {
@@ -297,30 +299,6 @@ sealed trait Property[T] extends Element { self =>
     */
   private[chisel3] def getPropertyType: fir.PropertyType = {
     tpe.getPropertyType()
-  }
-
-  /** Internal API: returns a ref that can be assigned to, if consistent with the binding.
-    */
-  private[chisel3] override def lref(implicit info: SourceInfo): ir.Node = {
-    requireIsHardware(this)
-    requireVisible()
-    topBindingOpt match {
-      case Some(binding: ReadOnlyBinding) =>
-        throwException(s"internal error: attempted to generate LHS ref to ReadOnlyBinding $binding")
-      case Some(binding: TopBinding) => ir.Node(this)
-      case opt => throwException(s"internal error: unknown binding $opt in generating LHS ref")
-    }
-  }
-
-  /** Internal API: returns a ref, if bound.
-    */
-  private[chisel3] override def ref: ir.Arg = {
-    requireIsHardware(this)
-    requireVisible()
-    topBindingOpt match {
-      case Some(binding: TopBinding) => ir.Node(this)
-      case opt => throwException(s"internal error: unknown binding $opt in generating RHS ref")
-    }
   }
 
   /** Perform addition as defined by FIRRTL spec section Integer Add Operation.


### PR DESCRIPTION

Partial fix for https://github.com/chipsalliance/chisel/pull/4291

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This fixes an issue with views of List of Property.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
