### PR TITLE
Visit layerblocks in aop.Select methods

### DIFF
--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -43,7 +43,7 @@ object Select {
           else
             Seq.empty
         head ++ collect(ifRegion)(f) ++ collect(elseRegion)(f)
-      case LayerBlock(_, _, region) => collect(region)(f)
+      case LayerBlock(_, _, region)  => collect(region)(f)
       case cmd if f.isDefinedAt(cmd) => Some(f(cmd))
       case _                         => None
     }
@@ -544,7 +544,7 @@ object Select {
         searchCommands(ifRegion, pred +: preds, processCommand)
         searchCommands(elseRegion, pred.not +: preds, processCommand)
       case LayerBlock(_, _, region) => searchCommands(region, preds, processCommand)
-      case cmd => processCommand(cmd, preds)
+      case cmd                      => processCommand(cmd, preds)
     }
 
     searchCommands(module._component.get.asInstanceOf[DefModule].commands, Seq.empty, processCommand)

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -43,6 +43,7 @@ object Select {
           else
             Seq.empty
         head ++ collect(ifRegion)(f) ++ collect(elseRegion)(f)
+      case LayerBlock(_, _, region) => collect(region)(f)
       case cmd if f.isDefinedAt(cmd) => Some(f(cmd))
       case _                         => None
     }
@@ -542,6 +543,7 @@ object Select {
         }
         searchCommands(ifRegion, pred +: preds, processCommand)
         searchCommands(elseRegion, pred.not +: preds, processCommand)
+      case LayerBlock(_, _, region) => searchCommands(region, preds, processCommand)
       case cmd => processCommand(cmd, preds)
     }
 


### PR DESCRIPTION
Fix a bug introduced when converting layer blocks to be region based [1] where methods in the `aop.Select` object were not updated to walk into the regions of layer blocks.

[1]: b166cfa064426a06d7d68207406a0cabf5194c3b

#### Release Notes

Fix a bug in `aop.Select` where `layer.block`s would not be visited.