### PR TITLE
[cd] Guard cd-circt PR on llvm-firtool publish to Maven

### DIFF
--- a/.github/scripts/check-maven-for-llvm-firtool-version.sh
+++ b/.github/scripts/check-maven-for-llvm-firtool-version.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Strip firtool- prefix from argument
+VERSION=${1#firtool-}
+
+POM="https://repo1.maven.org/maven2/org/chipsalliance/llvm-firtool/$VERSION/llvm-firtool-$VERSION.pom"
+
+# Return 1 if not found
+curl -o/dev/null -sfIL $POM || false

--- a/.github/scripts/check-maven-for-llvm-firtool-version.sh
+++ b/.github/scripts/check-maven-for-llvm-firtool-version.sh
@@ -6,4 +6,4 @@ VERSION=${1#firtool-}
 POM="https://repo1.maven.org/maven2/org/chipsalliance/llvm-firtool/$VERSION/llvm-firtool-$VERSION.pom"
 
 # Return 1 if not found
-curl -o/dev/null -sfIL $POM || false
+curl -o/dev/null -sfIL "$POM" || false

--- a/.github/workflows/cd-circt.yml
+++ b/.github/workflows/cd-circt.yml
@@ -21,4 +21,5 @@ jobs:
           pr-reviewers: |
             seldridge
             jackkoenig
+          should-create-pr: '.github/scripts/check-maven-for-llvm-firtool-version.sh'
           github-token: ${{ secrets.CHISEL_BOT_TOKEN }}


### PR DESCRIPTION


#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Now CIRCT bumping CD will wait for the repackaging of firtool as a Maven dependency for use with firtool-resolver.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
