### PR TITLE
Add skipIfLayersEnabled param to layer.block

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -150,8 +150,11 @@ object layer {
     * not a _proper_ ancestor requirement.)
     *
     * @param layer the layer this block is associated with
-    * @param skipIfAlreadyInBlock if true, then this will not create a layer
-    * block if already inside a layer block
+    * @param skipIfAlreadyInBlock if true, then this will not create a layer if
+    * this `block` is already inside another layerblock
+    * @param skipIfLayersEnabled if true, then this will not create a layer if
+    * any layers have been enabled for the current module block if already
+    * inside a layer block
     * @param thunk the Chisel code that goes into the layer block
     * @param sourceInfo a source locator
     * @throws java.lang.IllegalArgumentException if the layer of the currnet
@@ -159,14 +162,15 @@ object layer {
     */
   def block[A](
     layer:                Layer,
-    skipIfAlreadyInBlock: Boolean = false
+    skipIfAlreadyInBlock: Boolean = false,
+    skipIfLayersEnabled:  Boolean = false
   )(thunk:                => A
   )(
     implicit sourceInfo: SourceInfo
   ): Unit = {
     // Do nothing if we are already in a layer block and are not supposed to
     // create new layer blocks.
-    if (skipIfAlreadyInBlock && Builder.layerStack.size > 1) {
+    if (skipIfAlreadyInBlock && Builder.layerStack.size > 1 || skipIfLayersEnabled && Builder.enabledLayers.nonEmpty) {
       thunk
       return
     }

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -91,6 +91,15 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )("layerblock C")
   }
 
+  they should "respect the 'skipIfLayersEnabled' parameter" in {
+    class Foo extends RawModule {
+      layer.enable(A)
+      layer.block(A.B, skipIfLayersEnabled = true) {}
+    }
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))()("layerblock")
+  }
+
   they should "allow for defines to layer-colored probes" in {
 
     class Foo extends RawModule {


### PR DESCRIPTION
Add a second control parameter to `layer.block` that will cause no layer to be created if the current module has any layers enabled.  This is intended as a safe default for library writers that are putting operations into layer blocks.  Certain verification operations do not work well with other verification operations (e.g., force and assert) due to interactions where layers may result in the creation of multiple always blocks.  This option allows operations to be placed in the body of a testbench (the likely module that has layers enabled) and avoid any of the interactions of disjoint always blocks.

#### Release Notes

Add `skipIfLayersEnabled` parameter to `layer.block` which will elide the block if any layers are currently enabled.  This is an advanced library-writer API that only comes up when a library writer wants to provide default layers for operations, but wants to allow the user to override this default choice.