### PR TITLE
bump jextract from version 21 to 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '21'
+          java-version: '22'
       - name: Install CIRCT
         id: install-circt
         if: ${{ inputs.circt }}

--- a/circtpanamabinding/includeStructs.txt
+++ b/circtpanamabinding/includeStructs.txt
@@ -1,7 +1,9 @@
 MlirContext
+MlirDialect
 MlirDialectHandle
 MlirStringRef
 MlirType
+MlirTypeID
 MlirValue
 MlirLocation
 MlirAttribute

--- a/panama.sc
+++ b/panama.sc
@@ -30,7 +30,7 @@ object utils extends Module {
   // 21, 1-2, {linux-x64, macos-x64, windows-x64}
   // 22, 1-2, {linux-x64, macos-aarch64, macos-x64, windows-x64}
   def jextract(jdkVersion: Int, jextractVersion: String, os: String, platform: String) =
-    s"https://download.java.net/java/early_access/jextract/21/1/openjdk-${jdkVersion}-jextract+${jextractVersion}_${os}-${platform}_bin.tar.gz"
+    s"https://download.java.net/java/early_access/jextract/22/6/openjdk-${jdkVersion}-jextract+${jextractVersion}_${os}-${platform}_bin.tar.gz"
 
   // use T.persistent to avoid download repeatedly
   def circtInstallDir: T[os.Path] = T.persistent {
@@ -64,11 +64,11 @@ object utils extends Module {
         val tarPath = T.dest / "jextract.tar.gz"
         if (!os.exists(tarPath)) {
           val url = jextract(
-            21,
-            "1-2",
+            22,
+            "6-47",
             if (linux) "linux" else if (mac) "macos" else throw new Exception("unsupported os"),
             // There is no macos-aarch64 for jextract 21, use x64 for now
-            if (amd64 || mac) "x64" else if (aarch64) "aarch64" else throw new Exception("unsupported arch")
+            if (amd64) "x64" else if (aarch64) "aarch64" else throw new Exception("unsupported arch")
           )
           T.ctx().log.info(s"Downloading jextract from ${url}")
           mill.util.Util.download(url, os.rel / "jextract.tar.gz")
@@ -127,7 +127,6 @@ trait HasJextractGeneratedSources extends JavaModule {
           ++ Seq(
             "-t", target(),
             "--header-class-name", headerClassName(),
-            "--source",
             "--output", T.dest.toString
           ) ++ includeFunctions().flatMap(f => Seq("--include-function", f)) ++
           includeConstants().flatMap(f => Seq("--include-constant", f)) ++
@@ -142,7 +141,7 @@ trait HasJextractGeneratedSources extends JavaModule {
     }
   }
 
-  override def javacOptions = T(super.javacOptions() ++ Seq("--enable-preview", "--release", "21"))
+  override def javacOptions = T(super.javacOptions() ++ Seq("--release", "22"))
 }
 
 // Java Codegen for all declared functions.
@@ -173,7 +172,7 @@ trait HasCIRCTPanamaBindingModule extends JavaModule {
 
   override def moduleDeps = super.moduleDeps ++ Some(circtPanamaBindingModule)
   //
-  override def javacOptions = T(super.javacOptions() ++ Seq("--enable-preview", "--release", "21"))
+  override def javacOptions = T(super.javacOptions() ++ Seq("--release", "22"))
 
   override def forkArgs: T[Seq[String]] = T(
     super.forkArgs() ++ Seq("--enable-native-access=ALL-UNNAMED", "--enable-preview")


### PR DESCRIPTION
* Add MlirDialect and MlirTypeID to includeStructs.txt
* macOS support are available in jextract 22

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Dependency update


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
