### PR TITLE
Fix potential name collision caused by LTL properties

### DIFF
--- a/src/main/scala-2/chisel3/util/circt/LTLIntrinsics.scala
+++ b/src/main/scala-2/chisel3/util/circt/LTLIntrinsics.scala
@@ -37,7 +37,7 @@ private[chisel3] object UnaryLTLIntrinsic {
   )(
     implicit sourceInfo: SourceInfo
   ): Bool =
-    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(_in).suggestName(intrinsicName)
+    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(_in)
 }
 
 /** Base instrinsic for all binary intrinsics with `lhs`, `rhs`, and `out` ports. */
@@ -50,7 +50,7 @@ private[chisel3] object BinaryLTLIntrinsic {
   )(
     implicit sourceInfo: SourceInfo
   ): Bool =
-    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(lhs, rhs).suggestName(intrinsicName)
+    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(lhs, rhs)
 }
 
 /** A wrapper intrinsic for the CIRCT `ltl.and` operation. */

--- a/src/main/scala-2/chisel3/util/circt/LTLIntrinsics.scala
+++ b/src/main/scala-2/chisel3/util/circt/LTLIntrinsics.scala
@@ -37,7 +37,7 @@ private[chisel3] object UnaryLTLIntrinsic {
   )(
     implicit sourceInfo: SourceInfo
   ): Bool =
-    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(_in)
+    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(_in).suggestName(f"ltl_$intrinsicName")
 }
 
 /** Base instrinsic for all binary intrinsics with `lhs`, `rhs`, and `out` ports. */
@@ -50,7 +50,7 @@ private[chisel3] object BinaryLTLIntrinsic {
   )(
     implicit sourceInfo: SourceInfo
   ): Bool =
-    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(lhs, rhs)
+    BaseIntrinsic(f"ltl_$intrinsicName", Bool(), params)(lhs, rhs).suggestName(f"ltl_$intrinsicName")
 }
 
 /** A wrapper intrinsic for the CIRCT `ltl.and` operation. */

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -49,15 +49,15 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input a : UInt<1>")
     chirrtl should include("input b : UInt<1>")
     chirrtl should include("input c : UInt<1>")
