### PR TITLE
[ChiselSim][svsim] Switch to shouldIncludeFile

### DIFF
--- a/src/main/scala-2/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala-2/chisel3/simulator/EphemeralSimulator.scala
@@ -23,16 +23,13 @@ object EphemeralSimulator extends PeekPokeAPI {
     layerControl: LayerControl.Type = LayerControl.EnableAll
   )(body:         (T) => Unit
   ): Unit = {
-    makeSimulator(layerControl).simulate(module, layerControl)({ module => body(module.wrapped) }).result
+    makeSimulator().simulate(module, layerControl)({ module => body(module.wrapped) }).result
   }
 
-  private class DefaultSimulator(val workspacePath: String, layerControl: LayerControl.Type)
-      extends SingleBackendSimulator[verilator.Backend] {
+  private class DefaultSimulator(val workspacePath: String) extends SingleBackendSimulator[verilator.Backend] {
     val backend = verilator.Backend.initializeFromProcessEnvironment()
     val tag = "default"
-    val commonCompilationSettings = CommonCompilationSettings(
-      fileFilter = layerControl.filter
-    )
+    val commonCompilationSettings = CommonCompilationSettings()
     val backendSpecificCompilationSettings = verilator.Backend.CompilationSettings()
 
     // Try to clean up temporary workspace if possible
@@ -40,14 +37,13 @@ object EphemeralSimulator extends PeekPokeAPI {
       (new Directory(new File(workspacePath))).deleteRecursively()
     }
   }
-  private def makeSimulator(layerControl: LayerControl.Type): DefaultSimulator = {
+  private def makeSimulator(): DefaultSimulator = {
     // TODO: Use ProcessHandle when we can drop Java 8 support
     // val id = ProcessHandle.current().pid().toString()
     val id = java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
     val className = getClass().getName().stripSuffix("$")
     new DefaultSimulator(
-      workspacePath = Files.createTempDirectory(s"${className}_${id}_").toString,
-      layerControl = layerControl
+      workspacePath = Files.createTempDirectory(s"${className}_${id}_").toString
     )
   }
 }

--- a/src/main/scala-2/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala-2/chisel3/simulator/LayerControl.scala
@@ -13,20 +13,6 @@ object LayerControl {
   /** The type of all layer control variations */
   sealed trait Type {
 
-    /** Return true if a file should be included in the build.  This will always
-      * return true for any non-layer file.
-      * @param file the file to check
-      */
-    final def filter(file: File): Boolean = file.getName match {
-      case nonLayer if !nonLayer.startsWith("layers-") => true
-      case layer                                       => shouldEnable(layer)
-    }
-
-    /** Return true if a layer should be included in the build.
-      * @param layerFilename the filename of a layer
-      */
-    protected def shouldEnable(layerFilename: String): Boolean
-
     /** Return the layers that should be enabled in a circuit.  The layers must exist in the design.
       *
       * @param design an Annotation that contains an elaborated design used to check that the requested layers exist
@@ -82,7 +68,6 @@ object LayerControl {
 
   /** Enable all layers */
   final case object EnableAll extends Type {
-    override protected def shouldEnable(layerFilename: String) = true
 
     override protected def getLayerSubset(module: ElaboratedModule[_]): Seq[Layer] = module.layers
   }
@@ -103,7 +88,6 @@ object LayerControl {
           re.matches(_)
       }
     }
-    override protected def shouldEnable(filename: String) = _shouldEnable(filename)
 
     override protected def getLayerSubset(module: ElaboratedModule[_]): Seq[Layer] = {
       val definedLayers = module.layers

--- a/src/main/scala-2/chisel3/simulator/Simulator.scala
+++ b/src/main/scala-2/chisel3/simulator/Simulator.scala
@@ -128,8 +128,12 @@ trait Simulator {
 
     processBackends(
       compiler,
-      commonCompilationSettings.copy(verilogPreprocessorDefines =
-        commonCompilationSettings.verilogPreprocessorDefines ++ layerControl.preprocessorDefines(elaboratedModule)
+      commonCompilationSettings.copy(
+        verilogPreprocessorDefines =
+          commonCompilationSettings.verilogPreprocessorDefines ++ layerControl.preprocessorDefines(
+            elaboratedModule
+          ),
+        fileFilter = commonCompilationSettings.fileFilter.orElse(layerControl.shouldIncludeFile(elaboratedModule))
       )
     )
     compiler.results.toSeq

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -63,7 +63,7 @@ trait ChiselRunners extends Assertions {
             VerilogPreprocessorDefine("STOP_COND", s"!${Workspace.testbenchModuleName}.reset")
           ) ++ layerControl.preprocessorDefines(elaboratedModule),
           includeDirs = Some(Seq(workspace.primarySourcesPath)),
-          fileFilter = layerControl.filter
+          fileFilter = layerControl.shouldIncludeFile(elaboratedModule)
         )
       },
       verilator.Backend

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -15,7 +15,7 @@ case class CommonCompilationSettings(
   libraryExtensions: Option[Seq[String]] = None,
   libraryPaths:      Option[Seq[String]] = None,
   includeDirs:       Option[Seq[String]] = None,
-  fileFilter:        File => Boolean = _ => true)
+  fileFilter:        PartialFunction[File, Boolean] = PartialFunction.empty)
 object CommonCompilationSettings {
   object VerilogPreprocessorDefine {
     def apply(name: String, value: String) = new VerilogPreprocessorDefine(name, Some(value))

--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -318,7 +318,7 @@ final class Workspace(
       .flatMap(p => Files.walk(Paths.get(p)).iterator().asScala.toSeq)
       .map(_.toFile)
       .filter(_.isFile)
-      .filter(commonSettings.fileFilter)
+      .filter(commonSettings.fileFilter.orElse { case _ => true })
       .map { file => workingDirectory.toPath().relativize(file.toPath()).toString() }
 
     val traceFileStem = (backendSpecificSettings match {


### PR DESCRIPTION
Provide initial work that better handles the problem of needing to filter
files in order to enable specific layers.  This adds a new member
function, `shouldIncludeFile` which returns a `PartialFunction` that is
defined only if the file being examined is a layer file (as defined in the
FIRRTL ABI for extract layers) and returns true if that layer file should
be included in order to enable the requested layers.

Change both ChiselSim and svsim to no longer use the `filter` function of
`LayerControl`.  Migrate both to use `shouldIncludeFile` partial function.
The latter is a much better API as it reserves the handling of files that
are outside the domain of the filter to ChiselSim and svsim.

Remove `LayerControl`'s filter as this is no longer load-bearing.