### PR TITLE
[Scala3] Redux: Convert cloneType to an extension method

### DIFF
--- a/core/src/main/scala-2/chisel3/Bits.scala
+++ b/core/src/main/scala-2/chisel3/Bits.scala
@@ -160,10 +160,10 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @note For [[SInt]]s only, this will do sign extension.
     * @group Bitwise
     */
-  final def pad(that: Int): this.type = macro SourceInfoTransform.thatArg
+  final def pad(that: Int): Bits = macro SourceInfoWhiteboxTransform.thatArg
 
   /** @group SourceInfoTransformMacro */
-  def do_pad(that: Int)(implicit sourceInfo: SourceInfo): this.type = _padImpl(that)
+  def do_pad(that: Int)(implicit sourceInfo: SourceInfo): Bits = _padImpl(that)
 
   /** Bitwise inversion operator
     *
@@ -182,8 +182,6 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * $sumWidthInt
     * @group Bitwise
     */
-  // REVIEW TODO: redundant
-  // REVIEW TODO: should these return this.type or Bits?
   final def <<(that: BigInt): Bits = macro SourceInfoWhiteboxTransform.thatArg
 
   /** @group SourceInfoTransformMacro */

--- a/core/src/main/scala/chisel3/BitsImpl.scala
+++ b/core/src/main/scala/chisel3/BitsImpl.scala
@@ -21,9 +21,9 @@ private[chisel3] trait BitsImpl extends Element { self: Bits =>
   // Arguments against: generates down to a FIRRTL UInt anyways
 
   // Only used for in a few cases, hopefully to be removed
-  private[chisel3] def cloneTypeWidth(width: Width): this.type
+  private[chisel3] def cloneTypeWidth(width: Width): Bits
 
-  def cloneType: this.type = cloneTypeWidth(width)
+  override def _cloneType: Data = cloneTypeWidth(width)
 
   /** A non-ambiguous name of this `Bits` instance for use in generated Verilog names
     * Inserts the width directly after the typeName, e.g. UInt4, SInt1
@@ -167,7 +167,7 @@ private[chisel3] trait BitsImpl extends Element { self: Bits =>
   // Pad literal to that width
   protected def _padLit(that: Int): this.type
 
-  protected def _padImpl(that: Int)(implicit sourceInfo: SourceInfo): this.type = this.width match {
+  protected def _padImpl(that: Int)(implicit sourceInfo: SourceInfo): Bits = this.width match {
     case KnownWidth(w) if w >= that => this
     case _ if this.isLit            => this._padLit(that)
     case _                          => binop(sourceInfo, cloneTypeWidth(this.width.max(Width(that))), PadOp, that)
@@ -222,8 +222,7 @@ private[chisel3] trait UIntImpl extends BitsImpl with Num[UInt] { self: UInt =>
     }
   }
 
-  private[chisel3] override def cloneTypeWidth(w: Width): this.type =
-    new UInt(w).asInstanceOf[this.type]
+  private[chisel3] override def cloneTypeWidth(w: Width): UInt = new UInt(w)
 
   override protected def _padLit(that: Int): this.type = {
     val value = this.litValue
@@ -403,8 +402,7 @@ private[chisel3] trait SIntImpl extends BitsImpl with Num[SInt] { self: SInt =>
     }
   }
 
-  private[chisel3] override def cloneTypeWidth(w: Width): this.type =
-    new SInt(w).asInstanceOf[this.type]
+  private[chisel3] override def cloneTypeWidth(w: Width): SInt = new SInt(w)
 
   override protected def _padLit(that: Int): this.type = {
     val value = this.litValue
@@ -529,7 +527,7 @@ private[chisel3] trait ResetTypeImpl extends Element { self: Reset =>
 
   override def toString: String = stringAccessor("Reset")
 
-  def cloneType: this.type = Reset().asInstanceOf[this.type]
+  override def _cloneType: Data = Reset()
 
   override def litOption = None
 
@@ -558,7 +556,7 @@ private[chisel3] trait AsyncResetImpl extends Element { self: AsyncReset =>
 
   override def toString: String = stringAccessor("AsyncReset")
 
-  def cloneType: this.type = AsyncReset().asInstanceOf[this.type]
+  override def _cloneType: Data = AsyncReset()
 
   override def litOption = None
 
@@ -599,9 +597,9 @@ private[chisel3] trait BoolImpl extends UIntImpl { self: Bool =>
     }
   }
 
-  private[chisel3] override def cloneTypeWidth(w: Width): this.type = {
+  private[chisel3] override def cloneTypeWidth(w: Width): Bool = {
     require(!w.known || w.get == 1)
-    new Bool().asInstanceOf[this.type]
+    new Bool()
   }
 
   /** Convert to a [[scala.Option]] of [[scala.Boolean]] */

--- a/core/src/main/scala/chisel3/ChiselEnumImpl.scala
+++ b/core/src/main/scala/chisel3/ChiselEnumImpl.scala
@@ -30,7 +30,7 @@ private[chisel3] abstract class EnumTypeImpl(private[chisel3] val factory: Chise
     }
   }
 