-    chirrtl should include(f"node _T = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_delay<delay = 2, length = 2> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_delay<delay = 5> : UInt<1>, c) $sourceLoc")
-    chirrtl should include(f"node _T_3 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node _T_4 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_3) $sourceLoc")
-    chirrtl should include(f"node _T_5 = intrinsic(circt_ltl_delay<delay = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node _T_6 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_5) $sourceLoc")
-    chirrtl should include(f"node _T_7 = intrinsic(circt_ltl_delay<delay = 1> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node _T_8 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_7) $sourceLoc")
+    chirrtl should include(f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 2, length = 2> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node ltl_delay_2 = intrinsic(circt_ltl_delay<delay = 5> : UInt<1>, c) $sourceLoc")
+    chirrtl should include(f"node ltl_delay_3 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node ltl_concat = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_3) $sourceLoc")
+    chirrtl should include(f"node ltl_delay_4 = intrinsic(circt_ltl_delay<delay = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node ltl_concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_4) $sourceLoc")
+    chirrtl should include(f"node ltl_delay_5 = intrinsic(circt_ltl_delay<delay = 1> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node ltl_concat_2 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_5) $sourceLoc")
   }
   it should "compile sequence delay operations" in {
     ChiselStage.emitSystemVerilog(new DelaysMod)
@@ -77,9 +77,9 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input c : UInt<1>")
     chirrtl should include("input d : UInt<1>")
     chirrtl should include("input e : UInt<1>")
-    chirrtl should include(f"node _T = intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
-    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_concat : UInt<1>, c, d) $sourceLoc")
-    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_concat : UInt<1>, _T_1, e) $sourceLoc")
+    chirrtl should include(f"intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(f"node ltl_concat_1 = intrinsic(circt_ltl_concat : UInt<1>, c, d) $sourceLoc")
+    chirrtl should include(f"intrinsic(circt_ltl_concat : UInt<1>, ltl_concat_1, e) $sourceLoc")
   }
   it should "compile sequence concat operations" in {
     ChiselStage.emitSystemVerilog(new ConcatMod)
@@ -102,14 +102,14 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input c : UInt<1>")
     chirrtl should include("input d : UInt<1>")
     chirrtl should include("input e : UInt<1>")
-    chirrtl should include(f"node _T = intrinsic(circt_ltl_repeat<base = 1, more = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_repeat<base = 2, more = 2> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_repeat<base = 5> : UInt<1>, c) $sourceLoc")
+    chirrtl should include(f"node ltl_repeat = intrinsic(circt_ltl_repeat<base = 1, more = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node ltl_repeat_1 = intrinsic(circt_ltl_repeat<base = 2, more = 2> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node ltl_repeat_2 = intrinsic(circt_ltl_repeat<base = 5> : UInt<1>, c) $sourceLoc")
     chirrtl should include(
-      f"node _T_3 = intrinsic(circt_ltl_goto_repeat<base = 1, more = 2> : UInt<1>, d) $sourceLoc"
+      f"node ltl_goto_repeat = intrinsic(circt_ltl_goto_repeat<base = 1, more = 2> : UInt<1>, d) $sourceLoc"
     )
     chirrtl should include(
-      f"node _T_4 = intrinsic(circt_ltl_non_consecutive_repeat<base = 1, more = 2> : UInt<1>, e) $sourceLoc"
+      f"node ltl_non_consecutive_repeat = intrinsic(circt_ltl_non_consecutive_repeat<base = 1, more = 2> : UInt<1>, e) $sourceLoc"
     )
   }
   it should "compile sequence repeat operations" in {
@@ -140,28 +140,28 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     val sourceLoc = "@[Foo.scala 1:2]"
 
     // Sequences
-    chirrtl should include(f"node _T = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_and : UInt<1>, _T, b) $sourceLoc")
-    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_or : UInt<1>, _T, b) $sourceLoc")
-    chirrtl should include(f"node _T_3 = intrinsic(circt_ltl_intersect : UInt<1>, _T, b) $sourceLoc")
-    chirrtl should include(f"node _T_4 = intrinsic(circt_ltl_intersect : UInt<1>, _T_3, _T_1) $sourceLoc")
-    chirrtl should include(f"node _T_5 = intrinsic(circt_ltl_intersect : UInt<1>, _T_4, _T_2) $sourceLoc")
-    chirrtl should include(f"node _T_6 = intrinsic(circt_ltl_clock : UInt<1>, _T, clock) $sourceLoc")
+    chirrtl should include(f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node ltl_and = intrinsic(circt_ltl_and : UInt<1>, ltl_delay, b) $sourceLoc")
+    chirrtl should include(f"node ltl_or = intrinsic(circt_ltl_or : UInt<1>, ltl_delay, b) $sourceLoc")
+    chirrtl should include(f"node ltl_intersect = intrinsic(circt_ltl_intersect : UInt<1>, ltl_delay, b) $sourceLoc")
+    chirrtl should include(f"node ltl_intersect_1 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect, ltl_and) $sourceLoc")
+    chirrtl should include(f"node ltl_intersect_2 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_1, ltl_or) $sourceLoc")
+    chirrtl should include(f"node ltl_clock = intrinsic(circt_ltl_clock : UInt<1>, ltl_delay, clock) $sourceLoc")
 
     // Properties
-    chirrtl should include(f"node _T_7 = intrinsic(circt_ltl_eventually : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node _T_8 = intrinsic(circt_ltl_and : UInt<1>, _T_7, b) $sourceLoc")
-    chirrtl should include(f"node _T_9 = intrinsic(circt_ltl_or : UInt<1>, _T_7, b) $sourceLoc")
-    chirrtl should include(f"node _T_10 = intrinsic(circt_ltl_intersect : UInt<1>, _T_7, b) $sourceLoc")
+    chirrtl should include(f"node ltl_eventually = intrinsic(circt_ltl_eventually : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node ltl_and_1 = intrinsic(circt_ltl_and : UInt<1>, ltl_eventually, b) $sourceLoc")
+    chirrtl should include(f"node ltl_or_1 = intrinsic(circt_ltl_or : UInt<1>, ltl_eventually, b) $sourceLoc")
+    chirrtl should include(f"node ltl_intersect_3 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_eventually, b) $sourceLoc")
     chirrtl should include(
-      f"node _T_11 = intrinsic(circt_ltl_intersect : UInt<1>, _T_10, _T_8) $sourceLoc"
+      f"node ltl_intersect_4 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_3, ltl_and_1) $sourceLoc"
     )
-    chirrtl should include(f"node _T_12 = intrinsic(circt_ltl_intersect : UInt<1>, _T_11, _T_9) $sourceLoc")
-    chirrtl should include(f"node _T_13 = intrinsic(circt_ltl_clock : UInt<1>, _T_7, clock) $sourceLoc")
+    chirrtl should include(f"node ltl_intersect_5 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_4, ltl_or_1) $sourceLoc")
+    chirrtl should include(f"node ltl_clock_1 = intrinsic(circt_ltl_clock : UInt<1>, ltl_eventually, clock) $sourceLoc")
 
     // Until
-    chirrtl should include(f"node _T_14 = intrinsic(circt_ltl_until : UInt<1>, _T, b) $sourceLoc")
-    chirrtl should include(f"node _T_15 = intrinsic(circt_ltl_until : UInt<1>, _T_7, b) $sourceLoc")
+    chirrtl should include(f"node ltl_until = intrinsic(circt_ltl_until : UInt<1>, ltl_delay, b) $sourceLoc")
+    chirrtl should include(f"node ltl_until_1 = intrinsic(circt_ltl_until : UInt<1>, ltl_eventually, b) $sourceLoc")
   }
   it should "compile and, or, intersect, and clock operations" in {
     ChiselStage.emitSystemVerilog(new AndOrClockMod)
@@ -194,20 +194,20 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     val sourceLoc = "@[Foo.scala 1:2]"
 
     // Overlapping
-    chirrtl should include(f"node _T = intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
-    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(f"intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(f"intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
 
     // Non-overlapping (emitted as `a ## true |-> b`)
     chirrtl should include(
-      f"node _T_2 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
+      f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
     )
-    chirrtl should include(f"node _T_3 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_2) $sourceLoc")
-    chirrtl should include(f"node _T_4 = intrinsic(circt_ltl_implication : UInt<1>, _T_3, b) $sourceLoc")
+    chirrtl should include(f"node ltl_concat = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay) $sourceLoc")
+    chirrtl should include(f"node ltl_implication_2 = intrinsic(circt_ltl_implication : UInt<1>, ltl_concat, b) $sourceLoc")
     chirrtl should include(
-      f"node _T_5 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
+      f"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
     )
-    chirrtl should include(f"node _T_6 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_5) $sourceLoc")
-    chirrtl should include(f"node _T_7 = intrinsic(circt_ltl_implication : UInt<1>, _T_6, b) $sourceLoc")
+    chirrtl should include(f"node ltl_concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_1) $sourceLoc")
+    chirrtl should include(f"node ltl_implication_3 = intrinsic(circt_ltl_implication : UInt<1>, ltl_concat_1, b) $sourceLoc")
   }
   it should "compile property implication operation" in {
     ChiselStage.emitSystemVerilog(new PropImplicationMod)
@@ -280,9 +280,9 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
       val sourceLoc = "@[Foo.scala 1:2]"
       chirrtl should include("node has_been_reset = intrinsic(circt_has_been_reset : UInt<1>, clock, reset)")
       chirrtl should include("node disable = eq(has_been_reset, UInt<1>(0h0))")
-      chirrtl should include(f"node _T = intrinsic(circt_ltl_clock : UInt<1>, a, clock) $sourceLoc")
-      chirrtl should include(f"node _T_1 = eq(disable, UInt<1>(0h0)) $sourceLoc")
-      chirrtl should include(f"intrinsic(circt_verif_$op, _T, _T_1) $sourceLoc")
+      chirrtl should include(f"node ltl_clock = intrinsic(circt_ltl_clock : UInt<1>, a, clock) $sourceLoc")
+      chirrtl should include(f"node _T = eq(disable, UInt<1>(0h0)) $sourceLoc")
+      chirrtl should include(f"intrinsic(circt_verif_$op, ltl_clock, _T) $sourceLoc")
     }
   }
 
@@ -311,17 +311,17 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
       AssertProperty(a, clock = Some(c), disable = Some(b.asDisable))
     })
     // with clock; emitted as `assert(clock(a, c))`
