### PR TITLE
Add --remap-layers to ChiselStage

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -129,11 +129,12 @@ object layer {
     * layerblock is not an ancestor of the desired layer
     */
   def block[A](
-    layer: Layer
-  )(thunk: => A
+    _layer: Layer
+  )(thunk:  => A
   )(
     implicit sourceInfo: SourceInfo
   ): Unit = {
+    val layer = Builder.layerMap.getOrElse(_layer, _layer)
     var layersToCreate = List.empty[Layer]
     var currentLayer = layer
     while (currentLayer != Builder.layerStack.head && currentLayer != Layer.Root) {

--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -129,24 +129,24 @@ object layer {
     * layerblock is not an ancestor of the desired layer
     */
   def block[A](
-    _layer: Layer
-  )(thunk:  => A
+    layer: Layer
+  )(thunk: => A
   )(
     implicit sourceInfo: SourceInfo
   ): Unit = {
-    val layer = Builder.layerMap.getOrElse(_layer, _layer)
+    val _layer = Builder.layerMap.getOrElse(layer, layer)
     var layersToCreate = List.empty[Layer]
-    var currentLayer = layer
+    var currentLayer = _layer
     while (currentLayer != Builder.layerStack.head && currentLayer != Layer.Root) {
       layersToCreate = currentLayer :: layersToCreate
       currentLayer = currentLayer.parent
     }
     require(
       currentLayer != Layer.Root || Builder.layerStack.head == Layer.Root,
-      s"a layerblock associated with layer '${layer.fullName}' cannot be created under a layerblock of non-ancestor layer '${Builder.layerStack.head.fullName}'"
+      s"a layerblock associated with layer '${_layer.fullName}' cannot be created under a layerblock of non-ancestor layer '${Builder.layerStack.head.fullName}'"
     )
 
-    addLayer(layer)
+    addLayer(_layer)
 
     def createLayers(layers: List[Layer])(thunk: => A): A = layers match {
       case Nil => thunk

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -123,7 +123,8 @@ object Definition extends SourceInfoDoc {
         Some(context.globalNamespace),
         context.loggerOptions,
         context.definitions,
-        context.contextCache
+        context.contextCache,
+        context.layerMap
       )
     }
     dynamicContext.inDefinition = true

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -482,7 +482,8 @@ private[chisel3] class DynamicContext(
   // Definitions from other scopes in the same elaboration, use allDefinitions below
   val loggerOptions: LoggerOptions,
   val definitions:   ArrayBuffer[Definition[_]],
-  val contextCache:  BuilderContextCache) {
+  val contextCache:  BuilderContextCache,
+  val layerMap:      Map[layer.Layer, layer.Layer]) {
   val importedDefinitionAnnos = annotationSeq.collect { case a: ImportDefinitionAnnotation[_] => a }
 
   // Map from proto module name to ext-module name
@@ -866,6 +867,8 @@ private[chisel3] object Builder extends LazyLogging {
   def layerStack_=(s: List[layer.Layer]): Unit = {
     dynamicContext.layerStack = s
   }
+
+  def layerMap: Map[layer.Layer, layer.Layer] = dynamicContext.layerMap
 
   def inDefinition: Boolean = {
     dynamicContextVar.value

--- a/core/src/main/scala/chisel3/probe/Probe.scala
+++ b/core/src/main/scala/chisel3/probe/Probe.scala
@@ -17,7 +17,7 @@ private[chisel3] sealed trait ProbeBase {
   protected def apply[T <: Data](
     source:   => T,
     writable: Boolean,
-    _color:    Option[layer.Layer]
+    _color:   Option[layer.Layer]
   )(
     implicit sourceInfo: SourceInfo
   ): T = {

--- a/core/src/main/scala/chisel3/probe/Probe.scala
+++ b/core/src/main/scala/chisel3/probe/Probe.scala
@@ -36,7 +36,12 @@ private[chisel3] sealed trait ProbeBase {
 
     val ret: T = if (!data.mustClone(prevId)) data else data.cloneType.asInstanceOf[T]
     // Remap the color if the user is using the ChiselStage --remap-layer option.
-    val color = _color.map(c => Builder.layerMap.getOrElse(c, c))
+    val color = _color.map(c =>
+      Builder.inContext match {
+        case false => c
+        case true  => Builder.layerMap.getOrElse(c, c)
+      }
+    )
     // Record the layer in the builder if we are in a builder context.
     if (Builder.inContext && color.isDefined) {
       layer.addLayer(color.get)

--- a/core/src/main/scala/chisel3/probe/Probe.scala
+++ b/core/src/main/scala/chisel3/probe/Probe.scala
@@ -17,7 +17,7 @@ private[chisel3] sealed trait ProbeBase {
   protected def apply[T <: Data](
     source:   => T,
     writable: Boolean,
-    color:    Option[layer.Layer]
+    _color:    Option[layer.Layer]
   )(
     implicit sourceInfo: SourceInfo
   ): T = {
@@ -35,6 +35,8 @@ private[chisel3] sealed trait ProbeBase {
     // https://github.com/chipsalliance/chisel/issues/3609
 
     val ret: T = if (!data.mustClone(prevId)) data else data.cloneType.asInstanceOf[T]
+    // Remap the color if the user is using the ChiselStage --remap-layer option.
+    val color = _color.map(c => Builder.layerMap.getOrElse(c, c))
     // Record the layer in the builder if we are in a builder context.
     if (Builder.inContext && color.isDefined) {
       layer.addLayer(color.get)

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -72,7 +72,8 @@ abstract class InjectorAspect[T <: RawModule, M <: RawModule](
           None,
           loggerOptions,
           ArrayBuffer[Definition[_]](),
-          BuilderContextCache.empty
+          BuilderContextCache.empty,
+          chiselOptions.layerMap
         )
       // Add existing module names into the namespace. If injection logic instantiates new modules
       //  which would share the same name, they will get uniquified accordingly

--- a/src/main/scala/chisel3/stage/ChiselOptions.scala
+++ b/src/main/scala/chisel3/stage/ChiselOptions.scala
@@ -4,6 +4,7 @@ package chisel3.stage
 
 import chisel3.internal.firrtl.ir.Circuit
 import chisel3.internal.WarningFilter
+import chisel3.layer.Layer
 import java.io.File
 
 class ChiselOptions private[stage] (
@@ -13,7 +14,8 @@ class ChiselOptions private[stage] (
   val chiselCircuit:       Option[Circuit] = None,
   val sourceRoots:         Vector[File] = Vector.empty,
   val warningFilters:      Vector[WarningFilter] = Vector.empty,
-  val useLegacyWidth:      Boolean = false) {
+  val useLegacyWidth:      Boolean = false,
+  val layerMap:            Map[Layer, Layer] = Map.empty) {
 
   private[stage] def copy(
     printFullStackTrace: Boolean = printFullStackTrace,
@@ -22,7 +24,8 @@ class ChiselOptions private[stage] (
     chiselCircuit:       Option[Circuit] = chiselCircuit,
     sourceRoots:         Vector[File] = sourceRoots,
     warningFilters:      Vector[WarningFilter] = warningFilters,
-    useLegacyWidth:      Boolean = useLegacyWidth
+    useLegacyWidth:      Boolean = useLegacyWidth,
+    layerMap:            Map[Layer, Layer] = layerMap
   ): ChiselOptions = {
 
     new ChiselOptions(
@@ -32,7 +35,8 @@ class ChiselOptions private[stage] (
       chiselCircuit = chiselCircuit,
       sourceRoots = sourceRoots,
       warningFilters = warningFilters,
-      useLegacyWidth = useLegacyWidth
+      useLegacyWidth = useLegacyWidth,
+      layerMap = layerMap
     )
 
   }

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -29,7 +29,8 @@ package object stage {
           case SourceRootAnnotation(s)       => c.copy(sourceRoots = c.sourceRoots :+ s)
           case a: WarningConfigurationAnnotation     => c.copy(warningFilters = c.warningFilters ++ a.filters)
           case a: WarningConfigurationFileAnnotation => c.copy(warningFilters = c.warningFilters ++ a.filters)
-          case UseLegacyWidthBehavior => c.copy(useLegacyWidth = true)
+          case UseLegacyWidthBehavior         => c.copy(useLegacyWidth = true)
+          case RemapLayer(oldLayer, newLayer) => c.copy(layerMap = c.layerMap + ((oldLayer, newLayer)))
         }
       }
 

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -47,7 +47,8 @@ class Elaborate extends Phase {
             None,
             loggerOptions,
             ArrayBuffer[Definition[_]](),
-            BuilderContextCache.empty
+            BuilderContextCache.empty,
+            chiselOptions.layerMap
           )
         val (circuit, dut) =
           Builder.build(Module(gen()), context)

--- a/src/main/scala/circt/stage/Shell.scala
+++ b/src/main/scala/circt/stage/Shell.scala
@@ -7,6 +7,7 @@ import chisel3.stage.{
   ChiselGeneratorAnnotation,
   CircuitSerializationAnnotation,
   PrintFullStackTraceAnnotation,
+  RemapLayer,
   SourceRootAnnotation,
   ThrowOnFirstErrorAnnotation,
   UseLegacyWidthBehavior,
@@ -41,7 +42,8 @@ trait CLI { this: BareShell =>
     WarningConfigurationAnnotation,
     WarningConfigurationFileAnnotation,
     SourceRootAnnotation,
-    DumpFir
+    DumpFir,
+    RemapLayer
   ).foreach(_.addOptions(parser))
 
   parser.note("CIRCT (MLIR FIRRTL Compiler) options")

--- a/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
@@ -26,6 +26,10 @@ class ChiselAnnotationsSpecQux extends ChiselAnnotationsSpecFoo {
 
 class ChiselAnnotation
 
+object ChiselAnnotationsSpec {
+  object A extends Layer(Convention.Bind)
+}
+
 class ChiselAnnotationsSpec extends AnyFlatSpec with Matchers {
 
   behavior.of("ChiselGeneratorAnnotation elaboration")
@@ -68,18 +72,18 @@ class ChiselAnnotationsSpec extends AnyFlatSpec with Matchers {
   behavior.of("RemapLayer")
 
   it should "construct an existing in-tree layer" in {
-    RemapLayer(layers.Verification.getClass.getName, layers.Verification.Assert.getClass.getName)
+    RemapLayer(ChiselAnnotationsSpec.A.getClass.getName, ChiselAnnotationsSpec.A.getClass.getName)
   }
 
   it should "throw an exception if the layer does not exist" in {
     intercept[OptionsException] {
-      RemapLayer("foo.bar.Verification$", layers.Verification.getClass.getName)
+      RemapLayer("foo.bar.Verification$", ChiselAnnotationsSpec.A.getClass.getName)
     }.getMessage should startWith("Unable to reflectively find layer 'foo.bar.Verification$'")
   }
 
   it should "throw an exception if the object is not a layer" in {
     intercept[OptionsException] {
-      RemapLayer("circt.stage.ChiselStage$", layers.Verification.getClass.getName)
+      RemapLayer("circt.stage.ChiselStage$", ChiselAnnotationsSpec.A.getClass.getName)
     }.getMessage should startWith("Object 'circt.stage.ChiselStage$' must be a `Layer`")
   }
 

--- a/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
@@ -3,7 +3,8 @@
 package chiselTests.stage
 
 import chisel3._
-import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, DesignAnnotation}
+import chisel3.layer.{Convention, Layer}
+import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, DesignAnnotation, RemapLayer}
 import firrtl.options.OptionsException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -62,6 +63,24 @@ class ChiselAnnotationsSpec extends AnyFlatSpec with Matchers {
     intercept[OptionsException] { annotation.elaborate }.getMessage should startWith(
       s"Unable to create instance of module '$baz'"
     )
+  }
+
+  behavior.of("RemapLayer")
+
+  it should "construct an existing in-tree layer" in {
+    RemapLayer(layers.Verification.getClass.getName, layers.Verification.Assert.getClass.getName)
+  }
+
+  it should "throw an exception if the layer does not exist" in {
+    intercept[OptionsException] {
+      RemapLayer("foo.bar.Verification$", layers.Verification.getClass.getName)
+    }.getMessage should startWith("Unable to reflectively find layer 'foo.bar.Verification$'")
+  }
+
+  it should "throw an exception if the object is not a layer" in {
+    intercept[OptionsException] {
+      RemapLayer("circt.stage.ChiselStage$", layers.Verification.getClass.getName)
+    }.getMessage should startWith("Object 'circt.stage.ChiselStage$' must be a `Layer`")
   }
 
 }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest.matchers.should.Matchers
 object ChiselStageSpec {
 
   import chisel3._
-  import chisel3.probe.{Probe, ProbeValue, define}
+  import chisel3.probe.{define, Probe, ProbeValue}
   import chisel3.layer.{block, Convention, Layer}
 
   class FooBundle extends Bundle {

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -2,7 +2,6 @@
 
 package circtTests.stage
 
-import chisel3.layer.{block, Convention, Layer}
 import chisel3.stage.{ChiselGeneratorAnnotation, CircuitSerializationAnnotation}
 import chisel3.experimental.SourceLine
 
@@ -20,6 +19,8 @@ import org.scalatest.matchers.should.Matchers
 object ChiselStageSpec {
 
   import chisel3._
+  import chisel3.probe.{Probe, ProbeValue, define}
+  import chisel3.layer.{block, Convention, Layer}
 
   class FooBundle extends Bundle {
     val a = Input(Bool())
@@ -111,8 +112,10 @@ object ChiselStageSpec {
   object B extends Layer(Convention.Bind)
 
   class LayerRemappingTest extends RawModule {
+    val out = IO(Output(Probe(Bool(), A)))
     block(A) {
       val a = Wire(Bool())
+      define(out, ProbeValue(a))
     }
   }
 }
@@ -1248,6 +1251,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
         new ChiselStageSpec.LayerRemappingTest,
         Array("--remap-layer", "circtTests.stage.ChiselStageSpec$A$,circtTests.stage.ChiselStageSpec$B$")
       )
+      chirrtl should include("output out : Probe<UInt<1>, B>")
       chirrtl should include("layer B")
       chirrtl should include("layerblock B")
     }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -570,7 +570,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val lines = stdout.split("\n")
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala 95:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala 97:9: Negative shift amounts are illegal (got -1)"
       )
       lines(1) should include("    3.U >> -1")
       lines(2) should include("        ^")
@@ -591,7 +591,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines.size should equal(2)
       lines(0) should include(
-        "src/test/scala/circtTests/stage/ChiselStageSpec.scala 95:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala/circtTests/stage/ChiselStageSpec.scala 97:9: Negative shift amounts are illegal (got -1)"
       )
       (lines(1) should not).include("3.U >> -1")
     }


### PR DESCRIPTION
Add a new annotation/option to Chisel, `RemapLayer`, which is intended to
be used to allow a Chisel compilation to change which layers are used by
an upstream project's libraries in a downstream project.  The motivation
here is to fix mismatches between upstream and downstream when they have
different layers.

Add the ability for ChiselStage to globally remap a layer to another
layer.  This is intended to be used as a Chisel-level mechanism for a
downstream project to change the layers of all upstream projects.  This
may be necessary in order to produce compatible FIRRTL designs where the
upstream project and downstream project have different layers, but the
upstream project has put certain constructs (e.g., asserts) into
specific layers.

#### Release Notes

Add --remap-layers ChiselStage option for changing all layers in an upstream project.