### PR TITLE
Make layer.addLayer API public

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -127,10 +127,14 @@ object layer {
     implicit val root: Layer = Root
   }
 
-  /** Add a layer and all of its parents to the Builder.  This lets the Builder
-    * know that this layer was used and should be emitted in the FIRRTL.
+  /** Add a layer and all of its parents to the Builder.  This lets the Chisel
+    * know that this layer should be emitted into FIRRTL text.
+    *
+    * This API can be used to guarantee that a design will always have certain
+    * layers defined.  By default, layers are only included in the FIRRTL text
+    * if they have layer block users.
     */
-  private[chisel3] def addLayer(layer: Layer) = {
+  def addLayer(layer: Layer) = {
     var currentLayer: Layer = layer
     while (currentLayer != Layer.Root && !Builder.layers.contains(currentLayer)) {
       val layer = currentLayer

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -248,6 +248,14 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )()
   }
 
+  "addLayer API" should "add a layer to the output CHIRRTL even if no layer block references that layer" in {
+    class Foo extends RawModule {
+      layer.addLayer(A)
+    }
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))("layer A")("layer block")
+  }
+
   "Layers error checking" should "require that the current layer is an ancestor of the desired layer" in {
 
     class Foo extends RawModule {


### PR DESCRIPTION
Make the `chisel3.layer.addLayer` API public.  This is useful if a user wants to guarantee that a layer will show up in CHIRRTL even if no layer block refers to this layer.

This solves a problem where downstream build flows want to expect that certain layers will always exist.  However, without this API, there is no way to do this other than to create dummy layer blocks.  This is slightly cleaner without the empty layer block trick.  Additionally, there is no real harm to having this API public.

#### Release Notes

Add `chisel3.layer.addLayer` API.  This can be used to cause a layer to be emitted in FIRRTL even if it has no layer block users.  This API is added (it was private before) so that users can make their custom layers always be there.  This is important for downstream build flows which may want to enable layers or specialize them away and having the unpredictability of whether or not a layer will exist is not ideal and complicates the build system.