### PR TITLE
Add -default-layer-specialization=enable to Scala CLI example

### DIFF
--- a/.github/workflows/build-scala-cli-example/chisel-example.scala
+++ b/.github/workflows/build-scala-cli-example/chisel-example.scala
@@ -29,7 +29,7 @@ object Main extends App {
   println(
     ChiselStage.emitSystemVerilog(
       gen = new Foo,
-      firtoolOpts = Array("-disable-all-randomization", "-strip-debug-info")
+      firtoolOpts = Array("-disable-all-randomization", "-strip-debug-info", "-default-layer-specialization=enable")
     )
   )
 }


### PR DESCRIPTION
I would've just pushed to main on this, but I want CI to run first.