### PR TITLE
[test] Update tests for newer inline layer ABI

### DIFF
--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -425,9 +425,9 @@ class LayerSpec extends ChiselFlatSpec with Utils with FileCheck {
          |CHECK:      module Foo_A(
          |CHECK-NOT:    `ifdef
          |CHECK:        foo: assert property
-         |CHECK:        `ifdef A$B
+         |CHECK:        `ifdef layer_Foo$A$B
          |CHECK-NEXT:     bar: assert property
-         |CHECK-NEXT:     `ifdef A$B$C
+         |CHECK-NEXT:     `ifdef layer_Foo$A$B$C
          |CHECK-NEXT:       baz: assert property
          |CHECK-NEXT:     `endif
          |CHECK-NEXT:   `endif""".stripMargin


### PR DESCRIPTION
Fix the tests again for the even newer inline layer ABI.  This includes the public module name (circuit name for now) and a "layer_" prefix.