### PR TITLE
Restore common scalacOptions to project chisel

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -315,6 +315,14 @@ trait Chisel extends CrossSbtModule with HasScala2MacroAnno with HasScala2Plugin
   def coreModule = core(crossScalaVersion)
   def pluginModule = plugin()
 
+  override def scalacOptions = T {
+    if (v.isScala3(crossScalaVersion)) {
+      Seq.empty[String]
+    } else {
+      super.scalacOptions() ++ v.scala2CommonOptions
+    }
+  }
+
   override def moduleDeps = super.moduleDeps ++ Seq(coreModule, svsimModule)
 
   object test extends SbtModuleTests with TestModule.ScalaTest with ScalafmtModule {


### PR DESCRIPTION
They were accidentally dropped in https://github.com/chipsalliance/chisel/pull/4492

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