-    chirrtl should include("node _T = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
-    chirrtl should include("intrinsic(circt_verif_assert, _T)")
+    chirrtl should include("node ltl_clock = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
+    chirrtl should include("intrinsic(circt_verif_assert, ltl_clock)")
 
     // with disable; emitted as `assert(a, disable)`
-    chirrtl should include("node _T_1 = eq(b, UInt<1>(0h0))")
-    chirrtl should include("intrinsic(circt_verif_assert, a, _T_1)")
+    chirrtl should include("node _T = eq(b, UInt<1>(0h0))")
+    chirrtl should include("intrinsic(circt_verif_assert, a, _T)")
 
     // with clock and disable; emitted as `assert(clock(disable(a, b), c))`
-    chirrtl should include("node _T_2 = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
-    chirrtl should include("node _T_3 = eq(b, UInt<1>(0h0))")
-    chirrtl should include("intrinsic(circt_verif_assert, _T_2, _T_3)")
+    chirrtl should include("node ltl_clock_1 = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
+    chirrtl should include("node _T_1 = eq(b, UInt<1>(0h0))")
+    chirrtl should include("intrinsic(circt_verif_assert, ltl_clock_1, _T_1)")
   }
 
   class SequenceConvMod extends RawModule {
@@ -343,34 +343,34 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include(s"intrinsic(circt_verif_assert, a) $sourceLoc")
 
     // a b
-    chirrtl should include(s"node _T = intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, _T) $sourceLoc")
+    chirrtl should include(s"node ltl_concat = intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat) $sourceLoc")
 
     // Delay() a
-    chirrtl should include(s"node _T_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, _T_1) $sourceLoc")
+    chirrtl should include(s"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, ltl_delay) $sourceLoc")
 
     // a Delay() b
-    chirrtl should include(s"node _T_2 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(s"node _T_3 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_2) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, _T_3) $sourceLoc")
+    chirrtl should include(s"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(s"node ltl_concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_1) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat_1) $sourceLoc")
 
     // a Delay(2) b
-    chirrtl should include(s"node _T_4 = intrinsic(circt_ltl_delay<delay = 2, length = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(s"node _T_5 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_4) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, _T_5) $sourceLoc")
+    chirrtl should include(s"node ltl_delay_2 = intrinsic(circt_ltl_delay<delay = 2, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(s"node ltl_concat_2 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_2) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat_2) $sourceLoc")
 
     // a Delay(42, 1337) b
     chirrtl should include(
-      s"node _T_6 = intrinsic(circt_ltl_delay<delay = 42, length = 1295> : UInt<1>, b) $sourceLoc"
+      s"node ltl_delay_3 = intrinsic(circt_ltl_delay<delay = 42, length = 1295> : UInt<1>, b) $sourceLoc"
     )
