### PR TITLE
Fix Select.attachedTo

### DIFF
--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -392,7 +392,7 @@ object Select {
         .block
         .getCommands()
     ) {
-      case Attach(_, seq) if seq.contains(signal) => seq
+      case Attach(_, seq) if seq.contains(Node(signal)) => seq
     }.flatMap { seq => seq.map(_.id.asInstanceOf[Data]) }.toSet
   }
 

--- a/src/test/scala/chiselTests/aop/SelectSpec.scala
+++ b/src/test/scala/chiselTests/aop/SelectSpec.scala
@@ -88,6 +88,20 @@ class SelectSpec extends ChiselFlatSpec {
 
   }
 
+  "Test" should "pass if selecting attach" in {
+    import chisel3.experimental.{attach, Analog}
+    class AttachTest extends RawModule {
+      val a, b, c = IO(Analog(8.W))
+      attach(a, b, c)
+    }
+    val dut = ChiselGeneratorAnnotation(() => new AttachTest)
+      .elaborate(1)
+      .asInstanceOf[DesignAnnotation[AttachTest]]
+      .design
+    Select.attachedTo(dut)(dut.a) should be(Set(dut.a, dut.b, dut.c))
+
+  }
+
   "Test" should "pass if selecting ops by kind" in {
     val dut = ChiselGeneratorAnnotation(() => {
       new SelectTester(Seq(0, 1, 2))


### PR DESCRIPTION
Previously it would always fail to find anything.

Working on the Mill build, I was lazy in setting up scalacOptions and applied `-Xlint:infer-any` to everything which caught this. Unfortuantely, `Iterable.contains` is not type safe but if you screw up the type, this lint will catch it inferring `Any` (or `Object`).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
