### PR TITLE
[Scala3] Add core -Xsource:3 for Scala3 cross compilation support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,7 +316,8 @@ lazy val core = (project in file("core"))
       "-Xcheckinit",
       "-Xlint:infer-any",
       "-Xsource:3",
-      "-Xsource-features:case-apply-copy-access"
+      "-Xsource-features:case-apply-copy-access",
+      "-Xsource-features:infer-override",
 //      , "-Xlint:missing-interpolator"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -314,7 +314,9 @@ lazy val core = (project in file("core"))
       "-language:reflectiveCalls",
       "-unchecked",
       "-Xcheckinit",
-      "-Xlint:infer-any"
+      "-Xlint:infer-any",
+      "-Xsource:3",
+      "-Xsource-features:case-apply-copy-access"
 //      , "-Xlint:missing-interpolator"
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -316,8 +316,6 @@ lazy val core = (project in file("core"))
       "-Xcheckinit",
       "-Xlint:infer-any",
       "-Xsource:3",
-      "-Xsource-features:case-apply-copy-access",
-      "-Xsource-features:infer-override",
 //      , "-Xlint:missing-interpolator"
     )
   )

--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -76,7 +76,7 @@ object doNotDedup {
     * @return Unmodified signal `module`
     */
   def apply[T <: RawModule](module: T): Unit = {
-    annotate(new ChiselAnnotation { def toFirrtl = NoDedupAnnotation(module.toNamed) })
+    annotate(new ChiselAnnotation { def toFirrtl: NoDedupAnnotation = NoDedupAnnotation(module.toNamed) })
   }
 }
 
@@ -89,6 +89,6 @@ object dedupGroup {
     * @return Unmodified signal `module`
     */
   def apply[T <: BaseModule](module: T, group: String): Unit = {
-    annotate(new ChiselAnnotation { def toFirrtl = DedupGroupAnnotation(module.toTarget, group) })
+    annotate(new ChiselAnnotation { def toFirrtl: DedupGroupAnnotation = DedupGroupAnnotation(module.toTarget, group) })
   }
 }