-    chirrtl should include(s"node _T_7 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_6) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, _T_7) $sourceLoc")
+    chirrtl should include(s"node ltl_concat_3 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_3) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat_3) $sourceLoc")
 
     // a Delay(9001, None) sb
-    chirrtl should include(s"node _T_8 = intrinsic(circt_ltl_delay<delay = 9001> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(s"node _T_9 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_8) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, _T_9) $sourceLoc")
+    chirrtl should include(s"node ltl_delay_4 = intrinsic(circt_ltl_delay<delay = 9001> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(s"node ltl_concat_4 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_4) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat_4) $sourceLoc")
   }
   it should "compile Sequence(...) convenience constructor" in {
     ChiselStage.emitSystemVerilog(new SequenceConvMod)
@@ -406,22 +406,5 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
 
     assert(assertBlockLoc < delayIntrinsicLoc)
     assert(assumeblockLoc < implicationIntrinsicLoc)
-  }
-
-  it should "not produce name collisions with clock" in {
-    class Test extends RawModule {
-      val io = IO(Input(UInt(8.W)))
-
-      val clockWire = Wire(Clock())
-
-      withClock(clockWire) {
-        AssertProperty(Property.eventually(io.orR))
-      }
-
-      val clock = IO(Input(Clock()))
-      clockWire := clock
-    }
-
-    val chirrtl = ChiselStage.emitCHIRRTL(new Test)
   }
 }

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -49,15 +49,15 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input a : UInt<1>")
     chirrtl should include("input b : UInt<1>")
     chirrtl should include("input c : UInt<1>")
