### PR TITLE
[simulator] Add LayerControl infra

### DIFF
--- a/src/main/scala/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala/chisel3/simulator/LayerControl.scala
@@ -29,11 +29,6 @@ object LayerControl {
     override protected def shouldEnable(layerFilename: String) = true
   }
 
-  /** Disable all layers */
-  case object DisableAll extends Type {
-    override protected def shouldEnable(filename: String) = false
-  }
-
   /** Enable only the specified layers
     *
     * Nested layers should use a `.` as a delimiter.
@@ -41,10 +36,15 @@ object LayerControl {
     * @param layers a variadic list of layer names
     */
   case class Enable(layers: Layer*) extends Type {
-    private val re = {
-      val layersRe = layers.map(_.fullName.split("\\.").mkString("_")).mkString("|")
-      s"^layers_\\w+_($layersRe)\\.sv$$".r
+    private val _shouldEnable: String => Boolean = {
+      layers match {
+        case Nil => _ => false
+        case _ =>
+          val layersRe = layers.map(_.fullName.split("\\.").mkString("_")).mkString("|")
+          val re = s"^layers_\\w+_($layersRe)\\.sv$$".r
+          re.matches(_)
+      }
     }
-    override protected def shouldEnable(filename: String) = re.matches(filename)
+    override protected def shouldEnable(filename: String) = _shouldEnable(filename)
   }
 }

--- a/src/main/scala/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala/chisel3/simulator/LayerControl.scala
@@ -1,0 +1,50 @@
+package chisel3.simulator
+
+import java.io.File
+import chisel3.layer.Layer
+
+/** Utilities for enabling and disabling Chisel layers */
+object LayerControl {
+
+  /** The type of all layer control variations */
+  sealed trait Type {
+
+    /** Return true if a file should be included in the build.  This will always
+      * return true for any non-layer file.
+      * @param file the file to check
+      */
+    final def filter(file: File): Boolean = file.getName match {
+      case nonLayer if !nonLayer.startsWith("layers_") => true
+      case layer                                       => shouldEnable(layer)
+    }
+
+    /** Return true if a layer should be included in the build.
+      * @param layerFilename the filename of a layer
+      */
+    protected def shouldEnable(layerFilename: String): Boolean
+  }
+
+  /** Enable all layers */
+  case object EnableAll extends Type {
+    override protected def shouldEnable(layerFilename: String) = true
+  }
+
+  /** Disable all layers */
+  case object DisableAll extends Type {
+    override protected def shouldEnable(filename: String) = false
+  }
+
+  /** Enable only the specified layers
+    *
+    * Nested layers should use a `.` as a delimiter.
+    *
+    * @param layers a variadic list of layer names
+    */
+  case class Enable(layers: Layer*) extends Type {
+    private val re = {
+      val layersRe = layers.map(_.fullName.split("\\.").mkString("_")).mkString("|")
+      s"^layers_\\w+_($layersRe)\\.sv$$".r
+    }
+    override protected def shouldEnable(filename: String) = re.matches(filename)
+  }
+}

--- a/src/main/scala/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala/chisel3/simulator/LayerControl.scala
@@ -25,7 +25,7 @@ object LayerControl {
   }
 
   /** Enable all layers */
