### PR TITLE
Add Probes to .toString Data methods

### DIFF
--- a/core/src/main/scala/chisel3/DataImpl.scala
+++ b/core/src/main/scala/chisel3/DataImpl.scala
@@ -494,7 +494,7 @@ private[chisel3] trait DataImpl extends HasId with NamedComponent { self: Data =
         val name = thiz.earlyName
         val mod = thiz.parentNameOpt.map(_ + ".").getOrElse("")
 
-        s"$mod$name: $binding[$chiselTypeWithModifier}]"
+        s"$mod$name: $binding[$chiselTypeWithModifier]"
     }
   }
 

--- a/core/src/main/scala/chisel3/DataImpl.scala
+++ b/core/src/main/scala/chisel3/DataImpl.scala
@@ -474,20 +474,19 @@ private[chisel3] trait DataImpl extends HasId with NamedComponent { self: Data =
   //  DataView, Probe modifiers, a DontCare, and whether it is bound or a pure chisel type
   private[chisel3] def stringAccessor(chiselType: String): String = {
     // Add probe and layer color (if they exist) to the returned String
-    def addProbeModifier(chiselType: String): String = {
+    val chiselTypeWithModifier =
       probeInfo match {
         case None => chiselType
         case Some(ProbeInfo(writeable, layer)) =>
           val layerString = layer.map(x => s"[${x.fullName}]").getOrElse("")
           (if (writeable) "RWProbe" else "Probe") + s"$layerString<$chiselType>"
       }
-    }
     // Trace views to give better error messages
     // Reifying involves checking against ViewParent which requires being in a Builder context
     // Since we're just printing a String, suppress such errors and use this object
     val thiz = Try(reifySingleTarget(this)).toOption.flatten.getOrElse(this)
     thiz.topBindingOpt match {
-      case None => addProbeModifier(chiselType)
+      case None => chiselTypeWithModifier
       // Handle DontCares specially as they are "literal-like" but not actually literals
       case Some(DontCareBinding()) => s"$chiselType(DontCare)"
       case Some(topBinding) =>
@@ -495,7 +494,7 @@ private[chisel3] trait DataImpl extends HasId with NamedComponent { self: Data =
         val name = thiz.earlyName
         val mod = thiz.parentNameOpt.map(_ + ".").getOrElse("")
 
-        s"$mod$name: $binding[${addProbeModifier(chiselType)}]"
+        s"$mod$name: $binding[$chiselTypeWithModifier}]"
     }
   }
 

--- a/core/src/main/scala/chisel3/DataImpl.scala
+++ b/core/src/main/scala/chisel3/DataImpl.scala
@@ -478,8 +478,8 @@ private[chisel3] trait DataImpl extends HasId with NamedComponent { self: Data =
       probeInfo match {
         case None => chiselType
         case Some(ProbeInfo(writeable, layer)) =>
-          val layerString = layer.map(x => s", ${x.fullName}").getOrElse("")
-          (if (writeable) "RWProbe" else "Probe") + s"<$chiselType$layerString>"
+          val layerString = layer.map(x => s"[${x.fullName}]").getOrElse("")
+          (if (writeable) "RWProbe" else "Probe") + s"$layerString<$chiselType>"
       }
     }
     // Trace views to give better error messages

--- a/src/test/scala/chisel3/TypeEquivalenceSpec.scala
+++ b/src/test/scala/chisel3/TypeEquivalenceSpec.scala
@@ -314,7 +314,7 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
   it should "detect differences between Probe and Not-Probe" in {
     Probe(Bool()).findFirstTypeMismatch(Bool(), true, true, true) should be(
       Some(
-        ": Left (Bool with probeInfo: Some(writeable=false, color=None)) and Right (Bool with probeInfo: None) have different probeInfo."
+        ": Left (Probe<Bool> with probeInfo: Some(writeable=false, color=None)) and Right (Bool with probeInfo: None) have different probeInfo."
       )
     )
   }
@@ -326,7 +326,7 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
   it should "detect differences between Probe and Not-Probe within a Bundle" in {
     new BundleWithProbe(true).findFirstTypeMismatch(new BundleWithProbe(false), true, true, true) should be(
       Some(
-        ".maybeProbe: Left (Bool with probeInfo: Some(writeable=false, color=None)) and Right (Bool with probeInfo: None) have different probeInfo."
+        ".maybeProbe: Left (Probe<Bool> with probeInfo: Some(writeable=false, color=None)) and Right (Bool with probeInfo: None) have different probeInfo."
       )
     )
   }
@@ -334,21 +334,21 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
   it should "detect differences between probe types" in {
     RWProbe(Bool()).findFirstTypeMismatch(Probe(Bool()), true, true, true) should be(
       Some(
-        ": Left (Bool with probeInfo: Some(writeable=true, color=None)) and Right (Bool with probeInfo: Some(writeable=false, color=None)) have different probeInfo."
+        ": Left (RWProbe<Bool> with probeInfo: Some(writeable=true, color=None)) and Right (Probe<Bool> with probeInfo: Some(writeable=false, color=None)) have different probeInfo."
       )
     )
   }
 
   it should "detect differences through probes" in {
     Probe(Bool()).findFirstTypeMismatch(Probe(Clock()), true, true, true) should be(
-      Some(": Left (Bool) and Right (Clock) have different types.")
+      Some(": Left (Probe<Bool>) and Right (Probe<Clock>) have different types.")
     )
   }
 
   it should "detect differences in presence of probe colors" in {
     Probe(Bool()).findFirstTypeMismatch(Probe(Bool(), Green), true, true, true) should be(
       Some(
-        ": Left (Bool with probeInfo: Some(writeable=false, color=None)) and Right (Bool with probeInfo: Some(writeable=false, color=Some(Green))) have different probeInfo."
+        ": Left (Probe<Bool> with probeInfo: Some(writeable=false, color=None)) and Right (Probe[Green]<Bool> with probeInfo: Some(writeable=false, color=Some(Green))) have different probeInfo."
       )
     )
   }
@@ -356,7 +356,7 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
   it should "detect differences in probe colors" in {
     Probe(Bool(), Red).findFirstTypeMismatch(Probe(Bool(), Green), true, true, true) should be(
       Some(
-        ": Left (Bool with probeInfo: Some(writeable=false, color=Some(Red))) and Right (Bool with probeInfo: Some(writeable=false, color=Some(Green))) have different probeInfo."
+        ": Left (Probe[Red]<Bool> with probeInfo: Some(writeable=false, color=Some(Red))) and Right (Probe[Green]<Bool> with probeInfo: Some(writeable=false, color=Some(Green))) have different probeInfo."
       )
     )
   }
@@ -375,7 +375,7 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
       true
     ) should be(
       Some(
-        ".probe: Left (Bool with probeInfo: Some(writeable=false, color=Some(Red))) and Right (Bool with probeInfo: Some(writeable=false, color=Some(Green))) have different probeInfo."
+        ".probe: Left (Probe[Red]<Bool> with probeInfo: Some(writeable=false, color=Some(Red))) and Right (Probe[Green]<Bool> with probeInfo: Some(writeable=false, color=Some(Green))) have different probeInfo."
       )
     )
   }