-    chirrtl should include(f"node delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node delay_1 = intrinsic(circt_ltl_delay<delay = 2, length = 2> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node delay_2 = intrinsic(circt_ltl_delay<delay = 5> : UInt<1>, c) $sourceLoc")
-    chirrtl should include(f"node delay_3 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node concat = intrinsic(circt_ltl_concat : UInt<1>, a, delay_3) $sourceLoc")
-    chirrtl should include(f"node delay_4 = intrinsic(circt_ltl_delay<delay = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, delay_4) $sourceLoc")
-    chirrtl should include(f"node delay_5 = intrinsic(circt_ltl_delay<delay = 1> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node concat_2 = intrinsic(circt_ltl_concat : UInt<1>, a, delay_5) $sourceLoc")
+    chirrtl should include(f"node _T = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_delay<delay = 2, length = 2> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_delay<delay = 5> : UInt<1>, c) $sourceLoc")
+    chirrtl should include(f"node _T_3 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node _T_4 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_3) $sourceLoc")
+    chirrtl should include(f"node _T_5 = intrinsic(circt_ltl_delay<delay = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node _T_6 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_5) $sourceLoc")
+    chirrtl should include(f"node _T_7 = intrinsic(circt_ltl_delay<delay = 1> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node _T_8 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_7) $sourceLoc")
   }
   it should "compile sequence delay operations" in {
     ChiselStage.emitSystemVerilog(new DelaysMod)
@@ -77,9 +77,9 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input c : UInt<1>")
     chirrtl should include("input d : UInt<1>")
     chirrtl should include("input e : UInt<1>")
-    chirrtl should include(f"intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
-    chirrtl should include(f"node concat_1 = intrinsic(circt_ltl_concat : UInt<1>, c, d) $sourceLoc")
-    chirrtl should include(f"intrinsic(circt_ltl_concat : UInt<1>, concat_1, e) $sourceLoc")
+    chirrtl should include(f"node _T = intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_concat : UInt<1>, c, d) $sourceLoc")
+    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_concat : UInt<1>, _T_1, e) $sourceLoc")
   }
   it should "compile sequence concat operations" in {
     ChiselStage.emitSystemVerilog(new ConcatMod)
@@ -102,14 +102,14 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input c : UInt<1>")
     chirrtl should include("input d : UInt<1>")
     chirrtl should include("input e : UInt<1>")
-    chirrtl should include(f"node repeat = intrinsic(circt_ltl_repeat<base = 1, more = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node repeat_1 = intrinsic(circt_ltl_repeat<base = 2, more = 2> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(f"node repeat_2 = intrinsic(circt_ltl_repeat<base = 5> : UInt<1>, c) $sourceLoc")
+    chirrtl should include(f"node _T = intrinsic(circt_ltl_repeat<base = 1, more = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_repeat<base = 2, more = 2> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_repeat<base = 5> : UInt<1>, c) $sourceLoc")
     chirrtl should include(
-      f"node goto_repeat = intrinsic(circt_ltl_goto_repeat<base = 1, more = 2> : UInt<1>, d) $sourceLoc"
+      f"node _T_3 = intrinsic(circt_ltl_goto_repeat<base = 1, more = 2> : UInt<1>, d) $sourceLoc"
     )
     chirrtl should include(
-      f"node non_consecutive_repeat = intrinsic(circt_ltl_non_consecutive_repeat<base = 1, more = 2> : UInt<1>, e) $sourceLoc"
+      f"node _T_4 = intrinsic(circt_ltl_non_consecutive_repeat<base = 1, more = 2> : UInt<1>, e) $sourceLoc"
     )
   }
   it should "compile sequence repeat operations" in {
@@ -140,28 +140,28 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     val sourceLoc = "@[Foo.scala 1:2]"
 
     // Sequences
-    chirrtl should include(f"node delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node and = intrinsic(circt_ltl_and : UInt<1>, delay, b) $sourceLoc")
-    chirrtl should include(f"node or = intrinsic(circt_ltl_or : UInt<1>, delay, b) $sourceLoc")
-    chirrtl should include(f"node intersect = intrinsic(circt_ltl_intersect : UInt<1>, delay, b) $sourceLoc")
-    chirrtl should include(f"node intersect_1 = intrinsic(circt_ltl_intersect : UInt<1>, intersect, and) $sourceLoc")
-    chirrtl should include(f"node intersect_2 = intrinsic(circt_ltl_intersect : UInt<1>, intersect_1, or) $sourceLoc")
-    chirrtl should include(f"node clock_1 = intrinsic(circt_ltl_clock : UInt<1>, delay, clock) $sourceLoc")
+    chirrtl should include(f"node _T = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_and : UInt<1>, _T, b) $sourceLoc")
+    chirrtl should include(f"node _T_2 = intrinsic(circt_ltl_or : UInt<1>, _T, b) $sourceLoc")
+    chirrtl should include(f"node _T_3 = intrinsic(circt_ltl_intersect : UInt<1>, _T, b) $sourceLoc")
+    chirrtl should include(f"node _T_4 = intrinsic(circt_ltl_intersect : UInt<1>, _T_3, _T_1) $sourceLoc")
+    chirrtl should include(f"node _T_5 = intrinsic(circt_ltl_intersect : UInt<1>, _T_4, _T_2) $sourceLoc")
+    chirrtl should include(f"node _T_6 = intrinsic(circt_ltl_clock : UInt<1>, _T, clock) $sourceLoc")
 
     // Properties
-    chirrtl should include(f"node eventually = intrinsic(circt_ltl_eventually : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node and_1 = intrinsic(circt_ltl_and : UInt<1>, eventually, b) $sourceLoc")
-    chirrtl should include(f"node or_1 = intrinsic(circt_ltl_or : UInt<1>, eventually, b) $sourceLoc")
-    chirrtl should include(f"node intersect_3 = intrinsic(circt_ltl_intersect : UInt<1>, eventually, b) $sourceLoc")
+    chirrtl should include(f"node _T_7 = intrinsic(circt_ltl_eventually : UInt<1>, a) $sourceLoc")
+    chirrtl should include(f"node _T_8 = intrinsic(circt_ltl_and : UInt<1>, _T_7, b) $sourceLoc")
+    chirrtl should include(f"node _T_9 = intrinsic(circt_ltl_or : UInt<1>, _T_7, b) $sourceLoc")
+    chirrtl should include(f"node _T_10 = intrinsic(circt_ltl_intersect : UInt<1>, _T_7, b) $sourceLoc")
     chirrtl should include(
-      f"node intersect_4 = intrinsic(circt_ltl_intersect : UInt<1>, intersect_3, and_1) $sourceLoc"
+      f"node _T_11 = intrinsic(circt_ltl_intersect : UInt<1>, _T_10, _T_8) $sourceLoc"
     )
-    chirrtl should include(f"node intersect_5 = intrinsic(circt_ltl_intersect : UInt<1>, intersect_4, or_1) $sourceLoc")
-    chirrtl should include(f"node clock_2 = intrinsic(circt_ltl_clock : UInt<1>, eventually, clock) $sourceLoc")
+    chirrtl should include(f"node _T_12 = intrinsic(circt_ltl_intersect : UInt<1>, _T_11, _T_9) $sourceLoc")
+    chirrtl should include(f"node _T_13 = intrinsic(circt_ltl_clock : UInt<1>, _T_7, clock) $sourceLoc")
 
     // Until
-    chirrtl should include(f"node until = intrinsic(circt_ltl_until : UInt<1>, delay, b) $sourceLoc")
-    chirrtl should include(f"node until_1 = intrinsic(circt_ltl_until : UInt<1>, eventually, b) $sourceLoc")
+    chirrtl should include(f"node _T_14 = intrinsic(circt_ltl_until : UInt<1>, _T, b) $sourceLoc")
+    chirrtl should include(f"node _T_15 = intrinsic(circt_ltl_until : UInt<1>, _T_7, b) $sourceLoc")
   }
   it should "compile and, or, intersect, and clock operations" in {
     ChiselStage.emitSystemVerilog(new AndOrClockMod)
@@ -194,20 +194,20 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     val sourceLoc = "@[Foo.scala 1:2]"
 
     // Overlapping
-    chirrtl should include(f"intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
-    chirrtl should include(f"intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(f"node _T = intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(f"node _T_1 = intrinsic(circt_ltl_implication : UInt<1>, a, b) $sourceLoc")
 
     // Non-overlapping (emitted as `a ## true |-> b`)
     chirrtl should include(
-      f"node delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
+      f"node _T_2 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
     )
-    chirrtl should include(f"node concat = intrinsic(circt_ltl_concat : UInt<1>, a, delay) $sourceLoc")
-    chirrtl should include(f"node implication_2 = intrinsic(circt_ltl_implication : UInt<1>, concat, b) $sourceLoc")
+    chirrtl should include(f"node _T_3 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_2) $sourceLoc")
+    chirrtl should include(f"node _T_4 = intrinsic(circt_ltl_implication : UInt<1>, _T_3, b) $sourceLoc")
     chirrtl should include(
-      f"node delay_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
+      f"node _T_5 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
     )
-    chirrtl should include(f"node concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, delay_1) $sourceLoc")
-    chirrtl should include(f"node implication_3 = intrinsic(circt_ltl_implication : UInt<1>, concat_1, b) $sourceLoc")
+    chirrtl should include(f"node _T_6 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_5) $sourceLoc")
+    chirrtl should include(f"node _T_7 = intrinsic(circt_ltl_implication : UInt<1>, _T_6, b) $sourceLoc")
   }
   it should "compile property implication operation" in {
     ChiselStage.emitSystemVerilog(new PropImplicationMod)
@@ -280,9 +280,9 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
       val sourceLoc = "@[Foo.scala 1:2]"
       chirrtl should include("node has_been_reset = intrinsic(circt_has_been_reset : UInt<1>, clock, reset)")
       chirrtl should include("node disable = eq(has_been_reset, UInt<1>(0h0))")
-      chirrtl should include(f"node clock_1 = intrinsic(circt_ltl_clock : UInt<1>, a, clock) $sourceLoc")
-      chirrtl should include(f"node _T = eq(disable, UInt<1>(0h0)) $sourceLoc")
-      chirrtl should include(f"intrinsic(circt_verif_$op, clock_1, _T) $sourceLoc")
+      chirrtl should include(f"node _T = intrinsic(circt_ltl_clock : UInt<1>, a, clock) $sourceLoc")
+      chirrtl should include(f"node _T_1 = eq(disable, UInt<1>(0h0)) $sourceLoc")
+      chirrtl should include(f"intrinsic(circt_verif_$op, _T, _T_1) $sourceLoc")
     }
   }
 
@@ -311,17 +311,17 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
       AssertProperty(a, clock = Some(c), disable = Some(b.asDisable))
     })
     // with clock; emitted as `assert(clock(a, c))`
