### PR TITLE
[panama] Update bindings for CIRCT 1.96.0

### DIFF
--- a/panamalib/src/PanamaCIRCT.scala
+++ b/panamalib/src/PanamaCIRCT.scala
@@ -321,10 +321,6 @@ class PanamaCIRCT {
     CAPI.circtFirtoolOptionsSetCompanionMode(options.get, value.get)
   def circtFirtoolOptionsSetDisableAggressiveMergeConnections(options: CirctFirtoolFirtoolOptions, value: Boolean) =
     CAPI.circtFirtoolOptionsSetDisableAggressiveMergeConnections(options.get, value)
-  def circtFirtoolOptionsSetEmitOmir(options: CirctFirtoolFirtoolOptions, value: Boolean) =
-    CAPI.circtFirtoolOptionsSetEmitOmir(options.get, value)
-  def circtFirtoolOptionsSetOmirOutFile(options: CirctFirtoolFirtoolOptions, value: String) =
-    CAPI.circtFirtoolOptionsSetOmirOutFile(options.get, newString(value).get)
   def circtFirtoolOptionsSetLowerMemories(options: CirctFirtoolFirtoolOptions, value: Boolean) =
     CAPI.circtFirtoolOptionsSetLowerMemories(options.get, value)
   def circtFirtoolOptionsSetBlackBoxRootPath(options: CirctFirtoolFirtoolOptions, value: String) =


### PR DESCRIPTION
Remove OMIR options for the CAPI bindings.  These were removed from upstream CIRCT.