### PR TITLE
Flush staged commands before/after enter/exit regions.

### DIFF
--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -97,9 +97,13 @@ abstract class RawModule extends BaseModule {
   }
 
   private[chisel3] def withRegion[A](newRegion: VectorBuilder[Command])(thunk: => A): A = {
+    _currentRegion ++= stagedSecretCommands
+    stagedSecretCommands.clear()
     var oldRegion = _currentRegion
     changeRegion(newRegion)
     val result = thunk
+    _currentRegion ++= stagedSecretCommands
+    stagedSecretCommands.clear()
     changeRegion(oldRegion)
     result
   }
@@ -220,6 +224,7 @@ abstract class RawModule extends BaseModule {
 
     // Secret connections can be staged if user bored into children modules
     component.secretCommands ++= stagedSecretCommands
+    stagedSecretCommands.clear()
     _component = Some(component)
     _component
   }

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -89,8 +89,8 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       "      define w_bore = bar.w_bore"
     )()
 
-    // Check is valid FIRRTL and builds to SV.
-    circt.stage.ChiselStage.emitSystemVerilog(new Top)
+    // Check is valid FIRRTL.
+    circt.stage.ChiselStage.emitFIRRTLDialect(new Top)
   }
 
   it should "work upwards from child to parent" in {
@@ -169,8 +169,8 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       "      connect bar.out_bore, out_bore"
     )()
 
-    // Check is valid FIRRTL and builds to SV.
-    circt.stage.ChiselStage.emitSystemVerilog(new Top)
+    // Check is valid FIRRTL.
+    circt.stage.ChiselStage.emitFIRRTLDialect(new Top)
   }
 
   it should "work upwards from grandchild to grandparent into layer" in {

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -57,6 +57,42 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
     )()
   }
 
+  // This test requires ability to identify what region to add commands to,
+  // *after* building them.  This is not yet supported.
+  ignore should "work downwards from grandparent to grandchild through when" in {
+    class Bar extends RawModule {
+      val internalWire = Wire(Bool())
+    }
+    class Foo extends RawModule {
+      when(true.B) {
+        val bar = Module(new Bar)
+      }
+    }
+    class Top extends RawModule {
+      val foo = Module(new Foo)
+      val out = IO(Bool())
+      out := DontCare
+
+      when(true.B) {
+        val w = WireInit(
+          Bool(),
+          BoringUtils.tapAndRead((chisel3.aop.Select.collectDeep(foo) { case b: Bar => b }).head.internalWire)
+        )
+      }
+    }
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
+
+    // The define should be at the end of the when block.
+    matchesAndOmits(chirrtl)(
+      "    when UInt<1>(0h1) :",
+      "      inst bar of Bar",
+      "      define w_bore = bar.w_bore"
+    )()
+
+    // Check is valid FIRRTL and builds to SV.
+    circt.stage.ChiselStage.emitSystemVerilog(new Top)
+  }
+
   it should "work upwards from child to parent" in {
     class Foo(parentData: Data) extends RawModule {
       val outProbe = IO(probe.Probe(Bool()))
@@ -107,6 +143,63 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
       "module Top :",
       "connect foo.out_bore, parentWire"
     )()
+  }
+
+  it should "work upwards from grandchild to grandparent through when" in {
+    class Bar(grandParentData: Data) extends RawModule {
+      val out = IO(Bool())
+      out := BoringUtils.tapAndRead(grandParentData)
+    }
+    class Foo(parentData: Data) extends RawModule {
+      when(true.B) {
+        val bar = Module(new Bar(parentData))
+      }
+    }
+    class Top extends RawModule {
+      val parentWire = Wire(Bool())
+      parentWire := DontCare
+      val foo = Module(new Foo(parentWire))
+    }
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
+
+    // The connect should be at the end of the when block.
+    matchesAndOmits(chirrtl)(
+      "    when UInt<1>(0h1) :",
+      "      inst bar of Bar",
+      "      connect bar.out_bore, out_bore"
+    )()
+
+    // Check is valid FIRRTL and builds to SV.
+    circt.stage.ChiselStage.emitSystemVerilog(new Top)
+  }
+
+  it should "work upwards from grandchild to grandparent into layer" in {
+    object TestLayer extends layer.Layer(layer.LayerConfig.Extract())
+    class Bar(grandParentData: Data) extends RawModule {
+      val out = IO(Bool())
+      out := BoringUtils.tapAndRead(grandParentData)
+    }
+    class Foo(parentData: Data) extends RawModule {
+      layer.block(TestLayer) {
+        val bar = Module(new Bar(parentData))
+      }
+    }
+    class Top extends RawModule {
+      val parentWire = Wire(Bool())
+      parentWire := DontCare
+      val foo = Module(new Foo(parentWire))
+    }
+    val chirrtl = circt.stage.ChiselStage.emitCHIRRTL(new Top)
+
+    // The connect should be at the end of the layerblock.
+    matchesAndOmits(chirrtl)(
+      "    layerblock TestLayer :",
+      "      inst bar of Bar",
+      "      connect bar.out_bore, out_bore"
+    )()
+
+    // Check is valid FIRRTL and builds to SV.
+    circt.stage.ChiselStage.emitSystemVerilog(new Top)
   }
 
   it should "work from child to its sibling" in {


### PR DESCRIPTION
Fix BoringUtils (see tests) placement of connection commands so that they are added to the current command buffer.

Flush staged commands before changing regions to avoid needing multiple "staging" buffer lists.
Alternatively the current list could be saved and restored.

Tests from #4108 are included and finished, with this change two of them now pass (the ones encountered in practice, FWIW). The third is included but marked "ignore" as future work.

This is a bit of a change regarding "staged" commands, as now before the module is closed they are no longer "secret" since they are added to the normal command buffers.
They are still staged (deferred) which appears to be useful to ensure they appear after what's currently being constructed (specifically, not before).

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix
- Internal or build-related (includes code refactoring/cleanup)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Fix BoringUtils with regions in some cases.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
