### PR TITLE
Add utility for pretty Verilog emission in mdoc

### DIFF
--- a/docs-target/src/main/scala/chisel3/docs/package.scala
+++ b/docs-target/src/main/scala/chisel3/docs/package.scala
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import circt.stage.ChiselStage
+
+/** Useful utility methods for generating docs */
+package object docs {
+  def emitSystemVerilog(gen: => RawModule): String = {
+    val prettyArgs = Array("-disable-all-randomization", "-strip-debug-info", "-default-layer-specialization=enable")
+    ChiselStage.emitSystemVerilog(gen, firtoolOpts = prettyArgs)
+  }
+}

--- a/docs/src/appendix/experimental-features.md
+++ b/docs/src/appendix/experimental-features.md
@@ -42,7 +42,7 @@ class Example extends RawModule {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new Example)
+chisel3.docs.emitSystemVerilog(new Example)
 ```
 
 Partial specification is allowed, which results in "invalidated fields" as
@@ -58,7 +58,7 @@ class Example2 extends RawModule {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new Example2)
+chisel3.docs.emitSystemVerilog(new Example2)
 ```
 
 Bundle literals can also be nested arbitrarily.
@@ -80,7 +80,7 @@ class Example3 extends RawModule {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new Example3)
+chisel3.docs.emitSystemVerilog(new Example3)
 ```
 
 ## Vec Literals
@@ -98,7 +98,7 @@ class VecExample1 extends Module {
 }
 ```
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new VecExample1)
+chisel3.docs.emitSystemVerilog(new VecExample1)
 ```
 
 or explicitly as in:
@@ -114,7 +114,7 @@ class VecExample1a extends Module {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new VecExample1a)
+chisel3.docs.emitSystemVerilog(new VecExample1a)
 ```
 
 The following examples all use the explicit form.
@@ -131,7 +131,7 @@ class VecExample2 extends RawModule {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new VecExample2)
+chisel3.docs.emitSystemVerilog(new VecExample2)
 ```
 
 Registers can be initialized from Vec literals
@@ -147,7 +147,7 @@ class VecExample3 extends Module {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new VecExample3)
+chisel3.docs.emitSystemVerilog(new VecExample3)
 ```
 
 Vec literals can also be nested arbitrarily.
@@ -163,7 +163,7 @@ class VecExample5 extends RawModule {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new VecExample5)
+chisel3.docs.emitSystemVerilog(new VecExample5)
 ```
 
 ## Loading Memories for simulation or FPGA initialization

--- a/docs/src/cookbooks/cookbook.md
+++ b/docs/src/cookbooks/cookbook.md
@@ -38,7 +38,7 @@ class Foo extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 ### How do I create a Bundle from a UInt?
@@ -67,7 +67,7 @@ class Foo extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 ### How can I tieoff a Bundle/Vec to 0?
@@ -77,7 +77,6 @@ you are tying off, you can use `chiselTypeOf`:
 
 ```scala mdoc:silent:reset
 import chisel3._
