### PR TITLE
Deprecate all Injecting Aspect Code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,8 @@ lazy val warningSuppression = Seq(
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
     "cat=deprecation&origin=chisel3\\.ltl.*:s",
     // This is deprecated and planned to be removed
-    "cat=deprecation&origin=chisel3\\.aop.injecting.*:s"
+    "cat=deprecation&origin=chisel3\\.aop\\.injecting.*:s",
+    "cat=deprecation&origin=chisel3\\.stage\\.phases\\.MaybeInjectingPhase:s"
   ).mkString(",")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,9 @@ lazy val warningSuppression = Seq(
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
     "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
-    "cat=deprecation&origin=chisel3\\.ltl.*:s"
+    "cat=deprecation&origin=chisel3\\.ltl.*:s",
+    // This is deprecated and planned to be removed
+    "cat=deprecation&origin=chisel3\\.aop.injecting.*:s"
   ).mkString(",")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,8 @@ lazy val warningSuppression = Seq(
     "cat=deprecation&origin=chisel3\\.ltl.*:s",
     // This is deprecated and planned to be removed
     "cat=deprecation&origin=chisel3\\.aop\\.injecting.*:s",
-    "cat=deprecation&origin=chisel3\\.stage\\.phases\\.MaybeInjectingPhase:s"
+    "cat=deprecation&origin=chisel3\\.stage\\.phases\\.MaybeInjectingPhase:s",
+    "cat=deprecation&origin=chisel3\\.ModuleAspect:s"
   ).mkString(",")
 )
 

--- a/core/src/main/scala/chisel3/ModuleAspect.scala
+++ b/core/src/main/scala/chisel3/ModuleAspect.scala
@@ -11,6 +11,7 @@ import chisel3.internal.{Builder, PseudoModule}
   *
   * @param module Module for which this object is an aspect of
   */
+@deprecated("injecting aspects are being removed in Chisel 7", "6.6.0")
 abstract class ModuleAspect private[chisel3] (module: RawModule) extends RawModule with PseudoModule {
 
   Builder.addAspect(module, this)

--- a/src/main/scala/chisel3/aop/injecting/InjectStatement.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectStatement.scala
@@ -15,6 +15,7 @@ import firrtl.annotations.{Annotation, ModuleTarget, NoTargetAnnotation, SingleT
   * @param modules Additional modules that may be instantiated by s
   * @param annotations Additional annotations that should be passed down compiler
   */
+@deprecated("injecting aspects are being removed in Chisel 7", "6.6.0")
 case class InjectStatement(
   module:      ModuleTarget,
   s:           firrtl.ir.Statement,

--- a/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingAspect.scala
@@ -25,6 +25,7 @@ import scala.collection.mutable.ArrayBuffer
   * @tparam T Type of top-level module
   * @tparam M Type of root module (join point)
   */
+@deprecated("injecting aspects are being removed in Chisel 7", "6.6.0")
 case class InjectingAspect[T <: RawModule, M <: RawModule](
   selectRoots: T => Iterable[M],
   injection:   M => Unit)
@@ -41,6 +42,7 @@ case class InjectingAspect[T <: RawModule, M <: RawModule](
   * @tparam T Type of top-level module
   * @tparam M Type of root module (join point)
   */
+@deprecated("injecting aspects are being removed in Chisel 7", "6.6.0")
 abstract class InjectorAspect[T <: RawModule, M <: RawModule](
   selectRoots: T => Iterable[M],
   injection:   M => Unit)

--- a/src/main/scala/chisel3/aop/injecting/InjectingPhase.scala
+++ b/src/main/scala/chisel3/aop/injecting/InjectingPhase.scala
@@ -13,6 +13,7 @@ import scala.collection.mutable
   *
   * Consumes the [[chisel3.stage.DesignAnnotation]] and converts every [[Aspect]] into their annotations prior to executing FIRRTL
   */
+@deprecated("injecting aspects are being removed in Chisel 7", "6.6.0")
 class InjectingPhase extends Phase {
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val addStmtMap = mutable.HashMap[String, Seq[ir.Statement]]()

--- a/src/main/scala/chisel3/stage/phases/MaybeInjectingPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeInjectingPhase.scala
@@ -8,6 +8,7 @@ import firrtl.options.Phase
 
 /** Run `InjectingPhase` if a `InjectStatement` is present.
   */
+@deprecated("injecting aspects are being removed in Chisel 7", "6.6.0")
 class MaybeInjectingPhase extends Phase {
   override def prerequisites = Seq.empty
   override def optionalPrerequisites = Seq.empty


### PR DESCRIPTION
Deprecate injecting aspect code as of Chisel 6.6.0.  These were planned to be deprecated some time ago (see ROADMAP.md).  However, these had a long user in @sequencer.  He is now off of these and there is nothing blocking their removal.

I will follow this with a commit to remove these from `main` for Chisel 7.

For similar, verification-focused functionality can be selectively added to the circuit, use layers.

#### Release Notes

Deprecate injecting aspects as of Chisel 6.6.0 and plan for removal in Chisel 7.