### PR TITLE
[Module] Add afterModuleBuilt hook

### DIFF
--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -114,6 +114,7 @@ private[chisel3] trait ObjectModuleImpl {
     Builder.setPrefix(savePrefix)
     Builder.enabledLayers = saveEnabledLayers
 
+    module.moduleBuilt()
     module
   }
 
@@ -643,6 +644,11 @@ package experimental {
         }
       }
     }
+
+    /** Called once the module's definition has been fully built. At this point
+      * the module can be instantiated through its definition.
+      */
+    protected[chisel3] def moduleBuilt(): Unit = {}
 
     //
     // Chisel Internals

--- a/src/test/scala/chiselTests/RawModuleSpec.scala
+++ b/src/test/scala/chiselTests/RawModuleSpec.scala
@@ -4,7 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.aop.Select
-import chisel3.experimental.hierarchy.Definition
+import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
 import chisel3.reflect.DataMirror
 import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
@@ -169,5 +169,58 @@ class RawModuleSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
         ChiselStage.emitCHIRRTL { new ImplicitModuleDirectlyInRawModuleTester }
       }
     }
+  }
+
+  "RawModule with afterModuleBuilt" should "be able to create other modules" in {
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      override def desiredName = "Foo"
+      val port0 = IO(Input(Bool()))
+
+      afterModuleBuilt {
+        Module(new RawModule {
+          override def desiredName = "Bar"
+          val port1 = IO(Input(Bool()))
+        })
+      }
+    })
+
+    matchesAndOmits(chirrtl)(
+      "module Foo",
+      "input port0 : UInt<1>",
+      "module Bar",
+      "input port1 : UInt<1>"
+    )()
+  }
+
+  "RawModule with afterModuleBuilt" should "be able to instantiate the surrounding module" in {
+    @instantiable
+    class Foo extends RawModule {
+      override def desiredName = "Foo"
+      @public val port0 = IO(Input(Bool()))
+
+      afterModuleBuilt {
+        val fooDef = this.toDefinition
+        Module(new RawModule {
+          override def desiredName = "Bar"
+          val port1 = IO(Input(Bool()))
+          val foo1 = Instance(fooDef)
+          val foo2 = Instance(fooDef)
+          foo1.port0 := port1
+          foo2.port0 := port1
+        })
+      }
+    }
+    val chirrtl = ChiselStage.emitCHIRRTL(new Foo)
+
+    matchesAndOmits(chirrtl)(
+      "module Foo :",
+      "input port0 : UInt<1>",
+      "module Bar",
+      "input port1 : UInt<1>",
+      "inst foo1 of Foo",
+      "inst foo2 of Foo",
+      "connect foo1.port0, port1",
+      "connect foo2.port0, port1"
+    )()
   }
 }


### PR DESCRIPTION
Add the `afterModuleBuilt` hook to `RawModule`, similar to the existing `atModuleBodyEnd`. This hook is called after a module has been fully constructed and its resulting component definition has been added to the builder. Thus code inside the body of `afterModuleBuilt` can get the definition of the surrounding module and instantiate it, which is interesting for generating additional collateral like unit tests alongside a module.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement
- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
The new `afterModuleBuilt` hook can be used to schedule code to be executed once a module has been fully generated and its definition is available. This allows further collateral such as unit tests to be generated alongside a module.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
