### PR TITLE
Bump emitted FIRRTL to 4.1.0

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -15,7 +15,7 @@ object Serializer {
   val Indent = "  "
 
   // The version supported by the serializer.
-  val version = Version(4, 0, 0)
+  val version = Version(4, 1, 0)
 
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -8,7 +8,7 @@ import firrtl.testutils._
 class ExtModuleTests extends FirrtlFlatSpec {
   "extmodule" should "serialize and re-parse equivalently" in {
     val input =
-      """|FIRRTL version 4.0.0
+      """|FIRRTL version 4.1.0
          |circuit Top :
          |  extmodule Top :
          |    input y : UInt<0>

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -1089,7 +1089,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
 
       val text = ChiselStage.emitCHIRRTL(new ChiselStageSpec.Foo(hasDontTouch = true))
       info("found a version string")
-      text should include("FIRRTL version 4.0.0")
+      text should include("FIRRTL version 4.1.0")
       info("found an Annotation")
       text should include("firrtl.transforms.DontTouchAnnotation")
       info("found a circuit")


### PR DESCRIPTION
FIRRTL spec version 4.0.0 was released.  Chisel is currently emitting things _beyond_ this and it should now mark the emitted FIRRTL as being 4.1.0.

#### Release Notes

Bump emitted FIRRTL version to 4.1.0.