-    chirrtl should include("node clock = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
-    chirrtl should include("intrinsic(circt_verif_assert, clock)")
+    chirrtl should include("node _T = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
+    chirrtl should include("intrinsic(circt_verif_assert, _T)")
 
     // with disable; emitted as `assert(a, disable)`
-    chirrtl should include("node _T = eq(b, UInt<1>(0h0))")
-    chirrtl should include("intrinsic(circt_verif_assert, a, _T)")
+    chirrtl should include("node _T_1 = eq(b, UInt<1>(0h0))")
+    chirrtl should include("intrinsic(circt_verif_assert, a, _T_1)")
 
     // with clock and disable; emitted as `assert(clock(disable(a, b), c))`
-    chirrtl should include("node clock_1 = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
-    chirrtl should include("node _T_1 = eq(b, UInt<1>(0h0))")
-    chirrtl should include("intrinsic(circt_verif_assert, clock_1, _T_1)")
+    chirrtl should include("node _T_2 = intrinsic(circt_ltl_clock : UInt<1>, a, c)")
+    chirrtl should include("node _T_3 = eq(b, UInt<1>(0h0))")
+    chirrtl should include("intrinsic(circt_verif_assert, _T_2, _T_3)")
   }
 
   class SequenceConvMod extends RawModule {
@@ -343,34 +343,34 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include(s"intrinsic(circt_verif_assert, a) $sourceLoc")
 
     // a b
-    chirrtl should include(s"node concat = intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, concat) $sourceLoc")
+    chirrtl should include(s"node _T = intrinsic(circt_ltl_concat : UInt<1>, a, b) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, _T) $sourceLoc")
 
     // Delay() a
-    chirrtl should include(s"node delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, delay) $sourceLoc")
+    chirrtl should include(s"node _T_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, _T_1) $sourceLoc")
 
     // a Delay() b
-    chirrtl should include(s"node delay_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(s"node concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, delay_1) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, concat_1) $sourceLoc")
+    chirrtl should include(s"node _T_2 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(s"node _T_3 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_2) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, _T_3) $sourceLoc")
 
     // a Delay(2) b
-    chirrtl should include(s"node delay_2 = intrinsic(circt_ltl_delay<delay = 2, length = 0> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(s"node concat_2 = intrinsic(circt_ltl_concat : UInt<1>, a, delay_2) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, concat_2) $sourceLoc")
+    chirrtl should include(s"node _T_4 = intrinsic(circt_ltl_delay<delay = 2, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(s"node _T_5 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_4) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, _T_5) $sourceLoc")
 
     // a Delay(42, 1337) b
     chirrtl should include(
-      s"node delay_3 = intrinsic(circt_ltl_delay<delay = 42, length = 1295> : UInt<1>, b) $sourceLoc"
+      s"node _T_6 = intrinsic(circt_ltl_delay<delay = 42, length = 1295> : UInt<1>, b) $sourceLoc"
     )
