### PR TITLE
[choice] Adds a means to declare a choice group without use

### DIFF
--- a/src/test/scala/chiselTests/ModuleChoiceSpec.scala
+++ b/src/test/scala/chiselTests/ModuleChoiceSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.choice.{Case, Group, ModuleChoice}
+import chisel3.choice.{addGroup, Case, Group, ModuleChoice}
 import chiselTests.{ChiselFlatSpec, MatchesAndOmits, Utils}
 import _root_.circt.stage.ChiselStage
 
@@ -128,4 +128,23 @@ class ModuleChoiceSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
 
   }
 
+}
+class AddGroupSpec extends ChiselFlatSpec with Utils with MatchesAndOmits {
+  it should "emit options for a registered group even if there are no consumers" in {
+    class ModuleWithoutChoice extends Module {
+      addGroup(Platform)
+      val out = IO(UInt(8.W))
+      val in = IO(UInt(8.W))
+      out := in
+    }
+
+    val chirrtl = ChiselStage.emitCHIRRTL(new ModuleWithoutChoice, Array("--full-stacktrace"))
+
+    info("CHIRRTL emission looks correct")
+    matchesAndOmits(chirrtl)(
+      "option Platform :",
+      "FPGA",
+      "ASIC"
+    )()
+  }
 }


### PR DESCRIPTION
Per @seldridge's suggestion here I add analog of `addLayer` for `ModuleChoice` called `addGroup`. This permits defining a group in a circuit without necessarily using that group in a circuit, allowing for commonly reused top-level modules to always have these choices defined regardless of what is instantiated in their module hierarchies. 

Short of reworking the group API a bit to more explicitly register the `Case`s in the `Group` at construction time i couldn't figure out a means to do what i wanted, so i resorted to using Scala reflection. If there's a smarter way to do this i'm all ears. 


### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference)

#### Release Notes
Introduce `choice.addGroup` which enables declaration of a `choice.Group` without its use (akin to `layer.addLayer`)
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
