### PR TITLE
Error rather than throw on scope violations

### DIFF
--- a/core/src/main/scala/chisel3/BitsImpl.scala
+++ b/core/src/main/scala/chisel3/BitsImpl.scala
@@ -142,24 +142,29 @@ private[chisel3] trait BitsImpl extends Element { self: Bits =>
     _applyImpl(castToInt(x, "High index"), castToInt(y, "Low index"))
 
   private[chisel3] def unop[T <: Data](sourceInfo: SourceInfo, dest: T, op: PrimOp): T = {
+    implicit val info: SourceInfo = sourceInfo
     requireIsHardware(this, "bits operated on")
     pushOp(DefPrim(sourceInfo, dest, op, this.ref))
   }
   private[chisel3] def binop[T <: Data](sourceInfo: SourceInfo, dest: T, op: PrimOp, other: BigInt): T = {
+    implicit val info: SourceInfo = sourceInfo
     requireIsHardware(this, "bits operated on")
     pushOp(DefPrim(sourceInfo, dest, op, this.ref, ILit(other)))
   }
   private[chisel3] def binop[T <: Data](sourceInfo: SourceInfo, dest: T, op: PrimOp, other: Bits): T = {
+    implicit val info: SourceInfo = sourceInfo
     requireIsHardware(this, "bits operated on")
     requireIsHardware(other, "bits operated on")
     pushOp(DefPrim(sourceInfo, dest, op, this.ref, other.ref))
   }
   private[chisel3] def compop(sourceInfo: SourceInfo, op: PrimOp, other: Bits): Bool = {
+    implicit val info: SourceInfo = sourceInfo
     requireIsHardware(this, "bits operated on")
     requireIsHardware(other, "bits operated on")
     pushOp(DefPrim(sourceInfo, Bool(), op, this.ref, other.ref))
   }
   private[chisel3] def redop(sourceInfo: SourceInfo, op: PrimOp): Bool = {
+    implicit val info: SourceInfo = sourceInfo
     requireIsHardware(this, "bits operated on")
     pushOp(DefPrim(sourceInfo, Bool(), op, this.ref))
   }

--- a/core/src/main/scala/chisel3/ChiselEnumImpl.scala
+++ b/core/src/main/scala/chisel3/ChiselEnumImpl.scala
@@ -33,6 +33,7 @@ private[chisel3] abstract class EnumTypeImpl(private[chisel3] val factory: Chise
   override def cloneType: this.type = factory().asInstanceOf[this.type]
 
   private[chisel3] def compop(sourceInfo: SourceInfo, op: PrimOp, other: EnumType): Bool = {
+    implicit val info: SourceInfo = sourceInfo
     requireIsHardware(this, "bits operated on")
     requireIsHardware(other, "bits operated on")
 

--- a/core/src/main/scala/chisel3/MemImpl.scala
+++ b/core/src/main/scala/chisel3/MemImpl.scala
@@ -165,13 +165,14 @@ private[chisel3] trait MemBaseImpl[T <: Data] extends HasId with NamedComponent 
     dir:        MemPortDirection,
     clock:      Clock
   ): T = {
+    implicit val info: SourceInfo = sourceInfo
     if (Builder.currentModule != _parent) {
       throwException(
         s"Cannot create a memory port in a different module (${Builder.currentModule.get.name}) than where the memory is (${_parent.get.name})."
       )
     }
     requireIsHardware(idx, "memory port index")
-    val i = Vec.truncateIndex(idx, length)(sourceInfo)
+    val i = Vec.truncateIndex(idx, length)
 
     val port = pushCommand(
       DefMemPort(sourceInfo, t.cloneTypeFull, Node(this), dir, i.ref, clock.ref)

--- a/core/src/main/scala/chisel3/When.scala
+++ b/core/src/main/scala/chisel3/When.scala
@@ -150,7 +150,7 @@ final class WhenContext private[chisel3] (
   // Create the `When` operation and run the `block` thunk inside the
   // `ifRegion`.  Any commands that this thunk creates will be put inside this
   // block.
-  private val whenCommand = pushCommand(new When(sourceInfo, cond().ref))
+  private val whenCommand = pushCommand(new When(sourceInfo, cond().ref(sourceInfo)))
   Builder.pushWhen(this)
   scope = Some(Scope.If)
   try {

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -268,7 +268,7 @@ private[chisel3] trait HasId extends chisel3.InstanceId {
   private[chisel3] def setRef(parent: Node, index: Int): Unit = setRef(LitIndex(parent, index))
   private[chisel3] def setRef(parent: Node, index: UInt): Unit = index.litOption match {
     case Some(lit) if lit.isValidInt => setRef(LitIndex(parent, lit.intValue))
-    case _                           => setRef(Index(parent, index.ref))
+    case _                           => setRef(Index(parent, index.ref(UnlocatableSourceInfo)))
   }
   private[chisel3] def getRef:       Arg = _ref.get
   private[chisel3] def getOptionRef: Option[Arg] = _ref

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -124,7 +124,7 @@ case class ClassType private[chisel3] (name: String) { self =>
         override def convert(value: Underlying, ctx: Component, info: SourceInfo): fir.Expression =
           Converter.convert(value, ctx, info)
         type Underlying = Arg
-        override def convertUnderlying(value: Property[ClassType] with self.Type) = value.ref
+        override def convertUnderlying(value: Property[ClassType] with self.Type, info: SourceInfo) = value.ref(info)
       }
   }
   def copy(name: String = this.name) = new ClassType(name)
@@ -147,7 +147,7 @@ object AnyClassType {
       override def convert(value: Underlying, ctx: Component, info: SourceInfo): fir.Expression =
         Converter.convert(value, ctx, info)
       type Underlying = Arg
-      override def convertUnderlying(value: Property[ClassType] with AnyClassType) = value.ref
+      override def convertUnderlying(value: Property[ClassType] with AnyClassType, info: SourceInfo) = value.ref(info)
     }
 }
 

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -1157,7 +1157,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
       .map(p => {
         val param = p._2 match {
           case pable: PrintableParam =>
-            val (fmt, fmtArgs) = Converter.unpack(pable.value, parent)
+            val (fmt, fmtArgs) = Converter.unpack(pable.value, parent, UnlocatableSourceInfo)
             args = fmtArgs
             StringParam(fmt)
           case others => others
@@ -1707,7 +1707,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
 
   def visitPrintf(parent: Component, printf: Printf): Unit = {
     val loc = util.convert(printf.sourceInfo)
-    val (fmt, args) = Converter.unpack(printf.pable, parent)
+    val (fmt, args) = Converter.unpack(printf.pable, parent, printf.sourceInfo)
     util
       .OpBuilder("firrtl.printf", firCtx.currentBlock, loc)
       .withNamedAttr("formatString", circt.mlirStringAttrGet(fmt))
@@ -1739,7 +1739,7 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
     opName: String
   ): Unit = {
     val loc = util.convert(verifi.sourceInfo)
-    val (fmt, args) = Converter.unpack(verifi.pable, parent)
+    val (fmt, args) = Converter.unpack(verifi.pable, parent, verifi.sourceInfo)
     util
       .OpBuilder(opName, firCtx.currentBlock, loc)
       .withNamedAttr("message", circt.mlirStringAttrGet(fmt))

--- a/src/test/scala/chiselTests/WhenSpec.scala
+++ b/src/test/scala/chiselTests/WhenSpec.scala
@@ -170,38 +170,44 @@ class WhenSpec extends ChiselFlatSpec with Utils {
   "Using a value that has escaped from a when scope in a connection" should "give a reasonable error message" in {
     implicit val info: SourceInfo = SourceLine("Foo.scala", 12, 3)
     val e = the[ChiselException] thrownBy {
-      ChiselStage.emitCHIRRTL(new Module {
-        override def desiredName = "Top"
-        val foo, bar = IO(Output(UInt(8.W)))
-        val a = IO(Input(Bool()))
-        lazy val w = Wire(UInt(8.W))
-        when(a) {
-          foo := w
-        }
-        bar := w
-      })
+      ChiselStage.emitCHIRRTL(
+        new Module {
+          override def desiredName = "Top"
+          val foo, bar = IO(Output(UInt(8.W)))
+          val a = IO(Input(Bool()))
+          lazy val w = Wire(UInt(8.W))
+          when(a) {
+            foo := w
+          }
+          bar := w
+        },
+        args = Array("--throw-on-first-error")
+      )
     }
     val msg =
-      "Source foo_w in Top has escaped the scope of the block (@[Foo.scala:12:3]) in which it was constructed."
+      "'Top.foo_w: Wire[UInt<8>]' has escaped the scope of the block (@[Foo.scala:12:3]) in which it was constructed."
     e.getMessage should include(msg)
   }
 
   "Using a value that has escaped from a when scope in an operation" should "give a reasonable error message" in {
     implicit val info: SourceInfo = SourceLine("Foo.scala", 12, 3)
     val e = the[ChiselException] thrownBy {
-      ChiselStage.emitCHIRRTL(new Module {
-        override def desiredName = "Top"
-        val foo, bar = IO(Output(UInt(8.W)))
-        val a = IO(Input(Bool()))
-        lazy val w = Wire(UInt(8.W))
-        when(a) {
-          foo := w
-        }
-        bar := w + 1.U
-      })
+      ChiselStage.emitCHIRRTL(
+        new Module {
+          override def desiredName = "Top"
+          val foo, bar = IO(Output(UInt(8.W)))
+          val a = IO(Input(Bool()))
+          lazy val w = Wire(UInt(8.W))
+          when(a) {
+            foo := w
+          }
+          bar := w + 1.U
+        },
+        args = Array("--throw-on-first-error")
+      )
     }
     val msg =
-      "operand 'Top.foo_w: Wire[UInt<8>]' has escaped the scope of the block (@[Foo.scala:12:3]) in which it was constructed."
+      "'Top.foo_w: Wire[UInt<8>]' has escaped the scope of the block (@[Foo.scala:12:3]) in which it was constructed."
     e.getMessage should include(msg)
   }
 
@@ -232,7 +238,7 @@ class WhenSpec extends ChiselFlatSpec with Utils {
         out := c
       }
     }
-    val e = the[ChiselException] thrownBy ChiselStage.emitCHIRRTL(new Foo)
+    val e = the[ChiselException] thrownBy ChiselStage.emitCHIRRTL(new Foo, args = Array("--throw-on-first-error"))
     e.getMessage should include("has escaped the scope of the block")
   }
 }


### PR DESCRIPTION
I am making changes that are tripping scope issues and it was very annoying. I did this work to help myself so it probably belongs in upstream!

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

* Errors are aggregated by default and all reported at the end whereas exceptions throw immediately. This allows users to fix multiple scope violations at the same time.
* `Printable.unpack` now takes an implicit `SourceInfo`
* `PropertyType.convertUnderlying` now takes an explicit `SourceInfo`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