-import circt.stage.ChiselStage
 
 class MyBundle extends Bundle {
   val foo = UInt(4.W)
@@ -96,8 +95,10 @@ class Foo(typ: MyBundle) extends Module {
   // but this will work no matter the type of bundleB:
   bundleB := 0.U.asTypeOf(chiselTypeOf(bundleB))
 }
-
-ChiselStage.emitSystemVerilog(new Foo(new MyBundle))
+```
+```scala mdoc:invisible
+// Hidden but will make sure this actually compiles
+chisel3.docs.emitSystemVerilog(new Foo(new MyBundle))
 ```
 ### How do I create a Vec of Bools from a UInt?
 
@@ -122,7 +123,7 @@ class Foo extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 ### How do I create a UInt from a Vec of Bool?
@@ -147,7 +148,7 @@ class Foo extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 ### How do I connect a subset of Bundle fields?
@@ -195,9 +196,7 @@ class Foo extends Module {
 ```
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-import circt.stage.ChiselStage
-
-ChiselStage.emitSystemVerilog(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 
@@ -230,7 +229,7 @@ class Foo extends Module {
 ```
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 
@@ -273,8 +272,8 @@ class MyModule2 extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new MyModule)
-getVerilogString(new MyModule2)
+chisel3.docs.emitSystemVerilog(new MyModule)
+chisel3.docs.emitSystemVerilog(new MyModule2)
 ```
 
 
@@ -345,7 +344,7 @@ it becoming a hardware field of the `Bundle`.
 Note that this also means you must pass `gen` as a function, for example:
 
 ```scala mdoc:silent
-getVerilogString(new Top(new UsingAFunctionBundle(() => UInt(8.W))))
+chisel3.docs.emitSystemVerilog(new Top(new UsingAFunctionBundle(() => UInt(8.W))))
 ```
 
 ##### Aliased Warning
@@ -380,7 +379,7 @@ class UsingByNameParameters[T <: Data](gen: => T) extends Bundle {
 With this usage, you do not include `() =>` when passing the argument:
 
 ```scala mdoc:silent
-getVerilogString(new Top(new UsingByNameParameters(UInt(8.W))))
+chisel3.docs.emitSystemVerilog(new Top(new UsingByNameParameters(UInt(8.W))))
 ```
 
 Note that as this is just syntactic sugar over (1), the [same warning applies](#aliased-warning).
@@ -398,7 +397,7 @@ class DirectionedBundle[T <: Data](gen: T) extends Bundle {
 ```
 
 ```scala mdoc:invisible
-getVerilogString(new Top(new DirectionedBundle(UInt(8.W))))
+chisel3.docs.emitSystemVerilog(new Top(new DirectionedBundle(UInt(8.W))))
 ```
 
 This approach is admittedly a little ugly and may mislead others reading the code because it implies that this Bundle is intended to be used as an `Output`.
@@ -416,7 +415,7 @@ class UsingCloneTypeBundle[T <: Data](gen: T) extends Bundle {
 ```
 
 ```scala mdoc:invisible
-getVerilogString(new Top(new UsingCloneTypeBundle(UInt(8.W))))
+chisel3.docs.emitSystemVerilog(new Top(new UsingCloneTypeBundle(UInt(8.W))))
 ```
 
 ### <a name="bundle-unable-to-clone"></a> How do I deal with the "unable to clone" error?
@@ -535,7 +534,7 @@ class DetectTwoOnes extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new DetectTwoOnes)
+chisel3.docs.emitSystemVerilog(new DetectTwoOnes)
 ```
 
 Note: the `is` statement can take multiple conditions e.g. `is (sTwo1s, sOne1) { ... }`.
@@ -580,7 +579,7 @@ class Foo extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 If you **really** need to do this for a one-off case (Think thrice! It is likely you can better structure the code using bundles), then rocket-chip has a [Split utility](https://github.com/freechipsproject/rocket-chip/blob/723af5e6b69e07b5f94c46269a208a8d65e9d73b/src/main/scala/util/Misc.scala#L140) which can accomplish this.
@@ -592,7 +591,6 @@ Below, the left-hand side connection to `io.out(0)` is not allowed.
 
 ```scala mdoc:silent:reset
 import chisel3._
-import circt.stage.ChiselStage
 
 class Foo extends Module {
   val io = IO(new Bundle {
@@ -630,7 +628,7 @@ class Foo extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 ## How do I create an optional I/O?
@@ -656,7 +654,7 @@ class ModuleWithOptionalIOs(flag: Boolean) extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new ModuleWithOptionalIOs(true))
+chisel3.docs.emitSystemVerilog(new ModuleWithOptionalIOs(true))
 ```
 
 The following is an example where an entire `IO` is optional:
@@ -674,7 +672,7 @@ class ModuleWithOptionalIO(flag: Boolean) extends Module {
 
 ```scala mdoc:invisible
 // Hidden but will make sure this actually compiles
-getVerilogString(new ModuleWithOptionalIO(true))
+chisel3.docs.emitSystemVerilog(new ModuleWithOptionalIO(true))
 ```
 
 ## How do I create I/O without a prefix?
@@ -693,7 +691,7 @@ class MyModule extends Module {
 ```
 
 ```scala mdoc:verilog
-getVerilogString(new MyModule)
+chisel3.docs.emitSystemVerilog(new MyModule)
 ```
 
 If you have a `Bundle` from which you would like to create ports without the
@@ -717,7 +715,7 @@ class MyModule extends Module {
 Note that `io_` is nowhere to be seen!
 
 ```scala mdoc:verilog
-getVerilogString(new MyModule)
+chisel3.docs.emitSystemVerilog(new MyModule)
 ```
 
 ## How do I override the implicit clock or reset within a Module?
@@ -750,12 +748,7 @@ class MyModule extends Module with ImplicitClock {
 This gives the following Verilog:
 
 ```scala mdoc:verilog
-def func(): String = {
-  // This example uses a Reg to we need to disable randomization
-  val prettyArgs = Array("--disable-all-randomization", "--strip-debug-info")
-  circt.stage.ChiselStage.emitSystemVerilog(new MyModule, firtoolOpts = prettyArgs)
-}
-func()
+chisel3.docs.emitSystemVerilog(new MyModule)
 ```
 
 If you do not care about the name of the overriden clock, you can just assign it to `val implicitClock`:
@@ -800,7 +793,7 @@ Unlike `Vecs` which represent a singular Chisel type and must have the same widt
 `Seq` is a purely Scala construct, so their elements are independent from the perspective of Chisel and can have different widths.
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new Top(4))
+chisel3.docs.emitSystemVerilog(new Top(4))
   // remove the body of the module by removing everything after ');'
   .split("\\);")
   .head + ");\n"
@@ -932,7 +925,7 @@ class Foo extends Module {
 The above code loses the `x` name, instead using `_GEN_3` (the other `_GEN_*` signals are expected).
 
 ```scala mdoc:verilog
-getVerilogString(new Foo)
+chisel3.docs.emitSystemVerilog(new Foo)
 ```
 
 This can be worked around by creating a wire and connecting the dynamic index to the wire:
@@ -957,7 +950,7 @@ class Foo2 extends Module {
 
 Which produces:
 ```scala mdoc:verilog
-getVerilogString(new Foo2)
+chisel3.docs.emitSystemVerilog(new Foo2)
 ```
 
 ### How can I dynamically set/parametrize the name of a module?
@@ -987,7 +980,7 @@ class Salt extends Module {
 Elaborating the Chisel module `Salt` yields our "desired names" for `Salt` and `Coffee` in the output Verilog:
 
 ```scala mdoc:verilog
-getVerilogString(new Salt)
+chisel3.docs.emitSystemVerilog(new Salt)
 ```
 
 ## Directionality
@@ -999,7 +992,6 @@ to a register:
 
 ```scala mdoc:silent:reset
 import chisel3._
-import circt.stage.ChiselStage
 import chisel3.util.Decoupled
 class BadRegConnect extends Module {
   val io = IO(new Bundle {
@@ -1012,7 +1004,7 @@ class BadRegConnect extends Module {
 ```
 
 ```scala mdoc:crash
-ChiselStage.emitSystemVerilog(new BadRegConnect)
+getVerilogString(new BadRegConnect)
 ```
 
 While there is no construct to "strip direction" in Chisel3, wrapping a type in `Output(...)`
@@ -1022,7 +1014,6 @@ This will have the desired result when used to construct a Register:
 
 ```scala mdoc:silent:reset
 import chisel3._
-import circt.stage.ChiselStage
 import chisel3.util.Decoupled
 class CoercedRegConnect extends Module {
   val io = IO(new Bundle {
@@ -1038,7 +1029,7 @@ class CoercedRegConnect extends Module {
 
 <!-- Just make sure it actually works -->
 ```scala mdoc:invisible
-ChiselStage.emitSystemVerilog(new CoercedRegConnect {
+chisel3.docs.emitSystemVerilog(new CoercedRegConnect {
   // Provide default connections that would just muddy the example
   io.enq.ready := true.B
   // dontTouch so that it shows up in the Verilog

--- a/docs/src/cookbooks/dataview.md
+++ b/docs/src/cookbooks/dataview.md
@@ -40,7 +40,7 @@ class MyModule extends RawModule {
   val out = IO(Output(new Bar(UInt(8.W))))
   out := in.viewAs[Bar[UInt]]
 }
-circt.stage.ChiselStage.emitSystemVerilog(new MyModule)
+chisel3.docs.emitSystemVerilog(new MyModule)
 ```
 If you think about type parameterized classes as really being a family of different classes
 (one for each type parameter), you can think about the `implicit def` as a generator of `DataViews`
@@ -84,7 +84,7 @@ class MyModule extends RawModule {
   val out = IO(Output(new Bar(Some(8))))
   out := in.viewAs[Bar]
 }
-circt.stage.ChiselStage.emitSystemVerilog(new MyModule)
+chisel3.docs.emitSystemVerilog(new MyModule)
 ```
 
 ## How do I connect a subset of Bundle fields?
@@ -116,7 +116,7 @@ class MyModule extends Module {
 }
 ```
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new MyModule)
+chisel3.docs.emitSystemVerilog(new MyModule)
 ```
 
 ### How do I view a Bundle as a parent type when the parent type is abstract (like a trait)?
@@ -204,5 +204,5 @@ class MyModule extends Module {
 }
 ```
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new MyModule)
+chisel3.docs.emitSystemVerilog(new MyModule)
 ```

--- a/docs/src/cookbooks/hierarchy.md
+++ b/docs/src/cookbooks/hierarchy.md
@@ -58,7 +58,7 @@ class AddTwo(width: Int) extends Module {
 }
 ```
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new AddTwo(10))
+chisel3.docs.emitSystemVerilog(new AddTwo(10))
 ```
 
 ### Using Instantiate
@@ -80,7 +80,7 @@ class AddTwoInstantiate(width: Int) extends Module {
 }
 ```
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new AddTwoInstantiate(16))
+chisel3.docs.emitSystemVerilog(new AddTwoInstantiate(16))
 ```
 
 ## How do I access internal fields of an instance?
@@ -191,7 +191,7 @@ class Top extends Module {
 ```
 
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new Top())
+chisel3.docs.emitSystemVerilog(new Top())
 ```
 
 ## How do I parameterize a module by its children instances?
@@ -231,7 +231,7 @@ class AddTwo(addOneDef: Definition[AddOne]) extends Module {
 }
 ```
 ```scala mdoc:verilog
-circt.stage.ChiselStage.emitSystemVerilog(new AddTwo(Definition(new AddOne(10))))
+chisel3.docs.emitSystemVerilog(new AddTwo(Definition(new AddOne(10))))
 ```
 
 ## How do I use the new hierarchy-specific Select functions?

--- a/docs/src/cookbooks/naming.md
+++ b/docs/src/cookbooks/naming.md
@@ -4,11 +4,7 @@ sidebar_position: 1
 
 ```scala mdoc:invisible
 import chisel3._
-import circt.stage.ChiselStage
-def emitSystemVerilog(gen: => RawModule): String = {
-  val prettyArgs = Array("--disable-all-randomization", "--strip-debug-info")
-  ChiselStage.emitSystemVerilog(gen, firtoolOpts = prettyArgs)
-}
+import chisel3.docs.emitSystemVerilog
 ```
 # Naming Cookbook
 
@@ -98,11 +94,7 @@ We can override `desiredName` of the module to include the type name of the `gen
 ```scala mdoc:invisible:reset
 import chisel3._
 import chisel3.util.Queue
-import circt.stage.ChiselStage
-def emitSystemVerilog(gen: => RawModule): String = {
-  val prettyArgs = Array("--disable-all-randomization", "--strip-debug-info")
-  ChiselStage.emitSystemVerilog(gen, firtoolOpts = prettyArgs)
-}
+import chisel3.docs.emitSystemVerilog
 ```
 
 ```scala mdoc
@@ -174,11 +166,7 @@ new MyBundle(UInt(8.W), 3).typeName
 
 ```scala mdoc:invisible:reset
 import chisel3._
-import circt.stage.ChiselStage
-def emitSystemVerilog(gen: => RawModule): String = {
-  val prettyArgs = Array("--disable-all-randomization", "--strip-debug-info")
-  ChiselStage.emitSystemVerilog(gen, firtoolOpts = prettyArgs)
-}
+import chisel3.docs.emitSystemVerilog
 ```
 
 Auto-generated `typeName`s take the form of `{Bundle Name}_{Parameter Value 1}_{Parameter Value 2}_{...}`, and so our `MyBundle` can be equivalently expressed with:
@@ -221,9 +209,7 @@ class AliasedBundle extends Bundle with HasTypeAlias {
 Let's see what happens when we generate FIRRTL using this `Bundle`:
 
 ```scala mdoc:invisible
-def emitFIRRTL(gen: => RawModule): String = {
-  ChiselStage.emitCHIRRTL(gen)
-}
+import circt.stage.ChiselStage.{emitCHIRRTL => emitFIRRTL}
 ```
 ```scala mdoc
 emitFIRRTL(new Module {

--- a/docs/src/explanations/bundles-and-vecs.md
+++ b/docs/src/explanations/bundles-and-vecs.md
@@ -93,9 +93,7 @@ class MyFlippedModule extends RawModule {
 This generates the following Verilog:
 
 ```scala mdoc:verilog
-import circt.stage.ChiselStage
-
-ChiselStage.emitSystemVerilog(new MyFlippedModule())
+chisel3.docs.emitSystemVerilog(new MyFlippedModule())
 ```
 
 ### MixedVec

--- a/docs/src/explanations/chisel-enum.md
+++ b/docs/src/explanations/chisel-enum.md
@@ -13,7 +13,6 @@ In contrast with `Chisel.util.Enum`, `ChiselEnum` are subclasses of `Data`, whic
 
 ```scala mdoc
 // Imports used in the following examples
-import circt.stage.ChiselStage
 import chisel3._
 import chisel3.util._
 ```
@@ -75,7 +74,7 @@ class AluMux1File extends Module {
 ```
 
 ```scala mdoc:verilog
-ChiselStage.emitSystemVerilog(new AluMux1File)
+chisel3.docs.emitSystemVerilog(new AluMux1File)
 ```
 
 ChiselEnum also allows for the user to directly set the Values by passing an `UInt` to `Value(...)`
@@ -122,7 +121,7 @@ class ToUInt extends RawModule {
 
 ```scala mdoc:invisible
 // Always need to run Chisel to see if there are elaboration errors
-ChiselStage.emitSystemVerilog(new ToUInt)
+chisel3.docs.emitSystemVerilog(new ToUInt)
 ```
 
 You can cast from a `UInt` to an enum by passing the `UInt` to the apply method of the `ChiselEnum` object:
@@ -139,8 +138,9 @@ However, if you cast from a `UInt` to an Enum type when there are undefined stat
 that the `UInt` could hit, you will see a warning like the following:
 
 ```scala mdoc:passthrough
-val (log, _) = grabLog(ChiselStage.emitCHIRRTL(new FromUInt))
-println(s"```\n$log```")
+println("```")
+_root_.circt.stage.ChiselStage.emitCHIRRTL(new FromUInt): Unit // Suppress String output
+println("```")
 ```
 
 (Note that the name of the Enum is ugly as an artifact of our documentation generation flow, it will
@@ -162,8 +162,9 @@ class SafeFromUInt extends Module {
 Now there will be no warning:
 
 ```scala mdoc:passthrough
-val (log2, _) = grabLog(ChiselStage.emitCHIRRTL(new SafeFromUInt))
-println(s"```\n$log2```")
+println("```")
+_root_.circt.stage.ChiselStage.emitCHIRRTL(new SafeFromUInt): Unit // Suppress String output
+println("```")
 ```
 
 You can also suppress the warning by using `suppressEnumCastWarning`. This is
@@ -186,7 +187,7 @@ class SuppressedFromUInt extends Module {
 ```
 
 ```scala mdoc:invisible
-val (log3, _) = grabLog(ChiselStage.emitCHIRRTL(new SuppressedFromUInt))
+val (log3, _) = grabLog(_root_.circt.stage.ChiselStage.emitCHIRRTL(new SuppressedFromUInt))
 assert(log3.isEmpty)
 ```
 
@@ -221,7 +222,7 @@ class LoadStoreExample extends Module {
 
 ```scala mdoc:invisible
 // Always need to run Chisel to see if there are elaboration errors
-ChiselStage.emitSystemVerilog(new LoadStoreExample)
+chisel3.docs.emitSystemVerilog(new LoadStoreExample)
 ```
 
 Some additional useful methods defined on the `ChiselEnum` object are:

--- a/docs/src/explanations/chisel-type-vs-scala-type.md
+++ b/docs/src/explanations/chisel-type-vs-scala-type.md
@@ -274,12 +274,16 @@ It is commonly used to assign data to all-zeros, as described in [this cookbook 
 also be used (though not really recommended, as there is no checking on
 width matches) to convert one Chisel type to another:
 
+```scala mdoc:invisible
+import chisel3.docs.emitSystemVerilog
+```
+
 ```scala mdoc
 class SimilarToMyBundle(w: Int) extends Bundle{
   val foobar = UInt((2*w).W)
 }
 
-ChiselStage.emitSystemVerilog(new Module {
+emitSystemVerilog(new Module {
   val in = IO(Input(new MyBundle(3)))
   val out = IO(Output(new SimilarToMyBundle(3)))
 

--- a/docs/src/explanations/connectable.md
+++ b/docs/src/explanations/connectable.md
@@ -235,7 +235,7 @@ class Example0 extends RawModule {
 This generates the following Verilog, where each member of `incoming` drives every member of `outgoing`:
 
 ```scala mdoc:verilog
-getVerilogString(new Example0)
+chisel3.docs.emitSystemVerilog(new Example0)
 ```
 
 > You may be thinking "Wait, I'm confused! Isn't `incoming` flipped and `outgoing` aligned?" -- Noo! Whether `incoming` is aligned with `outgoing` makes no sense; remember, you only evaluate alignment between members of the same component or Chisel type.
@@ -274,7 +274,7 @@ class Example1 extends RawModule {
 This generates the following Verilog, where the aligned members are driven `incoming` to `outgoing` and flipped members are driven `outgoing` to `incoming`:
 
 ```scala mdoc:verilog
-getVerilogString(new Example1)
+chisel3.docs.emitSystemVerilog(new Example1)
 ```
 
 ### Port-Direction Computation versus Connection-Direction Computation
@@ -327,7 +327,7 @@ class Example2 extends RawModule {
 This generates the following Verilog, where the aligned members are driven `incoming` to `outgoing` and flipped members are ignored:
 
 ```scala mdoc:verilog
-getVerilogString(new Example2)
+chisel3.docs.emitSystemVerilog(new Example2)
 ```
 
 ### Flipped connection operator (`:>=`)
@@ -346,7 +346,7 @@ class Example3 extends RawModule {
 This generates the following Verilog, where the aligned members are ignored and the flipped members are driven `outgoing` to `incoming`:
 
 ```scala mdoc:verilog
-getVerilogString(new Example3)
+chisel3.docs.emitSystemVerilog(new Example3)
 ```
 
 > Note: Astute observers will realize that `c :<>= p` is semantically equivalent to `c :<= p` followed by `c :>= p`.
@@ -368,7 +368,7 @@ class Example4 extends RawModule {
 This generates the following Verilog, where all members are driven from the literal to `w`, regardless of alignment:
 
 ```scala mdoc:verilog
-getVerilogString(new Example4)
+chisel3.docs.emitSystemVerilog(new Example4)
 ```
 
 > Note: Astute observers will realize that `c :#= p` is semantically equivalent to `c :<= p` followed by `p :>= c` (note `p` and `c` switched places in the second connection).
@@ -389,7 +389,7 @@ class Example4b extends RawModule {
 This generates the following Verilog, where all members are driven from the literal to `w`, regardless of alignment:
 
 ```scala mdoc:verilog
-getVerilogString(new Example4b)
+chisel3.docs.emitSystemVerilog(new Example4b)
 ```
 ## Connectable
 
@@ -432,7 +432,7 @@ class Example9 extends RawModule {
 This generates the following Verilog, where `p.b` is driven from `c.b`:
 
 ```scala mdoc:verilog
-getVerilogString(new Example9)
+chisel3.docs.emitSystemVerilog(new Example9)
 ```
 
 ### Defaults with waived connections
@@ -464,7 +464,7 @@ class Example10 extends RawModule {
 This generates the following Verilog, where `p.b` is driven from `c.b`, and `p.a`, `c.b`, and `c.c` are initialized to default values:
 
 ```scala mdoc:verilog
-getVerilogString(new Example10)
+chisel3.docs.emitSystemVerilog(new Example10)
 ```
 
 ### Connecting types with optional members
@@ -487,7 +487,7 @@ class Example6 extends RawModule {
 This generates the following Verilog, where `ready` and `valid` are connected, and `bits` is ignored:
 
 ```scala mdoc:verilog
-getVerilogString(new Example6)
+chisel3.docs.emitSystemVerilog(new Example6)
 ```
 
 ### Always ignore errors caused by extra members (partial connection operator)
@@ -517,7 +517,7 @@ class Example11 extends RawModule {
 This generates the following Verilog, where nothing is connected:
 
 ```scala mdoc:verilog
-getVerilogString(new Example11)
+chisel3.docs.emitSystemVerilog(new Example11)
 ```
 
 ### Connecting components with different widths
@@ -541,7 +541,7 @@ class Example14 extends RawModule {
 This generates the following Verilog, where `p` is truncated prior to driving `c`:
 
 ```scala mdoc:verilog
-getVerilogString(new Example14)
+chisel3.docs.emitSystemVerilog(new Example14)
 ```
 
 ### Excluding members from any operator on a Connectable
@@ -570,7 +570,7 @@ class Example15 extends RawModule {
 This generates the following Verilog, where the `special` field is not connected:
 
 ```scala mdoc:verilog
-getVerilogString(new Example15)
+chisel3.docs.emitSystemVerilog(new Example15)
 ```
 
 ## Techniques for connecting structurally inequivalent Chisel types
@@ -625,7 +625,7 @@ class Example12 extends RawModule {
 Note that the `bits` fields are unconnected.
 
 ```scala mdoc:verilog
-getVerilogString(new Example12)
+chisel3.docs.emitSystemVerilog(new Example12)
 ```
 
 The second example will use a static cast and `.waive(_.bits)` to connect them as `MyReadyValid`.
@@ -651,7 +651,7 @@ Note that the `bits` fields ARE connected, even though they are waived, as `.wai
 To always omit the connection, use `.exclude` on one side and either `.exclude` or `.waive` on the other side.
 
 ```scala mdoc:verilog
-getVerilogString(new Example13)
+chisel3.docs.emitSystemVerilog(new Example13)
 ```
 
 ### Connecting sub-types to super-types by waiving extra members
@@ -678,7 +678,7 @@ class Example5 extends RawModule {
 This generates the following Verilog, where `ready` and `valid` are connected, and `bits` is ignored:
 
 ```scala mdoc:verilog
-getVerilogString(new Example5)
+chisel3.docs.emitSystemVerilog(new Example5)
 ```
 
 ### Connecting different sub-types
@@ -706,7 +706,7 @@ class Example7 extends RawModule {
 This generates the following Verilog, where `ready` and `valid` are connected, and `bits` and `echo` are ignored:
 
 ```scala mdoc:verilog
-getVerilogString(new Example7)
+chisel3.docs.emitSystemVerilog(new Example7)
 ```
 
 ## FAQ

--- a/docs/src/explanations/connection-operators.md
+++ b/docs/src/explanations/connection-operators.md
@@ -20,14 +20,12 @@ Chisel contains two connection operators, `:=` and `<>`. This document provides 
 // Imports used by the following examples
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 ```
 
 The diagram for the experiment can be viewed [here](https://docs.google.com/document/d/14C918Hdahk2xOGSJJBT-ZVqAx99_hg3JQIq-vaaifQU/edit?usp=sharing).
 ![Experiment Image](https://raw.githubusercontent.com/chipsalliance/chisel3/master/docs/src/images/connection-operators-experiment.svg?sanitize=true)
 
 ```scala mdoc:silent
-
 class Wrapper extends Module{
   val io = IO(new Bundle {
   val in = Flipped(DecoupledIO(UInt(8.W)))
@@ -51,8 +49,8 @@ class PipelineStage extends Module{
 }
 ```
 Below we can see the resulting Verilog for this example:
-```scala mdoc
-ChiselStage.emitSystemVerilog(new Wrapper)
+```scala mdoc:verilog
+chisel3.docs.emitSystemVerilog(new Wrapper)
 ```
 ## Concept 1: `<>` is Commutative
 
@@ -69,7 +67,6 @@ Achieving this involves flipping the RHS and LHS of the `<>` operator and seeing
 ```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 
 class Wrapper extends Module{
   val io = IO(new Bundle {
@@ -94,8 +91,8 @@ class PipelineStage extends Module{
 }
 ```
 Below we can see the resulting Verilog for this example:
-```scala mdoc
-ChiselStage.emitSystemVerilog(new Wrapper)
+```scala mdoc:verilog
+chisel3.docs.emitSystemVerilog(new Wrapper)
 ```
 ### Conclusion:
 The Verilog remained the same without incurring errors, showing that the `<>` operator is commutative.
@@ -111,7 +108,6 @@ We replace all instances of `<>` with `:=` in the sample code above.
 ```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 
 class Wrapper extends Module{
   val io = IO(new Bundle {
@@ -137,7 +133,7 @@ class PipelineStage extends Module{
 ```
 Below we can see the resulting error message for this example:
 ```scala mdoc:crash
-ChiselStage.emitSystemVerilog(new Wrapper)
+circt.stage.ChiselStage.emitSystemVerilog(new Wrapper)
 ```
 ### Conclusion:
 The := operator goes field-by-field on the LHS and attempts to connect it to the same-named signal from the RHS. If something on the LHS is actually an Input, or the corresponding signal on the RHS is an Output, you will get an error as shown above.
@@ -150,7 +146,6 @@ We will find out using the sample codes below:
 ```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 
 class Wrapper extends Module{
   val io = IO(new Bundle {
@@ -179,8 +174,8 @@ class PipelineStage extends Module{
 }
 ```
 Below we can see the resulting Verilog for this example:
-```scala mdoc
-ChiselStage.emitSystemVerilog(new Wrapper)
+```scala mdoc:verilog
+chisel3.docs.emitSystemVerilog(new Wrapper)
 ```
 ### Conclusion:
 If `<>` were used to assign the unidrectioned wire `tmp` to DontCare, we would get an error. But in the example above, we used `:=` and no errors occurred.
@@ -197,7 +192,6 @@ We will find out using the sample codes below:
 ```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 
 class Wrapper extends Module{
   val io = IO(new Bundle {
@@ -226,8 +220,8 @@ class PipelineStage extends Module{
 }
 ```
 Below we can see the resulting Verilog for this example:
-```scala mdoc
-ChiselStage.emitSystemVerilog(new Wrapper)
+```scala mdoc:verilog
+chisel3.docs.emitSystemVerilog(new Wrapper)
 ```
 ### Conclusion:
 Both `<>` and `:=` can be used to assign directioned things (IOs) to DontCare as shown in `io.in` and `p.io.a` respectively. This is basically equivalent because in this case both `<>` and `:=` will determine the direction from the LHS.
@@ -241,7 +235,6 @@ If there is at least one known flow what will `<>` do? This will be shown using 
 ```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 
 class Wrapper extends Module{
   val io = IO(new Bundle {
@@ -272,7 +265,7 @@ class PipelineStage extends Module{
 ```
 Below we can see the resulting Verilog for this example:
 ```scala mdoc
-ChiselStage.emitSystemVerilog(new Wrapper)
+chisel3.docs.emitSystemVerilog(new Wrapper)
 ```
 ### Conclusion:
 The connection above went smoothly with no errors, this goes to show `<>` will work as long as there is at least one directioned thing (IO or submodule's IO) to "fix" the direction.
@@ -285,7 +278,6 @@ This experiment creates a MockDecoupledIO which has the same fields by name as a
 ```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 
 class MockDecoupledIO extends Bundle {
   val valid = Output(Bool())
@@ -315,8 +307,8 @@ class PipelineStage extends Module{
 }
 ```
 Below we can see the resulting Verilog for this example:
-```scala mdoc
-ChiselStage.emitSystemVerilog(new Wrapper)
+```scala mdoc:verilog
+chisel3.docs.emitSystemVerilog(new Wrapper)
 ```
 And here is another experiment, where we remove one of the fields of MockDecoupledIO:
 ( Scastie link for the experiment:https://scastie.scala-lang.org/ChtkhKCpS9CvJkjjqpdeIA)
@@ -324,7 +316,6 @@ And here is another experiment, where we remove one of the fields of MockDecoupl
 ```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util.DecoupledIO
-import circt.stage.ChiselStage
 
 class MockDecoupledIO extends Bundle {
   val valid = Output(Bool())
@@ -355,7 +346,7 @@ class PipelineStage extends Module{
 ```
 Below we can see the resulting error for this example:
 ```scala mdoc:crash
-ChiselStage.emitSystemVerilog(new Wrapper)
+circt.stage.ChiselStage.emitSystemVerilog(new Wrapper)
 ```
 This one fails because there is a field `bits` missing.
 

--- a/docs/src/explanations/dataview.md
+++ b/docs/src/explanations/dataview.md
@@ -90,7 +90,7 @@ class MyModule extends RawModule {
 Of course, this would result in very different looking Verilog:
 
 ```scala mdoc:verilog
-getVerilogString(new MyModule {
+chisel3.docs.emitSystemVerilog(new MyModule {
   override def desiredName = "MyModule"
   axi := DontCare // Just to generate Verilog in this stub
 })
@@ -146,7 +146,7 @@ class AXIStub extends RawModule {
 This will generate Verilog that matches the standard naming convention:
 
 ```scala mdoc:verilog
-getVerilogString(new AXIStub)
+chisel3.docs.emitSystemVerilog(new AXIStub)
 ```
 
 Note that if both the _Target_ and the _View_ types are subtypes of `Data` (as they are in this example),
@@ -174,7 +174,7 @@ class ConnectionExample extends RawModule {
 This results in the corresponding fields being connected in the emitted Verilog:
 
 ```scala mdoc:verilog
-getVerilogString(new ConnectionExample)
+chisel3.docs.emitSystemVerilog(new ConnectionExample)
 ```
 
 ## Other Use Cases
@@ -247,7 +247,7 @@ class TupleExample extends RawModule {
 
 ```scala mdoc:invisible
 // Always emit Verilog to make sure it actually works
-getVerilogString(new TupleExample)
+chisel3.docs.emitSystemVerilog(new TupleExample)
 ```
 
 Note that this example ignored `DataProduct` which is another required piece (see [the documentation
@@ -305,7 +305,7 @@ class PartialDataViewModule extends Module {
 ```
 
 ```scala mdoc:verilog
-getVerilogString(new PartialDataViewModule)
+chisel3.docs.emitSystemVerilog(new PartialDataViewModule)
 ```
 
 While `PartialDataViews` need not be total for the _Target_, both `PartialDataViews` and `DataViews`
@@ -436,7 +436,7 @@ class FooToBar extends Module {
 ```
 
 ```scala mdoc:verilog
-getVerilogString(new FooToBar)
+chisel3.docs.emitSystemVerilog(new FooToBar)
 ```
 
 However, it's possible that some user of `Foo` and `Bar` wants different behavior,
@@ -456,7 +456,7 @@ class FooToBarSwizzled extends Module {
 ```
 
 ```scala mdoc:verilog
-getVerilogString(new FooToBarSwizzled)
+chisel3.docs.emitSystemVerilog(new FooToBarSwizzled)
 ```
 
 ### DataProduct

--- a/docs/src/explanations/interfaces-and-connections.md
+++ b/docs/src/explanations/interfaces-and-connections.md
@@ -18,7 +18,7 @@ As we saw earlier, users can define their own interfaces by defining a class tha
 
 ```scala mdoc:invisible
 import chisel3._
-import circt.stage.ChiselStage
+import chisel3.docs.emitSystemVerilog
 ```
 
 ```scala mdoc:silent
@@ -128,7 +128,7 @@ class Block2 extends Module {
 ```
 Below we can see the resulting error for this example:
 ```scala mdoc:crash
-ChiselStage.emitSystemVerilog(new Block2)
+emitSystemVerilog(new Block2)
 ```
 Bidirectional connections should only be used with **directioned elements** (like IOs), e.g. connecting two wires isn't supported since Chisel can't necessarily figure out the directions automatically.
 For example, putting two temporary wires and connecting them here will not work, even though the directions could be known from the endpoints:
@@ -151,7 +151,7 @@ class BlockWithTemporaryWires extends Module {
 ```
 Below we can see the resulting error for this example:
 ```scala mdoc:crash
-ChiselStage.emitSystemVerilog(new BlockWithTemporaryWires)
+emitSystemVerilog(new BlockWithTemporaryWires)
 ```
 For more details and information, see [Deep Dive into Connection Operators](connection-operators)
 

--- a/docs/src/explanations/layers.md
+++ b/docs/src/explanations/layers.md
@@ -223,6 +223,7 @@ be optimized to remove/add ports or to move logic into a layer block.
 The complete Verilog output for this example is reproduced below:
 
 ```scala mdoc:verilog
+// Use ChiselStage instead of chisel3.docs.emitSystemVerilog because we want layers printed here (obviously)
 import circt.stage.ChiselStage
 ChiselStage.emitSystemVerilog(new Foo, firtoolOpts=Array("-strip-debug-info", "-disable-all-randomization"))
 ```

--- a/docs/src/explanations/naming.md
+++ b/docs/src/explanations/naming.md
@@ -24,11 +24,7 @@ import chisel3.experimental.{prefix, noPrefix}
 ```
 
 ```scala mdoc:invisible
-import circt.stage.ChiselStage
-def emitSystemVerilog(gen: => RawModule): String = {
-  val prettyArgs = Array("--disable-all-randomization", "--strip-debug-info")
-  ChiselStage.emitSystemVerilog(gen, firtoolOpts = prettyArgs)
-}
+import chisel3.docs.emitSystemVerilog
 ```
 
 Chisel users must also include the compiler plugin in their build settings.

--- a/docs/src/explanations/polymorphism-and-parameterization.md
+++ b/docs/src/explanations/polymorphism-and-parameterization.md
@@ -192,7 +192,6 @@ You can also parametrize modules based on other modules rather than just types. 
 ```scala mdoc:silent
 import chisel3.RawModule
 import chisel3.experimental.BaseModule
-import circt.stage.ChiselStage
 
 // Provides a more specific interface since generic Module
 // provides no compile-time information on generic module's IOs.
@@ -227,14 +226,11 @@ class X[T <: BaseModule with MyAdder](genT: => T) extends Module {
     subMod.in1 := io.in1
     subMod.in2 := io.in2
 }
-
-println(ChiselStage.emitSystemVerilog(new X(new Mod1)))
-println(ChiselStage.emitSystemVerilog(new X(new Mod2)))
 ```
 
 Output:
 
 ```scala mdoc:verilog
-ChiselStage.emitSystemVerilog(new X(new Mod1))
-ChiselStage.emitSystemVerilog(new X(new Mod2))
+chisel3.docs.emitSystemVerilog(new X(new Mod1))
+chisel3.docs.emitSystemVerilog(new X(new Mod2))
 ```

--- a/docs/src/explanations/ports.md
+++ b/docs/src/explanations/ports.md
@@ -42,7 +42,6 @@ Here is an example of how to use this API:
 ```scala mdoc
 import chisel3.reflect.DataMirror
 import chisel3.stage.ChiselGeneratorAnnotation
-import circt.stage.ChiselStage
 
 class Adder extends Module {
   val a = IO(Input(UInt(8.W)))
@@ -63,6 +62,10 @@ class Test extends Module {
     println(s"Found port $name: $port")
   }}
 }
-
-ChiselStage.emitSystemVerilog(new Test)
+```
+This will print the following:
+```scala mdoc:passthrough
+println("```")
+chisel3.docs.emitSystemVerilog(new Test): Unit // suppress String output, just want to see stdout
+println("```")
 ```

--- a/docs/src/explanations/warnings.md
+++ b/docs/src/explanations/warnings.md
@@ -68,7 +68,6 @@ def compile(gen: => chisel3.RawModule, args: Array[String] = Array()): Unit = {
 ```
 
 ```scala mdoc
-import circt.stage.ChiselStage.emitSystemVerilog
 import chisel3._
 class TooWideIndexModule extends RawModule {
   val in = IO(Input(Vec(4, UInt(8.W))))


### PR DESCRIPTION
And deploy this utility, replacing most uses of ChiselStage with chisel3.docs.emitSystemVerilog.

h/t @keithdr93 for pointing this out on gitter

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Documentation or website-related


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This cleans up a lot of boilerplate and removes the default layer emission in all of the uses.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
