### PR TITLE
Fix auto generated DedupGroups to be sensitive to module prefix

### DIFF
--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -682,6 +682,17 @@ package experimental {
       */
     def desiredName: String = simpleClassName(this.getClass)
 
+    /** The name that will be proposed for this module, subject to uniquification.
+      *
+      * Includes the module prefix for user-defined modules (but not for blackboxes).
+      */
+    private[chisel3] def _proposedName: String = this match {
+      // PseudoModules (e.g. Instances) and BlackBoxes have their names set by desiredName.
+      case _: PseudoModule => desiredName
+      case _: BaseBlackBox => desiredName
+      case _ => this.modulePrefix + desiredName
+    }
+
     /** Legalized name of this module. */
     final lazy val name = {
       def err(msg: String, cause: Throwable = null) = {
@@ -693,9 +704,8 @@ package experimental {
         // PseudoModules are not "true modules" and thus should share
         // their original modules names without uniquification
         this match {
-          case _: PseudoModule => Module.currentModulePrefix + desiredName
-          case _: BaseBlackBox => Builder.globalNamespace.name(desiredName)
-          case _ => Builder.globalNamespace.name(this.modulePrefix + desiredName)
+          case _: PseudoModule => _proposedName
+          case _ => Builder.globalNamespace.name(_proposedName)
         }
       } catch {
         case e: NullPointerException =>

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -34,7 +34,7 @@ class AddDedupGroupAnnotations extends Phase {
       case DefClass(_, _, _, _)              => false
       case x                                 => true
     }.collect {
-      case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id.desiredName)
+      case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id._proposedName)
     }
     annos ++ annotations
   }


### PR DESCRIPTION

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Also fix logic for naming PseudoModules which should ignore the prefix.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
