### PR TITLE
Add layer specification to LTL, verification ops

### DIFF
--- a/src/test/scala/chiselTests/DataEqualitySpec.scala
+++ b/src/test/scala/chiselTests/DataEqualitySpec.scala
@@ -22,7 +22,9 @@ class EqualityTester(lhsGen: => Data, rhsGen: => Data) extends BasicTester {
 
   assert(equalityModule.out)
 
-  stop()
+  when(RegNext(next = true.B, init = false.B)) {
+    stop()
+  }
 }
 
 class AnalogBundle extends Bundle {

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -659,6 +659,8 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
       define(b.refs.reg, RWProbeValue(r))
     }
     runTester(new BasicTester {
+      layer.enable(layers.Verification)
+      layer.enable(layers.Verification.Assert)
       val dut = Module(new Top)
 
       val (cycle, done) = Counter(true.B, 20)

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -1173,7 +1173,10 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
         AssertProperty((count <= 42.U))
       }
 
-      val btor2 = ChiselStage.emitBtor2(new Counter)
+      val btor2 = ChiselStage.emitBtor2(
+        new Counter,
+        firtoolOpts = Array("-enable-layers=Verification,Verification::Assert")
+      )
       btor2 should include("""1 sort bitvec 1
                              |2 input 1 reset
                              |3 sort bitvec 32


### PR DESCRIPTION
Put verification operations into layer blocks.

#### Release Notes

Put verification operations (asserts, assumes, covers, and stop) into Chisel-defined layers by default. Assertions are placed in `Verification.Assert`, assumptions are placed in `Verification.Assume`, covers are placed in `Verification.Cover`, and stop is placed in `Verification`. For users of ChiselSim/svsim, all layers are enabled by default, so no changes are necessary. For users that previously relied on these operations being enabled by default, either enable in-CIRCT specialization with `-enable-layers=Verification,Verification::Assert,Verification::Assume,Verification::Cover` or follow the FIRRTL ABI and include bind files for the layers that should be enabled.