-    chirrtl should include(s"node concat_3 = intrinsic(circt_ltl_concat : UInt<1>, a, delay_3) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, concat_3) $sourceLoc")
+    chirrtl should include(s"node _T_7 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_6) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, _T_7) $sourceLoc")
 
     // a Delay(9001, None) sb
-    chirrtl should include(s"node delay_4 = intrinsic(circt_ltl_delay<delay = 9001> : UInt<1>, b) $sourceLoc")
-    chirrtl should include(s"node concat_4 = intrinsic(circt_ltl_concat : UInt<1>, a, delay_4) $sourceLoc")
-    chirrtl should include(s"intrinsic(circt_verif_assert, concat_4) $sourceLoc")
+    chirrtl should include(s"node _T_8 = intrinsic(circt_ltl_delay<delay = 9001> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(s"node _T_9 = intrinsic(circt_ltl_concat : UInt<1>, a, _T_8) $sourceLoc")
+    chirrtl should include(s"intrinsic(circt_verif_assert, _T_9) $sourceLoc")
   }
   it should "compile Sequence(...) convenience constructor" in {
     ChiselStage.emitSystemVerilog(new SequenceConvMod)
@@ -408,7 +408,7 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     assert(assumeblockLoc < implicationIntrinsicLoc)
   }
 
