### PR TITLE
Add layer.elideBlocks API

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -170,7 +170,9 @@ object layer {
   ): Unit = {
     // Do nothing if we are already in a layer block and are not supposed to
     // create new layer blocks.
-    if (skipIfAlreadyInBlock && Builder.layerStack.size > 1 || skipIfLayersEnabled && Builder.enabledLayers.nonEmpty) {
+    if (
+      skipIfAlreadyInBlock && Builder.layerStack.size > 1 || skipIfLayersEnabled && Builder.enabledLayers.nonEmpty || Builder.elideLayerBlocks
+    ) {
       thunk
       return
     }
@@ -201,6 +203,23 @@ object layer {
     }
 
     createLayers(layersToCreate)(thunk)
+  }
+
+  /** API that will cause any calls to `block` in the `thunk` to not create new
+    * layer blocks.
+    *
+    * This is an advanced, library-writer's API that is not intended for broad
+    * use.  You may consider using this if you are writing an API which
+    * automatically puts code into layer blocks and you want to provide a way
+    * for a user to completely opt out of this.
+    *
+    * @param thunk the Chisel code that should not go into a layer block
+    */
+  def elideBlocks[A](thunk: => A): A = {
+    Builder.elideLayerBlocks = true
+    val result = thunk
+    Builder.elideLayerBlocks = false
+    return result
   }
 
   /** Call this function from within a `Module` body to enable this layer globally for that module. */

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -554,11 +554,12 @@ private[chisel3] class DynamicContext(
   var whenStack:            List[WhenContext] = Nil
   // Clock and Reset are "Delayed" because ImplicitClock and ImplicitReset need to set these values,
   // But the clock or reset defined by the user won't yet be initialized
-  var currentClock:   Option[Delayed[Clock]] = None
-  var currentReset:   Option[Delayed[Reset]] = None
-  var currentDisable: Disable.Type = Disable.BeforeReset
-  var enabledLayers:  mutable.LinkedHashSet[layer.Layer] = mutable.LinkedHashSet.empty
-  var layerStack:     List[layer.Layer] = layer.Layer.root :: Nil
+  var currentClock:     Option[Delayed[Clock]] = None
+  var currentReset:     Option[Delayed[Reset]] = None
+  var currentDisable:   Disable.Type = Disable.BeforeReset
+  var enabledLayers:    mutable.LinkedHashSet[layer.Layer] = mutable.LinkedHashSet.empty
+  var layerStack:       List[layer.Layer] = layer.Layer.root :: Nil
+  var elideLayerBlocks: Boolean = false
   val errors = new ErrorLog(warningFilters, sourceRoots, throwOnFirstError)
   val namingStack = new NamingStack
 
@@ -866,6 +867,11 @@ private[chisel3] object Builder extends LazyLogging {
   def layerStack: List[layer.Layer] = dynamicContext.layerStack
   def layerStack_=(s: List[layer.Layer]): Unit = {
     dynamicContext.layerStack = s
+  }
+
+  def elideLayerBlocks: Boolean = dynamicContext.elideLayerBlocks
+  def elideLayerBlocks_=(a: Boolean): Unit = {
+    dynamicContext.elideLayerBlocks = a
   }
 
   def layerMap: Map[layer.Layer, layer.Layer] = dynamicContext.layerMap

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -100,6 +100,16 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))()("layerblock")
   }
 
+  they should "create no layer blocks when wrapped in 'elideBlocks'" in {
+    class Foo extends RawModule {
+      layer.elideBlocks {
+        layer.block(A.B) {}
+      }
+    }
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))()("layerblock")
+  }
+
   they should "allow for defines to layer-colored probes" in {
 
     class Foo extends RawModule {


### PR DESCRIPTION
Add an API, `chisel3.layer.elideBlocks` that will cause any calls to create a layer block inside its thunk to _not_ be created.  This is an advanced API intended to be used in situations where a library has to avoid additional layer block creation.

This is specifically being added because we have an API, backed by an in-tree CIRCT transforms, which can create bound modules and does so _after_ layers are converted to modules.  While this API is intended to be replaced with layers, initially it needs to have a way to prevent layers from being added to the design to prevent creation of a bind-under-bind in the output.

I expect this API to be short lived...


#### Release Notes

Add `chisel3.layer.elideBlocks` API that can be used to prevent the creation of additional layer blocks. This is an advanced, library writer's API that is not intended for general use.