### PR TITLE
Add new InlineAllInstances trait

### DIFF
--- a/src/main/scala/chisel3/util/experimental/Inline.scala
+++ b/src/main/scala/chisel3/util/experimental/Inline.scala
@@ -50,6 +50,17 @@ trait InlineInstance { self: BaseModule =>
     .map(chisel3.experimental.annotate(_))
 }
 
+/** Inlines all instances of a module. If this module dedups with any other
+  * module, instances of that other module will also be inlined.
+  */
+trait InlineInstanceAllowDedup { self: BaseModule =>
+  chisel3.experimental.annotate(
+    new ChiselAnnotation {
+      def toFirrtl: Annotation = InlineAnnotation(self.toNamed)
+    }
+  )
+}
+
 /** Flattens an instance of a module
   *
   * @example {{{

--- a/src/test/scala/chiselTests/InlineSpec.scala
+++ b/src/test/scala/chiselTests/InlineSpec.scala
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import circt.stage.ChiselStage
+import org.scalatest.matchers.should.Matchers
+import chiselTests.{ChiselFlatSpec, MatchesAndOmits}
+import chisel3.util.experimental.{InlineInstance, InlineInstanceAllowDedup}
+
+class InlineInstanceSpec extends ChiselFlatSpec with MatchesAndOmits {
+  class ModuleA extends RawModule {
+    val w = dontTouch(WireInit(false.B))
+  }
+
+  class ModuleB extends RawModule with InlineInstance {
+    val w = dontTouch(WireInit(false.B))
+  }
+
+  class TopModule extends RawModule {
+    val a = Module(new ModuleA)
+    val b = Module(new ModuleB)
+  }
+
+  "InlineInstanceAllowDedup" should "Inline any module that dedups with a module marked inline" in {
+    val verilog = ChiselStage.emitSystemVerilog(new TopModule)
+    matchesAndOmits(verilog)(
+      "module TopModule()",
+      "module ModuleA();"
+    )(
+      "module ModuleB()"
+    )
+  }
+}
+
+class InlineInstanceAllowDedupSpec extends ChiselFlatSpec with MatchesAndOmits {
+  class ModuleA extends RawModule {
+    val w = dontTouch(WireInit(false.B))
+  }
+
+  class ModuleB extends RawModule with InlineInstanceAllowDedup {
+    val w = dontTouch(WireInit(false.B))
+  }
+
+  class TopModule extends RawModule {
+    val a = Module(new ModuleA)
+    val b = Module(new ModuleB)
+  }
+
+  "InlineInstanceAllowDedup" should "Inline any module that dedups with a module marked inline" in {
+    val verilog = ChiselStage.emitSystemVerilog(new TopModule)
+    matchesAndOmits(verilog)(
+      "module TopModule()"
+    )(
+      "module ModuleA()",
+      "module ModuleB()"
+    )
+  }
+}


### PR DESCRIPTION
The InlineInstance trait can be attached to a module, to cause firtool to inline instance of that module. The inline annotation is tricky to wield because, if an inline module dedups with another module, we will inline all instances of both modules.

To make InlineInstance easier to use, whenever we mark a module as inline, we also mark it as "no dedup".

This of course does not work well when we have a module which we want to inline AND dedup. So, this PR adds a new InlineAllInstances trait which allows a module to be marked inline without blocking dedup.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).
- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
