### PR TITLE
Add Scala 2.13.15 to compiler plugin cross-build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,7 +231,8 @@ lazy val pluginScalaVersions = Seq(
   "2.13.11",
   "2.13.12",
   "2.13.13",
-  "2.13.14"
+  "2.13.14",
+  "2.13.15"
 )
 
 lazy val plugin = (project in file("plugin"))


### PR DESCRIPTION
Bump to using Scala 2.13.15 (and mill update) is separate as this is intended to be backported but we will not backport the more complete version bump.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Dependency update


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Add support for Scala 2.13.15

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
