### PR TITLE
Fix Arg.name and earlyLocalName for probes

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -262,7 +262,7 @@ private[chisel3] object ir {
 
   sealed trait ProbeDetails { this: Arg =>
     val probe: Arg
-    override def name: String = s"$probe"
+    override def name: String = s"${probe.name}"
   }
   case class ProbeExpr(probe: Arg) extends Arg with ProbeDetails
   case class RWProbeExpr(probe: Arg) extends Arg with ProbeDetails

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -101,6 +101,9 @@ private[chisel3] object ir {
       case Some(Index(Node(imm), arg))    => s"${earlyLocalName(imm, includeRoot)}[${arg.localName}]"
       case Some(Slot(Node(imm), name))    => s"${earlyLocalName(imm, includeRoot)}.$name"
       case Some(OpaqueSlot(Node(imm)))    => s"${earlyLocalName(imm, includeRoot)}"
+      case Some(ProbeExpr(Node(ref)))     => s"probe(${earlyLocalName(ref, includeRoot)})"
+      case Some(RWProbeExpr(Node(ref)))   => s"rwprobe(${earlyLocalName(ref, includeRoot)})"
+      case Some(ProbeRead(Node(ref)))     => s"read(${earlyLocalName(ref, includeRoot)})"
       case Some(arg) if includeRoot       => arg.name
       case None if includeRoot =>
         id match {

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -101,9 +101,9 @@ private[chisel3] object ir {
       case Some(Index(Node(imm), arg))    => s"${earlyLocalName(imm, includeRoot)}[${arg.localName}]"
       case Some(Slot(Node(imm), name))    => s"${earlyLocalName(imm, includeRoot)}.$name"
       case Some(OpaqueSlot(Node(imm)))    => s"${earlyLocalName(imm, includeRoot)}"
-      case Some(ProbeExpr(Node(ref)))     => s"probe(${earlyLocalName(ref, includeRoot)})"
-      case Some(RWProbeExpr(Node(ref)))   => s"rwprobe(${earlyLocalName(ref, includeRoot)})"
-      case Some(ProbeRead(Node(ref)))     => s"read(${earlyLocalName(ref, includeRoot)})"
+      case Some(ProbeExpr(Node(ref)))     => s"${earlyLocalName(ref, includeRoot)}"
+      case Some(RWProbeExpr(Node(ref)))   => s"${earlyLocalName(ref, includeRoot)}"
+      case Some(ProbeRead(Node(ref)))     => s"${earlyLocalName(ref, includeRoot)}"
       case Some(arg) if includeRoot       => arg.name
       case None if includeRoot =>
         id match {

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -383,7 +383,7 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
     }
     exc.getMessage should include("Cannot define a probe on a non-equivalent type.")
     exc.getMessage should include(
-      "Left (ProbeSpec_Anon.p: IO[UInt<4>]) and Right (ProbeSpec_Anon.Node(ProbeSpec_Anon.w: Wire[Bool]): OpResult[Bool]) have different types"
+      "Left (ProbeSpec_Anon.p: IO[UInt<4>]) and Right (ProbeSpec_Anon.probe(w): OpResult[Bool]) have different types"
     )
 
   }

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -733,4 +733,13 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
       "output b : Probe<UInt<2>, LayerA.LayerB>"
     )()
   }
+
+  "Probes" should "have valid names" in {
+    class TestMod extends RawModule {
+      val a = IO(Output(Probe(UInt())))
+      val w = WireInit(UInt(32.W), 0.U)
+      a := w
+      require(reflect.DataMirror.queryNameGuess(a) == "a")
+    }
+  }
 }

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -383,7 +383,7 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
     }
     exc.getMessage should include("Cannot define a probe on a non-equivalent type.")
     exc.getMessage should include(
-      "Left (ProbeSpec_Anon.p: IO[UInt<4>]) and Right (ProbeSpec_Anon.probe(w): OpResult[Bool]) have different types"
+      "Left (ProbeSpec_Anon.p: IO[UInt<4>]) and Right (ProbeSpec_Anon.w: OpResult[Bool]) have different types"
     )
 
   }
@@ -736,10 +736,11 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
 
   "Probes" should "have valid names" in {
     class TestMod extends RawModule {
-      val a = IO(Output(Probe(UInt())))
+      val a = IO(Output(Probe(UInt(32.W))))
       val w = WireInit(UInt(32.W), 0.U)
-      a := w
+      probe.define(a, ProbeValue(w))
       require(reflect.DataMirror.queryNameGuess(a) == "a")
     }
+    ChiselStage.emitCHIRRTL(new TestMod)
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix

Names for probe Args will be the default `toString`. For example, if you use `DataMirror` to get the `earlyName` of a probe (derived from `Arg.name`), you will see this default `toString`.

```scala
import chisel3._
import chisel3.probe._
import chisel3.reflect.DataMirror
import chisel3.util.experimental.BoringUtils
import circt.stage.ChiselStage

class ProbedClockedData[D <: Data](gen: => D) extends Bundle {
  val dataProbe = Probe(gen)
  def data      = probe.read(dataProbe)

  val clockProbe = Probe(Clock())
  def clock      = probe.read(clockProbe)

  val resetProbe = Probe(Reset())
  def reset      = probe.read(resetProbe)

  def tapAndConnect(ref: D, clock: Clock, reset: Reset) = {
    dataProbe  := BoringUtils.tap(ref)
    clockProbe := BoringUtils.tap(clock)
    resetProbe := BoringUtils.tap(reset)
  }
}

class Dut extends Module {
  val io = IO(new Bundle {
    val in  = Input(UInt(4.W))
    val out = Output(UInt(4.W))
  })
}

class TestHarness extends Module {
  val dut    = Module(new Dut)
  val probed = Wire(new ProbedClockedData(chiselTypeOf(dut.io)))
  probed.tapAndConnect(dut.io, dut.clock, dut.reset)

  println(s"probed.data name: ${DataMirror.queryNameGuess(probed.data)}")
}

object Main extends App {
  println(ChiselStage.emitCHIRRTL(gen = new TestHarness))
}
```

```
probed.data name: Node(TestHarness.probed.dataProbe: Wire[AnonymousBundle])
```

If that name is ever used for an identifier, Chisel will throw an exception due to the invalid name.

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
