### PR TITLE
Add skipIfAlreadyInBlock arg to layer.block

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -123,17 +123,27 @@ object layer {
     * not a _proper_ ancestor requirement.)
     *
     * @param layer the layer this block is associated with
+    * @param skipIfAlreadyInBlock if true, then this will not create a layer
+    * block if already inside a layer block
     * @param thunk the Chisel code that goes into the layer block
     * @param sourceInfo a source locator
     * @throws java.lang.IllegalArgumentException if the layer of the currnet
     * layerblock is not an ancestor of the desired layer
     */
   def block[A](
-    layer: Layer
-  )(thunk: => A
+    layer:                Layer,
+    skipIfAlreadyInBlock: Boolean = false
+  )(thunk:                => A
   )(
     implicit sourceInfo: SourceInfo
   ): Unit = {
+    // Do nothing if we are already in a layer block and are not supposed to
+    // create new layer blocks.
+    if (skipIfAlreadyInBlock && Builder.layerStack.size > 1) {
+      thunk
+      return
+    }
+
     val _layer = Builder.layerMap.getOrElse(layer, layer)
     var layersToCreate = List.empty[Layer]
     var currentLayer = _layer

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -69,6 +69,19 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )()
   }
 
+  they should "respect the 'skipIfAlreadyInBlock' parameter" in {
+    class Foo extends RawModule {
+      layer.block(A, skipIfAlreadyInBlock = true) {
+        // This will fail to compile if `skipIfAlreadyInBlock=false`.
+        layer.block(C, skipIfAlreadyInBlock = true) {}
+      }
+    }
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+      "layerblock A"
+    )("layerblock C")
+  }
+
   they should "allow for defines to layer-colored probes" in {
 
     class Foo extends RawModule {


### PR DESCRIPTION
Add an argument to `layer.block` which can be used to prevent a layer block from being created if the current builder state indicates that we are already inside a layer block.  This API is intended to be used for library writers to provide a way to _maybe_ put an operation into a layer block.  Specifically, this is intended for verification statements which should go into a default layer block (e.g., `Verification.Assert`), but should not do this if the Chisel user is already in another layer block.

#### Release Notes

Add `skipIfAlreadyInLayerBlock: Boolean` parameter to `layer.block`. This is a more advanced API for a library writer to write an API where hardware is, by default, created in a layer block. However, if the user wraps the API in a layer block, then the layer block the API would create is elided.