### PR TITLE
Fix Boring.rwTap on instance ports

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -257,11 +257,7 @@ object BoringUtils {
     def drill(source: A, path: Seq[BaseModule], connectionLocation: Seq[BaseModule], up: Boolean): A = {
       path.zip(connectionLocation).foldLeft(source) {
         case (rhs, (module, conLoc)) if (module.isFullyClosed) => boringError(module); DontCare.asInstanceOf[A]
-        case (rhs, (module, _))
-            if ((up || isDriveDone(rhs)) && module == path(0) && isPort(rhs) &&
-              (!createProbe.nonEmpty || !createProbe.get.writable)) => {
-          // When drilling from the original source, or driving to the sink, if it's already a port just return it.
-          // As an exception, insist rwTaps are done from within the module and exported out.
+        case (rhs, (module, _)) if ((up || isDriveDone(rhs)) && module == path(0) && isPort(rhs)) => {
           rhs
         }
         case (rhs, (module, conLoc)) =>

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -231,7 +231,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
     )()
   }
 
-  it should "work if boring to an Instance's output port" in {
+  it should "work if driving an Instance's input port" in {
     import chisel3.experimental.hierarchy._
     @instantiable
     class Bar extends RawModule {

--- a/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsTapSpec.scala
@@ -573,6 +573,53 @@ class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils wi
     val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Top(Definition(new Foo)))
   }
 
+  it should "work to rwTap an Instance[..]'s port" in {
+    import chisel3.experimental.hierarchy._
+    class UnitTestHarness extends Module {
+      val dut = Instantiate(new Dut)
+      probe.force(dut.widgetProbes.head, 0xffff.U)
+    }
+
+    @instantiable
+    class Widget extends Module {
+      @public val in = IO(Input(UInt(32.W)))
+      @public val out = IO(Output(UInt(32.W)))
+      out := ~in
+    }
+
+    @instantiable
+    class Dut extends Module {
+      val widgets: Seq[Instance[Widget]] = Seq.tabulate(1) { i =>
+        val widget = Instantiate(new Widget)
+        widget.in := i.U
+        printf(s"widget[${i}].in = ${i}\n")
+        printf(s"widget[${i}].out = ")
+        printf(cf"${widget.out}\n")
+        widget
+      }
+      @public val widgetProbes = widgets.map { widget =>
+        val widgetProbe = IO(probe.RWProbe(UInt(32.W)))
+        val define = BoringUtils.rwTap(widget.out)
+        probe.define(widgetProbe, define)
+        widgetProbe
+      }
+    }
+    val str =
+      matchesAndOmits(circt.stage.ChiselStage.emitCHIRRTL(new UnitTestHarness))(
+        "module Widget :",
+        "input clock : Clock",
+        "input reset : Reset",
+        "input in : UInt<32>",
+        "output out : UInt<32>",
+        "node _out_T = not(in)",
+        "connect out, _out_T",
+        "module Dut :",
+        "define widgetProbes_0 = rwprobe(widgets_0.out)",
+        "public module UnitTestHarness :",
+        "force(clock, _T, dut.widgetProbes_0, UInt<32>(0hffff))"
+      )()
+  }
+
   it should "work with DecoupledIO in a hierarchy" in {
     import chisel3.util.{Decoupled, DecoupledIO}
     class Bar() extends RawModule {


### PR DESCRIPTION
Previous behavior would always put the new probe expression in the instance's module body, but this is incompatible with instances built with Instantiate.

Given FIRRTL now supports this, we can improve this API.

Additionally, added a few more D/I + BoringUtils tests

### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

BoringUtils.rwTap can now works on a port of an `instance: Instance[..]`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
