### PR TITLE
[ChiselSim] Add Inline Layer Control

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -8,7 +8,7 @@ import chisel3.internal.firrtl.ir.{LayerBlock, Node}
 import chisel3.util.simpleClassName
 import java.nio.file.{Path, Paths}
 import scala.annotation.tailrec
-import scala.collection.mutable.LinkedHashSet
+import scala.collection.mutable.{ArrayBuffer, LinkedHashSet}
 
 /** This object contains Chisel language features for creating layers.  Layers
   * are collections of hardware that are not always present in the circuit.
@@ -119,6 +119,19 @@ object layer {
       case null              => false
       case _ if this == that => true
       case _                 => this.canWriteTo(that.parent)
+    }
+
+    /** Return a list containg this layer and all its parents, excluding the root
+      * layer.  The deepest layer (this layer) is the first element in the list.
+      *
+      * @return a sequence of all layers
+      */
+    private[chisel3] def layerSeq: List[Layer] = {
+      def rec(current: Layer, acc: List[Layer]): List[Layer] = current match {
+        case Layer.root => acc
+        case _          => rec(current.parent, current :: acc)
+      }
+      rec(this, Nil)
     }
   }
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1130,7 +1130,7 @@ private[chisel3] object Builder extends LazyLogging {
           case layer.LayerConfig.Inline     => LayerConfig.Inline
           case layer.LayerConfig.Root       => ???
         }
