### PR TITLE
Change Path to emit relative targets

### DIFF
--- a/core/src/main/scala/chisel3/properties/Path.scala
+++ b/core/src/main/scala/chisel3/properties/Path.scala
@@ -2,7 +2,7 @@
 
 package chisel3.properties
 
-import chisel3.{Data, HasTarget, MemBase, SramTarget}
+import chisel3.{Data, HasTarget, MemBase, Module, SramTarget}
 import chisel3.experimental.BaseModule
 import firrtl.annotations.{InstanceTarget, IsMember, ModuleTarget, ReferenceTarget}
 import firrtl.ir.PathPropertyLiteral
@@ -52,7 +52,8 @@ object Path {
   def apply(module: BaseModule, isMemberPath: Boolean): Path = {
     val _isMemberPath = isMemberPath // avoid name shadowing below
     new TargetPath {
-      def toTarget():   IsMember = module.toAbsoluteTarget
+      private val scope = Module.currentModule
+      def toTarget():   IsMember = module.toRelativeTarget(scope)
       def isMemberPath: Boolean = _isMemberPath
     }
   }
@@ -63,7 +64,8 @@ object Path {
   def apply(data: Data, isMemberPath: Boolean): Path = {
     val _isMemberPath = isMemberPath // avoid name shadowing below
     new TargetPath {
-      def toTarget():   IsMember = data.toAbsoluteTarget
+      private val scope = Module.currentModule
+      def toTarget():   IsMember = data.toRelativeTarget(scope)
       def isMemberPath: Boolean = _isMemberPath
     }
   }
@@ -74,7 +76,8 @@ object Path {
   def apply(mem: MemBase[_], isMemberPath: Boolean): Path = {
     val _isMemberPath = isMemberPath // avoid name shadowing below
     new TargetPath {
-      def toTarget():   IsMember = mem.toAbsoluteTarget
+      private val scope = Module.currentModule
+      def toTarget():   IsMember = mem.toRelativeTarget(scope)
       def isMemberPath: Boolean = _isMemberPath
     }
   }
@@ -83,7 +86,8 @@ object Path {
     */
   private[chisel3] def apply(mem: SramTarget): Path = {
     new TargetPath {
-      def toTarget():   IsMember = mem.toAbsoluteTarget
+      private val scope = Module.currentModule
+      def toTarget():   IsMember = mem.toRelativeTarget(scope)
       def isMemberPath: Boolean = false
     }
   }


### PR DESCRIPTION
Chisel will now reject attempts to create a Path within a Module that is not a direct ancestor of the target. Note that such paths are already rejected by firtool.

I'm marking this as API Modification since it is a pretty big behavioral change but I don't think the change is actually observable by users unless they are doing things with the paths in the `.fir`.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash
#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
