### PR TITLE
Add APIs to omit module prefix separator

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/InstantiateImpl.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/InstantiateImpl.scala
@@ -73,7 +73,7 @@ private[chisel3] trait InstantiateImpl {
 
   import chisel3.internal.BuilderContextCache
   // Include type of module in key since different modules could have the same arguments
-  private case class CacheKey[A <: BaseModule](args: Any, tt: Any, modulePrefix: List[String])
+  private case class CacheKey[A <: BaseModule](args: Any, tt: Any, modulePrefix: String)
       extends BuilderContextCache.Key[Definition[A]]
 
   protected def _instanceImpl[K, A <: BaseModule](
@@ -90,7 +90,7 @@ private[chisel3] trait InstantiateImpl {
     f:    K => A,
     tt:   Any
   ): Definition[A] = {
-    val modulePrefix = Builder.getModulePrefixList
+    val modulePrefix = Module.currentModulePrefix
     Builder.contextCache
       .getOrElseUpdate(
         CacheKey[A](boxAllData(args), tt, modulePrefix), {

--- a/docs/src/explanations/moduleprefix.md
+++ b/docs/src/explanations/moduleprefix.md
@@ -43,6 +43,24 @@ The result will be a design with two module definitions: `Top` and `Foo_Sub`.
 Note that the `val sub =` part must be pulled outside of the `withModulePrefix` block,
 or else the module will not be accessible to the rest of the `Top` module.
 
+You can omit the prefix separator (`_`) by passing `false` as the second argument:
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class Top extends Module {
+  val sub = withModulePrefix("Foo", false) {
+    Module(new Sub)
+  }
+}
+
+class Sub extends Module {
+  // ..
+}
+```
+
+This results in two module definitions: `Top` and `FooSub`.
+
 ## localModulePrefix
 
 We can also set a module prefix on a module by overriding the `localModulePrefix` method.
@@ -80,6 +98,24 @@ class Sub extends Module {
 ```
 
 This results in the two module definitions `Top` and `Foo_Sub`.
+
+You can also override `localModulePrefixUseSeparator` to `false` to omit the separator.
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class Top extends Module {
+  override def localModulePrefix = Some("Foo")
+  override def localModulePrefixUseSeparator = false
+  val sub = Module(new Sub)
+}
+
+class Sub extends Module {
+  // ..
+}
+```
+
+This results in the two module definitions `FooTop` and `FooSub`.
 
 ## Multiple Prefixes
 

--- a/src/test/scala/chiselTests/ModulePrefixSpec.scala
+++ b/src/test/scala/chiselTests/ModulePrefixSpec.scala
@@ -276,6 +276,24 @@ class ModulePrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with
     matchesAndOmits(chirrtl)(lines: _*)()
   }
 
+  it should "support omitting the separator" in {
+    class Foo extends Module
+    class Top extends Module {
+      val foo = withModulePrefix("Prefix", false) {
+        Module(new Foo)
+      }
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+
+    val lines = """
+      module PrefixFoo :
+      module Top :
+        inst foo of PrefixFoo
+        """.linesIterator.map(_.trim).toSeq
+    matchesAndOmits(chirrtl)(lines: _*)()
+  }
+
   behavior.of("BaseModule.localModulePrefix")
 
   it should "set the prefix for a Module and its children" in {
@@ -353,6 +371,56 @@ class ModulePrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with
         inst f1 of Outer_Inner_Foo
         inst f2 of Outer_Prefix_Inner_Foo
         inst bar of Outer_Prefix_Bar
+      """.linesIterator.map(_.trim).toSeq
+
+    matchesAndOmits(chirrtl)(lines: _*)()
+  }
+
+  it should "omit the prefix if localModulePrefixUseSeparator is false" in {
+    class Foo extends RawModule {
+      override def localModulePrefix = Some("Inner")
+      override def localModulePrefixUseSeparator = false
+    }
+    class Top extends RawModule {
+      override def localModulePrefix = Some("Outer")
+      override def localModulePrefixUseSeparator = false
+      override def localModulePrefixAppliesToSelf = false
+      val foo = Module(new Foo)
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+    val lines =
+      """
+      module OuterInnerFoo :
+      module Top :
+        inst foo of OuterInnerFoo
+      """.linesIterator.map(_.trim).toSeq
+
+    matchesAndOmits(chirrtl)(lines: _*)()
+  }
+
+  it should "support mixing and matching of separator omission" in {
+    class Foo extends RawModule {
+      override def localModulePrefix = Some("Inner")
+    }
+    class Bar extends RawModule {
+      override def localModulePrefix = Some("Middle")
+      val foo = Module(new Foo)
+    }
+    class Top extends RawModule {
+      override def localModulePrefix = Some("Outer")
+      override def localModulePrefixUseSeparator = false
+      val bar = Module(new Bar)
+    }
+
+    val chirrtl = emitCHIRRTL(new Top)
+    val lines =
+      """
+      module OuterMiddle_Inner_Foo :
+      module OuterMiddle_Bar :
+        inst foo of OuterMiddle_Inner_Foo
+      module OuterTop :
+        inst bar of OuterMiddle_Bar
       """.linesIterator.map(_.trim).toSeq
 
     matchesAndOmits(chirrtl)(lines: _*)()


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

* `withModulePrefix` now optionally takes a 2nd parameter `includeSeparator` (passing `false` will omit separator).
* Overriding `localModulePrefixUseSeparator` in a Module to false will omit separator for local prefix applied by overriding `localModulePrefix` in that Module.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
