### PR TITLE
Fix missing string interpolators, add -Xlint:missing-interpolator

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -85,6 +85,7 @@ object v {
     "-explaintypes",
     "-Xcheckinit",
     "-Xlint:infer-any",
+    "-Xlint:missing-interpolator",
     "-language:reflectiveCalls",
     s"-Wconf:${warnConf.mkString(",")}"
   )

--- a/core/src/main/scala/chisel3/AggregateImpl.scala
+++ b/core/src/main/scala/chisel3/AggregateImpl.scala
@@ -404,7 +404,7 @@ private[chisel3] abstract class VecImpl[T <: Data] private[chisel3] (gen: => T, 
         SpecifiedDirection.Unspecified
       case ActualDirection.Bidirectional.Flipped => SpecifiedDirection.Flip
       case ActualDirection.Empty                 => SpecifiedDirection.Unspecified
-      case dir                                   => throwException("Unexpected directionality: $dir")
+      case dir                                   => throwException(s"Unexpected directionality: $dir")
     }
     // TODO port technically isn't directly child of this data structure, but the result of some
     // muxes / demuxes. However, this does make access consistent with the top-level bindings.

--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -249,7 +249,7 @@ private[chisel3] object Connection {
         case List(a, b) =>
           BiConnect.markAnalogConnected(sourceInfo, a, b, currentModule)
           BiConnect.markAnalogConnected(sourceInfo, b, a, currentModule)
-        case _ => throw new InternalErrorException("Match error: as.toList=${as.toList}")
+        case _ => throw new InternalErrorException(s"Match error: as.toList=${as.toList}")
       }
     } catch { // convert Exceptions to Builder.error's so compilation can continue
       case attach.AttachException(message) => Builder.error(message)

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Hierarchy.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Hierarchy.scala
@@ -105,7 +105,7 @@ object Hierarchy {
     def toTarget: IsModule = i match {
       case d: Definition[T] => new Definition.DefinitionBaseModuleExtensions(d).toTarget
       case i: Instance[T]   => new Instance.InstanceBaseModuleExtensions(i).toTarget
-      case _ => throw new InternalErrorException("Match error: toTarget i=$i")
+      case _ => throw new InternalErrorException(s"Match error: toTarget i=$i")
     }
 
     /** Returns the toAbsoluteTarget of this hierarchy
@@ -114,7 +114,7 @@ object Hierarchy {
     def toAbsoluteTarget: IsModule = i match {
       case d: Definition[T] => new Definition.DefinitionBaseModuleExtensions(d).toAbsoluteTarget
       case i: Instance[T]   => new Instance.InstanceBaseModuleExtensions(i).toAbsoluteTarget
-      case _ => throw new InternalErrorException("Match error: toAbsoluteTarget i=$i")
+      case _ => throw new InternalErrorException(s"Match error: toAbsoluteTarget i=$i")
     }
 
     /** Returns the toRelativeTarget of this hierarchy
@@ -123,7 +123,7 @@ object Hierarchy {
     def toRelativeTarget(root: Option[BaseModule]): IsModule = i match {
       case d: Definition[T] => new Definition.DefinitionBaseModuleExtensions(d).toRelativeTarget(root)
       case i: Instance[T]   => new Instance.InstanceBaseModuleExtensions(i).toRelativeTarget(root)
-      case _ => throw new InternalErrorException("Match error: toAbsoluteTarget i=$i")
+      case _ => throw new InternalErrorException(s"Match error: toAbsoluteTarget i=$i")
     }
 
     /** Returns the toRelativeTarget of this hierarchy
@@ -132,7 +132,7 @@ object Hierarchy {
     def toRelativeTargetToHierarchy(root: Option[Hierarchy[BaseModule]]): IsModule = i match {
       case d: Definition[T] => new Definition.DefinitionBaseModuleExtensions(d).toRelativeTargetToHierarchy(root)
       case i: Instance[T]   => new Instance.InstanceBaseModuleExtensions(i).toRelativeTargetToHierarchy(root)
-      case _ => throw new InternalErrorException("Match error: toAbsoluteTarget i=$i")
+      case _ => throw new InternalErrorException(s"Match error: toAbsoluteTarget i=$i")
     }
 
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -34,7 +34,7 @@ final case class Instance[+A] private[chisel3] (private[chisel3] val underlying:
     case Proto(value: IsInstantiable) => None
     case Clone(i: BaseModule) => Some(i)
     case Clone(i: InstantiableClone[_]) => i.getInnerContext
-    case _ => throw new InternalErrorException("Match error: underlying=$underlying")
+    case _ => throw new InternalErrorException(s"Match error: underlying=$underlying")
   }
 
   /** @return the context this instance. Note that for non-module clones, getInnerDataContext will be the same as getClonedParent */
@@ -42,7 +42,7 @@ final case class Instance[+A] private[chisel3] (private[chisel3] val underlying:
     case Proto(value: BaseModule) => value._parent
     case Clone(i: BaseModule) => i._parent
     case Clone(i: InstantiableClone[_]) => i.getInnerContext
-    case _ => throw new InternalErrorException("Match error: underlying=$underlying")
+    case _ => throw new InternalErrorException(s"Match error: underlying=$underlying")
   }
 
   /** Used by Chisel's internal macros. DO NOT USE in your normal Chisel code!!!
@@ -85,7 +85,7 @@ object Instance extends SourceInfoDoc {
     def toTarget: IsModule = i.underlying match {
       case Proto(x: BaseModule) => x.getTarget
       case Clone(x: IsClone[_] with BaseModule) => x.getTarget
-      case _ => throw new InternalErrorException("Match error: i.underlying=${i.underlying}")
+      case _ => throw new InternalErrorException(s"Match error: i.underlying=${i.underlying}")
     }
 
     /** If this is an instance of a Module, returns the toAbsoluteTarget of this instance
@@ -94,7 +94,7 @@ object Instance extends SourceInfoDoc {
     def toAbsoluteTarget: IsModule = i.underlying match {
       case Proto(x) => x.toAbsoluteTarget
       case Clone(x: IsClone[_] with BaseModule) => x.toAbsoluteTarget
-      case _ => throw new InternalErrorException("Match error: i.underlying=${i.underlying}")
+      case _ => throw new InternalErrorException(s"Match error: i.underlying=${i.underlying}")
     }
 
     /** Returns a FIRRTL ReferenceTarget that references this object, relative to an optional root.
@@ -110,13 +110,13 @@ object Instance extends SourceInfoDoc {
     def toRelativeTarget(root: Option[BaseModule]): IsModule = i.underlying match {
       case Proto(x) => x.toRelativeTarget(root)
       case Clone(x: IsClone[_] with BaseModule) => x.toRelativeTarget(root)
-      case _ => throw new InternalErrorException("Match error: i.underlying=${i.underlying}")
+      case _ => throw new InternalErrorException(s"Match error: i.underlying=${i.underlying}")
     }
 
     def toRelativeTargetToHierarchy(root: Option[Hierarchy[BaseModule]]): IsModule = i.underlying match {
       case Proto(x) => x.toRelativeTargetToHierarchy(root)
       case Clone(x: IsClone[_] with BaseModule) => x.toRelativeTargetToHierarchy(root)
-      case _ => throw new InternalErrorException("Match error: i.underlying=${i.underlying}")
+      case _ => throw new InternalErrorException(s"Match error: i.underlying=${i.underlying}")
     }
 
     def suggestName(name: String): Unit = i.underlying match {

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -75,7 +75,7 @@ object Lookupable {
             newChild.bind(CrossModuleBinding)
             newChild.setAllParents(Some(m))
             newChild
-          case _ => throw new InternalErrorException("Match error: newParent=$newParent")
+          case _ => throw new InternalErrorException(s"Match error: newParent=$newParent")
         }
     }
   }
@@ -197,7 +197,7 @@ object Lookupable {
             val wrMap = mapping.flatMap { case (from, _, wr) => Option.when(wr.isReadOnly)(from -> wr) }.toMap
             AggregateViewBinding(newMap, Option.when(wrMap.nonEmpty)(wrMap))
         }
-      case _ => throw new InternalErrorException("Match error: data.topBinding=${data.topBinding}")
+      case _ => throw new InternalErrorException(s"Match error: data.topBinding=${data.topBinding}")
     }
 
     // TODO Unify the following with `.viewAs`
@@ -211,7 +211,7 @@ object Lookupable {
             Builder.unnamedViews += agg
           case _ => ()
         }
-      case _ => throw new InternalErrorException("Match error: newBinding=$newBinding")
+      case _ => throw new InternalErrorException(s"Match error: newBinding=$newBinding")
     }
 
     result.bind(newBinding)
@@ -271,7 +271,7 @@ object Lookupable {
             val newChild = Module.do_pseudo_apply(new InstanceClone(m.getProto, () => m.instanceName))
             newChild._parent = i._parent
             Clone(newChild)
-          case _ => throw new InternalErrorException("Match error: rec(m)=${rec(m)}")
+          case _ => throw new InternalErrorException(s"Match error: rec(m)=${rec(m)}")
         }
       case Clone(m: InstanceClone[_]) =>
         rec(m) match {
@@ -280,9 +280,9 @@ object Lookupable {
             val newChild = Module.do_pseudo_apply(new InstanceClone(m.getProto, () => m.instanceName))
             newChild._parent = i._parent
             Clone(newChild)
-          case _ => throw new InternalErrorException("Match error: rec(m)=${rec(m)}")
+          case _ => throw new InternalErrorException(s"Match error: rec(m)=${rec(m)}")
         }
-      case _ => throw new InternalErrorException("Match error: module=$module")
+      case _ => throw new InternalErrorException(s"Match error: module=$module")
     }
   }
 
@@ -389,7 +389,7 @@ object Lookupable {
             newChild.setRef(mem.getRef, true)
             newChild
           case _ =>
-            throw new InternalErrorException("Match error: newParent=$newParent")
+            throw new InternalErrorException(s"Match error: newParent=$newParent")
         }
     }
   }

--- a/src/main/scala/chisel3/aop/Select.scala
+++ b/src/main/scala/chisel3/aop/Select.scala
@@ -493,7 +493,7 @@ object Select {
     case Slot(imm: Node, name) => Seq(imm.id.asInstanceOf[Record].elements(name))
     case Index(imm, _)    => getEffected(imm)
     case LitIndex(imm, _) => getEffected(imm)
-    case _                => throw new InternalErrorException("Match error: a=$a")
+    case _                => throw new InternalErrorException(s"Match error: a=$a")
   }
 
   // Given an arg, return the corresponding id. Don't use on a loc of a connect.
@@ -522,7 +522,7 @@ object Select {
     case e: ChiselException =>
       i.getOptionRef.get match {
         case l: LitArg => l.num.intValue.toString
-        case _ => throw new InternalErrorException("Match error: i.getOptionRef.get=${i.getOptionRef.get}")
+        case _ => throw new InternalErrorException(s"Match error: i.getOptionRef.get=${i.getOptionRef.get}")
       }
   }
 

--- a/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/QMCMinimizer.scala
@@ -261,7 +261,7 @@ object QMCMinimizer extends Minimizer {
           (maxt ++ dc, false)
         case x if !x.mask.testBit(i) => // default to ?
           (mint, true)
-        case _ => throw new InternalErrorException("Match error: table.default=${table.default}")
+        case _ => throw new InternalErrorException(s"Match error: table.default=${table.default}")
       }
 
       implicants.foreach(_.isPrime = true)

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -261,7 +261,7 @@ class CIRCT extends Phase {
             )
         })
 
-    logger.info(s"""Running CIRCT: '${cmd.mkString(" ")}""" + input.fold(_ => " < $$input'", _ => "'"))
+    logger.info(s"""Running CIRCT: '${cmd.mkString(" ")}""" + input.fold(_ => " < $$" + "input'", _ => "'"))
     val stdoutStream, stderrStream = new java.io.ByteArrayOutputStream
     val stdoutWriter = new java.io.PrintWriter(stdoutStream)
     val stderrWriter = new java.io.PrintWriter(stderrStream)


### PR DESCRIPTION
We hit an internal error and it isn't useful because of missing String interpolators. Fix that

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