@@ -383,7 +383,7 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
   it should "detect differences in probe color presence within a Bundle" in {
     new BundleWithAColor(Some(Red)).findFirstTypeMismatch(new BundleWithAColor(None), true, true, true) should be(
       Some(
-        ".probe: Left (Bool with probeInfo: Some(writeable=false, color=Some(Red))) and Right (Bool with probeInfo: Some(writeable=false, color=None)) have different probeInfo."
+        ".probe: Left (Probe[Red]<Bool> with probeInfo: Some(writeable=false, color=Some(Red))) and Right (Probe<Bool> with probeInfo: Some(writeable=false, color=None)) have different probeInfo."
       )
     )
   }
@@ -391,7 +391,7 @@ class TypeEquivalenceSpec extends AnyFlatSpec {
   it should "detect differences in probe within a Vector" in {
     Vec(3, Probe(Bool())).findFirstTypeMismatch(Vec(3, Bool()), true, true, true) should be(
       Some(
-        "[_]: Left (Bool with probeInfo: Some(writeable=false, color=None)) and Right (Bool with probeInfo: None) have different probeInfo."
+        "[_]: Left (Probe<Bool> with probeInfo: Some(writeable=false, color=None)) and Right (Bool with probeInfo: None) have different probeInfo."
       )
     )
   }

--- a/src/test/scala/chiselTests/DataPrint.scala
+++ b/src/test/scala/chiselTests/DataPrint.scala
@@ -26,17 +26,26 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
     val f = EnumTest.Type()
   }
 