-  override def cloneType: this.type = factory().asInstanceOf[this.type]
+  override def _cloneType: Data = factory()
 
   private[chisel3] def compop(sourceInfo: SourceInfo, op: PrimOp, other: EnumType): Bool = {
     requireIsHardware(this, "bits operated on")
@@ -355,7 +355,8 @@ private[chisel3] trait ChiselEnumImpl { self: ChiselEnum =>
 // This is an enum type that can be connected directly to UInts. It is used as a "glue" to cast non-literal UInts
 // to enums.
 private[chisel3] class UnsafeEnum(override val width: Width) extends EnumType(UnsafeEnum, selfAnnotating = false) {
-  override def cloneType: this.type = new UnsafeEnum(width).asInstanceOf[this.type]
+
+  override def _cloneType: Data = new UnsafeEnum(width)
 }
 private object UnsafeEnum extends ChiselEnum
 

--- a/core/src/main/scala/chisel3/ClockImpl.scala
+++ b/core/src/main/scala/chisel3/ClockImpl.scala
@@ -13,7 +13,7 @@ private[chisel3] trait ClockImpl extends Element {
 
   override def toString: String = stringAccessor("Clock")
 
-  def cloneType: this.type = Clock().asInstanceOf[this.type]
+  override def _cloneType: Data = Clock()
 
   override def connect(that: Data)(implicit sourceInfo: SourceInfo): Unit =
     that match {

--- a/core/src/main/scala/chisel3/DataImpl.scala
+++ b/core/src/main/scala/chisel3/DataImpl.scala
@@ -768,28 +768,12 @@ private[chisel3] trait DataImpl extends HasId with NamedComponent { self: Data =
   private[chisel3] def width: Width
   private[chisel3] def firrtlConnect(that: Data)(implicit sourceInfo: SourceInfo): Unit
 
-  /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
+  /** Private implementation of cloneType
     *
-    * cloneType must be defined for any Chisel object extending Data.
-    * It is responsible for constructing a basic copy of the object being cloned.
-    *
-    * @return a copy of the object.
+    * _cloneType must be defined for any Chisel object extending Data.
+    * It is implemented by Chisel itself or by the compiler plugin for user-defined types.
     */
-  def cloneType: this.type
-
-  /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
-    *
-    * Returns a copy of this data type, with hardware bindings (if any) removed.
-    * Directionality data and probe information is still preserved.
-    */
-  private[chisel3] def cloneTypeFull: this.type = {
-    val clone = this.cloneType // get a fresh object, without bindings
-    // Only the top-level direction needs to be fixed up, cloneType should do the rest
-    clone.specifiedDirection = specifiedDirection
-    probe.setProbeModifier(clone, probeInfo)
-    clone.isConst = isConst
-    clone
-  }
+  def _cloneType: Data
 
   /** The "strong connect" operator.
     *
@@ -981,6 +965,7 @@ private[chisel3] trait ObjectDataImpl {
     *
     * @param lhs The [[Data]] hardware on the left-hand side of the equality
     */
+  // TODO fold this into DataExtensions
   implicit class DataEquality[T <: Data](lhs: T)(implicit sourceInfo: SourceInfo) {
 
     /** Dynamic recursive equality operator for generic [[Data]]
@@ -1057,6 +1042,33 @@ private[chisel3] trait ObjectDataImpl {
       } else {
         self.viewAsReadOnly(_ => "Cannot connect to read-only value")
       }
+    }
+  }
+
+  implicit class DataExtensions[T <: Data](self: T) {
+
+    /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
+      *
+      * cloneType must be defined for any Chisel object extending Data.
+      * It is responsible for constructing a basic copy of the object being cloned.
+      *
+      * @return a copy of the object.
+      */
+    def cloneType: T = self._cloneType.asInstanceOf[T]
+
+    /** Internal API; Chisel users should look at chisel3.chiselTypeOf(...).
+      *
+      * Returns a copy of this data type, with hardware bindings (if any) removed.
+      * Directionality data and probe information is still preserved.
+      */
+    private[chisel3] def cloneTypeFull: T = {
+      val clone = self.cloneType // get a fresh object, without bindings
+      // Only the top-level direction needs to be fixed up, cloneType should do the rest
+      clone.specifiedDirection = self.specifiedDirection
+      // TODO do we need to exclude probe and const from cloneTypeFull on Properties?
+      probe.setProbeModifier(clone, self.probeInfo)
+      clone.isConst = self.isConst
+      clone.asInstanceOf[T]
     }
   }
 }
@@ -1230,7 +1242,8 @@ final case object DontCare extends Element with connectable.ConnectableDocs {
   private[chisel3] override val width: Width = UnknownWidth
 
   bind(DontCareBinding(), SpecifiedDirection.Output)
-  override def cloneType: this.type = DontCare
+
+  override def _cloneType: Data = DontCare
 
   override def toString: String = "DontCare()"
 

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -352,7 +352,7 @@ package internal {
     private[chisel3] class ClonePorts(elts: (String, Data)*) extends Record {
       val elements = ListMap(elts.map { case (name, d) => name -> d.cloneTypeFull }: _*)
       def apply(field: String) = elements(field)
-      override def cloneType = (new ClonePorts(elts: _*)).asInstanceOf[this.type]
+      override protected def _cloneTypeImpl: Record = (new ClonePorts(elts: _*))
     }
 
     private[chisel3] def cloneIORecord(

--- a/core/src/main/scala/chisel3/experimental/Analog.scala
+++ b/core/src/main/scala/chisel3/experimental/Analog.scala
@@ -34,7 +34,7 @@ final class Analog private (private[chisel3] val width: Width) extends Element {
 
   override def litOption: Option[BigInt] = None
 
-  def cloneType: this.type = new Analog(width).asInstanceOf[this.type]
+  override def _cloneType: Data = new Analog(width)
 
   // Used to enforce single bulk connect of Analog types, multi-attach is still okay
   // Note that this really means 1 bulk connect per Module because a port can

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -132,7 +132,8 @@ package object experimental {
   object BundleLiterals {
     implicit class AddBundleLiteralConstructor[T <: Record](x: T) {
       def Lit(elems: (T => (Data, Data))*)(implicit sourceInfo: SourceInfo): T = {
-        x._makeLit(elems: _*)
+        val fs = elems.map(_.asInstanceOf[Data => (Data, Data)])
+        x._makeLit(fs: _*).asInstanceOf[T]
       }
     }
   }

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -82,7 +82,7 @@ package object internal {
       val _pad = Wire(UInt(width.W))
       _pad := b
       _pad.asInstanceOf[A] // This cast is safe because we know A is UInt on this path
-    case u => u.pad(width)
+    case u => u.pad(width).asInstanceOf[A]
   }
 
   // Resize that to this width (if known)

--- a/core/src/main/scala/chisel3/probe/ProbeValueBase.scala
+++ b/core/src/main/scala/chisel3/probe/ProbeValueBase.scala
@@ -28,6 +28,6 @@ private[chisel3] trait ProbeValueBase {
       } else { source.ref }
       clone.setRef(ProbeExpr(ref))
     }
-    clone
+    clone.asInstanceOf[T]
   }
 }

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -278,18 +278,8 @@ sealed trait Property[T] extends Element { self =>
 
   /** Clone type by simply constructing a new Property[T].
     */
-  override def cloneType: this.type = new Property[T] {
+  override def _cloneType: Data = new Property[T] {
     val tpe = self.tpe
-  }.asInstanceOf[this.type]
-
-  /** Clone type with extra information preserved.
-    *
-    * The only extra information present on a Property type is directionality.
-    */
-  private[chisel3] override def cloneTypeFull: this.type = {
-    val clone = this.cloneType
-    clone.specifiedDirection = specifiedDirection
-    clone
   }
 
   /** Get the IR PropertyType for this Property.


### PR DESCRIPTION
Redux of #3771. Turns out we need this for Scala3 after all

Ran into errors related to this while adding Scala3 cross-compilation support. Here's a sample of what an error with Dotty looks like:

```
[error] -- [E007] Type Mismatch Error: chisel3/core/src/main/scala/chisel3/AggregateImpl.scala:838:4 
[error] 838 |    clone
[error]     |    ^^^^^
[error]     |    Found:    (clone : chisel3.Record & chisel3.RecordImpl)
[error]     |    Required: (RecordImpl.this : chisel3.Record & chisel3.RecordImpl)
```

I suspect this is due to the tightening of the type system in Scala3, specifically changes which make `this.type` a more stricter representation of the current instance. I think this SIP might have a more detailed specification of the related changes: https://docs.scala-lang.org/sips/42.type.html#related-scala-issues-resolved-by-the-literal-types-implementation

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API Modification
- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
Move cloneType to an extension method in preparation for Scala3 

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
