### PR TITLE
[svsim] Escape '$' in defines for VCS only

### DIFF
--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -22,7 +22,7 @@ object CommonCompilationSettings {
     def apply(name: String) = new VerilogPreprocessorDefine(name, None)
   }
   case class VerilogPreprocessorDefine private (name: String, value: Option[String]) {
-    private[svsim] def toCommandlineArgument(backend: Backend): String = {
+    final def toCommandlineArgument(backend: Backend): String = {
       value match {
         case Some(v) => s"+define+${backend.escapeDefine(name)}=${backend.escapeDefine(v)}"
         case None    => s"+define+${backend.escapeDefine(name)}"

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -22,10 +22,10 @@ object CommonCompilationSettings {
     def apply(name: String) = new VerilogPreprocessorDefine(name, None)
   }
   case class VerilogPreprocessorDefine private (name: String, value: Option[String]) {
-    private[svsim] def toCommandlineArgument: String = {
+    private[svsim] def toCommandlineArgument(backend: Backend): String = {
       value match {
-        case Some(v) => s"+define+${name}=${v}"
-        case None    => s"+define+${name}"
+        case Some(v) => s"+define+${backend.escapeDefine(name)}=${backend.escapeDefine(v)}"
+        case None    => s"+define+${backend.escapeDefine(name)}"
       }
     }
   }
@@ -75,6 +75,12 @@ trait Backend {
     commonSettings:          CommonCompilationSettings,
     backendSpecificSettings: CompilationSettings
   ): Backend.Parameters
+
+  /** This function will be applied to all defines (both the keys and the values).
+    * This can be used to workaround subtleties in how different simulators
+    * parse defines and require different escaping.
+    */
+  def escapeDefine(string: String): String
 }
 
 final object Backend {

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -193,7 +193,7 @@ final class Backend(
               VerilogPreprocessorDefine(svsim.Backend.HarnessCompilationFlags.supportsDelayInPublicFunctions)
             ),
             backendSpecificSettings.traceSettings.verilogPreprocessorDefines
-          ).flatten.map(_.toCommandlineArgument),
+          ).flatten.map(_.toCommandlineArgument(this)),
         ).flatten,
         environment = environment ++ Seq(
           "VCS_HOME" -> vcsHome,
@@ -212,4 +212,9 @@ final class Backend(
     )
     //format: on
   }
+
+  /** VCS seems to require that dollar signs in arguments are escaped.  This is
+    * different from Verilator.
+    */
+  override def escapeDefine(string: String): String = string.replace("$", "\\$")
 }

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -160,7 +160,7 @@ final class Backend(
                 VerilogPreprocessorDefine(svsim.Backend.HarnessCompilationFlags.enableVcdTracingSupport)
               )
             },
-          ).flatten.map(_.toCommandlineArgument),
+          ).flatten.map(_.toCommandlineArgument(this)),
         ).flatten,
         environment = Seq()
       ),
@@ -168,4 +168,6 @@ final class Backend(
     )
     //format: on
   }
+
+  override def escapeDefine(string: String): String = string
 }

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -43,6 +43,8 @@ case class CustomVerilatorBackend(actualBackend: verilator.Backend) extends Back
       backendSpecificSettings
     )
   }
+
+  override def escapeDefine(string: String): String = string
 }
 
 class VerilatorSpec extends BackendSpec {


### PR DESCRIPTION
Add an abstract function to `svsim.Backend` which can be used to control how define key and values will be escaped.  Add escaping for '$' for VCS only.

This is done to work around what I think is a difference in how VCS and Verilator handle the `+define+key=value` command line argument.  In svsim, we call both like the following (this is a key only, no value):

    <tool> '+define+Foo$Bar'

While Verilator will accept this, VCS will not and instead wants:

    <tool> '+define+Foo\$Bar'

As far as I can tell, the problem seems to be the single quotes not being respected by VCS.  This is _likely_ due to the fact that the VCS entrypoint is shell and may have some oddities in how it is handling command line options.  (This is speculation.)

I expect that this could have manifested for anything that was using a Verilog system function, e.g.., `+define+RANDOM+$random`.  For that specific case, we were already escaping it internally.

The immediate need for this is to get inline layers and their `$`-ridden ABI (that I wrote...) working with VCS.  They are already working with Verilator.

#### Release Notes

Fix a bug where defines passed to VCS could be ignored by VCS if they included `$`.