### PR TITLE
[simulator] Switch ChiselSim to use new Layer ABI

### DIFF
--- a/src/main/scala/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala/chisel3/simulator/LayerControl.scala
@@ -14,7 +14,7 @@ object LayerControl {
       * @param file the file to check
       */
     final def filter(file: File): Boolean = file.getName match {
-      case nonLayer if !nonLayer.startsWith("layers_") => true
+      case nonLayer if !nonLayer.startsWith("layers-") => true
       case layer                                       => shouldEnable(layer)
     }
 
@@ -40,8 +40,8 @@ object LayerControl {
       layers match {
         case Nil => _ => false
         case _ =>
-          val layersRe = layers.map(_.fullName.split("\\.").mkString("_")).mkString("|")
-          val re = s"^layers_\\w+_($layersRe)\\.sv$$".r
+          val layersRe = layers.map(_.fullName.split("\\.").mkString("-")).mkString("|")
+          val re = s"^layers-\\w+-($layersRe)\\.sv$$".r
           re.matches(_)
       }
     }

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -171,7 +171,7 @@ package object simulator {
       Files
         .walk(supportArtifactsPath)
         .filter(_.toFile.isFile)
-        .filter(_.getFileName.toString.startsWith("layers_"))
+        .filter(_.getFileName.toString.startsWith("layers-"))
         .forEach(moveFile)
 
       // Initialize Module Info

--- a/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
+++ b/src/test/scala/chiselTests/simulator/LayerControlSpec.scala
@@ -13,20 +13,20 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
     it("should always filter to true") {
       val layerControl = LayerControl.EnableAll
       layerControl.filter(new File("foo")) should be(true)
-      layerControl.filter(new File("layers_foo_bar.sv")) should be(true)
+      layerControl.filter(new File("layers-foo-bar.sv")) should be(true)
     }
   }
   describe("LayerControl.Enable()") {
     it("should return true for non-layers and false for layers") {
       val layerControl = LayerControl.Enable()
       layerControl.filter(new File("foo")) should be(true)
-      layerControl.filter(new File("layers_foo_bar.sv")) should be(false)
+      layerControl.filter(new File("layers-foo-bar.sv")) should be(false)
     }
   }
   describe("LayerControl.DisableAll") {
     it("should return true for non-layers and false for layers") {
       LayerControl.DisableAll.filter(new File("foo")) should be(true)
-      LayerControl.DisableAll.filter(new File("layers_foo_bar.sv")) should be(false)
+      LayerControl.DisableAll.filter(new File("layers-foo-bar.sv")) should be(false)
     }
   }
   describe("LayerControl.Enable") {
@@ -37,10 +37,10 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
       }
       val layerControl = LayerControl.Enable(A, B.C)
       layerControl.filter(new File("foo")) should be(true)
-      layerControl.filter(new File("layers_foo.sv")) should be(false)
-      layerControl.filter(new File("layers_foo_A.sv")) should be(true)
-      layerControl.filter(new File("layers_foo_A_B.sv")) should be(false)
-      layerControl.filter(new File("layers_foo_B_C.sv")) should be(true)
+      layerControl.filter(new File("layers-foo.sv")) should be(false)
+      layerControl.filter(new File("layers-foo-A.sv")) should be(true)
+      layerControl.filter(new File("layers-foo-A-B.sv")) should be(false)
+      layerControl.filter(new File("layers-foo-B-C.sv")) should be(true)
     }
   }
 }


### PR DESCRIPTION
The Layer filename ABI changed in FIRRTL [[1]].  This will show up in CIRCT 1.85.0.  This commit gets Chisel working with this new ABI.

[1]: https://github.com/chipsalliance/firrtl-spec/commit/d35f2bb5f460d5c866cb9021ad7d45d8f0430ec1

#### Release Notes

Update Chisel to support new Layer filename ABI. This requires CIRCT 1.85.0+.  CIRCT versions before this will not work.