### PR TITLE
Change default layers to use lowercase directories

### DIFF
--- a/core/src/main/scala/chisel3/layers/Layers.scala
+++ b/core/src/main/scala/chisel3/layers/Layers.scala
@@ -1,17 +1,34 @@
 package chisel3.layers
 
 import chisel3.experimental.UnlocatableSourceInfo
-import chisel3.layer.{Layer, LayerConfig}
+import chisel3.layer.{CustomOutputDir, Layer, LayerConfig}
+import java.nio.file.Paths
 
 /** The root [[chisel3.layer.Layer]] for all shared verification collateral. */
-object Verification extends Layer(LayerConfig.Extract())(_parent = Layer.Root, _sourceInfo = UnlocatableSourceInfo) {
+object Verification
+    extends Layer(LayerConfig.Extract(CustomOutputDir(Paths.get("verification"))))(
+      _parent = Layer.Root,
+      _sourceInfo = UnlocatableSourceInfo
+    ) {
 
   /** The [[chisel3.layer.Layer]] where all assertions will be placed. */
-  object Assert extends Layer(LayerConfig.Extract())(_parent = Verification, _sourceInfo = UnlocatableSourceInfo)
+  object Assert
+      extends Layer(LayerConfig.Extract(CustomOutputDir(Paths.get("verification", "assert"))))(
+        _parent = Verification,
+        _sourceInfo = UnlocatableSourceInfo
+      )
 
   /** The [[chisel3.layer.Layer]] where all assumptions will be placed. */
-  object Assume extends Layer(LayerConfig.Extract())(_parent = Verification, _sourceInfo = UnlocatableSourceInfo)
+  object Assume
+      extends Layer(LayerConfig.Extract(CustomOutputDir(Paths.get("verification", "assume"))))(
+        _parent = Verification,
+        _sourceInfo = UnlocatableSourceInfo
+      )
 
   /** The [[chisel3.layer.Layer]] where all covers will be placed. */
-  object Cover extends Layer(LayerConfig.Extract())(_parent = Verification, _sourceInfo = UnlocatableSourceInfo)
+  object Cover
+      extends Layer(LayerConfig.Extract(CustomOutputDir(Paths.get("verification", "cover"))))(
+        _parent = Verification,
+        _sourceInfo = UnlocatableSourceInfo
+      )
 }

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -292,7 +292,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
       layer.addLayer(ExpensiveAsserts)
     }
 
-    ChiselStage.emitCHIRRTL(new Foo) should include("""layer ExpensiveAsserts, bind, "Verification/ExpensiveAsserts"""")
+    ChiselStage.emitCHIRRTL(new Foo) should include("""layer ExpensiveAsserts, bind, "verification/ExpensiveAsserts"""")
   }
 
   "addLayer API" should "add a layer to the output CHIRRTL even if no layer block references that layer" in {
@@ -303,17 +303,28 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))("layer A")("layer block")
   }
 
-  "Default Layers" should "always be emitted in CHIRRTL (whereas non-default layers are optionally emitted)" in {
+  "Default Layers" should "always be emitted" in {
     class Foo extends RawModule {}
+    val chirrtl = ChiselStage.emitCHIRRTL(new Foo)
 
-    matchesAndOmits(ChiselStage.emitCHIRRTL(new Foo))(
+    info("default layers are emitted")
+    matchesAndOmits(chirrtl)(
       "layer Verification",
       "layer Assert",
       "layer Assume",
       "layer Cover"
-    )(
-      "layer B"
-    )
+    )()
+
+    info("user-defined layers are not emitted if not used")
+    chirrtl should not include("layer B")
+
+    info("default layers have lowercase directories")
+    matchesAndOmits(chirrtl)(
+      """layer Verification, bind, "verification"""",
+      """layer Assert, bind, "verification/assert"""",
+      """layer Assume, bind, "verification/assume"""",
+      """layer Cover, bind, "verification/cover""""
+    )()
   }
 
   "Layers error checking" should "require that the current layer is an ancestor of the desired layer" in {

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -316,7 +316,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
     )()
 
     info("user-defined layers are not emitted if not used")
-    chirrtl should not include("layer B")
+    (chirrtl should not).include("layer B")
 
     info("default layers have lowercase directories")
     matchesAndOmits(chirrtl)(


### PR DESCRIPTION
Change directories for default layers to use lowercase output directories. While this is independently likely a better choice, it is a somewhat pragmatic, as these directory names match the legacy names of `firtool`'s extract-test-code feature (which was a custom SiFive pass for the SFC before being open-sourced in `firtool`).  This will help us land an extract-test-code replacement without having to disturb build flows. Secondarily, and independently, lower case directories are likely better.

There are two alternative changes which were rejected:

1. The layers could be renamed to be lowercase.  Generally, it's better to have objects and classes be uppercase.

2. The automatic directory names could be mangled to be lowercase as opposed to the exact layer names.

#### Release Notes

Change directories for default layers to be lowercase.