-  case object EnableAll extends Type {
+  final case object EnableAll extends Type {
     override protected def shouldEnable(layerFilename: String) = true
   }
 
@@ -35,7 +35,7 @@ object LayerControl {
     *
     * @param layers a variadic list of layer names
     */
-  case class Enable(layers: Layer*) extends Type {
+  final case class Enable(layers: Layer*) extends Type {
     private val _shouldEnable: String => Boolean = {
       layers match {
         case Nil => _ => false

--- a/src/main/scala/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala/chisel3/simulator/LayerControl.scala
@@ -47,4 +47,8 @@ object LayerControl {
     }
     override protected def shouldEnable(filename: String) = _shouldEnable(filename)
   }
+
+  /** Disables all layers.  This is the same as `Enable()`. */
+  val DisableAll = Enable()
+
 }

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -38,7 +38,8 @@ trait ChiselRunners extends Assertions {
   private val timeStampFormat = new SimpleDateFormat("yyyyMMddHHmmss")
   def runTester(
     t:                    => BasicTester,
-    additionalVResources: Seq[String] = Seq()
+    additionalVResources: Seq[String] = Seq(),
+    layerControl:         LayerControl.Type = LayerControl.EnableAll
   ): Boolean = {
     val workspacePath = Seq(
       "test_run_dir",
@@ -62,7 +63,8 @@ trait ChiselRunners extends Assertions {
             VerilogPreprocessorDefine("PRINTF_COND", s"!${Workspace.testbenchModuleName}.reset"),
             VerilogPreprocessorDefine("STOP_COND", s"!${Workspace.testbenchModuleName}.reset")
           ),
-          includeDirs = Some(Seq(workspace.primarySourcesPath))
+          includeDirs = Some(Seq(workspace.primarySourcesPath)),
+          fileFilter = layerControl.filter
         )
       },
       verilator.Backend
@@ -113,15 +115,17 @@ trait ChiselRunners extends Assertions {
   }
   def assertTesterPasses(
     t:                    => BasicTester,
-    additionalVResources: Seq[String] = Seq()
+    additionalVResources: Seq[String] = Seq(),
+    layerControl:         LayerControl.Type = LayerControl.EnableAll
   ): Unit = {
-    assert(runTester(t, additionalVResources))
+    assert(runTester(t, additionalVResources, layerControl))
   }
   def assertTesterFails(
     t:                    => BasicTester,
-    additionalVResources: Seq[String] = Seq()
+    additionalVResources: Seq[String] = Seq(),
+    layerControl:         LayerControl.Type = LayerControl.EnableAll
   ): Unit = {
-    assert(!runTester(t, additionalVResources))
+    assert(!runTester(t, additionalVResources, layerControl))
   }
 
   def assertKnownWidth(expected: Int, args: Iterable[String] = Nil)(gen: => Data)(implicit pos: Position): Unit = {

--- a/src/test/scala/chiselTests/simulator/EphemeraSimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/EphemeraSimulatorSpec.scala
@@ -44,8 +44,8 @@ class EphemeralSimulatorSpec extends AnyFunSpec with Matchers {
           }
         }
       }
-      it("should disable all layers when provided with DisableAll") {
-        simulate(new Foo, layerControl = LayerControl.DisableAll) { dut =>
+      it("should disable all layers when provided with Enable()") {
+        simulate(new Foo, layerControl = LayerControl.Enable()) { dut =>
           dut.clock.step()
         }
       }

--- a/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
+++ b/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
@@ -16,9 +16,9 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
       layerControl.filter(new File("layers_foo_bar.sv")) should be(true)
     }
   }
-  describe("LayerControl.DisableAll") {
+  describe("LayerControl.Enable()") {
     it("should return true for non-layers and false for layers") {
-      val layerControl = LayerControl.DisableAll
+      val layerControl = LayerControl.Enable()
       layerControl.filter(new File("foo")) should be(true)
       layerControl.filter(new File("layers_foo_bar.sv")) should be(false)
     }

--- a/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
+++ b/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
@@ -23,6 +23,12 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
       layerControl.filter(new File("layers_foo_bar.sv")) should be(false)
     }
   }
+  describe("LayerControl.DisableAll") {
+    it("should return true for non-layers and false for layers") {
+      LayerControl.DisableAll.filter(new File("foo")) should be(true)
+      LayerControl.DisableAll.filter(new File("layers_foo_bar.sv")) should be(false)
+    }
+  }
   describe("LayerControl.Enable") {
     it("should return true for non-layers and filter layers properly") {
       object A extends Layer(Convention.Bind)

--- a/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
+++ b/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.simulator
+
+import java.io.File
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import chisel3.layer.{Convention, Layer}
+import chisel3.simulator.LayerControl
+
+class LayerControlSpec extends AnyFunSpec with Matchers {
+  describe("LayerControl.EnableAll") {
+    it("should always filter to true") {
+      val layerControl = LayerControl.EnableAll
+      layerControl.filter(new File("foo")) should be(true)
+      layerControl.filter(new File("layers_foo_bar.sv")) should be(true)
+    }
+  }
+  describe("LayerControl.DisableAll") {
+    it("should return true for non-layers and false for layers") {
+      val layerControl = LayerControl.DisableAll
+      layerControl.filter(new File("foo")) should be(true)
+      layerControl.filter(new File("layers_foo_bar.sv")) should be(false)
+    }
+  }
+  describe("LayerControl.Enable") {
+    it("should return true for non-layers and filter layers properly") {
+      object A extends Layer(Convention.Bind)
+      object B extends Layer(Convention.Bind) {
+        object C extends Layer(Convention.Bind)
+      }
+      val layerControl = LayerControl.Enable(A, B.C)
+      layerControl.filter(new File("foo")) should be(true)
+      layerControl.filter(new File("layers_foo.sv")) should be(false)
+      layerControl.filter(new File("layers_foo_A.sv")) should be(true)
+      layerControl.filter(new File("layers_foo_A_B.sv")) should be(false)
+      layerControl.filter(new File("layers_foo_B_C.sv")) should be(true)
+    }
+  }
+}

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -1,5 +1,7 @@
 package svsim
 
+import java.io.File
+
 // -- Compilation Settings
 
 /** Settings supported by all svsim backends.
@@ -12,7 +14,8 @@ case class CommonCompilationSettings(
   defaultTimescale:  Option[CommonCompilationSettings.Timescale] = None,
   libraryExtensions: Option[Seq[String]] = None,
   libraryPaths:      Option[Seq[String]] = None,
-  includeDirs:       Option[Seq[String]] = None)
+  includeDirs:       Option[Seq[String]] = None,
+  fileFilter:        File => Boolean = _ => true)
 object CommonCompilationSettings {
   object VerilogPreprocessorDefine {
     def apply(name: String, value: String) = new VerilogPreprocessorDefine(name, Some(value))

--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -317,6 +317,7 @@ final class Workspace(
       .flatMap(p => Files.walk(Paths.get(p)).iterator().asScala.toSeq)
       .map(_.toFile)
       .filter(_.isFile)
+      .filter(commonSettings.fileFilter)
       .map { file => workingDirectory.toPath().relativize(file.toPath()).toString() }
 
     val traceFileStem = (backendSpecificSettings match {


### PR DESCRIPTION
Add some infrastructure for controlling which layers are enabled by
Chisel's simulator.  This is not currently exposed to the user, yet.  This
makes no changes to the existing behavior of all layers being enabled.

Add a function argument that can be used to choose (filter) which Verilog
files should be include in the build.  This is a _very_ low level API that
is being added to allow a user to enable bind convention layers when
writing a test.

Add the ability for the user of the EphemeralSimulator to control which
layers are enabled.

#### Metadata

This is broken into logical commits that can be reviewed independently.