+  object A extends layer.Layer(layer.LayerConfig.Extract()) {
+    object B extends layer.Layer(layer.LayerConfig.Extract())
+  }
+
   "Data types" should "have a meaningful string representation" in {
     ChiselStage.emitCHIRRTL {
       new RawModule {
         UInt().toString should be("UInt")
         UInt(8.W).toString should be("UInt<8>")
+        probe.Probe(UInt(8.W)).toString should be("Probe<UInt<8>>")
+        probe.RWProbe(UInt(8.W)).toString should be("RWProbe<UInt<8>>")
+        probe.Probe(UInt(8.W), A).toString should be("Probe<UInt<8>, A>")
+        probe.Probe(UInt(8.W), A.B).toString should be("Probe<UInt<8>, A.B>")
         SInt(15.W).toString should be("SInt<15>")
         Bool().toString should be("Bool")
         Clock().toString should be("Clock")
         Vec(3, UInt(2.W)).toString should be("UInt<2>[3]")
         EnumTest.Type().toString should be("EnumTest")
         (new BundleTest).toString should be("BundleTest")
+        (probe.Probe(new BundleTest)).toString should be("Probe<BundleTest>")
         new Bundle { val a = UInt(8.W) }.toString should be("AnonymousBundle")
         new Bundle { val a = UInt(8.W) }.a.toString should be("UInt<8>")
       }
@@ -45,6 +54,7 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
 
   class BoundDataModule extends Module { // not in the test to avoid anon naming suffixes
     Wire(UInt()).toString should be("BoundDataModule.?: Wire[UInt]")
+    Wire(probe.Probe(UInt(1.W))).toString should be("BoundDataModule.?: Wire[Probe<UInt<1>>]")
     Reg(SInt()).toString should be("BoundDataModule.?: Reg[SInt]")
     val io = IO(Output(Bool())) // needs a name so elaboration doesn't fail
     io.toString should be("BoundDataModule.io: IO[Bool]")

--- a/src/test/scala/chiselTests/DataPrint.scala
+++ b/src/test/scala/chiselTests/DataPrint.scala
@@ -37,8 +37,8 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
         UInt(8.W).toString should be("UInt<8>")
         probe.Probe(UInt(8.W)).toString should be("Probe<UInt<8>>")
         probe.RWProbe(UInt(8.W)).toString should be("RWProbe<UInt<8>>")
-        probe.Probe(UInt(8.W), A).toString should be("Probe<UInt<8>, A>")
-        probe.Probe(UInt(8.W), A.B).toString should be("Probe<UInt<8>, A.B>")
+        probe.Probe(UInt(8.W), A).toString should be("Probe[A]<UInt<8>>")
+        probe.Probe(UInt(8.W), A.B).toString should be("Probe[A.B]<UInt<8>>")
         SInt(15.W).toString should be("SInt<15>")
         Bool().toString should be("Bool")
         Clock().toString should be("Clock")
@@ -55,6 +55,7 @@ class DataPrintSpec extends ChiselFlatSpec with Matchers {
   class BoundDataModule extends Module { // not in the test to avoid anon naming suffixes
     Wire(UInt()).toString should be("BoundDataModule.?: Wire[UInt]")
     Wire(probe.Probe(UInt(1.W))).toString should be("BoundDataModule.?: Wire[Probe<UInt<1>>]")
+    Wire(probe.Probe(UInt(1.W), A)).toString should be("BoundDataModule.?: Wire[Probe[A]<UInt<1>>]")
     Reg(SInt()).toString should be("BoundDataModule.?: Reg[SInt]")
     val io = IO(Output(Bool())) // needs a name so elaboration doesn't fail
     io.toString should be("BoundDataModule.io: IO[Bool]")

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -342,7 +342,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     }
     intercept[ChiselException] { ChiselStage.emitCHIRRTL(new Foo, Array("--throw-on-first-error")) }
       .getMessage() should include(
-      "Cannot define 'Foo.a: IO[Bool]' from colors {'C'} since at least one of these is NOT enabled when 'Foo.a: IO[Bool]' is enabled"
+      "Cannot define 'Foo.a: IO[Probe[A]<Bool>]' from colors {'C'} since at least one of these is NOT enabled when 'Foo.a: IO[Probe[A]<Bool>]' is enabled"
     )
   }
 
@@ -358,7 +358,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
 
     intercept[ChiselException] { ChiselStage.convert(new Foo, Array("--throw-on-first-error")) }
       .getMessage() should include(
-      "Cannot define 'Foo.a: IO[Bool]' from colors {'C'} since at least one of these is NOT enabled when 'Foo.a: IO[Bool]' is enabled"
+      "Cannot define 'Foo.a: IO[Probe[A]<Bool>]' from colors {'C'} since at least one of these is NOT enabled when 'Foo.a: IO[Probe[A]<Bool>]' is enabled"
     )
   }
 

--- a/src/test/scala/chiselTests/ProbeSpec.scala
+++ b/src/test/scala/chiselTests/ProbeSpec.scala
@@ -242,7 +242,7 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
       )
     }
     exc.getMessage should include(
-      "mismatched probe/non-probe types in ProbeSpec_Anon.io.out[0]: IO[Bool] and ProbeSpec_Anon.io.in[0]: IO[Bool]."
+      "mismatched probe/non-probe types in ProbeSpec_Anon.io.out[0]: IO[Probe<Bool>] and ProbeSpec_Anon.io.in[0]: IO[Bool]."
     )
   }
 
