### PR TITLE
Support boring on original Module after .toInstance call

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -478,7 +478,7 @@ object Lookupable {
         def getIoMap(hierarchy: Hierarchy[_]): Option[Map[Data, Data]] = {
           hierarchy.underlying match {
             case Clone(x: ModuleClone[_]) => Some(x.ioMap)
-            case Proto(x: BaseModule) => Some(x.getChiselPorts.map { case (_, data: Data) => data -> data }.toMap)
+            case Proto(x: BaseModule) => Some(x.getIOs.map { data => data -> data }.toMap)
             case Clone(x: InstantiableClone[_]) => getIoMap(x._innerContext)
             case Clone(x: InstanceClone[_]) => None
             case other => {


### PR DESCRIPTION
Note that simply using the "current ports" in Lookupable is totally fine. It's not possible to see BoringUtils introduced ports via `@public` so their visibility in the ports seen by Lookupable is irrelevant.

I waffled on if I think this should be legal or not. What eventually convinced me was the following: One of the main reasons `.toInstance` exists is to write generators that work with both normal `Modules` and with D/I `Instances`. What is the purpose of such parameterization in a generator? Obviously, this exists because the user may want to do things that only Modules can do (i.e., that don't work on Instances). One of the most common things in this category is boring, which you can do to Modules but obviously cannot do to Instances. Thus we should make sure it's allowed. I will also note that @azidar in the original PR barred boring after calling `.toDefinition`, but [I'm assuming] deliberately did not bar it after `.toInstance`.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
