### PR TITLE
Add test, docs of layer reparenting, NFC

### DIFF
--- a/docs/src/explanations/layers.md
+++ b/docs/src/explanations/layers.md
@@ -120,22 +120,20 @@ block users.  Layers can be unconditionally emitted using the
 Consider a use case where a design or design verification engineer would like to
 add some asserts and debug prints to a module.  The logic necessary for the
 asserts and debug prints requires additional computation.  All of this code
-should not be included in the final Verilog.  The engineer can use three layers
-to do this.
+should selectively included at Verilog elaboration time (not at Chisel
+elaboration time).  The engineer can use three layers to do this.
 
-There are four layers that emerge from this example.
+There are three layers used in this example:
 
 1. The built-in `Verification` layer
 1. The built-in `Assert` layer which is nested under the built-in `Verification`
    layer
-1. The built-in `Cover` layer which is also nested under the built-in
+1. A user-defined `Debug` layer which is also nested under the built-in
    `Verification` layer
-1. A user-defined `Debug` layer
 
 The `Verification` layer can be used to store common logic used by both the
-`Assert` and `Cover` layers.  The `Assert` and `Cover` layers contain,
-respectively, assertions and cover statements.  The `Debug` layer contains
-debugging prints.
+`Assert` and `Debug` layers.  The latter two layers allow for separation of,
+respectively, assertions from prints.
 
 One way to write this in Scala is the following:
 
@@ -145,7 +143,13 @@ import chisel3.layer.{Layer, LayerConfig, block}
 import chisel3.layers.Verification
 
 // User-defined layers are declared here.  Built-in layers do not need to be declared.
-object Debug extends Layer(LayerConfig.Extract())
+object UserDefined {
+  // Define an implicit val `root` of type `Layer` to cause layers which can see
+  // this to use `root` as their parent layer.  This allows us to nest the
+  // user-defined `Debug` layer under the built-in `Verification` layer.
+  implicit val root = Verification
+  object Debug extends Layer(LayerConfig.Extract())
+}
 
 class Foo extends Module {
   val a = IO(Input(UInt(32.W)))
@@ -165,17 +169,11 @@ class Foo extends Module {
       chisel3.assert(a >= a_d0, "a must always increment")
     }
 
-    // This adds a `Cover` layer block.
-    block(Verification.Cover) {
-      chisel3.cover(a === 8.U, "a_ took a value of 8")
-      chisel3.cover(a_d0 === 8.U, "a_d0 took a value of 8")
+    // This adds a `Debug` layer block.
+    block(UserDefined.Debug) {
+      printf("a: %x, a_d0: %x", a, a_d0)
     }
 
-  }
-
-  // This adds a `Debug` layer block.
-  block(Debug) {
-    printf("a: %x", a)
   }
 
 }
@@ -187,13 +185,12 @@ following filenames.  One file is created for each layer:
 
 1. `layers_Foo_Verification.sv`
 1. `layers_Foo_Verification_Assert.sv`
-1. `layers_Foo_Verification_Cover.sv`
-1. `layers_Foo_Debug.sv`
+1. `layers_Foo_Verification_Debug.sv`
 
 A user can then include any combination of these files in their design to
-include the optional functionality describe by the `Verification`, `Assert`,
-`Cover`, or `Debug` layers.  The `Assert` and `Cover` bind files automatically
-include the `Verification` bind file for the user.
+include the optional functionality describe by the `Verification`, `Assert`, or
+`Debug` layers.  The `Assert` and `Debug` bind files automatically include the
+`Verification` bind file for the user.
 
 #### Implementation Notes
 
@@ -209,18 +206,17 @@ circuit above (one for `Foo` and one for each layer block in module `Foo`):
 1. `Foo_Verification`
 1. `Foo_Verification_Assert`
 1. `Foo_Verification_Cover`
-1. `Foo_Debug`
+1. `Foo_Verification_Debug`
 
 These will typically be created in separate files with names that match the
 modules, i.e., `Foo.sv`, `Foo_Verification.sv`, `Foo_Verification_Assert.sv`,
-`Foo_Verification_Cover.sv`, and `Foo_Debug.sv`.
+`Foo_Verification_Debug.sv`.
 
 The ports of each module created from a layer block will be automatically
 determined based on what that layer block captured from outside the layer block.
 In the example above, the `Verification` layer block captured port `a`.  Both
-the `Assert` and `Cover` layer blocks captured `a` and `a_d0`.  The `Debug`
-layer only captured `a`.  Layer blocks may be optimized to remove/add ports or
-to move logic into a layer block.
+the `Assert` and `Debug` layer blocks captured `a` and `a_d0`.  Layer blocks may
+be optimized to remove/add ports or to move logic into a layer block.
 
 #### Verilog Output
 

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -248,6 +248,18 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )()
   }
 
+  they should "allow manually overriding the parent layer" in {
+
+    implicit val Parent = layers.Verification
+    object ExpensiveAsserts extends layer.Layer(layer.LayerConfig.Extract())
+
+    class Foo extends RawModule {
+      layer.addLayer(ExpensiveAsserts)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo) should include("""layer ExpensiveAsserts, bind, "Verification/ExpensiveAsserts"""")
+  }
+
   "addLayer API" should "add a layer to the output CHIRRTL even if no layer block references that layer" in {
     class Foo extends RawModule {
       layer.addLayer(A)


### PR DESCRIPTION
Add a test and update documentation that shows how a layer can be declared with a custom parent.  This is particularly useful for the case of creating user-defined layers which nest under built-in layers.