### PR TITLE
[svsim] Handle Chisel assertions more elegantly

### DIFF
--- a/src/main/scala-2/chisel3/simulator/Simulator.scala
+++ b/src/main/scala-2/chisel3/simulator/Simulator.scala
@@ -37,6 +37,7 @@ final object Simulator {
     workspace:                        Workspace,
     customSimulationWorkingDirectory: Option[String],
     verbose:                          Boolean,
+    stderrStream:                     java.io.OutputStream,
     body:                             (SimulatedModule[T]) => U)
       extends BackendProcessor {
     val results = scala.collection.mutable.Stack[BackendInvocationDigest[U]]()
@@ -67,7 +68,7 @@ final object Simulator {
             )
           val compilationEndTime = System.nanoTime()
           val simulationOutcome = Try {
-            simulation.runElaboratedModule(elaboratedModule = elaboratedModule)(body)
+            simulation.runElaboratedModule(elaboratedModule = elaboratedModule, stderrStream = stderrStream)(body)
           }
           val simulationEndTime = System.nanoTime()
           BackendInvocationDigest(
@@ -99,6 +100,7 @@ trait Simulator {
   def customSimulationWorkingDirectory: Option[String] = None
   def verbose:                          Boolean = false
   def firtoolArgs:                      Seq[String] = Seq()
+  def stderrStream:                     java.io.OutputStream = Console.err
   def commonCompilationSettings: CommonCompilationSettings
 
   private[simulator] def processBackends(
@@ -119,6 +121,7 @@ trait Simulator {
       workspace,
       customSimulationWorkingDirectory,
       verbose,
+      stderrStream,
       { (module: SimulatedModule[T]) =>
         val outcome = body(module)
         module.completeSimulation()

--- a/src/main/scala-2/chisel3/simulator/package.scala
+++ b/src/main/scala-2/chisel3/simulator/package.scala
@@ -93,14 +93,16 @@ package object simulator {
       conservativeCommandResolution: Boolean = false,
       verbose:                       Boolean = false,
       traceEnabled:                  Boolean = false,
-      executionScriptLimit:          Option[Int] = None
+      executionScriptLimit:          Option[Int] = None,
+      stderrStream:                  java.io.OutputStream = Console.err
     )(body:                          SimulatedModule[T] => U
     ): U = {
-      simulation.run(conservativeCommandResolution, verbose, traceEnabled, executionScriptLimit) { controller =>
-        val module = new SimulatedModule(elaboratedModule, controller)
-        AnySimulatedModule.withValue(module) {
-          body(module)
-        }
+      simulation.run(conservativeCommandResolution, verbose, traceEnabled, executionScriptLimit, stderrStream) {
+        controller =>
+          val module = new SimulatedModule(elaboratedModule, controller)
+          AnySimulatedModule.withValue(module) {
+            body(module)
+          }
       }
     }
   }

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -138,6 +138,7 @@ final class Backend(
               Seq(
                 // Use verilator support
                 s"-D${svsim.Backend.HarnessCompilationFlags.enableVerilatorSupport}",
+                "-DVL_USER_FATAL", // Handle $fatal
               ),
 
               backendSpecificSettings.traceStyle match {


### PR DESCRIPTION
This is a bugfix but I'm not sure if it should be backported [yet] because adding new arguments, even with default arguments, to public methods breaks binary compatibility. I don't feel like dealing with that at the moment. If we need to backport it later, we can. We could backport just the bugfix part of it I guess.

The returned exception is now a lot more elegant than `svsim.Simulation.UnexpectedEndOfMessages`. This also fixes an issue where the Verilator crashes could create core dumps depending on the user's ulimit settings.

I have not yet tested this with VCS, so there may be follow up work (possibly in a follow up PR).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

* svsim now overrides Verilators $fatal handling to more elegantly report the error.
* svsim can now accept a java.io.OutputStream to consume the stderr from the simulation process. This is especially useful for testing.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
