### PR TITLE
[scala3] Fix Scala3 difference in Probe API

### DIFF
--- a/core/src/main/scala-3/chisel3/probe/Probe.scala
+++ b/core/src/main/scala-3/chisel3/probe/Probe.scala
@@ -12,8 +12,8 @@ object Probe extends ProbeBase {
   def apply[T <: Data](source: => T)(using sourceInfo: SourceInfo): T =
     super.apply(source, false, None)
 
-  def apply[T <: Data](source: => T, color: Option[layer.Layer])(using sourceInfo: SourceInfo): T =
-    super.apply(source, false, color)
+  def apply[T <: Data](source: => T, color: layer.Layer)(using sourceInfo: SourceInfo): T =
+    super.apply(source, false, Some(color))
 }
 
 object RWProbe extends ProbeBase with SourceInfoDoc {


### PR DESCRIPTION
The Probe.apply API is supposed to take a second argument of type `Layer`. However, this was incorrectly taking an argument of type `Option[Layer]`. Revert to the former.