-        Layer(l.sourceInfo, l.name, config, children.map(foldLayers).toSeq)
+        Layer(l.sourceInfo, l.name, config, children.map(foldLayers).toSeq, l)
       }
 
       val optionDefs = groupByIntoSeq(options)(opt => opt.group).map {

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -425,10 +425,11 @@ private[chisel3] object ir {
   }
 
   final case class Layer(
-    sourceInfo: SourceInfo,
-    name:       String,
-    config:     LayerConfig,
-    children:   Seq[Layer])
+    sourceInfo:  SourceInfo,
+    name:        String,
+    config:      LayerConfig,
+    children:    Seq[Layer],
+    chiselLayer: layer.Layer)
 
   class LayerBlock(val sourceInfo: SourceInfo, val layer: chisel3.layer.Layer) extends Command {
     val region = new Block(sourceInfo)

--- a/src/main/scala-2/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala-2/chisel3/simulator/EphemeralSimulator.scala
@@ -23,7 +23,7 @@ object EphemeralSimulator extends PeekPokeAPI {
     layerControl: LayerControl.Type = LayerControl.EnableAll
   )(body:         (T) => Unit
   ): Unit = {
-    makeSimulator(layerControl).simulate(module)({ module => body(module.wrapped) }).result
+    makeSimulator(layerControl).simulate(module, layerControl)({ module => body(module.wrapped) }).result
   }
 
   private class DefaultSimulator(val workspacePath: String, layerControl: LayerControl.Type)

--- a/src/main/scala-2/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala-2/chisel3/simulator/LayerControl.scala
@@ -1,7 +1,11 @@
 package chisel3.simulator
 
 import java.io.File
-import chisel3.layer.Layer
+import chisel3.RawModule
+import chisel3.layer.{ABI, Layer}
+import chisel3.simulator.ElaboratedModule
+import chisel3.stage.DesignAnnotation
+import svsim.CommonCompilationSettings.VerilogPreprocessorDefine
 
 /** Utilities for enabling and disabling Chisel layers */
 object LayerControl {
@@ -22,11 +26,41 @@ object LayerControl {
       * @param layerFilename the filename of a layer
       */
     protected def shouldEnable(layerFilename: String): Boolean
+
+    /** Return the layers that should be enabled in a circuit.  The layers must exist in the design.
+      *
+      * @param design an Annotation that contains an elaborated design used to check that the requested layers exist
+      * @return all layers that should be enabled
+      * @throws IllegalArgumentException if the requested layers
+      */
+    protected def getLayerSubset(module: ElaboratedModule[_]): Seq[Layer]
+
+    /** Return the preprocessor defines that should be set to enable the layers of
+      * this `LayerControl.Type`.
+      *
+      * This requires passing an elaborated module in order to know what layers
+      * exist in the design.
+      *
+      * @param module an elaborated module
+      * @return preprocessor defines to control the enabling of these layers
+      */
+    final def preprocessorDefines(
+      module: ElaboratedModule[_ <: RawModule]
+    ): Seq[VerilogPreprocessorDefine] = getLayerSubset(module).flatMap {
+      case layer =>
+        layer.config.abi match {
+          case abi: chisel3.layer.ABI.PreprocessorDefine.type =>
+            Some(VerilogPreprocessorDefine(abi.toMacroIdentifier(layer, module.wrapped.circuitName)))
+          case _ => None
+        }
+    }
   }
 
   /** Enable all layers */
   final case object EnableAll extends Type {
     override protected def shouldEnable(layerFilename: String) = true
+
+    override protected def getLayerSubset(module: ElaboratedModule[_]): Seq[Layer] = module.layers
   }
 
   /** Enable only the specified layers
@@ -46,6 +80,19 @@ object LayerControl {
       }
     }
     override protected def shouldEnable(filename: String) = _shouldEnable(filename)
+
+    override protected def getLayerSubset(module: ElaboratedModule[_]): Seq[Layer] = {
+      val definedLayers = module.layers
+      layers.foreach { layer =>
+        require(
+          definedLayers.contains(layer),
+          s"""cannot enable layer '${layer.fullName}' as it is not one of the defined layers: ${definedLayers.map(
+            _.fullName
+          )}"""
+        )
+      }
+      layers
+    }
   }
 
   /** Disables all layers.  This is the same as `Enable()`. */

--- a/src/main/scala-2/chisel3/simulator/package.scala
+++ b/src/main/scala-2/chisel3/simulator/package.scala
@@ -3,6 +3,7 @@ package chisel3
 import svsim._
 import chisel3.reflect.DataMirror
 import chisel3.experimental.dataview.reifyIdentityView
+import chisel3.stage.DesignAnnotation
 import scala.collection.mutable
 import java.nio.file.{Files, Path, Paths}
 import firrtl.seqToAnnoSeq
@@ -14,7 +15,8 @@ package object simulator {
     */
   final class ElaboratedModule[T] private[simulator] (
     private[simulator] val wrapped: T,
-    private[simulator] val ports:   Seq[(Data, ModuleInfo.Port)])
+    private[simulator] val ports:   Seq[(Data, ModuleInfo.Port)],
+    private[simulator] val layers:  Seq[chisel3.layer.Layer])
 
   /**
     * A class that enables using a Chisel module to control an `svsim.Simulation`.
@@ -222,7 +224,8 @@ package object simulator {
           ports = ports.map(_._2)
         )
       )
-      new ElaboratedModule(dut, ports)
+      val layers = outputAnnotations.collectFirst { case DesignAnnotation(_, layers) => layers }.get
+      new ElaboratedModule(dut, ports, layers)
     }
   }
 }

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -392,7 +392,9 @@ object ChiselOutputFileAnnotation extends HasShellOptions {
   * @param design top-level Chisel design
   * @tparam DUT Type of the top-level Chisel design
   */
-case class DesignAnnotation[DUT <: RawModule](design: DUT) extends NoTargetAnnotation with Unserializable
+case class DesignAnnotation[DUT <: RawModule](design: DUT, layers: Seq[chisel3.layer.Layer] = Seq.empty)
+    extends NoTargetAnnotation
+    with Unserializable
 
 /** Use legacy Chisel width behavior.
   *

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -61,7 +61,7 @@ trait ChiselRunners extends Assertions {
             VerilogPreprocessorDefine("ASSERT_VERBOSE_COND", s"!${Workspace.testbenchModuleName}.reset"),
             VerilogPreprocessorDefine("PRINTF_COND", s"!${Workspace.testbenchModuleName}.reset"),
             VerilogPreprocessorDefine("STOP_COND", s"!${Workspace.testbenchModuleName}.reset")
-          ),
+          ) ++ layerControl.preprocessorDefines(elaboratedModule),
           includeDirs = Some(Seq(workspace.primarySourcesPath)),
           fileFilter = layerControl.filter
         )

--- a/src/test/scala/chiselTests/aop/SelectSpec.scala
+++ b/src/test/scala/chiselTests/aop/SelectSpec.scala
@@ -193,7 +193,7 @@ class SelectSpec extends ChiselFlatSpec {
     }
     val top = ChiselGeneratorAnnotation(() => {
       new Top()
-    }).elaborate.collectFirst { case DesignAnnotation(design: Top) => design }.get
+    }).elaborate.collectFirst { case DesignAnnotation(design: Top, _) => design }.get
     Select.collectDeep(top) { case x => x } should equal(Seq(top, top.inst0))
     Select.getDeep(top)(x => Seq(x)) should equal(Seq(top, top.inst0))
     Select.instances(top) should equal(Seq(top.inst0))
@@ -220,7 +220,7 @@ class SelectSpec extends ChiselFlatSpec {
     }
     val top = ChiselGeneratorAnnotation(() => {
       new Top()
-    }).elaborate.collectFirst { case DesignAnnotation(design: Top) => design }.get
+    }).elaborate.collectFirst { case DesignAnnotation(design: Top, _) => design }.get
     intercept[Exception] { Select.collectDeep(top) { case x => x } }
     intercept[Exception] { Select.getDeep(top)(x => Seq(x)) }
     intercept[Exception] { Select.instances(top) }

--- a/src/test/scala/chiselTests/experimental/TraceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/TraceSpec.scala
@@ -72,7 +72,7 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
     }
 
     val (testDir, annos) = compile("TraceFromAnnotations", () => new Module1)
-    val dut = annos.collectFirst { case DesignAnnotation(dut) => dut }.get.asInstanceOf[Module1]
+    val dut = annos.collectFirst { case DesignAnnotation(dut: Module1, _) => dut }.get
     // out of Builder.
 
     val oneTarget = finalTarget(annos)(dut.m0.r.a.a).head
@@ -215,7 +215,7 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
     }
 
     val (_, annos) = compile("TraceFromCollideBundle", () => new CollideModule)
-    val dut = annos.collectFirst { case DesignAnnotation(dut) => dut }.get.asInstanceOf[CollideModule]
+    val dut = annos.collectFirst { case DesignAnnotation(dut: CollideModule, _) => dut }.get
 
     val topName = "CollideModule"
 
@@ -259,7 +259,7 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
     }
 
     val (_, annos) = compile("Inline", () => new Module1)
-    val dut = annos.collectFirst { case DesignAnnotation(dut) => dut }.get.asInstanceOf[Module1]
+    val dut = annos.collectFirst { case DesignAnnotation(dut: Module1, _) => dut }.get
 
     val m0_i = finalTarget(annos)(dut.m0.i).head
     m0_i should be(refTarget("Module1", "m0_i"))
@@ -276,7 +276,7 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
     }
 
     val (_, annos) = compile("ConstantProp", () => new Module0)
-    val dut = annos.collectFirst { case DesignAnnotation(dut) => dut }.get.asInstanceOf[Module0]
+    val dut = annos.collectFirst { case DesignAnnotation(dut: Module0, _) => dut }.get
 
     val i0 = finalTarget(annos)(dut.i0).head
     i0 should be(refTarget("Module0", "i0"))
@@ -319,7 +319,7 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
     }
 
     val (_, annos) = compile("NestedModule", () => new M3)
-    val m3 = annos.collectFirst { case DesignAnnotation(dut) => dut }.get.asInstanceOf[M3]
+    val m3 = annos.collectFirst { case DesignAnnotation(dut: M3, _) => dut }.get
 
     val m2_m1_not = finalTarget(annos)(m3.m2.m1.bar).head
     val m2_not = finalTarget(annos)(m3.m2.foo).head
@@ -337,7 +337,7 @@ class TraceSpec extends ChiselFlatSpec with Matchers {
       Seq(a, b).foreach { a => traceName(a); dontTouch(a) }
     }
     val (_, annos) = compile("NestedModule", () => new M)
-    val dut = annos.collectFirst { case DesignAnnotation(dut) => dut }.get.asInstanceOf[M]
+    val dut = annos.collectFirst { case DesignAnnotation(dut: M, _) => dut }.get
     val allTargets = finalTargetMap(annos)
     allTargets(dut.a.toAbsoluteTarget) should be(Seq(refTarget("M", "a")))
     allTargets(dut.b(0).toAbsoluteTarget) should be(Seq(refTarget("M", "b_0")))


### PR DESCRIPTION
Add support for ChiselSim to turn on inline layers.  This requires a different approach than how this worked for extract layers in order to continue to support the ability to "enable all" layers.  For extract layers, this was straightforward: all files which looked like layer files could be included.  However, for inline layers, to enable all layers requires knowledge of the layers that exist because Verilog preprocessor defines must be hand-crafted.

The first part of this patch adds support for layer ABIs.  After that, the `DesignAnnotation` is widened to include information about what layers were elaborated.  Finally, ChiselSim and svsim classes/functions are untangled to make it possible to add information to the compiler options after elaborating the circuit.

There are stubs in here to add support for extract layers to work the same way. I'd like to land this patch first and then clean that up following.

Commits should be reviewed individually.

#### Release Notes

Fix ChiselSim so that inline layers can be enabled using the existing `layerControl` argument to simulators.