### PR TITLE
Add --firtool-option arg to ChiselStage

### DIFF
--- a/src/main/scala/circt/stage/Annotations.scala
+++ b/src/main/scala/circt/stage/Annotations.scala
@@ -118,7 +118,24 @@ private[stage] case object FirtoolBinaryPath extends HasShellOptions {
 /** Annotation that tells [[circt.stage.phases.CIRCT CIRCT]] what firtool executable to use */
 case class FirtoolBinaryPath(option: String) extends NoTargetAnnotation with CIRCTOption
 
+/** Annotation that passes a command line option to `firtool`.
+  *
+  * @param option an option to pass to `firtool`
+  */
 case class FirtoolOption(option: String) extends NoTargetAnnotation with CIRCTOption
+
+object FirtoolOption extends HasShellOptions {
+
+  override def options = Seq(
+    new ShellOption[String](
+      longOption = "firtool-option",
+      toAnnotationSeq = a => Seq(FirtoolOption(a)),
+      helpText = """an option to pass to "firtool" to control firrtl compilation""",
+      helpValueName = Some("<option>")
+    )
+  )
+
+}
 
 /** Annotation that indicates that firtool should run using the
   * `--split-verilog` option.  This has two effects: (1) Verilog will be emitted

--- a/src/main/scala/circt/stage/Shell.scala
+++ b/src/main/scala/circt/stage/Shell.scala
@@ -15,6 +15,7 @@ import chisel3.stage.{
   WarningConfigurationFileAnnotation,
   WarningsAsErrorsAnnotation
 }
+import circt.stage.FirtoolOption
 import firrtl.options.BareShell
 import firrtl.options.TargetDirAnnotation
 import logger.{ClassLogLevelAnnotation, LogClassNamesAnnotation, LogFileAnnotation, LogLevelAnnotation}
@@ -51,7 +52,8 @@ trait CLI { this: BareShell =>
     CIRCTTargetAnnotation,
     PreserveAggregate,
     SplitVerilog,
-    FirtoolBinaryPath
+    FirtoolBinaryPath,
+    FirtoolOption
   ).foreach(_.addOptions(parser))
 }
 

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -418,6 +418,30 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       }
       log2 shouldNot include("Done elaborating.")
     }
+
+    it("should support firtool options") {
+      val targetDir = new File("test_run_dir/ChiselStageSpec")
+
+      val args: Array[String] = Array(
+        "--target",
+        "systemverilog",
+        "--target-dir",
+        targetDir.toString,
+        "--firtool-option=-strip-debug-info"
+      )
+
+      (new ChiselStage)
+        .execute(
+          args,
+          Seq(ChiselGeneratorAnnotation(() => new ChiselStageSpec.Bar))
+        )
+        .collectFirst {
+          case EmittedVerilogCircuitAnnotation(a) => a
+        }
+        .get
+        .value
+      should not include("ChiselStageSpec.scala")
+    }
   }
 
   describe("ChiselStage exception handling") {


### PR DESCRIPTION
Now that ChiselStage supports the '--module' argument with parameters, it's useful to also be able to pass `firtool` arguments as well.  This adds a '--firtool-option' argument that will pass whatever follows onto `firtool`.

#### Release Notes

Add `--firtool-option` argument to `ChiselStage` and `ChiselMain`.