### PR TITLE
Deprecate more Aspect parts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,13 @@ lazy val warningSuppression = Seq(
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
     "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
-    "cat=deprecation&origin=chisel3\\.ltl.*:s"
+    "cat=deprecation&origin=chisel3\\.ltl.*:s",
+    // This is deprecated and planned to be removed
+    "cat=deprecation&origin=chisel3\\.aop\\.inspecting.*:s",
+    "cat=deprecation&origin=chisel3\\.aop\\.Aspect:s",
+    "cat=deprecation&origin=chisel3\\.aop\\.Aspect$:s",
+    "cat=deprecation&origin=chisel3\\.stage\\.phases.AspectPhase:s",
+    "cat=deprecation&origin=chisel3\\.stage\\.phases.MaybeAspectPhase:s"
   ).mkString(",")
 )
 

--- a/core/src/main/scala/chisel3/aop/Aspect.scala
+++ b/core/src/main/scala/chisel3/aop/Aspect.scala
@@ -11,6 +11,7 @@ import firrtl.AnnotationSeq
   * what behavior should be done to instance, via the FIRRTL Annotation Mechanism
   * @tparam T Type of top-level module
   */
+@deprecated("aspects are being removed in Chisel 7", "6.6.0")
 abstract class Aspect[T <: RawModule] extends Annotation with Unserializable with NoTargetAnnotation {
 
   /** variable to save [[AnnotationSeq]] from [[chisel3.stage.phases.AspectPhase]]
@@ -35,12 +36,14 @@ abstract class Aspect[T <: RawModule] extends Annotation with Unserializable wit
 }
 
 /** Holds utility functions for Aspect stuff */
+@deprecated("aspects are being removed in Chisel 7", "6.6.0")
 object Aspect {
 
   /** Converts elaborated Chisel components to FIRRTL modules
     * @param chiselIR
     * @return
     */
+  @deprecated("aspects are being removed in Chisel 7", "6.6.0")
   def getFirrtl(chiselIR: chisel3.internal.firrtl.ir.Circuit): firrtl.ir.Circuit = {
     chisel3.internal.firrtl.Converter.convert(chiselIR)
   }

--- a/src/main/scala/chisel3/aop/AspectLibrary.scala
+++ b/src/main/scala/chisel3/aop/AspectLibrary.scala
@@ -8,6 +8,7 @@ import firrtl.options.{OptionsException, RegisteredLibrary, ShellOption}
 /** Enables adding aspects to a design from the commandline, e.g.
   *  sbt> runMain chisel3.stage.ChiselMain --module <module> --with-aspect <aspect>
   */
+@deprecated("aspects are being removed in Chisel 7", "6.6.0")
 final class AspectLibrary() extends RegisteredLibrary {
   val name = "AspectLibrary"
 

--- a/src/main/scala/chisel3/aop/inspecting/InspectingAspect.scala
+++ b/src/main/scala/chisel3/aop/inspecting/InspectingAspect.scala
@@ -11,6 +11,7 @@ import firrtl.AnnotationSeq
   * @param inspect Given top-level design, print things and return nothing
   * @tparam T Type of top-level module
   */
+@deprecated("aspects are being removed in Chisel 7", "6.6.0")
 case class InspectingAspect[T <: RawModule](inspect: T => Unit) extends InspectorAspect[T](inspect)
 
 /** Extend to make custom inspections of an elaborated design and printing out results
@@ -18,6 +19,7 @@ case class InspectingAspect[T <: RawModule](inspect: T => Unit) extends Inspecto
   * @param inspect Given top-level design, print things and return nothing
   * @tparam T Type of top-level module
   */
+@deprecated("aspects are being removed in Chisel 7", "6.6.0")
 abstract class InspectorAspect[T <: RawModule](inspect: T => Unit) extends Aspect[T] {
   override def toAnnotation(top: T): AnnotationSeq = {
     inspect(top)

--- a/src/main/scala/chisel3/stage/phases/AspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/AspectPhase.scala
@@ -14,6 +14,7 @@ import scala.collection.mutable
   *
   * Consumes the [[chisel3.stage.DesignAnnotation]] and converts every `Aspect` into their annotations prior to executing FIRRTL
   */
+@deprecated("aspects are being removed in Chisel 7", "6.6.0")
 class AspectPhase extends Phase {
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     var dut: Option[RawModule] = None

--- a/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
+++ b/src/main/scala/chisel3/stage/phases/MaybeAspectPhase.scala
@@ -8,6 +8,7 @@ import firrtl.options.{Dependency, Phase}
 
 /** Run [[AspectPhase]] if a [[chisel3.aop.Aspect]] is present.
   */
+@deprecated("aspects are being removed in Chisel 7", "6.6.0")
 class MaybeAspectPhase extends Phase {
 
   override def prerequisites = Seq(Dependency[Elaborate])


### PR DESCRIPTION
Deprecate the remaining parts of Aspects that were missed in earlier commits.  After this, the only non-deprecated part of the `aop` library are the `Select` utilities.

#### Release Notes

Deprecate everything in `aop` package except `Select` library.