--- a/core/src/main/scala/chisel3/BitsImpl.scala
+++ b/core/src/main/scala/chisel3/BitsImpl.scala
@@ -531,7 +531,7 @@ private[chisel3] trait ResetTypeImpl extends Element { self: Reset =>
 
   def cloneType: this.type = Reset().asInstanceOf[this.type]
 
-  override def litOption: None.type = None
+  override def litOption = None
 
   /** Not really supported */
   def toPrintable: Printable = PString("Reset")
@@ -560,7 +560,7 @@ private[chisel3] trait AsyncResetImpl extends Element { self: AsyncReset =>
 
   def cloneType: this.type = AsyncReset().asInstanceOf[this.type]
 
-  override def litOption: None.type = None
+  override def litOption = None
 
   /** Not really supported */
   def toPrintable: Printable = PString("AsyncReset")

--- a/core/src/main/scala/chisel3/BitsImpl.scala
+++ b/core/src/main/scala/chisel3/BitsImpl.scala
@@ -531,7 +531,7 @@ private[chisel3] trait ResetTypeImpl extends Element { self: Reset =>
 
   def cloneType: this.type = Reset().asInstanceOf[this.type]
 
-  override def litOption = None
+  override def litOption: None.type = None
 
   /** Not really supported */
   def toPrintable: Printable = PString("Reset")
@@ -560,7 +560,7 @@ private[chisel3] trait AsyncResetImpl extends Element { self: AsyncReset =>
 
   def cloneType: this.type = AsyncReset().asInstanceOf[this.type]
 
-  override def litOption = None
+  override def litOption: None.type = None
 
   /** Not really supported */
   def toPrintable: Printable = PString("AsyncReset")

--- a/core/src/main/scala/chisel3/BitsImpl.scala
+++ b/core/src/main/scala/chisel3/BitsImpl.scala
@@ -531,7 +531,7 @@ private[chisel3] trait ResetTypeImpl extends Element { self: Reset =>
 
   def cloneType: this.type = Reset().asInstanceOf[this.type]
 
-  override def litOption = None
+  override def litOption: Option[BigInt] = None
 
   /** Not really supported */
   def toPrintable: Printable = PString("Reset")
@@ -560,7 +560,7 @@ private[chisel3] trait AsyncResetImpl extends Element { self: AsyncReset =>
 
   def cloneType: this.type = AsyncReset().asInstanceOf[this.type]
 
-  override def litOption = None
+  override def litOption: Option[BigInt] = None
 
   /** Not really supported */
   def toPrintable: Printable = PString("AsyncReset")

--- a/core/src/main/scala/chisel3/DataImpl.scala
+++ b/core/src/main/scala/chisel3/DataImpl.scala
@@ -119,6 +119,7 @@ object ActualDirection {
       extends ActualDirection(_value) {
     @deprecated("Use companion object factory apply method", "Chisel 6.5")
     def this(dir: BidirectionalDirection) = this(dir, dir.value)
+    def copy(dir: BidirectionalDirection = this.dir, _value: Byte = this._value) = new Bidirectional(dir, _value)
   }
   object Bidirectional {
     val Default = new Bidirectional(ActualDirection.Default, ActualDirection.Default.value)
@@ -129,6 +130,7 @@ object ActualDirection {
     }
     @deprecated("Match on Bidirectional.Default and Bidirectional.Flipped directly instead", "Chisel 6.5")
     def unapply(dir: Bidirectional): Option[BidirectionalDirection] = Some(dir.dir)
+    def apply(dir:   BidirectionalDirection, _value: Byte) = new Bidirectional(dir, _value)
   }
 
   private[chisel3] def fromByte(b: Byte): ActualDirection = b match {

--- a/core/src/main/scala/chisel3/DataImpl.scala
+++ b/core/src/main/scala/chisel3/DataImpl.scala
@@ -118,8 +118,9 @@ object ActualDirection {
   case class Bidirectional private[chisel3] (dir: BidirectionalDirection, _value: Byte)
       extends ActualDirection(_value) {
     @deprecated("Use companion object factory apply method", "Chisel 6.5")
-    def this(dir: BidirectionalDirection) = this(dir, dir.value)
-    def copy(dir: BidirectionalDirection = this.dir, _value: Byte = this._value) = new Bidirectional(dir, _value)
+    def this(dir:                  BidirectionalDirection) = this(dir, dir.value)
+    private[chisel3] def copy(dir: BidirectionalDirection = this.dir, _value: Byte = this._value) =
+      new Bidirectional(dir, _value)
   }
   object Bidirectional {
     val Default = new Bidirectional(ActualDirection.Default, ActualDirection.Default.value)
@@ -129,8 +130,8 @@ object ActualDirection {
       case ActualDirection.Flipped => Flipped
     }
     @deprecated("Match on Bidirectional.Default and Bidirectional.Flipped directly instead", "Chisel 6.5")
-    def unapply(dir: Bidirectional): Option[BidirectionalDirection] = Some(dir.dir)
-    def apply(dir:   BidirectionalDirection, _value: Byte) = new Bidirectional(dir, _value)
+    def unapply(dir:                Bidirectional): Option[BidirectionalDirection] = Some(dir.dir)
+    private[chisel3] def apply(dir: BidirectionalDirection, _value: Byte) = new Bidirectional(dir, _value)
   }
 
   private[chisel3] def fromByte(b: Byte): ActualDirection = b match {

--- a/core/src/main/scala/chisel3/IO.scala
+++ b/core/src/main/scala/chisel3/IO.scala
@@ -26,7 +26,7 @@ object IO {
     if (!module.isIOCreationAllowed)
       Builder.error(
         s"This module cannot have IOs instantiated after disallowing IOs: ${module._whereIOCreationIsDisallowed
-          .map(_.makeMessage { s: String => s })
+          .map(_.makeMessage { (s: String) => s })
           .mkString(",")}"
       )
     require(!module.isClosed, "Can't add more ports after module close")

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -350,7 +350,7 @@ package internal {
       * FIRRTL yet its elements *do*) so have some very specialized behavior.
       */
     private[chisel3] class ClonePorts(elts: (String, Data)*) extends Record {
-      val elements = ListMap(elts.map { case (name, d) => name -> d.cloneTypeFull }: _*)
+      val elements: ListMap[String, Data] = ListMap(elts.map { case (name, d) => name -> d.cloneTypeFull }: _*)
       def apply(field: String) = elements(field)
       override def cloneType = (new ClonePorts(elts: _*)).asInstanceOf[this.type]
     }

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -258,10 +258,10 @@ abstract class RawModule extends BaseModule {
 
 /** Enforce that the Module.reset be Asynchronous (AsyncReset) */
 trait RequireAsyncReset extends Module {
-  override final def resetType: chisel3.Module.ResetType.Asynchronous.type = Module.ResetType.Asynchronous
+  override final def resetType: Module.ResetType.Type = Module.ResetType.Asynchronous
 }
 
 /** Enforce that the Module.reset be Synchronous (Bool) */
 trait RequireSyncReset extends Module {
-  override final def resetType: chisel3.Module.ResetType.Synchronous.type = Module.ResetType.Synchronous
+  override final def resetType: Module.ResetType.Type = Module.ResetType.Synchronous
 }

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -11,6 +11,7 @@ import chisel3.properties.{DynamicObject, Property, StaticObject}
 import chisel3.internal.Builder._
 import chisel3.internal.firrtl.ir._
 import chisel3.reflect.DataMirror
+import chisel3.Module.ResetType._
 import _root_.firrtl.annotations.{IsModule, ModuleTarget}
 import scala.collection.immutable.VectorBuilder
 import scala.collection.mutable.ArrayBuffer

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -258,10 +258,10 @@ abstract class RawModule extends BaseModule {
 
 /** Enforce that the Module.reset be Asynchronous (AsyncReset) */
 trait RequireAsyncReset extends Module {
-  override final def resetType: Module.ResetType.Type = Module.ResetType.Asynchronous
+  override final def resetType: Module.ResetType.Asynchronous.type = Module.ResetType.Asynchronous
 }
 
 /** Enforce that the Module.reset be Synchronous (Bool) */
 trait RequireSyncReset extends Module {
-  override final def resetType: Module.ResetType.Type = Module.ResetType.Synchronous
+  override final def resetType: Module.ResetType.Synchronous.type = Module.ResetType.Synchronous
 }

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -257,10 +257,10 @@ abstract class RawModule extends BaseModule {
 
 /** Enforce that the Module.reset be Asynchronous (AsyncReset) */
 trait RequireAsyncReset extends Module {
-  override final def resetType = Module.ResetType.Asynchronous
+  override final def resetType: chisel3.Module.ResetType.Asynchronous.type = Module.ResetType.Asynchronous
 }
 
 /** Enforce that the Module.reset be Synchronous (Bool) */
 trait RequireSyncReset extends Module {
-  override final def resetType = Module.ResetType.Synchronous
+  override final def resetType: chisel3.Module.ResetType.Synchronous.type = Module.ResetType.Synchronous
 }

--- a/core/src/main/scala/chisel3/Width.scala
+++ b/core/src/main/scala/chisel3/Width.scala
@@ -54,7 +54,7 @@ sealed case class KnownWidth private (value: Int) extends Width {
     case _             => that
   }
   override def toString: String = s"<${value.toString}>"
-  def copy(value: Int = this.value) = new KnownWidth(value)
+  private[chisel3] def copy(value: Int = this.value) = new KnownWidth(value)
 }
 object KnownWidth {
   private val maxCached = 1024

--- a/core/src/main/scala/chisel3/Width.scala
+++ b/core/src/main/scala/chisel3/Width.scala
@@ -54,6 +54,7 @@ sealed case class KnownWidth private (value: Int) extends Width {
     case _             => that
   }
   override def toString: String = s"<${value.toString}>"
+  def copy(value: Int = this.value) = new KnownWidth(value)
 }
 object KnownWidth {
   private val maxCached = 1024

--- a/core/src/main/scala/chisel3/connectable/Alignment.scala
+++ b/core/src/main/scala/chisel3/connectable/Alignment.scala
@@ -44,7 +44,7 @@ private[chisel3] sealed trait Alignment {
 
 // The alignment datastructure for a missing field
 private[chisel3] case class EmptyAlignment(isConsumer: Boolean) extends Alignment {
-  def member: DontCare.type = DontCare
+  def member = DontCare
   def invert: EmptyAlignment = this
   def coerced = false
   def coerce: EmptyAlignment = this

--- a/core/src/main/scala/chisel3/connectable/Alignment.scala
+++ b/core/src/main/scala/chisel3/connectable/Alignment.scala
@@ -44,7 +44,7 @@ private[chisel3] sealed trait Alignment {
 
 // The alignment datastructure for a missing field
 private[chisel3] case class EmptyAlignment(isConsumer: Boolean) extends Alignment {
-  def member = DontCare
+  def member: Data = DontCare
   def invert: EmptyAlignment = this
   def coerced = false
   def coerce: EmptyAlignment = this

--- a/core/src/main/scala/chisel3/connectable/Alignment.scala
+++ b/core/src/main/scala/chisel3/connectable/Alignment.scala
@@ -44,10 +44,10 @@ private[chisel3] sealed trait Alignment {
 
 // The alignment datastructure for a missing field
 private[chisel3] case class EmptyAlignment(isConsumer: Boolean) extends Alignment {
-  def member = DontCare
-  def invert = this
+  def member: DontCare.type = DontCare
+  def invert: EmptyAlignment = this
   def coerced = false
-  def coerce = this
+  def coerce: EmptyAlignment = this
   def swap(d: Data): Alignment = this
   def alignment: String = "none"
 }
@@ -60,7 +60,7 @@ private[chisel3] case class AlignedWithRoot(
   isConsumer: Boolean)
     extends NonEmptyAlignment {
   def invert = if (coerced) this else FlippedWithRoot(member, coerced, isConsumer)
-  def coerce = this.copy(member, true)
+  def coerce: AlignedWithRoot = this.copy(member, true)
   def swap(d: Data): Alignment = this.copy(member = d)
   def alignment: String = "aligned"
 }
@@ -71,7 +71,7 @@ private[chisel3] case class FlippedWithRoot(
   isConsumer: Boolean)
     extends NonEmptyAlignment {
   def invert = if (coerced) this else AlignedWithRoot(member, coerced, isConsumer)
-  def coerce = this.copy(member, true)
+  def coerce: FlippedWithRoot = this.copy(member, true)
   def swap(d: Data): Alignment = this.copy(member = d)
   def alignment: String = "flipped"
 }

--- a/core/src/main/scala/chisel3/dontTouch.scala
+++ b/core/src/main/scala/chisel3/dontTouch.scala
@@ -40,7 +40,7 @@ object dontTouch {
       case _:   Property[_] => ()
       case agg: Aggregate => agg.getElements.foreach(dontTouch.apply)
       case _:   Element =>
-        annotate(new ChiselAnnotation { def toFirrtl = DontTouchAnnotation(data.toNamed) })
+        annotate(new ChiselAnnotation { def toFirrtl: DontTouchAnnotation = DontTouchAnnotation(data.toNamed) })
       case _ => throw new ChiselException("Non-hardware dontTouch")
     }
     data

--- a/core/src/main/scala/chisel3/experimental/HasTypeAlias.scala
+++ b/core/src/main/scala/chisel3/experimental/HasTypeAlias.scala
@@ -10,7 +10,11 @@ import chisel3.Record
   *        alias name. Takes the default value of `"_stripped"`
   */
 case class RecordAlias private[chisel3] (info: SourceInfo, id: String, strippedSuffix: String = "_stripped") {
-  def copy(info: SourceInfo = this.info, id: String = this.id, strippedSuffix: String = this.strippedSuffix) =
+  private[chisel3] def copy(
+    info:           SourceInfo = this.info,
+    id:             String = this.id,
+    strippedSuffix: String = this.strippedSuffix
+  ) =
     new RecordAlias(info, id, strippedSuffix)
 }
 

--- a/core/src/main/scala/chisel3/experimental/HasTypeAlias.scala
+++ b/core/src/main/scala/chisel3/experimental/HasTypeAlias.scala
@@ -9,12 +9,17 @@ import chisel3.Record
   * @param strippedSuffix In the case of forced coersion by [[Input]] or [[Output]], the string to append to the end of the
   *        alias name. Takes the default value of `"_stripped"`
   */
-case class RecordAlias private[chisel3] (info: SourceInfo, id: String, strippedSuffix: String = "_stripped")
+case class RecordAlias private[chisel3] (info: SourceInfo, id: String, strippedSuffix: String = "_stripped") {
+  def copy(info: SourceInfo = this.info, id: String = this.id, strippedSuffix: String = this.strippedSuffix) =
+    new RecordAlias(info, id, strippedSuffix)
+}
 
 object RecordAlias {
-  def apply(id: String)(implicit info:  SourceInfo): RecordAlias = RecordAlias(info, id)
+  def apply(id: String)(implicit info:  SourceInfo): RecordAlias = new RecordAlias(info, id)
   def apply(id: String, strippedSuffix: String)(implicit info: SourceInfo): RecordAlias =
     RecordAlias(info, id, strippedSuffix)
+  def apply(info: SourceInfo, id: String, strippedSuffix: String): RecordAlias =
+    new RecordAlias(info, id, strippedSuffix)
 }
 
 trait HasTypeAlias {

--- a/core/src/main/scala/chisel3/experimental/Trace.scala
+++ b/core/src/main/scala/chisel3/experimental/Trace.scala
@@ -4,6 +4,7 @@ import chisel3.internal.HasId
 import chisel3.{Aggregate, Data, Element, RawModule}
 import firrtl.AnnotationSeq
 import firrtl.annotations.{Annotation, CompleteTarget, SingleTargetAnnotation}
+import firrtl.annoSeqToSeq
 
 /** The util that records the reference map from original [[Data]]/[[Module]] annotated in Chisel and final FIRRTL.
   * @example

--- a/core/src/main/scala/chisel3/experimental/VerificationIntrinsics.scala
+++ b/core/src/main/scala/chisel3/experimental/VerificationIntrinsics.scala
@@ -2,7 +2,7 @@ package chisel3.util.circt
 
 import chisel3._
 import chisel3.internal._
-import chisel3.experimental.{BaseModule, SourceInfo}
+import chisel3.experimental.{fromStringToStringParam, BaseModule, SourceInfo}
 
 /** Create an `ifelsefatal` style assertion.
   */

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -65,7 +65,7 @@ final case class Definition[+A] private[chisel3] (private[chisel3] val underlyin
 
   override def toDefinition: Definition[A] = this
   override def toInstance:   Instance[A] = new Instance(underlying)
-  def copy[T](underlying: Underlying[T] = this.underlying) = new Definition(underlying)
+  private[chisel3] def copy[T](underlying: Underlying[T] = this.underlying) = new Definition(underlying)
 }
 
 /** Factory methods for constructing [[Definition]]s */
@@ -138,7 +138,7 @@ object Definition extends SourceInfoDoc {
     module.toDefinition
   }
 
-  def apply[T](underlying: Underlying[T]) = new Definition(underlying)
+  private[chisel3] def apply[T](underlying: Underlying[T]) = new Definition(underlying)
 }
 
 /** Stores a [[Definition]] that is imported so that its Instances can be

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -65,7 +65,7 @@ final case class Definition[+A] private[chisel3] (private[chisel3] val underlyin
 
   override def toDefinition: Definition[A] = this
   override def toInstance:   Instance[A] = new Instance(underlying)
-
+  def copy[T](underlying: Underlying[T] = this.underlying) = new Definition(underlying)
 }
 
 /** Factory methods for constructing [[Definition]]s */
@@ -138,6 +138,7 @@ object Definition extends SourceInfoDoc {
     module.toDefinition
   }
 
+  def apply[T](underlying: Underlying[T]) = new Definition(underlying)
 }
 
 /** Stores a [[Definition]] that is imported so that its Instances can be

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -12,6 +12,8 @@ import chisel3.internal.sourceinfo.{DefinitionTransform, DefinitionWrapTransform
 import chisel3.experimental.{BaseModule, SourceInfo}
 import firrtl.annotations.{IsModule, ModuleTarget, NoTargetAnnotation}
 
+import firrtl.seqToAnnoSeq
+
 import scala.annotation.nowarn
 
 /** User-facing Definition type.

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -71,7 +71,7 @@ final case class Instance[+A] private[chisel3] (private[chisel3] val underlying:
   /** Returns the definition of this Instance */
   override def toDefinition: Definition[A] = new Definition(Proto(proto))
   override def toInstance:   Instance[A] = this
-  def copy[T](underlying: Underlying[T]) = new Instance(underlying)
+  private[chisel3] def copy[T](underlying: Underlying[T]) = new Instance(underlying)
 
 }
 
@@ -185,5 +185,5 @@ object Instance extends SourceInfoDoc {
 
     new Instance(Clone(clone))
   }
-  def apply[T](underlying: Underlying[T]) = new Instance(underlying)
+  private[chisel3] def apply[T](underlying: Underlying[T]) = new Instance(underlying)
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -71,6 +71,7 @@ final case class Instance[+A] private[chisel3] (private[chisel3] val underlying:
   /** Returns the definition of this Instance */
   override def toDefinition: Definition[A] = new Definition(Proto(proto))
   override def toInstance:   Instance[A] = this
+  def copy[T](underlying: Underlying[T]) = new Instance(underlying)
 
 }
 
@@ -184,5 +185,5 @@ object Instance extends SourceInfoDoc {
 
     new Instance(Clone(clone))
   }
-
+  def apply[T](underlying: Underlying[T]) = new Instance(underlying)
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -485,7 +485,7 @@ object Lookupable {
       val ret = that(definition.proto)
       val underlying = new InstantiableClone[B] {
         val getProto = ret
-        lazy val _innerContext: chisel3.experimental.hierarchy.core.Definition[A] = definition
+        lazy val _innerContext = definition
       }
       new Instance(Clone(underlying))
     }
@@ -493,7 +493,7 @@ object Lookupable {
       val ret = that(instance.proto)
       val underlying = new InstantiableClone[B] {
         val getProto = ret
-        lazy val _innerContext: chisel3.experimental.hierarchy.core.Instance[A] = instance
+        lazy val _innerContext = instance
       }
       new Instance(Clone(underlying))
     }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -413,12 +413,12 @@ object Lookupable {
     type C = F[lookupable.C]
     def definitionLookup[A](that: A => F[B], definition: Definition[A]): C = {
       val ret = that(definition.proto).asInstanceOf[Iterable[B]]
-      ret.map { x: B => lookupable.definitionLookup[A](_ => x, definition) }.asInstanceOf[C]
+      ret.map { (x: B) => lookupable.definitionLookup[A](_ => x, definition) }.asInstanceOf[C]
     }
     def instanceLookup[A](that: A => F[B], instance: Instance[A]): C = {
       import instance._
       val ret = that(proto).asInstanceOf[Iterable[B]]
-      ret.map { x: B => lookupable.instanceLookup[A](_ => x, instance) }.asInstanceOf[C]
+      ret.map { (x: B) => lookupable.instanceLookup[A](_ => x, instance) }.asInstanceOf[C]
     }
   }
   implicit def lookupOption[B](
@@ -428,12 +428,12 @@ object Lookupable {
     type C = Option[lookupable.C]
     def definitionLookup[A](that: A => Option[B], definition: Definition[A]): C = {
       val ret = that(definition.proto)
-      ret.map { x: B => lookupable.definitionLookup[A](_ => x, definition) }
+      ret.map { (x: B) => lookupable.definitionLookup[A](_ => x, definition) }
     }
     def instanceLookup[A](that: A => Option[B], instance: Instance[A]): C = {
       import instance._
       val ret = that(proto)
-      ret.map { x: B => lookupable.instanceLookup[A](_ => x, instance) }
+      ret.map { (x: B) => lookupable.instanceLookup[A](_ => x, instance) }
     }
   }
   implicit def lookupEither[L, R](
@@ -444,14 +444,14 @@ object Lookupable {
     type C = Either[lookupableL.C, lookupableR.C]
     def definitionLookup[A](that: A => Either[L, R], definition: Definition[A]): C = {
       val ret = that(definition.proto)
-      ret.map { x: R => lookupableR.definitionLookup[A](_ => x, definition) }.left.map { x: L =>
+      ret.map { (x: R) => lookupableR.definitionLookup[A](_ => x, definition) }.left.map { (x: L) =>
         lookupableL.definitionLookup[A](_ => x, definition)
       }
     }
     def instanceLookup[A](that: A => Either[L, R], instance: Instance[A]): C = {
       import instance._
       val ret = that(proto)
-      ret.map { x: R => lookupableR.instanceLookup[A](_ => x, instance) }.left.map { x: L =>
+      ret.map { (x: R) => lookupableR.instanceLookup[A](_ => x, instance) }.left.map { (x: L) =>
         lookupableL.instanceLookup[A](_ => x, instance)
       }
     }
@@ -485,7 +485,7 @@ object Lookupable {
       val ret = that(definition.proto)
       val underlying = new InstantiableClone[B] {
         val getProto = ret
-        lazy val _innerContext = definition
+        lazy val _innerContext: chisel3.experimental.hierarchy.core.Definition[A] = definition
       }
       new Instance(Clone(underlying))
     }
@@ -493,7 +493,7 @@ object Lookupable {
       val ret = that(instance.proto)
       val underlying = new InstantiableClone[B] {
         val getProto = ret
-        lazy val _innerContext = instance
+        lazy val _innerContext: chisel3.experimental.hierarchy.core.Instance[A] = instance
       }
       new Instance(Clone(underlying))
     }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -485,7 +485,7 @@ object Lookupable {
       val ret = that(definition.proto)
       val underlying = new InstantiableClone[B] {
         val getProto = ret
-        lazy val _innerContext = definition
+        lazy val _innerContext: Hierarchy[_] = definition
       }
       new Instance(Clone(underlying))
     }
@@ -493,7 +493,7 @@ object Lookupable {
       val ret = that(instance.proto)
       val underlying = new InstantiableClone[B] {
         val getProto = ret
-        lazy val _innerContext = instance
+        lazy val _innerContext: Hierarchy[_] = instance
       }
       new Instance(Clone(underlying))
     }

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -226,7 +226,7 @@ private[chisel3] object binding {
 
   /** Binding for Data's returned from accessing an Instance/Definition members, if not readable/writable port */
   case object CrossModuleBinding extends TopBinding {
-    def location: None.type = None
+    def location: Option[BaseModule] = None
   }
 
   sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -226,7 +226,7 @@ private[chisel3] object binding {
 
   /** Binding for Data's returned from accessing an Instance/Definition members, if not readable/writable port */
   case object CrossModuleBinding extends TopBinding {
-    def location = None
+    def location: None.type = None
   }
 
   sealed trait LitBinding extends UnconstrainedBinding with ReadOnlyBinding

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -14,7 +14,7 @@ import chisel3.internal.firrtl.Converter
 import chisel3.internal.naming._
 import _root_.firrtl.annotations.{Annotation, CircuitName, ComponentName, IsMember, ModuleName, Named, ReferenceTarget}
 import _root_.firrtl.annotations.AnnotationUtils.validComponentName
-import _root_.firrtl.AnnotationSeq
+import _root_.firrtl.{annoSeqToSeq, AnnotationSeq}
 import _root_.firrtl.renamemap.MutableRenameMap
 import _root_.firrtl.util.BackendCompilationUtilities._
 import _root_.firrtl.{ir => fir}

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -127,6 +127,7 @@ case class ClassType private[chisel3] (name: String) { self =>
         override def convertUnderlying(value: Property[ClassType] with self.Type) = value.ref
       }
   }
+  def copy(name: String = this.name) = new ClassType(name)
 }
 
 object ClassType {

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -348,7 +348,7 @@ private[chisel3] sealed trait ClassTypeProvider[A] {
 
 private[chisel3] object ClassTypeProvider {
   def apply[A](className: String) = new ClassTypeProvider[A] {
-    val classType = fir.ClassPropertyType(className)
+    val classType: fir.ClassPropertyType = fir.ClassPropertyType(className)
   }
   def apply[A](_classType: fir.PropertyType) = new ClassTypeProvider[A] {
     val classType = _classType
@@ -481,7 +481,7 @@ object Property {
 
   private[chisel3] def makeWithValueOpt[T](implicit _tpe: PropertyType[T]): Property[_tpe.Type] = {
     new Property[_tpe.Type] {
-      val tpe = _tpe
+      val tpe: chisel3.properties.PropertyType[T] = _tpe
     }
   }
 

--- a/core/src/main/scala/chisel3/reflect/DataMirror.scala
+++ b/core/src/main/scala/chisel3/reflect/DataMirror.scala
@@ -177,7 +177,7 @@ object DataMirror {
     // This prevents users from using the _lookup API
     implicit val mg = new chisel3.internal.MacroGenerated {}
 
-    inst._lookup { proto: T => modulePorts(proto) }
+    inst._lookup { (proto: T) => modulePorts(proto) }
   }
 
   /** Returns a recursive representation of a module's ports with underscore-qualified names
@@ -237,7 +237,7 @@ object DataMirror {
     // This prevents users from using the _lookup API
     implicit val mg = new chisel3.internal.MacroGenerated {}
 
-    inst._lookup { proto: T => fullModulePorts(proto) }
+    inst._lookup { (proto: T) => fullModulePorts(proto) }
   }
 
   /** Returns the parent module within which a module instance is instantiated


### PR DESCRIPTION
Part of the larger work of preparing for Scala3 support

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Adds -Xsource:3 to core in preparation of Scala3 migration. Add stricter type ascriptions for Scala3:
* ResetType.litOption return type changed from `None` to `Option[BigInt]`
* AsyncReset.litOption return type changed from `None` to `Option[BigInt]`
* RequireAsyncReset.resetType type changed from `ResetType.Type` to `Asynchronous.type`
* RequireAsyncReset.resetType type changed from `ResetType.Type` to `Synchronous.type`
* CrossModuleBinding.location return type changed from `None.type` to `Option[BaseModule]`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
