### PR TITLE
Refactor Lookupable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,8 @@ lazy val warningSuppression = Seq(
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
     "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
-    "cat=deprecation&origin=chisel3\\.ltl.*:s"
+    "cat=deprecation&origin=chisel3\\.ltl.*:s",
+    "cat=deprecation&msg=Looking up Modules is deprecated:s",
   ).mkString(",")
 )
 

--- a/build.sc
+++ b/build.sc
@@ -73,7 +73,11 @@ object v extends Module {
     "cat=deprecation&origin=firrtl\\.options\\.internal\\.WriteableCircuitAnnotation:s",
     "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
-    "cat=deprecation&origin=chisel3\\.ltl.*:s"
+    "cat=deprecation&origin=chisel3\\.ltl.*:s",
+    // Deprecated for external users, will eventually be removed.
+    "cat=deprecation&msg=Looking up Modules is deprecated:s",
+    // Only for testing of deprecated APIs
+    "cat=deprecation&msg=Use of @instantiable on user-defined types is deprecated:s"
   )
 
   // ScalacOptions

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/IsInstantiable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/IsInstantiable.scala
@@ -11,6 +11,10 @@ trait IsInstantiable
 
 object IsInstantiable {
   implicit class IsInstantiableExtensions[T <: IsInstantiable](i: T) {
+    @deprecated(
+      "Use of @instantiable on user-defined types is deprecated. Implement Lookupable for your type instead.",
+      "Chisel 7.0.0"
+    )
     def toInstance: Instance[T] = new Instance(Proto(i))
   }
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/package.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/package.scala
@@ -9,4 +9,6 @@ package object hierarchy {
   val Hierarchy = core.Hierarchy
   type IsInstantiable = core.IsInstantiable
   type IsLookupable = core.IsLookupable
+  type Lookupable[P] = core.Lookupable[P]
+  val Lookupable = core.Lookupable
 }


### PR DESCRIPTION
See Release Notes for description.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)
- API deprecation



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Historically, the Lookupable API is able to change the type of fields looked up from Definitions or Instances. This enabled Module fields to be looked up as Instances, as well as user-defined types to opt-in to this same Instance-boxing behavior.

This path-dependent type changing behavior is now deprecated. Looking up Modules is also deprecated, instead, the user should cast them Instances (via `.toInstance`). It is also deprecated to mark user-defined types as `@instantiable`. Instead, users should define Lookupable for their types using the new Lookupable.product[1-5] factory methods. See the Chisel website for more details.

* Deprecate user-extension of trait Lookupable.
* Deprecate Lookupable.lookupModule. Users should use Instances instead
  of Modules.
* Deprecate Lookupable.isInstantiable. User should use new factories to
  implement Lookupable for their user-defined types instead.
* Deprecate Lookupable.SimpleLookupable.
* Add Lookupable.isLookupable factory for "simple" Lookupables.
* Add Lookupable.product1-5 factories for Lookupables for user-defined types.
* Add Lookupable for Tuple3-5 (already existed for Tuple2).
* Add private LookupableImpl which is simpler to implement.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
