### PR TITLE
Aggregate PriorityMux and Mux1H Seq size errors

### DIFF
--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -324,6 +324,10 @@ class SourceInfoTransform(val c: Context) extends AutoSourceTransform {
   def inNEnUseDualPortSramNameArg(in: c.Tree, n: c.Tree, en: c.Tree, useDualPortSram: c.Tree, name: c.Tree): c.Tree = {
     q"$thisObj.$doFuncTerm($in, $n, $en, $useDualPortSram, $name)($implicitSourceInfo)"
   }
+
+  def selInArg(sel: c.Tree, in: c.Tree): c.Tree = {
+    q"$thisObj.$doFuncTerm($sel, $in)($implicitSourceInfo)"
+  }
 }
 
 // Workaround for https://github.com/sbt/sbt/issues/3966

--- a/src/main/scala-2/chisel3/util/Mux.scala
+++ b/src/main/scala-2/chisel3/util/Mux.scala
@@ -7,8 +7,62 @@ package chisel3.util
 
 import chisel3._
 import chisel3.experimental.SourceInfo
-import chisel3.internal.sourceinfo.MuxLookupTransform
+import chisel3.internal.sourceinfo.{MuxLookupTransform, SourceInfoTransform}
 import scala.language.experimental.macros
+
+/** Builds a Mux tree out of the input signal vector using a one hot encoded
+  * select signal. Returns the output of the Mux tree.
+  *
+  * @example {{{
+  * val hotValue = chisel3.util.Mux1H(Seq(
+  *  io.selector(0) -> 2.U,
+  *  io.selector(1) -> 4.U,
+  *  io.selector(2) -> 8.U,
+  *  io.selector(4) -> 11.U,
+  * ))
+  * }}}
+  *
+  * @note results unspecified unless exactly one select signal is high
+  */
+object Mux1H extends Mux1HImpl {
+  def apply[T <: Data](sel:    Seq[Bool], in: Seq[T]): T = macro SourceInfoTransform.selInArg
+  def do_apply[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+
+  def apply[T <: Data](in:    Iterable[(Bool, T)]): T = macro SourceInfoTransform.inArg
+  def do_apply[T <: Data](in: Iterable[(Bool, T)])(implicit sourceInfo: SourceInfo): T = _applyImpl(in)
+
+  def apply[T <: Data](sel:    UInt, in: Seq[T]): T = macro SourceInfoTransform.selInArg
+  def do_apply[T <: Data](sel: UInt, in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+
+  def apply(sel:    UInt, in: UInt): Bool = macro SourceInfoTransform.selInArg
+  def do_apply(sel: UInt, in: UInt)(implicit sourceInfo: SourceInfo): Bool = _applyImpl(sel, in)
+
+}
+
+/** Builds a Mux tree under the assumption that multiple select signals
+  * can be enabled. Priority is given to the first select signal.
+  *
+  * @example {{{
+  * val hotValue = chisel3.util.PriorityMux(Seq(
+  *  io.selector(0) -> 2.U,
+  *  io.selector(1) -> 4.U,
+  *  io.selector(2) -> 8.U,
+  *  io.selector(4) -> 11.U,
+  * ))
+  * }}}
+  * Returns the output of the Mux tree.
+  */
+object PriorityMux extends PriorityMuxImpl {
+
+  def apply[T <: Data](in:    Seq[(Bool, T)]): T = macro SourceInfoTransform.inArg
+  def do_apply[T <: Data](in: Seq[(Bool, T)])(implicit sourceInfo: SourceInfo): T = _applyImpl(in)
+
+  def apply[T <: Data](sel:    Seq[Bool], in: Seq[T]): T = macro SourceInfoTransform.selInArg
+  def do_apply[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+
+  def apply[T <: Data](sel:    Bits, in: Seq[T]): T = macro SourceInfoTransform.selInArg
+  def do_apply[T <: Data](sel: Bits, in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+}
 
 /** Creates a cascade of n Muxs to search for a key value. The Selector may be a UInt or an EnumType.
   *

--- a/src/main/scala-3/chisel3/util/Mux.scala
+++ b/src/main/scala-3/chisel3/util/Mux.scala
@@ -8,6 +8,53 @@ package chisel3.util
 import chisel3._
 import chisel3.experimental.SourceInfo
 
+/** Builds a Mux tree out of the input signal vector using a one hot encoded
+  * select signal. Returns the output of the Mux tree.
+  *
+  * @example {{{
+  * val hotValue = chisel3.util.Mux1H(Seq(
+  *  io.selector(0) -> 2.U,
+  *  io.selector(1) -> 4.U,
+  *  io.selector(2) -> 8.U,
+  *  io.selector(4) -> 11.U,
+  * ))
+  * }}}
+  *
+  * @note results unspecified unless exactly one select signal is high
+  */
+object Mux1H extends Mux1HImpl {
+
+  def apply[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+
+  def apply[T <: Data](in: Iterable[(Bool, T)])(implicit sourceInfo: SourceInfo): T = _applyImpl(in)
+
+  def apply[T <: Data](sel: UInt, in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+
+  def apply(sel: UInt, in: UInt)(implicit sourceInfo: SourceInfo): Bool = _applyImpl(sel, in)
+}
+
+/** Builds a Mux tree under the assumption that multiple select signals
+  * can be enabled. Priority is given to the first select signal.
+  *
+  * @example {{{
+  * val hotValue = chisel3.util.PriorityMux(Seq(
+  *  io.selector(0) -> 2.U,
+  *  io.selector(1) -> 4.U,
+  *  io.selector(2) -> 8.U,
+  *  io.selector(4) -> 11.U,
+  * ))
+  * }}}
+  * Returns the output of the Mux tree.
+  */
+object PriorityMux extends PriorityMuxImpl {
+
+  def apply[T <: Data](in: Seq[(Bool, T)])(implicit sourceInfo: SourceInfo): T = _applyImpl(in)
+
+  def apply[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+
+  def apply[T <: Data](sel: Bits, in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+}
+
 /** Creates a cascade of n Muxs to search for a key value. The Selector may be a UInt or an EnumType.
   *
   * @example {{{

--- a/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
+++ b/src/test/scala/chiselTests/util/PriorityMuxSpec.scala
@@ -65,9 +65,22 @@ class PriorityMuxSpec extends ChiselFlatSpec {
   }
 
   it should "give a error when given different size Seqs" in {
-    val e = intercept[IllegalArgumentException] {
-      PriorityMux(Seq(true.B, true.B), Seq(1.U, 2.U, 3.U))
+    val e = intercept[ChiselException] {
+      emitCHIRRTL(
+        new RawModule {
+          PriorityMux(Seq(true.B, false.B), Seq(1.U, 2.U, 3.U))
+        },
+        args = Array("--throw-on-first-error")
+      )
     }
+    e.getMessage should include("PriorityMuxSpec.scala") // Make sure source locator comes from this file
     e.getMessage should include("PriorityMux: input Seqs must have the same length, got sel 2 and in 3")
+  }
+
+  // The input bitvector is sign extended to the width of the sequence
+  it should "NOT error when given mismatched selector width and Seq size" in {
+    emitCHIRRTL(new RawModule {
+      PriorityMux("b10".U(2.W), Seq(1.U, 2.U, 3.U))
+    })
   }
 }


### PR DESCRIPTION
All I wanted to do was aggregate errors, but in for a penny, in for a pound.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API Modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

* This requires adding source locators to PriorityMux and Mux1H which requires SourceInfoTransform macros in Scala 2 and thus splitting the Scala 2 / Scala 3 public interfaces.
* Because macro applications do not support named arguments in Scala 2, this is an API change.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
