### PR TITLE
Fix BoringUtils input probe creation

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -272,7 +272,9 @@ object BoringUtils {
             // the creation of input probes.
             val bore =
               if (up) module.createSecretIO(purePortType)
-              else module.createSecretIO(Flipped(purePortTypeBase.cloneType))
+              else if (DataMirror.hasProbeTypeModifier(purePortTypeBase))
+                module.createSecretIO(Flipped(purePortTypeBase.cloneType))
+              else module.createSecretIO(Flipped(purePortTypeBase))
             module.addSecretIO(bore)
 
             // TODO: Check for wiring non-probes not in same block, reject/diagnose.

--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -268,8 +268,11 @@ object BoringUtils {
             }
 
             /** create a port, and drill up. */
-            // if drilling down, don't drill Probe types
-            val bore = if (up) module.createSecretIO(purePortType) else module.createSecretIO(Flipped(purePortTypeBase))
+            // If drilling down, drop modifiers (via cloneType).  This prevents
+            // the creation of input probes.
+            val bore =
+              if (up) module.createSecretIO(purePortType)
+              else module.createSecretIO(Flipped(purePortTypeBase.cloneType))
             module.addSecretIO(bore)
 
             // TODO: Check for wiring non-probes not in same block, reject/diagnose.


### PR DESCRIPTION
Fix a bug in BoringUtils where it could create input probes when tapping a probe.

Fixes #4576.

#### Release Notes

Fix a bug where `BoringUtils` methods could create input probes when tapping a probe type.