### PR TITLE
Add FormalTest marker

### DIFF
--- a/core/src/main/scala/chisel3/FormalTest.scala
+++ b/core/src/main/scala/chisel3/FormalTest.scala
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import chisel3.experimental.{BaseModule, Param}
+import chisel3.internal.Builder
+import chisel3.internal.firrtl.ir._
+import chisel3.internal.throwException
+import chisel3.experimental.{SourceInfo, UnlocatableSourceInfo}
+
+object FormalTest {
+  def apply(
+    module: BaseModule,
+    params: MapTestParam = MapTestParam(Map.empty),
+    name:   String = ""
+  )(implicit sourceInfo: SourceInfo): Unit = {
+    val proposedName = if (name != "") {
+      name
+    } else {
+      module._proposedName
+    }
+    val sanitizedName = Builder.globalNamespace.name(proposedName)
+    Builder.components += DefFormalTest(sanitizedName, module, params, sourceInfo)
+  }
+}
+
+/** Parameters for test declarations. */
+sealed abstract class TestParam
+case class IntTestParam(value: BigInt) extends TestParam
+case class DoubleTestParam(value: Double) extends TestParam
+case class StringTestParam(value: String) extends TestParam
+case class ArrayTestParam(value: Seq[TestParam]) extends TestParam
+case class MapTestParam(value: Map[String, TestParam]) extends TestParam

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -494,6 +494,17 @@ private[chisel3] object ir {
     params: Map[String, Param]
   ) extends Component
 
+  case class DefFormalTest(
+    name:       String,
+    module:     BaseModule,
+    params:     MapTestParam,
+    sourceInfo: SourceInfo
+  ) extends Component {
+    def id = module
+    val ports: Seq[Port] = Seq.empty
+    override val secretPorts = mutable.ArrayBuffer[Port]()
+  }
+
   case class DefIntrinsicModule(
     id:     BaseIntrinsicModule,
     name:   String,

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -647,6 +647,23 @@ case class IntModule(info: Info, name: String, ports: Seq[Port], intrinsic: Stri
   */
 case class DefClass(info: Info, name: String, ports: Seq[Port], body: Statement) extends DefModule with UseSerializer
 
+/** Parameters for test declarations.
+  */
+sealed abstract class TestParam extends FirrtlNode
+case class IntTestParam(value: BigInt) extends TestParam with UseSerializer
+case class DoubleTestParam(value: Double) extends TestParam with UseSerializer
+case class StringTestParam(value: String) extends TestParam with UseSerializer
+case class ArrayTestParam(value: Seq[TestParam]) extends TestParam with UseSerializer
+case class MapTestParam(value: Map[String, TestParam]) extends TestParam with UseSerializer
+
+/** Formal Test
+  */
+case class FormalTest(info: Info, name: String, moduleName: String, params: MapTestParam)
+    extends DefModule
+    with UseSerializer {
+  val ports: Seq[Port] = Seq.empty
+}
+
 case class Circuit(
   info:        Info,
   modules:     Seq[DefModule],

--- a/src/test/scala/chiselTests/RawModuleSpec.scala
+++ b/src/test/scala/chiselTests/RawModuleSpec.scala
@@ -228,4 +228,43 @@ class RawModuleSpec extends ChiselFlatSpec with Utils with FileCheck {
          |""".stripMargin
     )
   }
+
+  "RawModule marked as formal test" should "emit a formal test declaration" in {
+    class Foo extends RawModule {
+      FormalTest(this)
+      FormalTest(this, MapTestParam(Map("hello" -> StringTestParam("world"))))
+      FormalTest(
+        this,
+        MapTestParam(
+          Map(
+            "a_int" -> IntTestParam(42),
+            "b_double" -> DoubleTestParam(13.37),
+            "c_string" -> StringTestParam("hello"),
+            "d_array" -> ArrayTestParam(Seq(IntTestParam(42), StringTestParam("hello"))),
+            "e_map" -> MapTestParam(
+              Map(
+                "x" -> IntTestParam(42),
+                "y" -> StringTestParam("hello")
+              )
+            )
+          )
+        ),
+        "thisBetterWork"
+      )
+    }
+
+    generateFirrtlAndFileCheck(new Foo)(
+      """|CHECK: formal Foo of [[FOO:Foo_.*]] :
+         |CHECK: formal Foo_1 of [[FOO]] :
+         |CHECK:   hello = "world"
+         |CHECK: formal thisBetterWork of [[FOO]] :
+         |CHECK:   a_int = 42
+         |CHECK:   b_double = 13.37
+         |CHECK:   c_string = "hello"
+         |CHECK:   d_array = [42, "hello"]
+         |CHECK:   e_map = {x = 42, y = "hello"}
+         |CHECK: module [[FOO]] :
+         |""".stripMargin
+    )
+  }
 }


### PR DESCRIPTION
The FIRRTL spec defines a `formal` construct to indicate that a module should be executed as a formal test. Currently, there is no way to emit this construct from Chisel.

This PR adds a user-facing `FormalTest` class that can be used to mark a module as to be executed as a formal test. This would commonly be used inside a test harness module to mark the surrounding module as a test. For example:

    class TestHarness extends RawModule {
      new FormalTest(this)
    }

The formal test can be given an optional name and a map of parameters. The parameters are distinct from blackbox modules in that they do not map to Verilog parameters, but instead allow for any recursive nesting of integers, doubles, strings, arrays, and maps, as prescribed by the FIRRTL spec. Multiple formal test markers may be added to a single module, which may be useful if a test should be run with different sets of user-defined parameters.

This PR also adds the necessary IR nodes to the FIRRTL and Chisel FIRRTL IRs.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
