### PR TITLE
CIRCT converter: rename `portSyms` to `portSymbols`

### DIFF
--- a/lit/tests/Property/Good.sc
+++ b/lit/tests/Property/Good.sc
@@ -8,7 +8,7 @@ import chisel3.panamaom._
 import lit.utility._
 
 // SFC-FIRRTL-LABEL: circuit IntPropTest :
-// SFC-FIRRTL-NEXT: module IntPropTest :
+// SFC-FIRRTL: public module IntPropTest :
 // SFC-FIRRTL-NEXT: output intProp : Integer
 class IntPropTest extends RawModule {
   val intProp = IO(Output(Property[Int]()))

--- a/lit/tests/SmokeTest.sc
+++ b/lit/tests/SmokeTest.sc
@@ -11,14 +11,14 @@ class FooBundle extends Bundle {
 }
 
 // SFC-FIRRTL-LABEL: circuit FooModule :
-// SFC-FIRRTL-NEXT:    module FooModule :
+// SFC-FIRRTL:         public module FooModule :
 // SFC-FIRRTL-NEXT:      input clock : Clock
 // SFC-FIRRTL-NEXT:      input reset : UInt<1>
 // SFC-FIRRTL-NEXT:      output io : { flip foo : UInt<3>}
 // SFC-FIRRTL:           skip
 
 // MFC-FIRRTL-LABEL: circuit FooModule :
-// MFC-FIRRTL-NEXT:    module FooModule :
+// MFC-FIRRTL:         public module FooModule :
 // MFC-FIRRTL-NEXT:      input clock : Clock
 // MFC-FIRRTL-NEXT:      input reset : UInt<1>
 // MFC-FIRRTL-NEXT:      output io : { flip foo : UInt<3> }


### PR DESCRIPTION
Follow up the upstream PR llvm/circt#7734.