### PR TITLE
fix: evaluate target lazily in Path

### DIFF
--- a/core/src/main/scala/chisel3/properties/Path.scala
+++ b/core/src/main/scala/chisel3/properties/Path.scala
@@ -106,8 +106,8 @@ object Path {
 
   /** Construct a Path from a target
     */
-  def apply(target: IsMember): Path = apply(target, false)
-  def apply(target: IsMember, isMemberPath: Boolean): Path = {
+  def apply(target: => IsMember): Path = apply(target, false)
+  def apply(target: => IsMember, isMemberPath: Boolean): Path = {
     val _isMemberPath = isMemberPath // avoid name shadowing below
     new TargetPath {
       def toTarget():   IsMember = target


### PR DESCRIPTION
At the moment `toTarget` does not work properly with the D/I system, seeing that we cannot get the instanceName of a module when evaluating it, and even if we call `toTarget` in `atModuleBodyEnd` we will get the wrong circuit name since the definition of the module's parent is still in construction.

In order to construct `Path` properly, we need to defer the evaluation of `target` to the IR generation time in the `isMember` constructor, just as the other constructors already do.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [ ] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
