### PR TITLE
Add common layers to Chisel

### DIFF
--- a/src/main/scala/chisel3/layers/Layers.scala
+++ b/src/main/scala/chisel3/layers/Layers.scala
@@ -1,0 +1,16 @@
+package chisel3.layers
+
+import chisel3.layer.{Convention, Layer}
+
+/** The root [[chisel3.layer.Layer]] for all shared verification collateral. */
+object Verification extends Layer(Convention.Bind) {
+
+  /** The [[chisel3.layer.Layer]] where all assertions will be placed. */
+  object Assert extends Layer(Convention.Bind)
+
+  /** The [[chisel3.layer.Layer]] where all assumptions will be placed. */
+  object Assume extends Layer(Convention.Bind)
+
+  /** The [[chisel3.layer.Layer]] where all covers will be placed. */
+  object Cover extends Layer(Convention.Bind)
+}

--- a/src/main/scala/chisel3/layers/package.scala
+++ b/src/main/scala/chisel3/layers/package.scala
@@ -1,0 +1,4 @@
+package chisel3
+
+/** This package contains common [[layer.Layer]]s used by Chisel generators. */
+package object layers


### PR DESCRIPTION
Add the common layers that all Chisel projects are expected to use.  These layers will, in later commits, be used for in-tree Chisel generators to put hardware in.  I.e., it is expected that asserts will not be put under their corresponding layer.

CC: @SandeepRajendran 

#### Release Notes

Add Chisel-approved layers. These are intended to be used by downstream projects (Chisel users) to define their layer collateral and, in the future, by Chisel's libraries which generate verification collateral, e.g., assertions.