### PR TITLE
[util] Add a withShadowLayer Queue

### DIFF
--- a/core/src/main/scala-3/chisel3/probe/Probe.scala
+++ b/core/src/main/scala-3/chisel3/probe/Probe.scala
@@ -12,8 +12,8 @@ object Probe extends ProbeBase {
   def apply[T <: Data](source: => T)(using sourceInfo: SourceInfo): T =
     super.apply(source, false, None)
 
-  def apply[T <: Data](source: => T, color: Option[layer.Layer])(using sourceInfo: SourceInfo): T =
-    super.apply(source, false, color)
+  def apply[T <: Data](source: => T, color: layer.Layer)(using sourceInfo: SourceInfo): T =
+    super.apply(source, false, Some(color))
 }
 
 object RWProbe extends ProbeBase with SourceInfoDoc {

--- a/integration-tests/src/test/scala/chiselTest/QueueSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/QueueSpec.scala
@@ -239,14 +239,13 @@ class ShadowQueueFactoryTester(queueDepth: Int, tap: Int, useSyncReadMem: Boolea
   }
 
   private val (queue, shadow) =
-    Queue.withShadowLayer(
+    Queue.withShadow(
       enq = enq,
       entries = queueDepth,
-      useSyncReadMem = useSyncReadMem,
-      layerDataTuple = (probe.read(idIn), layers.Verification)
+      useSyncReadMem = useSyncReadMem
     )
   deq :<>= queue
-  probe.define(idOut, shadow)
+  probe.define(idOut, shadow(probe.read(idIn), layers.Verification))
 }
 
 class QueueSpec extends ChiselPropSpec {

--- a/integration-tests/src/test/scala/chiselTest/QueueSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/QueueSpec.scala
@@ -316,12 +316,24 @@ class QueueSpec extends ChiselPropSpec {
         probe.define(id, probe.ProbeValue(_id))
       }
 
-      private val (queue, shadow) = Queue.withShadowLayer(enq = in, layerDataTuple = (probe.read(id), layers.Verification))
+      private val (queue, shadow) =
+        Queue.withShadowLayer(enq = in, layerDataTuple = (probe.read(id), layers.Verification))
       out :<>= queue
       probe.define(outShadow, shadow)
     }
 
     println(ChiselStage.emitCHIRRTL(new Foo))
-    println(ChiselStage.emitSystemVerilog(new Foo, firtoolOpts=Array("-disable-all-randomization", "-strip-debug-info", "-enable-layers=Verification.Assert", "-enable-layers=Verification.Assume", "-enable-layers=Verification.Cover")))
+    println(
+      ChiselStage.emitSystemVerilog(
+        new Foo,
+        firtoolOpts = Array(
+          "-disable-all-randomization",
+          "-strip-debug-info",
+          "-enable-layers=Verification.Assert",
+          "-enable-layers=Verification.Assume",
+          "-enable-layers=Verification.Cover"
+        )
+      )
+    )
   }
 }

--- a/integration-tests/src/test/scala/chiselTest/QueueSpec.scala
+++ b/integration-tests/src/test/scala/chiselTest/QueueSpec.scala
@@ -208,6 +208,47 @@ class QueueFactoryTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap
   }
 }
 