-  it should "not produce name collisions" in {
+  it should "not produce name collisions with clock" in {
     class Test extends RawModule {
       val io = IO(Input(UInt(8.W)))
 

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -49,10 +49,16 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input a : UInt<1>")
     chirrtl should include("input b : UInt<1>")
     chirrtl should include("input c : UInt<1>")
-    chirrtl should include(f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 2, length = 2> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc"
+    )
+    chirrtl should include(
+      f"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 2, length = 2> : UInt<1>, b) $sourceLoc"
+    )
     chirrtl should include(f"node ltl_delay_2 = intrinsic(circt_ltl_delay<delay = 5> : UInt<1>, c) $sourceLoc")
-    chirrtl should include(f"node ltl_delay_3 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_delay_3 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc"
+    )
     chirrtl should include(f"node ltl_concat = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_3) $sourceLoc")
     chirrtl should include(f"node ltl_delay_4 = intrinsic(circt_ltl_delay<delay = 0> : UInt<1>, b) $sourceLoc")
     chirrtl should include(f"node ltl_concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_4) $sourceLoc")
@@ -103,7 +109,9 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("input d : UInt<1>")
     chirrtl should include("input e : UInt<1>")
     chirrtl should include(f"node ltl_repeat = intrinsic(circt_ltl_repeat<base = 1, more = 0> : UInt<1>, a) $sourceLoc")
-    chirrtl should include(f"node ltl_repeat_1 = intrinsic(circt_ltl_repeat<base = 2, more = 2> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_repeat_1 = intrinsic(circt_ltl_repeat<base = 2, more = 2> : UInt<1>, b) $sourceLoc"
+    )
     chirrtl should include(f"node ltl_repeat_2 = intrinsic(circt_ltl_repeat<base = 5> : UInt<1>, c) $sourceLoc")
     chirrtl should include(
       f"node ltl_goto_repeat = intrinsic(circt_ltl_goto_repeat<base = 1, more = 2> : UInt<1>, d) $sourceLoc"
@@ -140,23 +148,33 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     val sourceLoc = "@[Foo.scala 1:2]"
 
     // Sequences
-    chirrtl should include(f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc"
+    )
     chirrtl should include(f"node ltl_and = intrinsic(circt_ltl_and : UInt<1>, ltl_delay, b) $sourceLoc")
     chirrtl should include(f"node ltl_or = intrinsic(circt_ltl_or : UInt<1>, ltl_delay, b) $sourceLoc")
     chirrtl should include(f"node ltl_intersect = intrinsic(circt_ltl_intersect : UInt<1>, ltl_delay, b) $sourceLoc")
-    chirrtl should include(f"node ltl_intersect_1 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect, ltl_and) $sourceLoc")
-    chirrtl should include(f"node ltl_intersect_2 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_1, ltl_or) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_intersect_1 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect, ltl_and) $sourceLoc"
+    )
+    chirrtl should include(
+      f"node ltl_intersect_2 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_1, ltl_or) $sourceLoc"
+    )
     chirrtl should include(f"node ltl_clock = intrinsic(circt_ltl_clock : UInt<1>, ltl_delay, clock) $sourceLoc")
 
     // Properties
     chirrtl should include(f"node ltl_eventually = intrinsic(circt_ltl_eventually : UInt<1>, a) $sourceLoc")
     chirrtl should include(f"node ltl_and_1 = intrinsic(circt_ltl_and : UInt<1>, ltl_eventually, b) $sourceLoc")
     chirrtl should include(f"node ltl_or_1 = intrinsic(circt_ltl_or : UInt<1>, ltl_eventually, b) $sourceLoc")
-    chirrtl should include(f"node ltl_intersect_3 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_eventually, b) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_intersect_3 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_eventually, b) $sourceLoc"
+    )
     chirrtl should include(
       f"node ltl_intersect_4 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_3, ltl_and_1) $sourceLoc"
     )
-    chirrtl should include(f"node ltl_intersect_5 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_4, ltl_or_1) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_intersect_5 = intrinsic(circt_ltl_intersect : UInt<1>, ltl_intersect_4, ltl_or_1) $sourceLoc"
+    )
     chirrtl should include(f"node ltl_clock_1 = intrinsic(circt_ltl_clock : UInt<1>, ltl_eventually, clock) $sourceLoc")
 
     // Until
@@ -202,12 +220,16 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
       f"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
     )
     chirrtl should include(f"node ltl_concat = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay) $sourceLoc")
-    chirrtl should include(f"node ltl_implication_2 = intrinsic(circt_ltl_implication : UInt<1>, ltl_concat, b) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_implication_2 = intrinsic(circt_ltl_implication : UInt<1>, ltl_concat, b) $sourceLoc"
+    )
     chirrtl should include(
       f"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, UInt<1>(0h1)) $sourceLoc"
     )
     chirrtl should include(f"node ltl_concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_1) $sourceLoc")
-    chirrtl should include(f"node ltl_implication_3 = intrinsic(circt_ltl_implication : UInt<1>, ltl_concat_1, b) $sourceLoc")
+    chirrtl should include(
+      f"node ltl_implication_3 = intrinsic(circt_ltl_implication : UInt<1>, ltl_concat_1, b) $sourceLoc"
+    )
   }
   it should "compile property implication operation" in {
     ChiselStage.emitSystemVerilog(new PropImplicationMod)
@@ -347,16 +369,22 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat) $sourceLoc")
 
     // Delay() a
-    chirrtl should include(s"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc")
+    chirrtl should include(
+      s"node ltl_delay = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, a) $sourceLoc"
+    )
     chirrtl should include(s"intrinsic(circt_verif_assert, ltl_delay) $sourceLoc")
 
     // a Delay() b
-    chirrtl should include(s"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(
+      s"node ltl_delay_1 = intrinsic(circt_ltl_delay<delay = 1, length = 0> : UInt<1>, b) $sourceLoc"
+    )
     chirrtl should include(s"node ltl_concat_1 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_1) $sourceLoc")
     chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat_1) $sourceLoc")
 
     // a Delay(2) b
-    chirrtl should include(s"node ltl_delay_2 = intrinsic(circt_ltl_delay<delay = 2, length = 0> : UInt<1>, b) $sourceLoc")
+    chirrtl should include(
+      s"node ltl_delay_2 = intrinsic(circt_ltl_delay<delay = 2, length = 0> : UInt<1>, b) $sourceLoc"
+    )
     chirrtl should include(s"node ltl_concat_2 = intrinsic(circt_ltl_concat : UInt<1>, a, ltl_delay_2) $sourceLoc")
     chirrtl should include(s"intrinsic(circt_verif_assert, ltl_concat_2) $sourceLoc")
 

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -407,4 +407,23 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     assert(assertBlockLoc < delayIntrinsicLoc)
     assert(assumeblockLoc < implicationIntrinsicLoc)
   }
+
+  it should "not produce name collisions" in {
+    class Test extends RawModule {
+      val io = IO(Input(UInt(8.W)))
+
+      val clockWire = Wire(Clock())
+      val resetWire = Wire(Reset())
+
+      withClockAndReset(clockWire, resetWire) {
+        AssertProperty(Property.eventually(io.orR))
+      }
+
+      val clock = IO(Input(Clock()))
+      val reset = IO(Input(Reset()))
+
+      clockWire := clock
+      resetWire := reset
+    }
+  }
 }

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -413,17 +413,15 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
       val io = IO(Input(UInt(8.W)))
 
       val clockWire = Wire(Clock())
-      val resetWire = Wire(Reset())
 
-      withClockAndReset(clockWire, resetWire) {
+      withClock(clockWire) {
         AssertProperty(Property.eventually(io.orR))
       }
 
       val clock = IO(Input(Clock()))
-      val reset = IO(Input(Reset()))
-
       clockWire := clock
-      resetWire := reset
     }
+
+    val chirrtl = ChiselStage.emitCHIRRTL(new Test)
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

Some nodes created by LTL properties had `suggestName` called on them, potentially leading to name collisions with user code.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
