### PR TITLE
Add `withModulePrefix`

### DIFF
--- a/core/src/main/scala-2/chisel3/experimental/hierarchy/Instantiate.scala
+++ b/core/src/main/scala-2/chisel3/experimental/hierarchy/Instantiate.scala
@@ -57,7 +57,7 @@ object Instantiate extends InstantiateImpl {
   ): Instance[A] = _instanceImpl(args, f)
 
   /** This is not part of the public API, do not call directly! */
-  def _defination[K, A <: BaseModule: ru.WeakTypeTag](
+  def _definition[K, A <: BaseModule: ru.WeakTypeTag](
     args: K,
     f:    K => A
   ): Definition[A] = _definitionImpl(args, f)
@@ -160,11 +160,11 @@ object Instantiate extends InstantiateImpl {
           val funcArgTypes = args.map(_.asInstanceOf[Tree].tpe.widen)
           val constructor = q"(($funcArg: (..$funcArgTypes)) => new $tpname[..$tparams](...$conArgs))"
           val tup = q"(..$args)"
-          q"chisel3.experimental.hierarchy.Instantiate._defination[(..$funcArgTypes), $tpname]($tup, $constructor)"
+          q"chisel3.experimental.hierarchy.Instantiate._definition[(..$funcArgTypes), $tpname]($tup, $constructor)"
 
         case _ =>
           val msg =
-            s"Argument to Instantiate.defination(...) must be of form 'new <T <: chisel3.Module>(<arguments...>)'.\n" +
+            s"Argument to Instantiate.definition(...) must be of form 'new <T <: chisel3.Module>(<arguments...>)'.\n" +
               "Note that named arguments are currently not supported.\n" +
               s"Got: '$con'"
           c.error(con.pos, msg)

--- a/core/src/main/scala/chisel3/MemImpl.scala
+++ b/core/src/main/scala/chisel3/MemImpl.scala
@@ -23,6 +23,7 @@ private[chisel3] trait ObjectMemImpl {
     val mem = new Mem(mt, size, sourceInfo)
     mt.bind(MemTypeBinding(mem))
     pushCommand(DefMemory(sourceInfo, mem, mt, size))
+    ModulePrefixAnnotation.annotate(mem.toTarget)
     mem
   }
 

--- a/core/src/main/scala/chisel3/MemImpl.scala
+++ b/core/src/main/scala/chisel3/MemImpl.scala
@@ -23,7 +23,7 @@ private[chisel3] trait ObjectMemImpl {
     val mem = new Mem(mt, size, sourceInfo)
     mt.bind(MemTypeBinding(mem))
     pushCommand(DefMemory(sourceInfo, mem, mt, size))
-    ModulePrefixAnnotation.annotate(mem.toTarget)
+    ModulePrefixAnnotation.annotate(mem)
     mem
   }
 
@@ -208,6 +208,7 @@ private[chisel3] trait ObjectSyncReadMemImpl {
     val mem = new SyncReadMem(mt, size, ruw, sourceInfo)
     mt.bind(MemTypeBinding(mem))
     pushCommand(DefSeqMemory(sourceInfo, mem, mt, size, ruw))
+    ModulePrefixAnnotation.annotate(mem)
     mem
   }
 

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -926,6 +926,9 @@ package experimental {
           case None    => getRef.name
           case Some(c) => getRef.fullName(c)
         }
+
+    /** Returns the current nested module prefix */
+    val currentModulePrefix: String = Builder.getModulePrefix
   }
 }
 

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -928,7 +928,7 @@ package experimental {
         }
 
     /** Returns the current nested module prefix */
-    val currentModulePrefix: String = Builder.getModulePrefix
+    val modulePrefix: String = Builder.getModulePrefix
   }
 }
 

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -16,8 +16,10 @@ import _root_.firrtl.annotations.{
   Annotation,
   InstanceTarget,
   IsModule,
+  IsMember,
   ModuleName,
   ModuleTarget,
+  Target,
   SingleTargetAnnotation
 }
 import _root_.firrtl.AnnotationSeq
