### PR TITLE
Improve error messages for empty Mux1H and PriorityMux

### DIFF
--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -60,6 +60,7 @@ private[chisel3] object SeqUtils {
   )(
     implicit sourceInfo: SourceInfo
   ): T = {
+    require(in.nonEmpty, "PriorityMux must have a non-empty argument")
     if (in.size == 1) {
       in.head._2
     } else {
@@ -83,6 +84,7 @@ private[chisel3] object SeqUtils {
   )(
     implicit sourceInfo: SourceInfo
   ): T = {
+    require(in.nonEmpty, "Mux1H must have a non-empty argument")
     if (in.tail.isEmpty) {
       in.head._2
     } else {

--- a/src/test/scala/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala/chiselTests/OneHotMuxSpec.scala
@@ -25,6 +25,12 @@ class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselRunners {
   "UIntToOH should accept width of zero" in {
     assertTesterPasses(new ZeroWidthOHTester)
   }
+  "Mux1H should give a decent error when given an empty Seq" in {
+    val e = intercept[IllegalArgumentException] {
+      Mux1H(Seq.empty[(Bool, UInt)])
+    }
+    e.getMessage should include("Mux1H must have a non-empty argument")
+  }
 
 }
 

--- a/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
+++ b/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
@@ -56,4 +56,11 @@ class PriorityMuxSpec extends ChiselFlatSpec {
       out := PriorityMux(sel, in)
     })
   }
+
+  it should "give a decent error for empty Seqs" in {
+    val e = intercept[IllegalArgumentException] {
+      PriorityMux(0.U, Seq.empty[UInt])
+    }
+    e.getMessage should include("PriorityMux must have a non-empty argument")
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
