### PR TITLE
Elide metadata by default, add --include-util-metadata

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -120,6 +120,7 @@ object Definition extends SourceInfoDoc {
         Nil,
         context.throwOnFirstError,
         context.useLegacyWidth,
+        context.includeUtilMetadata,
         context.warningFilters,
         context.sourceRoots,
         Some(context.globalNamespace),

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -473,12 +473,13 @@ private[chisel3] class ChiselContext() {
 }
 
 private[chisel3] class DynamicContext(
-  val annotationSeq:     AnnotationSeq,
-  val throwOnFirstError: Boolean,
-  val useLegacyWidth:    Boolean,
-  val warningFilters:    Seq[WarningFilter],
-  val sourceRoots:       Seq[File],
-  val defaultNamespace:  Option[Namespace],
+  val annotationSeq:       AnnotationSeq,
+  val throwOnFirstError:   Boolean,
+  val useLegacyWidth:      Boolean,
+  val includeUtilMetadata: Boolean,
+  val warningFilters:      Seq[WarningFilter],
+  val sourceRoots:         Seq[File],
+  val defaultNamespace:    Option[Namespace],
   // Definitions from other scopes in the same elaboration, use allDefinitions below
   val loggerOptions: LoggerOptions,
   val definitions:   ArrayBuffer[Definition[_]],
@@ -967,6 +968,8 @@ private[chisel3] object Builder extends LazyLogging {
   }
 
   def useLegacyWidth: Boolean = dynamicContextVar.value.map(_.useLegacyWidth).getOrElse(false)
+
+  def includeUtilMetadata: Boolean = dynamicContextVar.value.map(_.includeUtilMetadata).getOrElse(false)
 
   // Builds a RenameMap for all Views that do not correspond to a single Data
   // These Data give a fake ReferenceTarget for .toTarget and .toReferenceTarget that the returned

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -485,3 +485,21 @@ object RemapLayer extends HasShellOptions {
   )
 
 }
+
+/** Include metadata for chisel utils.
+  *
+  * Some built-in Chisel utilities (like [[chisel3.util.SRAM]]) can optionally be built with metadata.
+  * Adding this option will include the metadata when building relevant blocks.
+  *
+  * Use as CLI option `--include-util-metadata`.
+  */
+case object IncludeUtilMetadata extends NoTargetAnnotation with ChiselOption with HasShellOptions with Unserializable {
+
+  val options = Seq(
+    new ShellOption[Unit](
+      longOption = "include-util-metadata",
+      toAnnotationSeq = _ => Seq(IncludeUtilMetadata),
+      helpText = "Include metadata for chisel utils"
+    )
+  )
+}

--- a/src/main/scala/chisel3/stage/ChiselOptions.scala
+++ b/src/main/scala/chisel3/stage/ChiselOptions.scala
@@ -15,7 +15,8 @@ class ChiselOptions private[stage] (
   val sourceRoots:         Vector[File] = Vector.empty,
   val warningFilters:      Vector[WarningFilter] = Vector.empty,
   val useLegacyWidth:      Boolean = false,
-  val layerMap:            Map[Layer, Layer] = Map.empty) {
+  val layerMap:            Map[Layer, Layer] = Map.empty,
+  val includeUtilMetadata: Boolean = false) {
 
   private[stage] def copy(
     printFullStackTrace: Boolean = printFullStackTrace,
@@ -25,7 +26,8 @@ class ChiselOptions private[stage] (
     sourceRoots:         Vector[File] = sourceRoots,
     warningFilters:      Vector[WarningFilter] = warningFilters,
     useLegacyWidth:      Boolean = useLegacyWidth,
-    layerMap:            Map[Layer, Layer] = layerMap
+    layerMap:            Map[Layer, Layer] = layerMap,
+    includeUtilMetadata: Boolean = includeUtilMetadata
   ): ChiselOptions = {
 
     new ChiselOptions(
@@ -36,7 +38,8 @@ class ChiselOptions private[stage] (
       sourceRoots = sourceRoots,
       warningFilters = warningFilters,
       useLegacyWidth = useLegacyWidth,
-      layerMap = layerMap
+      layerMap = layerMap,
+      includeUtilMetadata = includeUtilMetadata
     )
 
   }

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -31,6 +31,7 @@ package object stage {
           case a: WarningConfigurationFileAnnotation => c.copy(warningFilters = c.warningFilters ++ a.filters)
           case UseLegacyWidthBehavior         => c.copy(useLegacyWidth = true)
           case RemapLayer(oldLayer, newLayer) => c.copy(layerMap = c.layerMap + ((oldLayer, newLayer)))
+          case IncludeUtilMetadata            => c.copy(includeUtilMetadata = true)
         }
       }
 

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -42,6 +42,7 @@ class Elaborate extends Phase {
             annotations,
             chiselOptions.throwOnFirstError,
             chiselOptions.useLegacyWidth,
+            chiselOptions.includeUtilMetadata,
             chiselOptions.warningFilters,
             chiselOptions.sourceRoots,
             None,

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -532,8 +532,11 @@ object SRAM {
     // underlying target
     val mem = autoNameRecursively("sram")(new SramTarget)
 
+    val includeMetadata = Builder.includeUtilMetadata
+
     // user-facing interface into the SRAM
-    val sramIntfType = new SRAMInterface(size, tpe, numReadPorts, numWritePorts, numReadwritePorts, isVecMem, true)
+    val sramIntfType =
+      new SRAMInterface(size, tpe, numReadPorts, numWritePorts, numReadwritePorts, isVecMem, includeMetadata)
     val _out = Wire(sramIntfType)
     _out._underlying = Some(HasTarget(mem))
 


### PR DESCRIPTION
The new metadata like SRAMDescription is useful, but there are some composition issues with various CIRCT transforms that are not yet resolved. Since this stuff is new (not yet released), I argue we should guard it under a CLI option (`--include-util-metadata`) for the time being. Ultimately, I expect we will want to include it by default, but I think we need the support to mature a bit first.

The only metadata at the moment is `SRAMDescription`, but we probably should do similar things with `Queue` and possibly other utils so I added a generic CLI option to guard them all.

We could also make it possible to elide metadata on an API call by API call basis. I thought about doing that for SRAM but due to the fact that default arguments cause binary compatibility issues, we keep increasing the number of apply methods for SRAM. It's currently 8, adding a new option would up that to 16. If we want to add it as an option for SRAM, I think we need to tweak how that API works, possibly putting some (or all) of the arguments into a class that we carefully maintain compatibility for.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
