### PR TITLE
[test] Add Verilog test of inline emission, NFC

### DIFF
--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -5,6 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.hierarchy.core.{Definition, Instance}
 import chisel3.experimental.hierarchy.instantiable
+import chisel3.ltl.AssertProperty
 import chisel3.probe.{define, Probe, ProbeValue}
 import chiselTests.{ChiselFlatSpec, FileCheck, Utils}
 import java.nio.file.{FileSystems, Paths}
@@ -380,25 +381,60 @@ class LayerSpec extends ChiselFlatSpec with Utils with FileCheck {
     )
   }
 
-  "Inline layers" should "generated expected FIRRTL" in {
-    object A extends layer.Layer(layer.LayerConfig.Inline) {
-      object B extends layer.Layer(layer.LayerConfig.Inline)
-    }
-
-    class Foo extends RawModule {
-      layer.block(A) {
-        layer.block(A.B) {}
+  "Inline layers" should "generate expected FIRRTL and SystemVerilog" in {
+    object A extends layer.Layer(layer.LayerConfig.Extract()) {
+      object B extends layer.Layer(layer.LayerConfig.Inline) {
+        object C extends layer.Layer(layer.LayerConfig.Inline)
       }
     }
 
-    generateFirrtlAndFileCheck(new Foo) {
-      """|CHECK:      layer A, inline :
+    class Foo extends Module {
+      val a = IO(Input(UInt(2.W)))
+
+      layer.block(A) {
+        AssertProperty(a > 0.U, "foo")
+        layer.block(A.B) {
+          AssertProperty(a > 1.U, "bar")
+          layer.block(A.B.C) {
+            AssertProperty(a > 2.U, "baz")
+          }
+        }
+      }
+    }
+
+    info("FIRRTL okay")
+    generateFirrtlAndFileCheck(new Foo){
+      """|CHECK:      layer A, bind
          |CHECK-NEXT:   layer B, inline :
+         |CHECK-NEXT:     layer C, inline :
          |""".stripMargin
+    }
+
+    info("SystemVerilog okay")
+    val verilog = ChiselStage.emitSystemVerilog(
+      new Foo,
+      firtoolOpts = Array(
+        "-disable-all-randomization",
+        "-enable-layers=Verification,Verification.Assert,Verification.Assume,Verification.Cover"
+      )
+    )
+    fileCheckString(verilog){
+      """|CHECK:      module Foo(
+         |CHECK-NOT:    assert property
+         |
+         |CHECK:      module Foo_A(
+         |CHECK-NOT:    `ifdef
+         |CHECK:        foo: assert property
+         |CHECK:        `ifdef A_B
+         |CHECK-NEXT:     bar: assert property
+         |CHECK-NEXT:     `ifdef A_B_C
+         |CHECK-NEXT:       baz: assert property
+         |CHECK-NEXT:     `endif
+         |CHECK-NEXT:   `endif""".stripMargin
     }
   }
 
-  "Inline layers" should "be ignored when choosing default output directories" in {
+  they should "be ignored when choosing default output directories" in {
     object LayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {
       object InlineSublayer extends layer.Layer(layer.LayerConfig.Inline) {
         object SublayerWithDefaultOutputDir extends layer.Layer(layer.LayerConfig.Extract()) {}

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -403,7 +403,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with FileCheck {
     }
 
     info("FIRRTL okay")
-    generateFirrtlAndFileCheck(new Foo){
+    generateFirrtlAndFileCheck(new Foo) {
       """|CHECK:      layer A, bind
          |CHECK-NEXT:   layer B, inline :
          |CHECK-NEXT:     layer C, inline :
@@ -418,7 +418,7 @@ class LayerSpec extends ChiselFlatSpec with Utils with FileCheck {
         "-enable-layers=Verification,Verification.Assert,Verification.Assume,Verification.Cover"
       )
     )
-    fileCheckString(verilog){
+    fileCheckString(verilog) {
       """|CHECK:      module Foo(
          |CHECK-NOT:    assert property
          |

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -1200,31 +1200,31 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
         new Counter,
         firtoolOpts = Array("-enable-layers=Verification,Verification.Assert,Verification.Assume,Verification.Cover")
       )
-      btor2 should include("""1 sort bitvec 1
-                             |2 input 1 reset
-                             |3 sort bitvec 32
-                             |4 state 3 count
-                             |5 state 1 hbr
-                             |6 constd 1 0
-                             |7 init 1 5 6
-                             |8 constd 3 43
-                             |9 constd 3 1
-                             |10 constd 3 42
-                             |11 constd 3 0
-                             |12 eq 1 4 10
-                             |13 add 3 4 9
-                             |14 ite 3 12 11 13
-                             |15 ult 1 4 8
-                             |16 constd 1 -1
-                             |17 or 1 2 5
-                             |18 xor 1 2 16
-                             |19 and 1 5 18
-                             |20 implies 1 19 15
-                             |21 not 1 20
-                             |22 bad 21
-                             |23 ite 3 2 11 14
-                             |24 next 3 4 23
-                             |25 next 1 5 17""".stripMargin)
+      btor2 should include("""|1 sort bitvec 1
+                              |2 input 1 reset
+                              |3 sort bitvec 32
+                              |4 state 3 count
+                              |5 constd 1 0
+                              |6 state 1 hbr
+                              |7 init 1 6 5
+                              |8 constd 3 43
+                              |9 constd 3 1
+                              |10 constd 3 42
+                              |11 constd 3 0
+                              |12 eq 1 4 10
+                              |13 add 3 4 9
+                              |14 ite 3 12 11 13
+                              |15 ult 1 4 8
+                              |16 constd 1 -1
+                              |17 or 1 2 6
+                              |18 xor 1 2 16
+                              |19 and 1 6 18
+                              |20 implies 1 19 15
+                              |21 not 1 20
+                              |22 bad 21
+                              |23 ite 3 2 11 14
+                              |24 next 3 4 23
+                              |25 next 1 6 17""".stripMargin)
     }
 
     it("""should error if give a "--target-directory" option""") {


### PR DESCRIPTION
Add an integration test of SystemVerilog generation for inline layers. This relies on new support in firtool 1.97.0 which adds support for compiling this feature.  Previous versions of firtool could parse inline layers, but error when compiling them.