### PR TITLE
Make '--module' support arguments

### DIFF
--- a/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
+++ b/src/test/scala/chiselTests/stage/ChiselAnnotationsSpec.scala
@@ -48,24 +48,25 @@ class ChiselAnnotationsSpec extends AnyFlatSpec with Matchers {
 
   behavior.of("ChiselGeneratorAnnotation when stringly constructing from Module names")
 
-  it should "elaborate from a String" in {
-    val annotation = ChiselGeneratorAnnotation("chiselTests.stage.ChiselAnnotationsSpecFoo")
+  it should "elaborate a module without parameters" in {
+    val annotation = ChiselGeneratorAnnotation("chiselTests.stage.ChiselAnnotationsSpecFoo()")
+    val res = annotation.elaborate
+    res(0) shouldBe a[ChiselCircuitAnnotation]
+    res(1) shouldBe a[DesignAnnotation[_]]
+  }
+
+  it should "elaborate a module with parameters" in {
+    val annotation = ChiselGeneratorAnnotation("""chiselTests.stage.ChiselAnnotationsSpecBaz("hello")""")
     val res = annotation.elaborate
     res(0) shouldBe a[ChiselCircuitAnnotation]
     res(1) shouldBe a[DesignAnnotation[_]]
   }
 
   it should "throw an exception if elaboration from a String refers to nonexistant class" in {
-    val bar = "chiselTests.stage.ChiselAnnotationsSpecBar"
+    val bar = "chiselTests.stage.ChiselAnnotationsSpecBar()"
     val annotation = ChiselGeneratorAnnotation(bar)
-    intercept[OptionsException] { annotation.elaborate }.getMessage should startWith(s"Unable to locate module '$bar'")
-  }
-
-  it should "throw an exception if elaboration from a String refers to an anonymous class" in {
-    val baz = "chiselTests.stage.ChiselAnnotationsSpecBaz"
-    val annotation = ChiselGeneratorAnnotation(baz)
     intercept[OptionsException] { annotation.elaborate }.getMessage should startWith(
-      s"Unable to create instance of module '$baz'"
+      s"Unable to run module generator '$bar' because it or one of its arguments could not be found"
     )
   }
 

--- a/src/test/scala/circtTests/stage/ChiselMainSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselMainSpec.scala
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package circtTests.stage
+
+import chisel3._
+import circt.stage.ChiselMain
+import java.io.File
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import scala.io.Source
+
+object ChiselMainSpec {
+
+  class ParameterlessModule extends RawModule {
+    val a = IO(Input(Bool()))
+    val b = IO(Output(Bool()))
+
+    b :<= a
+  }
+
+  class BooleanModule(param: Boolean) extends RawModule {
+    override final def desiredName = s"${this.getClass().getSimpleName()}_$param"
+  }
+
+  class IntegerModule(param: Int) extends RawModule {
+    override final def desiredName = s"${this.getClass().getSimpleName()}_$param"
+  }
+
+  class DoubleModule(param: Double) extends RawModule {
+    override final def desiredName = s"${this.getClass().getSimpleName()}_$param"
+  }
+
+  object Enum {
+    sealed trait Type
+    class A extends Type {
+      override def toString = "A"
+    }
+    class B extends Type {
+      override def toString = "B"
+    }
+  }
+  class ObjectModule(param: Enum.Type) extends RawModule {
+    override final def desiredName = s"${this.getClass().getSimpleName()}_$param"
+  }
+
+  class StringModule(param: String) extends RawModule {
+    override final def desiredName = s"${this.getClass().getSimpleName()}_$param"
+  }
+
+  class MultipleParameters(bool: Boolean, int: Int) extends RawModule {
+    override final def desiredName = s"${this.getClass().getSimpleName()}_${bool}_$int"
+  }
+
+}
+
+class ChiselMainSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
+  import ChiselMainSpec._
+
+  val testDir = new File("test_run_dir/ChiselMainSpec")
+  case class Test(module: String, filename: String) {
+    def test() = {
+      val outFile = new File(testDir, filename)
+      outFile.delete()
+      outFile shouldNot exist
+
+      info(module)
+      ChiselMain.main(
+        Array(
+          "--module",
+          module,
+          "--target",
+          "chirrtl",
+          "--target-dir",
+          testDir.toString
+        )
+      )
+
+      outFile should exist
+    }
+  }
+
+  describe("ChiselMain") {
+
+    describe("support for modules without parameters") {
+
+      it("should elaborate a parameterless module") {
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$ParameterlessModule()",
+          "ParameterlessModule.fir"
+        ).test()
+
+      }
+
+    }
+
+    describe("support for modules with parameters") {
+
+      it("should elaborate a module with a Boolean parameter") {
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$BooleanModule(true)",
+          "BooleanModule_true.fir"
+        ).test()
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$BooleanModule(false)",
+          "BooleanModule_false.fir"
+        ).test()
+
+      }
+
+      it("should elaborate a module with an Integer parameter") {
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$IntegerModule(42)",
+          "IntegerModule_42.fir"
+        ).test()
+
+      }
+
+      it("should elaborate a module with a Double parameter") {
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$DoubleModule(3.141592654)",
+          "DoubleModule_3141592654.fir"
+        ).test()
+
+      }
+
+      it("should elaborate a module with an object parameter") {
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$ObjectModule(circtTests.stage.ChiselMainSpec$Enum$A())",
+          "ObjectModule_A.fir"
+        ).test()
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$ObjectModule(circtTests.stage.ChiselMainSpec$Enum$B())",
+          "ObjectModule_B.fir"
+        ).test()
+
+      }
+
+      it("should elaborate a module with a string parameter") {
+
+        Test(
+          """circtTests.stage.ChiselMainSpec$StringModule("hello")""",
+          "StringModule_hello.fir"
+        ).test()
+
+      }
+
+      it("should elaborate a module that takes multiple parameters") {
+
+        Test(
+          "circtTests.stage.ChiselMainSpec$MultipleParameters(true,42)",
+          "MultipleParameters_true_42.fir"
+        ).test()
+
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Dramatically increase the power of the '--module' argument to 'circt.stage.ChiselMain'.  This adds support for constructing modules with parameters using reflection as demonstrated elsewhere [[1]].

This is long missing support that I intended to add when both the original reflective construction was added [[2]] and turned on [[3]].  At the time, I didn't know how to do reflective construction of arbitrary modules and left that feature unfinished for the next 5 years.

This is done to move 'ChiselMain' more in the direction of being a command line utility for running Chisel generators.  This is related to the discussions of a hypothetical 'chisel-cli' that has been discussed on #4351.

This commit changes the API such that any class constructed this way must take a trailing '()'.  Anything without this will be interpreted as a string.  This is a change to how '--module' used to work where the argument was assumed to be a class.

This commit changes the API such that any class constructed this way must
take a trailing '()'.  Anything without this will be interpreted as a
string.  This is a change to how '--module' used to work where the
argument was assumed to be a class.

[1]: https://github.com/seldridge/reflective-builder
[2]: a423db5fa5a9fb106c1b0048b7dcf97fc83953b6
[3]: 4eff16bd76a461d76c52103b49889947ac1c9573

#### Release Notes

Improve `ChiselMain` so that it can accept parameters.  This provides a command-line entrypoint to build Chisel modules without having to create a dedicated main function. E.g., things like `scala-cli run -M circt.stage.ChiselMain Foo.scala -- --module Foo(42,"hello") --target systemverilog --split-verilog --target-dir build` are now possible. Previously, only parameter-less modules could be constructed this way.