+/** Test that a Shadow Queue keeps track of shadow identifiers that are fed to
+  * it.  This feeds data into a queue and an identifier (which is `data >> 1`)
+  * into the shadow queue.  It then checks that each data read out has the
+  * expected identifier.
+  */
+class ShadowQueueFactoryTester(queueDepth: Int, tap: Int, useSyncReadMem: Boolean) extends BasicTester {
+  val enq, deq = Wire(Decoupled(UInt(32.W)))
+
+  private val (dataCounter, _) = Counter(0 to 31 by 2, enable = enq.fire)
+
+  enq.valid :<= true.B
+  deq.ready :<= LFSR(16)(tap)
+
+  enq.bits :<= dataCounter
+
+  private val idIn = Wire(probe.Probe(UInt(4.W), layers.Verification))
+  private val idOut = Wire(probe.Probe(Valid(UInt(4.W)), layers.Verification))
+  layer.block(layers.Verification) {
+    probe.define(idIn, probe.ProbeValue(dataCounter >> 1))
+
+    when(deq.fire) {
+      assert(deq.bits >> 1 === probe.read(idOut).bits)
+    }
+  }
+
+  private val (_, done) = Counter(0 to 8, enable = deq.fire)
+  when(done) {
+    stop()
+  }
+
+  private val (queue, shadow) =
+    Queue.withShadowLayer(
+      enq = enq,
+      entries = queueDepth,
+      useSyncReadMem = useSyncReadMem,
+      layerDataTuple = (probe.read(idIn), layers.Verification)
+    )
+  deq :<>= queue
+  probe.define(idOut, shadow)
+}
+
 class QueueSpec extends ChiselPropSpec {
 
   property("Queue should have things pass through") {
@@ -305,35 +346,11 @@ class QueueSpec extends ChiselPropSpec {
   }
 
   property("A shadow queue should track an identifier") {
-    class Foo extends Module {
-      val in = IO(Flipped(Decoupled(UInt(8.W))))
-      val out = IO(Decoupled(UInt(8.W)))
-      val outShadow = IO(probe.Probe(Valid(UInt(4.W)), layers.Verification))
-
-      private val id = Wire(probe.Probe(UInt(4.W), layers.Verification))
-      layer.block(layers.Verification) {
-        val (_id, _) = Counter(in.fire, 15)
-        probe.define(id, probe.ProbeValue(_id))
+    forAll(vecSizes, Gen.choose(0, 15), Gen.oneOf(true, false)) { (depth, tap, isSync) =>
+      info(s"depth: $depth, tap: $tap, isSync: $isSync")
+      assertTesterPasses {
+        new ShadowQueueFactoryTester(depth, tap, isSync)
       }
-
-      private val (queue, shadow) =
-        Queue.withShadowLayer(enq = in, layerDataTuple = (probe.read(id), layers.Verification))
-      out :<>= queue
-      probe.define(outShadow, shadow)
     }
-
-    println(ChiselStage.emitCHIRRTL(new Foo))
-    println(
-      ChiselStage.emitSystemVerilog(
-        new Foo,
-        firtoolOpts = Array(
-          "-disable-all-randomization",
-          "-strip-debug-info",
-          "-enable-layers=Verification.Assert",
-          "-enable-layers=Verification.Assume",
-          "-enable-layers=Verification.Cover"
-        )
-      )
-    )
   }
 }

--- a/src/main/scala/chisel3/util/Queue.scala
+++ b/src/main/scala/chisel3/util/Queue.scala
@@ -223,10 +223,6 @@ object Queue {
         val probeEnq = BoringUtils.tapAndRead(enq)
         shadowEnq.valid :<= probeEnq.valid
         shadowEnq.bits :<= data
-        assert(
-          probeEnq.ready === shadowEnq.ready,
-          "ready signals of shadow queue not moving in lockstep with its original"
-        )
 
         val shadowQueue = Queue(shadowEnq, entries, pipe, flow, useSyncReadMem, flush.map(BoringUtils.tapAndRead))
 

--- a/src/main/scala/chisel3/util/Queue.scala
+++ b/src/main/scala/chisel3/util/Queue.scala
@@ -223,6 +223,10 @@ object Queue {
         val probeEnq = BoringUtils.tapAndRead(enq)
         shadowEnq.valid :<= probeEnq.valid
         shadowEnq.bits :<= data
+        assert(
+          probeEnq.ready === shadowEnq.ready,
+          "ready signals of shadow queue not moving in lockstep with its original"
+        )
 
         val shadowQueue = Queue(shadowEnq, entries, pipe, flow, useSyncReadMem, flush.map(BoringUtils.tapAndRead))
 

--- a/src/main/scala/chisel3/util/Queue.scala
+++ b/src/main/scala/chisel3/util/Queue.scala
@@ -191,9 +191,9 @@ object Queue {
   /** A factory for creating shadow queues.  This is created using the
     * `withShadowQueue` method.
     */
-  class ShadowFactory[T <: Data] private[Queue] (
-    enq:            ReadyValidIO[T],
-    deq:            ReadyValidIO[T],
+  class ShadowFactory private[Queue] (
+    enq:            ReadyValidIO[Data],
+    deq:            ReadyValidIO[Data],
     entries:        Int,
     pipe:           Boolean,
     flow:           Boolean,
@@ -265,7 +265,7 @@ object Queue {
     flow:           Boolean = false,
     useSyncReadMem: Boolean = false,
     flush:          Option[Bool] = None
-  ): (DecoupledIO[T], ShadowFactory[T]) = {
+  ): (DecoupledIO[T], ShadowFactory) = {
     val deq = apply(enq, entries, pipe, flow, useSyncReadMem, flush)
     (deq, new ShadowFactory(enq, deq, entries, pipe, flow, useSyncReadMem, flush))
   }

--- a/src/main/scala/chisel3/util/Queue.scala
+++ b/src/main/scala/chisel3/util/Queue.scala
@@ -220,9 +220,8 @@ object Queue {
 
       block(layer) {
         val shadowEnq = Wire(Decoupled(chiselTypeOf(data)))
-        val enqProbe = BoringUtils.tapAndRead(enq)
-        shadowEnq.ready :<= enqProbe.ready
-        shadowEnq.valid :<= enqProbe.valid
+        val probeEnq = BoringUtils.tapAndRead(enq)
+        shadowEnq.valid :<= probeEnq.valid
         shadowEnq.bits :<= data
 
         val shadowQueue = Queue(shadowEnq, entries, pipe, flow, useSyncReadMem, flush.map(BoringUtils.tapAndRead))

--- a/src/main/scala/chisel3/util/Queue.scala
+++ b/src/main/scala/chisel3/util/Queue.scala
@@ -142,6 +142,25 @@ class Queue[T <: Data](
     * generator's `typeName`
     */
   override def desiredName = s"Queue${entries}_${gen.typeName}"
+
+  /** Create a "shadow" `Queue` in a specific layer that will be queued and
+    * dequeued in lockstep with an original `Queue`.  Connections are made using
+    * `BoringUtils.tapAndRead` which allows this method to be called anywhere in
+    * the hierarchy.
+    *
+    * An intended use case of this is as a building block of a "shadow" design
+    * verification datapath which augments an existing design datapath with
+    * additional information.  E.g., a shadow datapath that tracks transations
+    * in an interconnect.
+    *
+    * @param data a hardware data that should be enqueued together with the
+    * original `Queue`'s data
+    * @param layer the `Layer` in which this queue should be created
+    * @return a layer-colored `Valid` interface of probe type
+    */
+  def shadow[A <: Data](data: A, layer: Layer): Valid[A] = {
+    (new Queue.ShadowFactory(enq = io.enq, deq = io.deq, entries, pipe, flow, useSyncReadMem, io.flush))(data, layer)
+  }
 }
 
 /** Factory for a generic hardware queue. */

--- a/src/main/scala/chisel3/util/Queue.scala
+++ b/src/main/scala/chisel3/util/Queue.scala
@@ -220,8 +220,9 @@ object Queue {
 
       block(layer) {
         val shadowEnq = Wire(Decoupled(chiselTypeOf(data)))
-        shadowEnq.ready :<= true.B
-        shadowEnq.valid :<= BoringUtils.tapAndRead(enq).fire
+        val enqProbe = BoringUtils.tapAndRead(enq)
+        shadowEnq.ready :<= enqProbe.ready
+        shadowEnq.valid :<= enqProbe.valid
         shadowEnq.bits :<= data
 
         val shadowQueue = Queue(shadowEnq, entries, pipe, flow, useSyncReadMem, flush.map(BoringUtils.tapAndRead))

--- a/src/main/scala/chisel3/util/Queue.scala
+++ b/src/main/scala/chisel3/util/Queue.scala
@@ -189,7 +189,7 @@ object Queue {
   }
 
   /** A factory for creating shadow queues.  This is created using the
-    * `withShadowQueue` method.
+    * `withShadow` method.
     */
   class ShadowFactory private[Queue] (
     enq:            ReadyValidIO[Data],


### PR DESCRIPTION
Add a method to the `Queue$` object that can be used to create a `Queue` and include a second queue that contains some data which will be tracked alongside the first `Queue`, but this will be kept in a layer.

This is added to help address a use case where design verification wants to track some extra, sidecar data that should be added to some data pipeline.  However, this sidecar data is expected to be removed from the design.  This would normally be addressed with a generator-time parameter. However, the generator-time parameter prevents removal of the sidecar data unless the design is re-elaborated.

E.g., below, this can be used to create a shadow queue outside the module which contains a queue. The shadow queue will operate in lockstep with the original queue:

``` scala
class Bar extends Module {
  val in = IO(Flipped(Decoupled(UInt(8.W))))
  val out = IO(Decoupled(UInt(8.W)))

  val (queue, shadow) = Queue.withShadow(enq = in)
  out :<>= queue
}

class Foo extends Module {
  val in = IO(Flipped(Decoupled(UInt(8.W))))
  val out = IO(Decoupled(UInt(8.W)))
  val outShadow = IO(probe.Probe(Valid(UInt(4.W)), layers.Verification))

  val bar = Module(new Bar)
  bar.in :<>= in
  out :<>= bar.out

  private val id = Wire(probe.Probe(UInt(4.W), layers.Verification))
  layer.block(layers.Verification) {
    val (_id, _) = Counter(in.fire, 15)
    probe.define(id, probe.ProbeValue(_id))
  }
  probe.define(outShadow, bar.shadow(probe.read(id), layers.Verification))
}
```

This compiles to the following Verilog:
``` verilog
// Generated by CIRCT firtool-1.99.2
// VCS coverage exclude_file
module ram_2x8(
  input        R0_addr,
               R0_en,
               R0_clk,
  output [7:0] R0_data,
  input        W0_addr,
               W0_en,
               W0_clk,
  input  [7:0] W0_data
);

  reg [7:0] Memory[0:1];
  always @(posedge W0_clk) begin
    if (W0_en & 1'h1)
      Memory[W0_addr] <= W0_data;
  end // always @(posedge)
  assign R0_data = R0_en ? Memory[R0_addr] : 8'bx;
endmodule

module Queue2_UInt8(
  input        clock,
               reset,
  output       io_enq_ready,
  input        io_enq_valid,
  input  [7:0] io_enq_bits,
  input        io_deq_ready,
  output       io_deq_valid,
  output [7:0] io_deq_bits
);

  reg  wrap;
  reg  wrap_1;
  reg  maybe_full;
  wire ptr_match = wrap == wrap_1;
  wire empty = ptr_match & ~maybe_full;
  wire full = ptr_match & maybe_full;
  wire do_enq = ~full & io_enq_valid;
  always @(posedge clock) begin
    if (reset) begin
      wrap <= 1'h0;
      wrap_1 <= 1'h0;
      maybe_full <= 1'h0;
    end
    else begin
      automatic logic do_deq = io_deq_ready & ~empty;
      if (do_enq)
        wrap <= wrap - 1'h1;
      if (do_deq)
        wrap_1 <= wrap_1 - 1'h1;
      if (~(do_enq == do_deq))
        maybe_full <= do_enq;
    end
  end // always @(posedge)
  ram_2x8 ram_ext (
    .R0_addr (wrap_1),
    .R0_en   (1'h1),
    .R0_clk  (clock),
    .R0_data (io_deq_bits),
    .W0_addr (wrap),
    .W0_en   (do_enq),
    .W0_clk  (clock),
    .W0_data (io_enq_bits)
  );
  assign io_enq_ready = ~full;
  assign io_deq_valid = ~empty;
endmodule

module Bar(
  input        clock,
               reset,
  output       in_ready,
  input        in_valid,
  input  [7:0] in_bits,
  input        out_ready,
  output       out_valid,
  output [7:0] out_bits
);

  wire out_ready_probe = out_ready;
  Queue2_UInt8 deq_q (
    .clock        (clock),
    .reset        (reset),
    .io_enq_ready (in_ready),
    .io_enq_valid (in_valid),
    .io_enq_bits  (in_bits),
    .io_deq_ready (out_ready),
    .io_deq_valid (out_valid),
    .io_deq_bits  (out_bits)
  );
endmodule

// VCS coverage exclude_file
module ram_2x4(
  input        R0_addr,
               R0_en,
               R0_clk,
  output [3:0] R0_data,
  input        W0_addr,
               W0_en,
               W0_clk,
  input  [3:0] W0_data
);

  reg [3:0] Memory[0:1];
  always @(posedge W0_clk) begin
    if (W0_en & 1'h1)
      Memory[W0_addr] <= W0_data;
  end // always @(posedge)
  assign R0_data = R0_en ? Memory[R0_addr] : 4'bx;
endmodule

module Foo(
  input        clock,
               reset,
  output       in_ready,
  input        in_valid,
  input  [7:0] in_bits,
  input        out_ready,
  output       out_valid,
  output [7:0] out_bits
);

  wire _bar_in_ready;
  Bar bar (
    .clock     (clock),
    .reset     (reset),
    .in_ready  (_bar_in_ready),
    .in_valid  (in_valid),
    .in_bits   (in_bits),
    .out_ready (out_ready),
    .out_valid (out_valid),
    .out_bits  (out_bits)
  );
  assign in_ready = _bar_in_ready;
endmodule


// ----- 8< ----- FILE "verification/layers-Foo-Verification.sv" ----- 8< -----

// Generated by CIRCT firtool-1.99.2
`ifndef layers_Foo_Verification
`define layers_Foo_Verification
bind Foo Foo_Verification verification (
  .in_ready                      (_bar_in_ready),
  .in_valid                      (in_valid),
  .clock                         (clock),
  .reset                         (reset),
  .bar_in_ready                  (_bar_in_ready),
  .bar_q_io_deq_ready_bore_ready (Foo.bar.out_ready_probe)
);
`endif // layers_Foo_Verification

// ----- 8< ----- FILE "verification/Queue2_UInt4.sv" ----- 8< -----

// Generated by CIRCT firtool-1.99.2
module Queue2_UInt4(
  input        clock,
               reset,
               io_enq_valid,
  input  [3:0] io_enq_bits,
  input        io_deq_ready,
  output       io_deq_valid,
  output [3:0] io_deq_bits
);

  wire io_enq_ready;
  reg  wrap;
  reg  wrap_1;
  reg  maybe_full;
  wire ptr_match = wrap == wrap_1;
  wire empty = ptr_match & ~maybe_full;
  wire do_enq = io_enq_ready & io_enq_valid;
  assign io_enq_ready = ~(ptr_match & maybe_full);
  always @(posedge clock) begin
    if (reset) begin
      wrap <= 1'h0;
      wrap_1 <= 1'h0;
      maybe_full <= 1'h0;
    end
    else begin
      automatic logic do_deq = io_deq_ready & ~empty;
      if (do_enq)
        wrap <= wrap - 1'h1;
      if (do_deq)
        wrap_1 <= wrap_1 - 1'h1;
      if (~(do_enq == do_deq))
        maybe_full <= do_enq;
    end
  end // always @(posedge)
  ram_2x4 ram_ext (
    .R0_addr (wrap_1),
    .R0_en   (1'h1),
    .R0_clk  (clock),
    .R0_data (io_deq_bits),
    .W0_addr (wrap),
    .W0_en   (do_enq),
    .W0_clk  (clock),
    .W0_data (io_enq_bits)
  );
  assign io_deq_valid = ~empty;
endmodule


// ----- 8< ----- FILE "verification/Foo_Verification.sv" ----- 8< -----

// Generated by CIRCT firtool-1.99.2
module Foo_Verification(
  input in_ready,
        in_valid,
        clock,
        reset,
        bar_in_ready,
        bar_q_io_deq_ready_bore_ready
);

  wire [3:0] _shadowDeq_bits_probe;
  wire       _shadowDeq_valid_probe;
  reg  [3:0] _id;
  wire [3:0] _id_probe = _id;
  always @(posedge clock) begin
    if (reset)
      _id <= 4'h0;
    else if (in_ready & in_valid)
      _id <= _id == 4'hE ? 4'h0 : _id + 4'h1;
  end // always @(posedge)
  Queue2_UInt4 shadowQueue_q (
    .clock        (clock),
    .reset        (reset),
    .io_enq_valid (bar_in_ready & in_valid),
    .io_enq_bits  (Foo_Verification._id_probe),
    .io_deq_ready (bar_q_io_deq_ready_bore_ready),
    .io_deq_valid (_shadowDeq_valid_probe),
    .io_deq_bits  (_shadowDeq_bits_probe)
  );
endmodule


// ----- 8< ----- FILE "ref_Foo.sv" ----- 8< -----

// Generated by CIRCT firtool-1.99.2
`define ref_Foo_outShadow_valid verification._shadowDeq_valid_probe
`define ref_Foo_outShadow_bits verification._shadowDeq_bits_probe
```

#### Release Notes

* Add `Queue.withShadow` utility that assists with adding data to a queue that will be relegated to a specific layer.