### PR TITLE
fix: wrap all intrinsics in layerblocks

### DIFF
--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -408,14 +408,15 @@ sealed abstract class AssertPropertyLike(defaultLayer: Layer) {
     *   emitted as `label: assert(...)`.
     */
   def apply(
-    prop:    Property,
+    prop:    => Property,
     clock:   Option[Clock] = Module.clockOption,
     disable: Option[Disable] = Module.disableOption,
     label:   Option[String] = None
   )(
     implicit sourceInfo: SourceInfo
   ): Unit = block(defaultLayer, skipIfAlreadyInBlock = true, skipIfLayersEnabled = true) {
-    val clocked = clock.fold(prop)(prop.clock(_))
+    val _prop = prop // evaluate prop expression once
+    val clocked = clock.fold(_prop)(_prop.clock(_))
     createIntrinsic(label)(sourceInfo)(clocked.inner, disable.map(!_.value))
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

This PR is based on #4436 and fixes #4429.

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Fix LTL intrinsics are generated outside the verification layer block

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
