### PR TITLE
Layers: color check all not any and don't consider enabled layers.

### DIFF
--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -180,8 +180,7 @@ package object internal {
         color
       case _ => return
     }
-    val enabledLayers = Builder.enabledLayers.view ++ Builder.layerStack.headOption
-    if (enabledLayers.exists(_.canWriteTo(destLayer))) {
+    if (Builder.layerStack.headOption.forall(_.canWriteTo(destLayer))) {
       return
     }
     Builder.error(errorMessage)

--- a/core/src/main/scala/chisel3/probe/PackageImpl.scala
+++ b/core/src/main/scala/chisel3/probe/PackageImpl.scala
@@ -52,7 +52,7 @@ private[chisel3] trait ObjectProbeImpl {
     requireHasProbeTypeModifier(probeExpr, "Expected source to be a probe expression.")
     requireCompatibleDestinationProbeColor(
       realSink,
-      s"""Cannot define '$realSink' from colors ${(Builder.enabledLayers.view ++ Builder.layerStack.headOption)
+      s"""Cannot define '$realSink' from colors ${(Builder.layerStack.headOption)
         .map(a => s"'${a.fullName}'")
         .mkString("{", ", ", "}")} since at least one of these is NOT enabled when '$realSink' is enabled"""
     )


### PR DESCRIPTION
Drop test specifically checking this incorrect behavior.

Add tests checking don't need to be under a layer block to define a probe with more colors, and that enabled layers don't change what is allowed to be defined.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification
- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Fix checking of layer-color probes to avoid rejecting valid uses and to detect actual problems that would otherwise be caught by CIRCT.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
