### PR TITLE
Fix test using incorrect enable-layers CIRCT CLI

### DIFF
--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -1175,7 +1175,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
       val btor2 = ChiselStage.emitBtor2(
         new Counter,
-        firtoolOpts = Array("-enable-layers=Verification,Verification::Assert")
+        firtoolOpts = Array("-enable-layers=Verification,Verification.Assert,Verification.Assume,Verification.Cover")
       )
       btor2 should include("""1 sort bitvec 1
                              |2 input 1 reset


### PR DESCRIPTION
There was a change to how nested layers are specified on the command line to CIRCT.  Previously, this used a "::" delimiter.  This was changed [1] to use a "." delimiter to match how these are referred to by both Chisel and FIRRTL.

[1]: https://github.com/llvm/circt/commit/6aa871500c87c892ba0893b005d60bdd96a043d5