### PR TITLE
Add default layers that are always emitted

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1090,6 +1090,8 @@ private[chisel3] object Builder extends LazyLogging {
             errors.checkpoint(logger)
             throw e
         }
+      // Register all layers.  This will ensure that the FIRRTL produce always includes these layers.
+      chisel3.layers.defaultLayers.foreach(layer.addLayer)
       errors.checkpoint(logger)
       logger.info("Done elaborating.")
 

--- a/core/src/main/scala/chisel3/layers/package.scala
+++ b/core/src/main/scala/chisel3/layers/package.scala
@@ -1,4 +1,20 @@
 package chisel3
 
 /** This package contains common [[layer.Layer]]s used by Chisel generators. */
-package object layers
+package object layers {
+
+  /** This is a list of layers that will _always_ be included in the design. This
+    * is done to provide predictability of what layers will be availble.
+    *
+    * This list is not user-extensible. If a user wants to have similar behavior
+    * for their design, then they should use [[chisel3.layer.addLayer]] API to
+    * add the layers that they always want to see in their output.
+    */
+  val defaultLayers: Seq[layer.Layer] = Seq(
+    Verification,
+    Verification.Assert,
+    Verification.Assume,
+    Verification.Cover
+  )
+
+}

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -256,6 +256,19 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))("layer A")("layer block")
   }
 
+  "Default Layers" should "always be emitted in CHIRRTL (whereas non-default layers are optionally emitted)" in {
+    class Foo extends RawModule {}
+
+    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+      "layer Verification",
+      "layer Assert",
+      "layer Assume",
+      "layer Cover"
+    )(
+      "layer B"
+    )
+  }
+
   "Layers error checking" should "require that the current layer is an ancestor of the desired layer" in {
 
     class Foo extends RawModule {


### PR DESCRIPTION
Add "default layers" that are always emitted in CHIRRTL.  These layers are the built-in Chisel layers:

  - Verification
  - Verification.Assert
  - Verification.Assume
  - Verification.Cover

This is done to create uniformity of CHIRRTL emitted by Chisel. Downstream build flows can count on these layers _always_ existing and can then know to expect them (either using them or specializing them away).

#### Release Notes

Cause default Chisel layers (Verification, Verification.Assert, Verification.Assume, and Verification.Cover) to always be emitted in FIRRTL.  This is done to improve the predictability of Chisel designs---these layers will always exist and downstream flows can choose how to handle them without the unpredictability of them only being emitted if they have user layer blocks.