@@ -31,8 +33,6 @@ private[chisel3] trait ObjectModuleImpl {
   protected def _applyImpl[T <: BaseModule](bc: => T)(implicit sourceInfo: SourceInfo): T = {
     // Instantiate the module definition.
     val module: T = evaluate[T](bc)
-
-    ModulePrefixAnnotation.annotate(module)
 
     // Handle connections at enclosing scope
     // We use _component because Modules that don't generate them may still have one
@@ -938,16 +938,16 @@ object withModulePrefix {
   }
 }
 
-private case class ModulePrefixAnnotation(target: IsModule, prefix: String) extends SingleTargetAnnotation[IsModule] {
-  def duplicate(n: IsModule): ModulePrefixAnnotation = this.copy(target = n)
+private case class ModulePrefixAnnotation(target: IsMember, prefix: String) extends SingleTargetAnnotation[IsMember] {
+  def duplicate(n: IsMember): ModulePrefixAnnotation = this.copy(target = n)
 }
 
 private object ModulePrefixAnnotation {
-  def annotate[T <: BaseModule](module: T): Unit = {
+  def annotate[T <: IsMember](target: T): Unit = {
       val prefix = Builder.getModulePrefix
       if (prefix != "") {
         val annotation: ChiselAnnotation = new ChiselAnnotation {
-          def toFirrtl: Annotation = ModulePrefixAnnotation(module.toTarget, prefix)
+          def toFirrtl: Annotation = ModulePrefixAnnotation(target, prefix)
         }
         chisel3.experimental.annotate(annotation)
       }

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -943,11 +943,11 @@ private case class ModulePrefixAnnotation(target: IsMember, prefix: String) exte
 }
 
 private object ModulePrefixAnnotation {
-  def annotate[T <: IsMember](target: T): Unit = {
+  def annotate[T <: HasId](target: T): Unit = {
       val prefix = Builder.getModulePrefix
       if (prefix != "") {
         val annotation: ChiselAnnotation = new ChiselAnnotation {
-          def toFirrtl: Annotation = ModulePrefixAnnotation(target, prefix)
+          def toFirrtl: Annotation = ModulePrefixAnnotation(target.toTarget, prefix)
         }
         chisel3.experimental.annotate(annotation)
       }

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -235,6 +235,10 @@ private[chisel3] trait ObjectModuleImpl {
     /** Explicitly Asynchronous Reset */
     case object Asynchronous extends Type
   }
+
+  def getModulePrefixList: List[String] = {
+    Builder.getModulePrefixList
+  }
 }
 
 private[chisel3] trait ModuleImpl extends RawModule with ImplicitClock with ImplicitReset {
@@ -920,7 +924,6 @@ package experimental {
           case None    => getRef.name
           case Some(c) => getRef.fullName(c)
         }
-
   }
 }
 

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -12,7 +12,14 @@ import chisel3.internal.firrtl.ir._
 import chisel3.experimental.{requireIsChiselType, BaseModule, SourceInfo, UnlocatableSourceInfo}
 import chisel3.properties.{Class, Property}
 import chisel3.reflect.DataMirror
-import _root_.firrtl.annotations.{InstanceTarget, IsModule, ModuleName, ModuleTarget, SingleTargetAnnotation, Annotation}
+import _root_.firrtl.annotations.{
+  Annotation,
+  InstanceTarget,
+  IsModule,
+  ModuleName,
+  ModuleTarget,
+  SingleTargetAnnotation
+}
 import _root_.firrtl.AnnotationSeq
 import chisel3.internal.plugin.autoNameRecursively
 import chisel3.util.simpleClassName
@@ -688,7 +695,7 @@ package experimental {
         this match {
           case _: PseudoModule => Module.currentModulePrefix + desiredName
           case _: BlackBox     => Builder.globalNamespace.name(desiredName)
-          case _               => Builder.globalNamespace.name(Module.currentModulePrefix + desiredName)
+          case _ => Builder.globalNamespace.name(Module.currentModulePrefix + desiredName)
         }
       } catch {
         case e: NullPointerException =>
@@ -931,7 +938,7 @@ object withModulePrefix {
   def apply[T](prefix: String)(block: => T): T = {
     Builder.pushModulePrefix(prefix)
     val res = block // execute block
-    Builder.popModulePrefix() 
+    Builder.popModulePrefix()
     res
   }
 }

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -931,9 +931,13 @@ package experimental {
 
 object withModulePrefix {
   def apply[T](prefix: String)(block: => T): T = {
-    Builder.pushModulePrefix(prefix)
+    if (prefix != "") {
+      Builder.pushModulePrefix(prefix)
+    }
     val res = block // execute block
-    Builder.popModulePrefix()
+    if (prefix != "") {
+      Builder.popModulePrefix()
+    }
     res
   }
 }

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -929,7 +929,13 @@ package experimental {
   }
 }
 
+/**
+ * Creates a block under which any generator that gets run results in a module whose name is prepended with the given prefix.
+ */
 object withModulePrefix {
+  /**
+    * @param arg prefix Prefix is the module prefix, blank means ignore.
+    */
   def apply[T](prefix: String)(block: => T): T = {
     if (prefix != "") {
       Builder.pushModulePrefix(prefix)

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -15,12 +15,12 @@ import chisel3.reflect.DataMirror
 import _root_.firrtl.annotations.{
   Annotation,
   InstanceTarget,
-  IsModule,
   IsMember,
+  IsModule,
   ModuleName,
   ModuleTarget,
-  Target,
-  SingleTargetAnnotation
+  SingleTargetAnnotation,
+  Target
 }
 import _root_.firrtl.AnnotationSeq
 import chisel3.internal.plugin.autoNameRecursively
@@ -948,12 +948,12 @@ private case class ModulePrefixAnnotation(target: IsMember, prefix: String) exte
 
 private object ModulePrefixAnnotation {
   def annotate[T <: HasId](target: T): Unit = {
-      val prefix = Builder.getModulePrefix
-      if (prefix != "") {
-        val annotation: ChiselAnnotation = new ChiselAnnotation {
-          def toFirrtl: Annotation = ModulePrefixAnnotation(target.toTarget, prefix)
-        }
-        chisel3.experimental.annotate(annotation)
+    val prefix = Builder.getModulePrefix
+    if (prefix != "") {
+      val annotation: ChiselAnnotation = new ChiselAnnotation {
+        def toFirrtl: Annotation = ModulePrefixAnnotation(target.toTarget, prefix)
       }
+      chisel3.experimental.annotate(annotation)
+    }
   }
 }

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -694,7 +694,7 @@ package experimental {
         // their original modules names without uniquification
         this match {
           case _: PseudoModule => Module.currentModulePrefix + desiredName
-          case _: BlackBox     => Builder.globalNamespace.name(desiredName)
+          case _: BaseBlackBox     => Builder.globalNamespace.name(desiredName)
           case _ => Builder.globalNamespace.name(Module.currentModulePrefix + desiredName)
         }
       } catch {

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -694,7 +694,7 @@ package experimental {
         // their original modules names without uniquification
         this match {
           case _: PseudoModule => Module.currentModulePrefix + desiredName
-          case _: BaseBlackBox     => Builder.globalNamespace.name(desiredName)
+          case _: BaseBlackBox => Builder.globalNamespace.name(desiredName)
           case _ => Builder.globalNamespace.name(Module.currentModulePrefix + desiredName)
         }
       } catch {

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -930,9 +930,10 @@ package experimental {
 }
 
 /**
- * Creates a block under which any generator that gets run results in a module whose name is prepended with the given prefix.
- */
+  * Creates a block under which any generator that gets run results in a module whose name is prepended with the given prefix.
+  */
 object withModulePrefix {
+
   /**
     * @param arg prefix Prefix is the module prefix, blank means ignore.
     */

--- a/core/src/main/scala/chisel3/experimental/hierarchy/InstantiateImpl.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/InstantiateImpl.scala
@@ -73,7 +73,7 @@ private[chisel3] trait InstantiateImpl {
 
   import chisel3.internal.BuilderContextCache
   // Include type of module in key since different modules could have the same arguments
-  private case class CacheKey[A <: BaseModule](args: Any, tt: ru.WeakTypeTag[A])
+  private case class CacheKey[A <: BaseModule](args: Any, tt: ru.WeakTypeTag[A], modulePrefix: List[String])
       extends BuilderContextCache.Key[Definition[A]]
 
   protected def _instanceImpl[K, A <: BaseModule: ru.WeakTypeTag](
@@ -88,9 +88,10 @@ private[chisel3] trait InstantiateImpl {
     args: K,
     f:    K => A
   ): Definition[A] = {
+    val modulePrefix = Builder.getModulePrefixList
     Builder.contextCache
       .getOrElseUpdate(
-        CacheKey(boxAllData(args), implicitly[ru.WeakTypeTag[A]]), {
+        CacheKey(boxAllData(args), implicitly[ru.WeakTypeTag[A]], modulePrefix), {
           // The definition needs to have no source locator because otherwise it will be unstably
           // derived from the first invocation of Instantiate for the particular Module
           Definition.do_apply(f(args))(UnlocatableSourceInfo)

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -461,7 +461,7 @@ private[chisel3] trait NamedComponent extends HasId {
 
 // Mutable global state for chisel that can appear outside a Builder context
 private[chisel3] class ChiselContext() {
-  val sep: String = "_"
+  val modulePrefixSeperator: String = "_"
   val idGen = new IdGen
 
   // Records the different prefixes which have been scoped at this point in time
@@ -1182,7 +1182,7 @@ private[chisel3] object Builder extends LazyLogging {
   def getModulePrefix: String = {
     val ctx = chiselContext.get()
     val modulePrefixStack = ctx.modulePrefixStack
-    val sep = ctx.sep
+    val sep = ctx.modulePrefixSeperator
     if (modulePrefixStack.isEmpty) {
       ""
     } else {

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1188,8 +1188,7 @@ private[chisel3] object Builder extends LazyLogging {
   }
 
   def getModulePrefixList: List[String] = {
-    val modulePrefixStack = chiselContext.get().modulePrefixStack
-    modulePrefixStack.toList
+    chiselContext.get().modulePrefixStack
   }
 
   initializeSingletons()

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -470,6 +470,8 @@ private[chisel3] class ChiselContext() {
   // The namespace outside of Builder context is useless, but it ensures that views can still be created
   // and the resulting .toTarget is very clearly useless (_$$View$$_...)
   val viewNamespace = Namespace.empty
+
+  var modulePrefixStack: Prefix = Nil
 }
 
 private[chisel3] class DynamicContext(
@@ -1160,6 +1162,31 @@ private[chisel3] object Builder extends LazyLogging {
       )
     }
   }
+
+  // Puts a module prefix string onto the module prefix stack
+  def pushModulePrefix(prefix: String): Unit = {
+    val context = chiselContext.get()
+    context.modulePrefixStack = prefix :: context.modulePrefixStack
+  }
+
+  // Remove the module prefix on top of the stack
+  def popModulePrefix(): List[String] = {
+    val context = chiselContext.get()
+    val tail = context.modulePrefixStack.tail
+    context.modulePrefixStack = tail
+    tail
+  }
+
+  // Returns the nested module prefix at this moment
+  def getModulePrefix: String = {
+    val modulePrefixStack = chiselContext.get().modulePrefixStack
+    if (modulePrefixStack.isEmpty) {
+      ""
+    } else {
+      modulePrefixStack.foldLeft("")((a, b) => b + "_" + a)
+    }
+  }
+
   initializeSingletons()
 }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -461,6 +461,7 @@ private[chisel3] trait NamedComponent extends HasId {
 
 // Mutable global state for chisel that can appear outside a Builder context
 private[chisel3] class ChiselContext() {
+  val sep: String = "_"
   val idGen = new IdGen
 
   // Records the different prefixes which have been scoped at this point in time
@@ -1179,11 +1180,13 @@ private[chisel3] object Builder extends LazyLogging {
 
   // Returns the nested module prefix at this moment
   def getModulePrefix: String = {
-    val modulePrefixStack = chiselContext.get().modulePrefixStack
+    val ctx = chiselContext.get()
+    val modulePrefixStack = ctx.modulePrefixStack
+    val sep = ctx.sep
     if (modulePrefixStack.isEmpty) {
       ""
     } else {
-      modulePrefixStack.foldLeft("")((a, b) => b + "_" + a)
+      modulePrefixStack.foldLeft("")((a, b) => b + sep + a)
     }
   }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1187,6 +1187,11 @@ private[chisel3] object Builder extends LazyLogging {
     }
   }
 
+  def getModulePrefixList: List[String] = {
+    val modulePrefixStack = chiselContext.get().modulePrefixStack
+    modulePrefixStack.toList
+  }
+
   initializeSingletons()
 }
 

--- a/docs/src/explanations.md
+++ b/docs/src/explanations.md
@@ -41,3 +41,4 @@ read these documents in the following order:
 * [Deep Dive into Legacy Connection Operators](explanations/connection-operators)
 * [Properties](explanations/properties)
 * [Layers](explanations/layers)
+* [Module Prefixing](explanations/moduleprefix)

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -123,7 +123,11 @@ However, `Instance` will not be effected, since it always creates an instance of
 If you wish to have one that is sensitive to the module prefix,
 you can explicitly name the module like this:
 
-```scala mdoc:silent
+```scala mdoc:silent:reset
+import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, Instantiate}
+import chisel3.experimental.ExtModule
+
 class Sub extends ExtModule {
   override def desiredName = modulePrefix + "Sub"
 }

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -120,3 +120,11 @@ When using `Definition` and `Instance`, all `Definition` calls will be affected 
 However, `Instance` will not be effected, since it always creates an instance of the captured definition.
 
 `BlackBox` and `ExtModule` are unaffected by `withModulePrefix`.
+If you wish to have one that is sensitive to the module prefix,
+you can explicitly name the module like this:
+
+```scala mdoc:silent
+class Sub extends ExtModule {
+  override def desiredName = modulePrefix + "Sub"
+}
+```

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -1,0 +1,117 @@
+# Module Prefixing
+
+Chisel supports a feature called module prefixing.
+Module prefixing allows you to create namespaces in the Verilog output of your design.
+They are especially useful for when you want to name a particular subsystem of your design,
+and you want to make it easy to identify which subsystem a file belongs to by its name.
+
+We can open a module prefix block using `withModulePrefix`:
+
+```scala mdoc:silent
+import chisel3._
+
+class Top extends Module {
+  withModulePrefix("Foo") {
+    // ...
+  }
+}
+```
+
+All modules defined inside of this block, whether an immediate submodule or a descendent, will be given a prefix `Foo`.
+(The prefix is separated by an underscore `_`).
+
+For example, suppose we write the following:
+
+```scala mdoc:silent
+import chisel3._
+
+class Top extends Module {
+  val sub = withModulePrefix("Foo") {
+    Module(new Sub)
+  }
+}
+
+class Sub extends Module {
+  // ..
+}
+```
+
+The result will be a design with two module definitions: `Top` and `Foo_Sub`.
+
+Note that the `val sub =` part must be pulled outside of the `withModulePrefix` block,
+or else the module will not be accessible to the rest of the `Top` module.
+
+If a generator is run in multiple prefix blocks, the result is multiple identical copies of the module definition,
+each with its own distinct prefix.
+For example, consider if we create two instances of `Sub` above like this:
+
+```scala mdoc:silent
+import chisel3._
+
+class Top extends Module {
+  val foo_sub = withModulePrefix("Foo") {
+    Module(new Sub)
+  }
+
+  val bar_sub = withModulePrefix("Bar") {
+    Module(new Sub)
+  }
+}
+
+class Sub extends Module {
+  // ..
+}
+```
+
+Then, the resulting Verilog will have three module definitions: `Top`, `Foo_Sub`, and `Bar_Sub`.
+Both `Foo_Sub` and `Bar_Sub` will be identical to each other.
+
+Module prefixes can also be nested.
+
+```scala mdoc:silent
+import chisel3._
+
+class Top extends Module {
+  val mid = withModulePrefix("Foo") {
+    Module(new Mid)
+  }
+}
+
+class Mid extends Module {
+  val sub = withModulePrefix("Bar") {
+    Module(new Sub)
+  }
+}
+
+class Sub extends Module {
+  // ..
+}
+```
+
+This results in three module definitions: `Top`, `Foo_Mid`, and `Foo_Bar_Sub`.
+
+The `withModulePrefix` blocks also work with the `Instantiate` API.
+
+```scala mdoc:silent
+import chisel3._
+import chisel3.experimental.hierarchy.{instantiable, Instantiate}
+
+@instantiable
+class Sub extends Module {
+  // ...
+}
+
+class Top extends Module {
+  val foo_sub = withModulePrefix("Foo") {
+    Instantiate(new Sub)
+  }
+
+  val bar_sub = withModulePrefix("Bar") {
+    Instantiate(new Sub)
+  }
+
+  val noprefix_sub = Instantiate(new Sub)
+}
+```
+
+In this example, we end up with four modules: `Top`, `Foo_Sub`, `Bar_Sub`, and `Sub`.

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -45,7 +45,7 @@ If a generator is run in multiple prefix blocks, the result is multiple identica
 each with its own distinct prefix.
 For example, consider if we create two instances of `Sub` above like this:
 
-```scala mdoc:silent
+```scala mdoc:silent:reset
 import chisel3._
 
 class Top extends Module {
@@ -68,7 +68,7 @@ Both `Foo_Sub` and `Bar_Sub` will be identical to each other.
 
 Module prefixes can also be nested.
 
-```scala mdoc:silent
+```scala mdoc:silent:reset
 import chisel3._
 
 class Top extends Module {
@@ -92,7 +92,7 @@ This results in three module definitions: `Top`, `Foo_Mid`, and `Foo_Bar_Sub`.
 
 The `withModulePrefix` blocks also work with the `Instantiate` API.
 
-```scala mdoc:silent
+```scala mdoc:silent:reset
 import chisel3._
 import chisel3.experimental.hierarchy.{instantiable, Instantiate}
 

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -119,4 +119,4 @@ In this example, we end up with four modules: `Top`, `Foo_Sub`, `Bar_Sub`, and `
 When using `Definition` and `Instance`, all `Definition` calls will be affected by `withModulePrefix`.
 However, `Instance` will not be effected, since it always creates an instance of the captured definition.
 
-`ExtModule` is unaffected by `withModulePrefix`.
+`BlackBox` and `ExtModule` are unaffected by `withModulePrefix`.

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -22,7 +22,7 @@ All modules defined inside of this block, whether an immediate submodule or a de
 
 For example, suppose we write the following:
 
-```scala mdoc:silent
+```scala mdoc:silent:reset
 import chisel3._
 
 class Top extends Module {

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -115,3 +115,8 @@ class Top extends Module {
 ```
 
 In this example, we end up with four modules: `Top`, `Foo_Sub`, `Bar_Sub`, and `Sub`.
+
+When using `Definition` and `Instance`, all `Definition` calls will be affected by `withModulePrefix`.
+However, `Instance` will not be effected, since it always creates an instance of the captured definition.
+
+`ExtModule` is unaffected by `withModulePrefix`.

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -636,7 +636,7 @@ object SRAM {
       descriptionInstance.hierarchyIn := Property(Path(mem))
       description := descriptionInstance.getPropertyReference
     }
-    ModulePrefixAnnotation.annotate(_out)
+    ModulePrefixAnnotation.annotate(mem)
     _out
   }
 

--- a/src/main/scala/chisel3/util/SRAM.scala
+++ b/src/main/scala/chisel3/util/SRAM.scala
@@ -636,6 +636,7 @@ object SRAM {
       descriptionInstance.hierarchyIn := Property(Path(mem))
       description := descriptionInstance.getPropertyReference
     }
+    ModulePrefixAnnotation.annotate(_out)
     _out
   }
 

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -87,7 +87,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     matchesAndOmits(chirrtl)(lines: _*)()
   }
 
-  it should "Instnantiate should create distinct module definitions when instantiated with distinct prefixes" in {
+  it should "Instantiate should create distinct module definitions when instantiated with distinct prefixes" in {
     class Top extends Module {
       val width = 8
       val in = IO(Input(UInt(width.W)))

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -230,7 +230,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
         """.linesIterator.map(_.trim).toSeq
   }
 
-  it should "withModulePrefix does not affect ExtModules" in {
+  it should "withModulePrefix does not automatically affect ExtModules" in {
     class Sub extends ExtModule {
     }
 

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.hierarchy.{Instantiate, Definition, Instance, instantiable, public}
+import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance, Instantiate}
 import circt.stage.ChiselStage.emitCHIRRTL
 
 class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with MatchesAndOmits {
@@ -90,7 +90,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
   it should "Instnantiate should create distinct module definitions when instantiated with distinct prefixes" in {
     class Top extends Module {
       val width = 8
-      val in  = IO(Input(UInt(width.W)))
+      val in = IO(Input(UInt(width.W)))
       val out = IO(Output(UInt(width.W)))
 
       val foo_inst = withModulePrefix("Foo") {
@@ -106,8 +106,8 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 
       foo_inst.in := in
       bar_inst.in := foo_inst.out
-      out         := bar_inst.out
-      np_inst.in  := in
+      out := bar_inst.out
+      np_inst.in := in
     }
 
     val chirrtl = emitCHIRRTL(new Top)
@@ -129,7 +129,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
   it should "Instnantiate should reference the same module definitions when instantiated with the same prefix" in {
     class Top extends Module {
       val width = 8
-      val in  = IO(Input(UInt(width.W)))
+      val in = IO(Input(UInt(width.W)))
       val out = IO(Output(UInt(width.W)))
       val foo_inst1 = withModulePrefix("Foo") {
         Instantiate(new AddOne(width))
@@ -141,7 +141,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 
       foo_inst1.in := in
       foo_inst2.in := in
-      out   := foo_inst1.out
+      out := foo_inst1.out
     }
 
     val chirrtl = emitCHIRRTL(new Top)
@@ -161,7 +161,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 // This has to be defined at the top-level because @instantiable doesn't work when nested.
 @instantiable
 class AddOne(width: Int) extends Module {
-  @public val in  = IO(Input(UInt(width.W)))
+  @public val in = IO(Input(UInt(width.W)))
   @public val out = IO(Output(UInt(width.W)))
   out := in + 1.U
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import circt.stage.ChiselStage.emitCHIRRTL
+
+class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with MatchesAndOmits {
+
+  behavior.of("withPrefix")
+
+  it should "do something" in {
+    class Foo extends RawModule {
+      val a = Wire(Bool())
+    }
+
+    class Top extends RawModule {
+      val foo = Module(new Foo)
+
+      withModulePrefix("Pref") {
+        val pref_foo = Module(new Foo)
+      }
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+    println(chirrtl)
+    matchesAndOmits(chirrtl)(
+      "module Foo :",
+      "  wire a : UInt<1>",
+      "module Pref_Foo :",
+      "  wire a : UInt<1>",
+      "module Top :",
+      "  inst foo of Foo",
+      "  inst pref_foo of Pref_Foo",
+    )()
+  }
+}

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -258,7 +258,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 
   it should "Using currentModulePrefix to force the name of an extmodule" in {
     class Sub extends ExtModule {
-      override def desiredName = currentModulePrefix + "Sub"
+      override def desiredName = modulePrefix + "Sub"
     }
 
     class Top extends Module {

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -6,8 +6,18 @@ import chisel3._
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance, Instantiate}
 import circt.stage.ChiselStage.emitCHIRRTL
 
-class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with MatchesAndOmits {
+object PrefixSpec {
+  // This has to be defined at the top-level because @instantiable doesn't work when nested.
+  @instantiable
+  class AddOne(width: Int) extends Module {
+    @public val in = IO(Input(UInt(width.W)))
+    @public val out = IO(Output(UInt(width.W)))
+    out := in + 1.U
+  }
+}
 
+class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with MatchesAndOmits {
+  import PrefixSpec._
   behavior.of("withModulePrefix")
 
   it should "prefix modules in a withModulePrefix block, but not outside" in {
@@ -153,13 +163,5 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
         """.linesIterator.map(_.trim).toSeq
 
     matchesAndOmits(chirrtl)(lines: _*)("AddOne_1", "Bar_AddOne")
-  }
-
-  // This has to be defined at the top-level because @instantiable doesn't work when nested.
-  @instantiable
-  class AddOne(width: Int) extends Module {
-    @public val in = IO(Input(UInt(width.W)))
-    @public val out = IO(Output(UInt(width.W)))
-    out := in + 1.U
   }
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -179,4 +179,24 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 
 //    matchesAndOmits(sv)(lines: _*)()
   }
+
+  it should "Definitions that appear within withModulePrefix get prefixed" in {
+    class Top extends Module {
+      val dfn = withModulePrefix("Foo") {
+        Definition(new AddOne(8))
+      }
+
+      val addone = Instance(dfn)
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+    println(chirrtl)
+
+    val lines = """
+  module Foo_AddOne
+  module Top
+        """.linesIterator.map(_.trim).toSeq
+
+    matchesAndOmits(chirrtl)(lines: _*)()
+  }
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -178,7 +178,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 //    println(sv)
 
     val chirrtl = emitCHIRRTL(new Top)
-    println(chirrtl)
+    //println(chirrtl)
 
     val lines = """
       module mem_1024x8(
@@ -206,6 +206,28 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
         """.linesIterator.map(_.trim).toSeq
 
     matchesAndOmits(chirrtl)(lines: _*)()
+  }
+
+  it should "allow definitions to be instantiated within a withModulePrefix block without prefixing it" in {
+    class Child(defn: Definition[AddOne]) extends Module {
+      val addone = Instance(defn)
+    }
+
+    class Top extends Module {
+      val defn =  Definition(new AddOne(8))
+
+      val child = withModulePrefix("Foo") {
+        Module(new Child(defn))
+      }
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+
+    val lines = """
+    module AddOne
+    module Foo_Child
+    public module Top
+        """.linesIterator.map(_.trim).toSeq
   }
 
   it should "withModulePrefix does not affect ExtModules" in {

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -256,7 +256,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     matchesAndOmits(chirrtl)(lines: _*)()
   }
 
-  it should "Using currentModulePrefix to force the name of an extmodule" in {
+  it should "Using modulePrefix to force the name of an extmodule" in {
     class Sub extends ExtModule {
       override def desiredName = modulePrefix + "Sub"
     }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -111,7 +111,6 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     }
 
     val chirrtl = emitCHIRRTL(new Top)
-    // println(chirrtl)
 
     val lines = """
       module Foo_AddOne :
@@ -145,7 +144,6 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     }
 
     val chirrtl = emitCHIRRTL(new Top)
-    // println(chirrtl)
 
     val lines = """
       module Foo_AddOne :

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -174,18 +174,27 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
       io.dataOut := smem.read(io.addr, io.enable)
     }
 
-//    val sv = ChiselStage.emitSystemVerilog(new Top)
-//    println(sv)
-
     val chirrtl = emitCHIRRTL(new Top)
-    //println(chirrtl)
 
     val lines = """
-      module mem_1024x8(
-      module Top(
+      {
+        "class":"chisel3.ModulePrefixAnnotation",
+        "target":"~Top|Top>smem",
+        "prefix":"Foo_"
+      },
+      {
+        "class":"chisel3.ModulePrefixAnnotation",
+        "target":"~Top|Top>cmem",
+        "prefix":"Bar_"
+      },
+      {
+        "class":"chisel3.ModulePrefixAnnotation",
+        "target":"~Top|Top>sram_sram",
+        "prefix":"Baz_"
+      }
         """.linesIterator.map(_.trim).toSeq
 
-//    matchesAndOmits(sv)(lines: _*)()
+    matchesAndOmits(chirrtl)(lines: _*)()
   }
 
   it should "Definitions that appear within withModulePrefix get prefixed" in {
@@ -198,7 +207,6 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     }
 
     val chirrtl = emitCHIRRTL(new Top)
-//    println(chirrtl)
 
     val lines = """
   module Foo_AddOne
@@ -238,6 +246,5 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     }
 
     val chirrtl = emitCHIRRTL(new Top)
-    //println(chirrtl)
   }
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -8,7 +8,7 @@ import circt.stage.ChiselStage.emitCHIRRTL
 
 class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with MatchesAndOmits {
 
-  behavior.of("withPrefix")
+  behavior.of("withModulePrefix")
 
   it should "prefix modules in a withModulePrefix block, but not outside" in {
     class Foo extends RawModule {

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.experimental.ExtModule
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance, Instantiate}
 import circt.stage.ChiselStage.emitCHIRRTL
 import circt.stage.ChiselStage
@@ -29,9 +30,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     class Top extends RawModule {
       val foo = Module(new Foo)
 
-      withModulePrefix("Pref") {
-        val pref_foo = Module(new Foo)
-      }
+      val pref_foo = withModulePrefix("Pref") { Module(new Foo) }
     }
 
     val chirrtl = emitCHIRRTL(new Top)
@@ -198,5 +197,17 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
         """.linesIterator.map(_.trim).toSeq
 
     matchesAndOmits(chirrtl)(lines: _*)()
+  }
+
+  it should "withModulePrefix does not affect ExtModules" in {
+    class Sub extends ExtModule {
+    }
+
+    class Top extends Module {
+      val sub_foo = withModulePrefix("Foo") { Module(new Sub) }
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+    println(chirrtl)
   }
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -154,12 +154,12 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 
     matchesAndOmits(chirrtl)(lines: _*)("AddOne_1", "Bar_AddOne")
   }
-}
 
-// This has to be defined at the top-level because @instantiable doesn't work when nested.
-@instantiable
-class AddOne(width: Int) extends Module {
-  @public val in = IO(Input(UInt(width.W)))
-  @public val out = IO(Output(UInt(width.W)))
-  out := in + 1.U
+  // This has to be defined at the top-level because @instantiable doesn't work when nested.
+  @instantiable
+  class AddOne(width: Int) extends Module {
+    @public val in = IO(Input(UInt(width.W)))
+    @public val out = IO(Output(UInt(width.W)))
+    out := in + 1.U
+  }
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -214,7 +214,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     }
 
     class Top extends Module {
-      val defn =  Definition(new AddOne(8))
+      val defn = Definition(new AddOne(8))
 
       val child = withModulePrefix("Foo") {
         Module(new Child(defn))
@@ -231,8 +231,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
   }
 
   it should "withModulePrefix does not automatically affect ExtModules" in {
-    class Sub extends ExtModule {
-    }
+    class Sub extends ExtModule {}
 
     class Top extends Module {
       val sub_foo = withModulePrefix("Foo") { Module(new Sub) }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -126,7 +126,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     matchesAndOmits(chirrtl)(lines: _*)("AddOne_1")
   }
 
-  it should "Instnantiate should reference the same module definitions when instantiated with the same prefix" in {
+  it should "Instantiate should reference the same module definitions when instantiated with the same prefix" in {
     class Top extends Module {
       val width = 8
       val in = IO(Input(UInt(width.W)))

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -255,4 +255,24 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
 
     matchesAndOmits(chirrtl)(lines: _*)()
   }
+
+  it should "Using currentModulePrefix to force the name of an extmodule" in {
+    class Sub extends ExtModule {
+      override def desiredName = currentModulePrefix + "Sub"
+    }
+
+    class Top extends Module {
+      val sub_foo = withModulePrefix("Foo") { Module(new Sub) }
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+
+    val lines = """
+      extmodule Foo_Sub
+        defname = Foo_Sub
+      module Top
+        """.linesIterator.map(_.trim).toSeq
+
+    matchesAndOmits(chirrtl)(lines: _*)()
+  }
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -246,5 +246,13 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     }
 
     val chirrtl = emitCHIRRTL(new Top)
+
+    val lines = """
+      extmodule Sub
+        defname = Sub
+      module Top
+        """.linesIterator.map(_.trim).toSeq
+
+    matchesAndOmits(chirrtl)(lines: _*)()
   }
 }

--- a/src/test/scala/chiselTests/PrefixSpec.scala
+++ b/src/test/scala/chiselTests/PrefixSpec.scala
@@ -36,12 +36,6 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     val chirrtl = emitCHIRRTL(new Top)
 
     val lines = """
-      {
-        "class":"chisel3.ModulePrefixAnnotation",
-        "target":"~Top|Pref_Foo",
-        "prefix":"Pref_"
-      }
-
       module Foo :
         wire a : UInt<1>
       module Pref_Foo :
@@ -73,19 +67,7 @@ class PrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with Match
     val chirrtl = emitCHIRRTL(new Top)
 
     val lines =
-      """circuit Top :%[[
-      [[
-        {
-          "class":"chisel3.ModulePrefixAnnotation",
-          "target":"~Top|Outer_Inner_Bar",
-          "prefix":"Outer_Inner_"
-        },
-        {
-          "class":"chisel3.ModulePrefixAnnotation",
-          "target":"~Top|Outer_Foo",
-          "prefix":"Outer_"
-        }
-      ]]
+      """
       module Outer_Inner_Bar :
         wire a : UInt<1>
       module Outer_Foo


### PR DESCRIPTION
Introduces a new API `withModulePrefix`.

Example:

```scala
class Submod extends RawModule {
  // ...
}

class Top extends RawModule {
  val noprefix_inst = Module(new Submod)

  withModulePrefix("Foo") {
    val foo_inst = Module(new Submod)
  }

  withModulePrefix("Bar") {
    val bar_inst = Module(new Submod)
  }
}
```

This will result in the definition of the following modules:

```firrtl
  module Submod :
    skip

  module Foo_Submod :
    skip

  module Bar_Submod : 
    skip

  public module Top :

    inst noprefix_inst of Submod
    inst foo_inst of Foo_Submod
    inst bar_inst of Bar_Submod
```

Only module definitions are prefixed. Other circuit components, such as wires and registers, are unaffected.

Module prefixes nest, where `Foo_Bar_Submod` indicating that a prefix `Foo` exists in the grantparent or higher of the instance of `Submod`.

When using this API with`Instantiate`, two instantiations under two distinct module prefix blocks will result in two "copies" of the definition, one for each prefix. Conversely, two instantiations under the same module prefix block will share the same prefixed definition.


### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
