### PR TITLE
Add Property expression for integer shift left

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -320,6 +320,16 @@ sealed trait Property[T] extends Element { self =>
   ): Property[T] =
     ev.shr(this, that)
 
+  /** Perform shift left as defined by FIRRTL spec section Integer Shift Left Operation.
+    */
+  final def <<(
+    that: Property[T]
+  )(
+    implicit ev: PropertyArithmeticOps[Property[T]],
+    sourceInfo:  SourceInfo
+  ): Property[T] =
+    ev.shl(this, that)
+
   /** Perform concatenation as defined by FIRRTL spec section List Concatenation Operation.
     */
   final def ++(
@@ -389,6 +399,7 @@ sealed trait PropertyArithmeticOps[T] {
   def add(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
   def mul(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
   def shr(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
+  def shl(lhs: T, rhs: T)(implicit sourceInfo: SourceInfo): T
 }
 
 object PropertyArithmeticOps {
@@ -403,6 +414,8 @@ object PropertyArithmeticOps {
         binOp(sourceInfo, fir.IntegerMulOp, lhs, rhs)
       def shr(lhs: Property[Int], rhs: Property[Int])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.IntegerShrOp, lhs, rhs)
+      def shl(lhs: Property[Int], rhs: Property[Int])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.IntegerShlOp, lhs, rhs)
     }
 
   implicit val longArithmeticOps: PropertyArithmeticOps[Property[Long]] =
@@ -413,6 +426,8 @@ object PropertyArithmeticOps {
         binOp(sourceInfo, fir.IntegerMulOp, lhs, rhs)
       def shr(lhs: Property[Long], rhs: Property[Long])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.IntegerShrOp, lhs, rhs)
+      def shl(lhs: Property[Long], rhs: Property[Long])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.IntegerShlOp, lhs, rhs)
     }
 
   implicit val bigIntArithmeticOps: PropertyArithmeticOps[Property[BigInt]] =
@@ -423,6 +438,8 @@ object PropertyArithmeticOps {
         binOp(sourceInfo, fir.IntegerMulOp, lhs, rhs)
       def shr(lhs: Property[BigInt], rhs: Property[BigInt])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.IntegerShrOp, lhs, rhs)
+      def shl(lhs: Property[BigInt], rhs: Property[BigInt])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.IntegerShlOp, lhs, rhs)
     }
 }
 

--- a/docs/src/explanations/properties.md
+++ b/docs/src/explanations/properties.md
@@ -148,6 +148,7 @@ on integral `Property` typed values.
 | `+`       | Perform addition as defined by FIRRTL spec section Integer Add Operation            |
 | `*`       | Perform multiplication as defined by FIRRTL spec section Integer Multiply Operation |
 | `>>`      | Perform shift right as defined by FIRRTL spec section Integer Shift Right Operation |
+| `<<`      | Perform shift left as defined by FIRRTL spec section Integer Shift Left Operation   |
 
 #### Sequence Operations
 

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -264,6 +264,7 @@ sealed abstract class PropPrimOp(name: String) {
 case object IntegerAddOp extends PropPrimOp("integer_add")
 case object IntegerMulOp extends PropPrimOp("integer_mul")
 case object IntegerShrOp extends PropPrimOp("integer_shr")
+case object IntegerShlOp extends PropPrimOp("integer_shl")
 case object ListConcatOp extends PropPrimOp("list_concat")
 
 /** Property expressions.

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -814,6 +814,21 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     )()
   }
 
+  it should "support shift left" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val a = IO(Input(Property[BigInt]()))
+      val b = IO(Input(Property[BigInt]()))
+      val c = IO(Output(Property[BigInt]()))
+      c := a << b
+    })
+
+    matchesAndOmits(chirrtl)(
+      "wire _c_propExpr : Integer",
+      "propassign _c_propExpr, integer_shl(a, b)",
+      "propassign c, _c_propExpr"
+    )()
+  }
+
   behavior.of("PropertySeqOps")
 
   it should "not support expressions involving Property types that don't provide a typeclass instance" in {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
This adds an API for integer Property shift left.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
