### PR TITLE
Rename localPrefixAppliesToSelf to localModulePrefixAppliesToSelf

### DIFF
--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -936,7 +936,7 @@ package experimental {
           case Some(c) => getRef.fullName(c)
         }
 
-    /** Additional module prefix, applies to this module if defined (unless localModulePrefix is false) and all children.
+    /** Additional module prefix, applies to this module if defined (unless localModulePrefixAppliesToSelf is false) and all children.
       */
     def localModulePrefix: Option[String] = None
 
@@ -944,14 +944,14 @@ package experimental {
       *
       * Users should override to false if [[localModulePrefix]] should apply only to children.
       */
-    def localPrefixAppliesToSelf: Boolean = true
+    def localModulePrefixAppliesToSelf: Boolean = true
 
     /** The resolved module prefix used for this Module.
       *
-      * Includes [[localModulePrefix]] if defined and if [[localPrefixAppliesToSelf]] is true.
+      * Includes [[localModulePrefix]] if defined and if [[localModulePrefixAppliesToSelf]] is true.
       */
     final val modulePrefix: String =
-      withModulePrefix(localModulePrefix.filter(_ => localPrefixAppliesToSelf).getOrElse("")) {
+      withModulePrefix(localModulePrefix.filter(_ => localModulePrefixAppliesToSelf).getOrElse("")) {
         Builder.getModulePrefix
       }
 

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -63,14 +63,14 @@ class Sub extends Module {
 
 This results in two module definitions: `Foo_Top` and `Foo_Sub`.
 
-You can also override `localPrefixAppliesToSelf` to `false` to only apply the prefix to the children.
+You can also override `localModulePrefixAppliesToSelf` to `false` to only apply the prefix to the children.
 
 ```scala mdoc:silent:reset
 import chisel3._
 
 class Top extends Module {
   override def localModulePrefix = Some("Foo")
-  override def localPrefixAppliesToSelf = false
+  override def localModulePrefixAppliesToSelf = false
   val sub = Module(new Sub)
 }
 
@@ -124,7 +124,7 @@ class Top extends Module {
 class Mid extends Module {
   // You can mix withModulePrefix and localModulePrefix.
   override def localModulePrefix = Some("Bar")
-  override def localPrefixAppliesToSelf = false
+  override def localModulePrefixAppliesToSelf = false
   val sub = Module(new Sub)
 }
 

--- a/src/test/scala/chiselTests/ModulePrefixSpec.scala
+++ b/src/test/scala/chiselTests/ModulePrefixSpec.scala
@@ -302,14 +302,14 @@ class ModulePrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with
     matchesAndOmits(chirrtl)(lines: _*)()
   }
 
-  it should "set the prefix for a Module's children but not the Module itself if localPrefixAppliesToSelf is false" in {
+  it should "set the prefix for a Module's children but not the Module itself if localModulePrefixAppliesToSelf is false" in {
 
     class Foo extends RawModule
     class Bar extends RawModule
 
     class Top extends RawModule {
       override def localModulePrefix = Some("Prefix")
-      override def localPrefixAppliesToSelf = false
+      override def localModulePrefixAppliesToSelf = false
       val foo = Module(new Foo)
       val bar = Module(new Bar)
     }


### PR DESCRIPTION
Labeling `No Release Notes` because the API this is modifying has not yet been released.

The slightly more concise `localPrefixAppliesToSelf` does not add value and may imply to users that it modifies more things than just `localModulePrefix`. So I decided to make it more verbose and clear.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
