### PR TITLE
Wrap printfs in the Verification layerblock

### DIFF
--- a/core/src/main/scala-2/chisel3/PrintfMacros.scala
+++ b/core/src/main/scala-2/chisel3/PrintfMacros.scala
@@ -5,6 +5,7 @@ package chisel3
 import chisel3.internal._
 import chisel3.internal.Builder.pushCommand
 import chisel3.experimental.SourceInfo
+import chisel3.{layer, layers}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
@@ -75,7 +76,9 @@ object PrintfMacrosCompat {
 
     Printable.checkScope(pable)
 
-    pushCommand(chisel3.internal.firrtl.ir.Printf(printfId, sourceInfo, clock.ref, pable))
+    layer.block(layers.Verification, skipIfAlreadyInBlock = true, skipIfLayersEnabled = true) {
+      pushCommand(chisel3.internal.firrtl.ir.Printf(printfId, sourceInfo, clock.ref, pable))
+    }
     printfId
   }
 

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -8,24 +8,20 @@ import circt.stage.ChiselStage
 class SinglePrintfTester() extends Module {
   val x = 254.U
   printf("x=%x", x)
-  stop()
 }
 
 class ASCIIPrintfTester() extends Module {
   printf((0x20 to 0x7e).map(_.toChar).mkString.replace("%", "%%"))
-  stop()
 }
 
 class MultiPrintfTester() extends Module {
   val x = 254.U
   val y = 255.U
   printf("x=%x y=%x", x, y)
-  stop()
 }
 
 class ASCIIPrintableTester extends Module {
   printf(PString((0x20 to 0x7e).map(_.toChar).mkString("")))
-  stop()
 }
 
 class ScopeTesterModule extends Module {
@@ -42,7 +38,10 @@ class ScopeTesterModule extends Module {
 
 class PrintfSpec extends ChiselFlatSpec {
   "A printf with a single argument" should "elaborate" in {
-    ChiselStage.emitCHIRRTL(new SinglePrintfTester)
+    val chirrtl = ChiselStage.emitCHIRRTL(new SinglePrintfTester)
+
+    info("printfs are wrapped in the `Verification` layerblock by default")
+    chirrtl should include("layerblock Verification")
   }
   "A printf with multiple arguments" should "elaborate" in {
     ChiselStage.emitCHIRRTL(new MultiPrintfTester)


### PR DESCRIPTION
Change the emission of printfs to emit these under the `Verification` layerblock.  This is done as part of replacing the `firtool` extract-test-code feature with layers and the "advanced layer sink" `firtool` feature.

The extract-test-code feature will extract asserts _and_ printfs together. This is technically a deviation from this behavior.  However, it seems better to not lump these in with asserts.  Nonetheless, this is a backwards compatible change from the perspective of extract-test-code because the `Verification` layer is always loaded if the `Assert` layer is present.  (Prints will always show up if you turn on assertions.)

In the future, we probably want to add a `Debug` layer under the `Verification` layer where these will live.  I would like to hold off on making this change until extract-test-code is gone.

#### Release Notes

Move printfs under the `Verification` layer by default.