### PR TITLE
Make it legal to extract zero bits from a zero-width UInt

### DIFF
--- a/core/src/main/scala/chisel3/BitsImpl.scala
+++ b/core/src/main/scala/chisel3/BitsImpl.scala
@@ -119,11 +119,14 @@ private[chisel3] trait BitsImpl extends Element { self: Bits =>
     }.getOrElse {
       requireIsHardware(this, "bits to be sliced")
 
-      widthOption match {
-        case Some(w) if w == 0 => Builder.error(s"Cannot extract from zero-width")
-        case Some(w) if y >= w => Builder.error(s"High and low indices $x and $y are both out of range [0, ${w - 1}]")
-        case Some(w) if x >= w => Builder.error(s"High index $x is out of range [0, ${w - 1}]")
-        case _                 =>
+      // Illegal zero-width extractions are already caught, any at this point are legal.
+      if (resultWidth != 0) {
+        widthOption match {
+          case Some(w) if w == 0 => Builder.error(s"Cannot extract from zero-width")
+          case Some(w) if y >= w => Builder.error(s"High and low indices $x and $y are both out of range [0, ${w - 1}]")
+          case Some(w) if x >= w => Builder.error(s"High index $x is out of range [0, ${w - 1}]")
+          case _                 =>
+        }
       }
 
       // FIRRTL does not yet support empty extraction so we must return the zero-width wire here:

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -663,4 +663,15 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
     blit.x.litOption should be(Some(0xa))
     blit.y.litOption should be(Some(0xb))
   }
+
+  property("It should be legal to extract zero bits from a zero-width UInt") {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val in = IO(Input(UInt(0.W)))
+      val out1, out2 = IO(Output(UInt(8.W)))
+      out1 := in.take(0)
+      out2 := in(-1, 0)
+    })
+    chirrtl should include("connect out1, UInt<0>(0h0)")
+    chirrtl should include("connect out2, UInt<0>(0h0)")
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