@@ -260,7 +260,7 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
       )
     }
     exc.getMessage should include(
-      "Connection between sink (ProbeSpec_Anon.io.out: IO[Bool]) and source (ProbeSpec_Anon.io.in: IO[Bool]) failed @: Sink io.out in ProbeSpec_Anon of Probed type cannot participate in a mono connection (:=)"
+      "Connection between sink (ProbeSpec_Anon.io.out: IO[Probe<Bool>]) and source (ProbeSpec_Anon.io.in: IO[Bool]) failed @: Sink io.out in ProbeSpec_Anon of Probed type cannot participate in a mono connection (:=)"
     )
   }
 
@@ -295,7 +295,7 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
       )
     }
     exc.getMessage should include(
-      "Connection between sink (OutProbe.p: IO[Bool]) and source (ProbeSpec_Anon.out: IO[Bool]) failed @: p in OutProbe cannot be written from module ProbeSpec_Anon."
+      "Connection between sink (OutProbe.p: IO[Probe<Bool>]) and source (ProbeSpec_Anon.out: IO[Probe<Bool>]) failed @: p in OutProbe cannot be written from module ProbeSpec_Anon."
     )
   }
 
@@ -383,7 +383,7 @@ class ProbeSpec extends ChiselFlatSpec with MatchesAndOmits with Utils {
     }
     exc.getMessage should include("Cannot define a probe on a non-equivalent type.")
     exc.getMessage should include(
-      "Left (ProbeSpec_Anon.p: IO[UInt<4>]) and Right (ProbeSpec_Anon.w: OpResult[Bool]) have different types"
+      "Left (ProbeSpec_Anon.p: IO[Probe<UInt<4>>]) and Right (ProbeSpec_Anon.w: OpResult[Probe<Bool>]) have different types"
     )
 
   }


### PR DESCRIPTION
### Contributor Checklist

- [N/A] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Probe chisel types now include the kind of probe and layer in their `.toString` method

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [x] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
