### PR TITLE
Escape special characters in Property String literals

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -147,7 +147,7 @@ private[chisel3] object PropertyType extends LowPriorityPropertyTypeInstances {
     }
 
   implicit val stringPropertyTypeInstance: SimplePropertyType[String] =
-    makeSimple[String](fir.StringPropertyType, fir.StringPropertyLiteral(_))
+    makeSimple[String](fir.StringPropertyType, s => fir.StringPropertyLiteral(fir.StringLit(s)))
 
   implicit val boolPropertyTypeInstance: SimplePropertyType[Boolean] =
     makeSimple[Boolean](fir.BooleanPropertyType, fir.BooleanPropertyLiteral(_))

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -241,7 +241,7 @@ case class DoublePropertyLiteral(value: Double) extends Expression with UseSeria
   val width = UnknownWidth
 }
 
-case class StringPropertyLiteral(value: String) extends Expression with UseSerializer {
+case class StringPropertyLiteral(value: StringLit) extends Expression with UseSerializer {
   def tpe = StringPropertyType
   val width = UnknownWidth
 }

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -113,7 +113,7 @@ object Serializer {
     case DoublePropertyLiteral(value) =>
       b ++= "Double("; b ++= value.toString(); b ++= ")"
     case StringPropertyLiteral(value) =>
-      b ++= "String(\""; b ++= value; b ++= "\")"
+      b ++= "String("; b ++= value.escape; b ++= ")"
     case BooleanPropertyLiteral(value) =>
       b ++= s"Bool(${value})"
     case PathPropertyLiteral(value) =>

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -576,7 +576,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
             case fir.DoublePropertyLiteral(value) =>
               val attrs = Seq(("value", circt.mlirFloatAttrDoubleGet(circt.mlirF64TypeGet(), value)))
               ("double", attrs, Seq.empty)
-            case fir.StringPropertyLiteral(value) =>
+            case fir.StringPropertyLiteral(fir.StringLit(value)) =>
               val attrs = Seq(("value", circt.mlirStringAttrGet(value)))
               ("string", attrs, Seq.empty)
             case fir.BooleanPropertyLiteral(value) =>

--- a/src/test/scala/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertySpec.scala
@@ -132,6 +132,31 @@ class PropertySpec extends ChiselFlatSpec with MatchesAndOmits {
     )()
   }
 
+  it should "escape special characters in Property String literals" in {
+    val input = "foo\"\n\t\\bar"
+    val expected = """foo\"\n\t\\bar"""
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val propOut = IO(Output(Property[String]()))
+      propOut := Property(input)
+    })
+
+    matchesAndOmits(chirrtl)(
+      s"""propassign propOut, String("$expected")"""
+    )()
+  }
+
+  it should "not escape characters that do not need escaping in Property String literals" in {
+    val input = "foo!@#$%^&*()_+bar"
+    val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
+      val propOut = IO(Output(Property[String]()))
+      propOut := Property(input)
+    })
+
+    matchesAndOmits(chirrtl)(
+      s"""propassign propOut, String("$input")"""
+    )()
+  }
+
   it should "support Boolean as a Property type" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val boolProp = IO(Input(Property[Boolean]()))


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

- Squash

#### Release Notes

This technically breaks backwards compatibility for `firrtl.ir.StringPropertyLiteral` but `firrtl.ir` is considered an internal API.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
