### PR TITLE
[scala3] Remove names from context parameters

### DIFF
--- a/core/src/main/scala-3/chisel3/Aggregate.scala
+++ b/core/src/main/scala-3/chisel3/Aggregate.scala
@@ -52,7 +52,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, length: Int)
 
   override def toString: String = super[VecImpl].toString
 
-  def apply(p: UInt)(using sourceInfo: SourceInfo): T = _applyImpl(p)
+  def apply(p: UInt)(using SourceInfo): T = _applyImpl(p)
 
   /** A reduce operation in a tree like structure instead of sequentially
     * @example An adder tree
@@ -75,7 +75,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, length: Int)
     redOp:   (T, T) => T,
     layerOp: (T) => T = (x: T) => x
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T = _reduceTreeImpl(redOp, layerOp)
 }
 
@@ -92,7 +92,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     * element
     * @note output elements are connected from the input elements
     */
-  def apply[T <: Data](elts: Seq[T])(using sourceInfo: SourceInfo): Vec[T] = _applyImpl(elts)
+  def apply[T <: Data](elts: Seq[T])(using SourceInfo): Vec[T] = _applyImpl(elts)
 
   /** Creates a new [[Vec]] composed of the input [[Data]] nodes.
     *
@@ -102,7 +102,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     * element
     * @note output elements are connected from the input elements
     */
-  def apply[T <: Data](elt0: T, elts: T*)(using sourceInfo: SourceInfo): Vec[T] = _applyImpl(elt0, elts: _*)
+  def apply[T <: Data](elt0: T, elts: T*)(using SourceInfo): Vec[T] = _applyImpl(elt0, elts: _*)
 
   /** Creates a new [[Vec]] of length `n` composed of the results of the given
     * function applied over a range of integer values starting from 0.
@@ -115,7 +115,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
   def tabulate[T <: Data](
     n: Int
   )(gen: (Int) => T)(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Vec[T] = _tabulateImpl(n)(gen)
 
   /** Creates a new 2D [[Vec]] of length `n by m` composed of the results of the given
@@ -131,7 +131,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     n: Int,
     m: Int
   )(gen: (Int, Int) => T)(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Vec[Vec[T]] = _tabulateImpl(n, m)(gen)
 
   /** Creates a new 3D [[Vec]] of length `n by m by p` composed of the results of the given
@@ -148,7 +148,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     m: Int,
     p: Int
   )(gen: (Int, Int, Int) => T)(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Vec[Vec[Vec[T]]] = _tabulateImpl(n, m, p)(gen)
 
   /** Creates a new [[Vec]] of length `n` composed of the result of the given
@@ -158,7 +158,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     * @param gen function that takes in an element T and returns an output
     * element of the same type
     */
-  def fill[T <: Data](n: Int)(gen: => T)(using sourceInfo: SourceInfo): Vec[T] = _fillImpl(n)(gen)
+  def fill[T <: Data](n: Int)(gen: => T)(using SourceInfo): Vec[T] = _fillImpl(n)(gen)
 
   /** Creates a new 2D [[Vec]] of length `n by m` composed of the result of the given
     * function applied to an element of data type T.
@@ -172,7 +172,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     n: Int,
     m: Int
   )(gen: => T)(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Vec[Vec[T]] = _fillImpl(n, m)(gen)
 
   /** Creates a new 3D [[Vec]] of length `n by m by p` composed of the result of the given
@@ -189,7 +189,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     m: Int,
     p: Int
   )(gen: => T)(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Vec[Vec[Vec[T]]] = _fillImpl(n, m, p)(gen)
 
   /** Creates a new [[Vec]] of length `n` composed of the result of the given
@@ -204,7 +204,7 @@ object VecInit extends VecInitImpl with SourceInfoDoc {
     start: T,
     len:   Int
   )(f: (T) => T)(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Vec[T] = _iterateImpl(start, len)(f)
 }
 
@@ -215,32 +215,32 @@ trait VecLike[T <: Data] extends VecLikeImpl[T] with SourceInfoDoc {
 
   /** Creates a dynamically indexed read or write accessor into the array.
     */
-  def apply(p: UInt)(using sourceInfo: SourceInfo): T
+  def apply(p: UInt)(using SourceInfo): T
 
   /** Outputs true if p outputs true for every element.
     */
-  def forall(p: T => Bool)(using sourceInfo: SourceInfo): Bool = _forallImpl(p)
+  def forall(p: T => Bool)(using SourceInfo): Bool = _forallImpl(p)
 
   /** Outputs true if p outputs true for at least one element.
     */
-  def exists(p: T => Bool)(using sourceInfo: SourceInfo): Bool = _existsImpl(p)
+  def exists(p: T => Bool)(using SourceInfo): Bool = _existsImpl(p)
 
   /** Outputs true if the vector contains at least one element equal to x (using
     * the === operator).
     */
-  def contains(x: T)(using sourceInfo: SourceInfo, ev: T <:< UInt): Bool = _containsImpl(x)
+  def contains(x: T)(using SourceInfo, T <:< UInt): Bool = _containsImpl(x)
 
   /** Outputs the number of elements for which p is true.
     */
-  def count(p: T => Bool)(using sourceInfo: SourceInfo): UInt = _countImpl(p)
+  def count(p: T => Bool)(using SourceInfo): UInt = _countImpl(p)
 
   /** Outputs the index of the first element for which p outputs true.
     */
-  def indexWhere(p: T => Bool)(using sourceInfo: SourceInfo): UInt = _indexWhereImpl(p)
+  def indexWhere(p: T => Bool)(using SourceInfo): UInt = _indexWhereImpl(p)
 
   /** Outputs the index of the last element for which p outputs true.
     */
-  def lastIndexWhere(p: T => Bool)(using sourceInfo: SourceInfo): UInt = _lastIndexWhereImpl(p)
+  def lastIndexWhere(p: T => Bool)(using SourceInfo): UInt = _lastIndexWhereImpl(p)
 
   /** Outputs the index of the element for which p outputs true, assuming that
     * the there is exactly one such element.
@@ -252,7 +252,7 @@ trait VecLike[T <: Data] extends VecLikeImpl[T] with SourceInfoDoc {
     * true is NOT checked (useful in cases where the condition doesn't always
     * hold, but the results are not used in those cases)
     */
-  def onlyIndexWhere(p: T => Bool)(using sourceInfo: SourceInfo): UInt = _onlyIndexWhereImpl(p)
+  def onlyIndexWhere(p: T => Bool)(using SourceInfo): UInt = _onlyIndexWhereImpl(p)
 }
 
 /** Base class for Aggregates based on key values pairs of String and Data

--- a/core/src/main/scala-3/chisel3/Bits.scala
+++ b/core/src/main/scala-3/chisel3/Bits.scala
@@ -32,7 +32,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @return This $coll with the `n` most significant bits removed.
     * @group Bitwise
     */
-  def tail(n: Int)(using sourceInfo: SourceInfo): UInt = _tailImpl(n)
+  def tail(n: Int)(using SourceInfo): UInt = _tailImpl(n)
 
   /** Head operator
     *
@@ -40,7 +40,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @return The `n` most significant bits of this $coll
     * @group Bitwise
     */
-  def head(n: Int)(using sourceInfo: SourceInfo): UInt = _headImpl(n)
+  def head(n: Int)(using SourceInfo): UInt = _headImpl(n)
 
   /** Returns the specified bit on this $coll as a [[Bool]], statically addressed.
     *
@@ -48,31 +48,31 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @return the specified bit
     */
 
-  final def extract(x: BigInt)(using sourceInfo: SourceInfo): Bool = _extractImpl(x)
+  final def extract(x: BigInt)(using SourceInfo): Bool = _extractImpl(x)
 
   /** Returns the specified bit on this $coll as a [[Bool]], statically addressed.
     *
     * @param x an index
     * @return the specified bit
     */
-  final def apply(x: Int)(using sourceInfo: SourceInfo): Bool = _applyImpl(x)
+  final def apply(x: Int)(using SourceInfo): Bool = _applyImpl(x)
 
   /** Grab the bottom n bits.  Return 0.U(0.W) if n==0. */
-  final def take(n: Int)(using sourceInfo: SourceInfo): UInt = _takeImpl(n)
+  final def take(n: Int)(using SourceInfo): UInt = _takeImpl(n)
 
   /** Returns the specified bit on this wire as a [[Bool]], dynamically addressed.
     *
     * @param x a hardware component whose value will be used for dynamic addressing
     * @return the specified bit
     */
-  final def extract(x: UInt)(using sourceInfo: SourceInfo): Bool = _extractImpl(x)
+  final def extract(x: UInt)(using SourceInfo): Bool = _extractImpl(x)
 
   /** Returns the specified bit on this wire as a [[Bool]], dynamically addressed.
     *
     * @param x a hardware component whose value will be used for dynamic addressing
     * @return the specified bit
     */
-  final def apply(x: UInt)(using sourceInfo: SourceInfo): Bool = _applyImpl(x)
+  final def apply(x: UInt)(using SourceInfo): Bool = _applyImpl(x)
 
   /** Returns a subset of bits on this $coll from `hi` to `lo` (inclusive), statically addressed.
     *
@@ -85,7 +85,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @param y the low bit
     * @return a hardware component contain the requested bits
     */
-  final def apply(x: Int, y: Int)(using sourceInfo: SourceInfo): UInt = _applyImpl(x, y)
+  final def apply(x: Int, y: Int)(using SourceInfo): UInt = _applyImpl(x, y)
 
   // REVIEW TODO: again, is this necessary? Or just have this and use implicits?
   /** Returns a subset of bits on this $coll from `hi` to `lo` (inclusive), statically addressed.
@@ -99,7 +99,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @param y the low bit
     * @return a hardware component contain the requested bits
     */
-  final def apply(x: BigInt, y: BigInt)(using sourceInfo: SourceInfo): UInt = _applyImpl(x, y)
+  final def apply(x: BigInt, y: BigInt)(using SourceInfo): UInt = _applyImpl(x, y)
 
   /** Pad operator
     *
@@ -109,14 +109,14 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @note For [[SInt]]s only, this will do sign extension.
     * @group Bitwise
     */
-  def pad(that: Int)(using sourceInfo: SourceInfo): Bits = _padImpl(that)
+  def pad(that: Int)(using SourceInfo): Bits = _padImpl(that)
 
   /** Bitwise inversion operator
     *
     * @return this $coll with each bit inverted
     * @group Bitwise
     */
-  def unary_~(using sourceInfo: SourceInfo): Bits = _impl_unary_~
+  def unary_~(using SourceInfo): Bits = _impl_unary_~
 
   /** Static left shift operator
     *
@@ -125,7 +125,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * $sumWidthInt
     * @group Bitwise
     */
-  def <<(that: BigInt)(using sourceInfo: SourceInfo): Bits = _impl_<<(that)
+  def <<(that: BigInt)(using SourceInfo): Bits = _impl_<<(that)
 
   /** Static left shift operator
     *
@@ -134,7 +134,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * $sumWidthInt
     * @group Bitwise
     */
-  def <<(that: Int)(using sourceInfo: SourceInfo): Bits = _impl_<<(that)
+  def <<(that: Int)(using SourceInfo): Bits = _impl_<<(that)
 
   /** Dynamic left shift operator
     *
@@ -143,7 +143,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * @note The width of the returned $coll is `width of this + pow(2, width of that) - 1`.
     * @group Bitwise
     */
-  def <<(that: UInt)(using sourceInfo: SourceInfo): Bits = _impl_<<(that)
+  def <<(that: UInt)(using SourceInfo): Bits = _impl_<<(that)
 
   /** Static right shift operator
     *
@@ -152,7 +152,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * $unchangedWidth
     * @group Bitwise
     */
-  def >>(that: BigInt)(using sourceInfo: SourceInfo): Bits = _impl_>>(that)
+  def >>(that: BigInt)(using SourceInfo): Bits = _impl_>>(that)
 
   /** Static right shift operator
     *
@@ -161,7 +161,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * $unchangedWidth
     * @group Bitwise
     */
-  def >>(that: Int)(using sourceInfo: SourceInfo): Bits = _impl_>>(that)
+  def >>(that: Int)(using SourceInfo): Bits = _impl_>>(that)
 
   /** Dynamic right shift operator
     *
@@ -171,17 +171,17 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * $unchangedWidth
     * @group Bitwise
     */
-  def >>(that: UInt)(using sourceInfo: SourceInfo): Bits = _impl_>>(that)
+  def >>(that: UInt)(using SourceInfo): Bits = _impl_>>(that)
 
   /** Returns the contents of this wire as a [[scala.collection.Seq]] of [[Bool]]. */
-  def asBools(using sourceInfo: SourceInfo): Seq[Bool] = _asBoolsImpl
+  def asBools(using SourceInfo): Seq[Bool] = _asBoolsImpl
 
   /** Reinterpret this $coll as an [[SInt]]
     *
     * @note The arithmetic value is not preserved if the most-significant bit is set. For example, a [[UInt]] of
     * width 3 and value 7 (0b111) would become an [[SInt]] of width 3 and value -1.
     */
-  def asSInt(using sourceInfo: SourceInfo): SInt = _asSIntImpl
+  def asSInt(using SourceInfo): SInt = _asSIntImpl
 
   def asBool: Bool = _asBoolImpl
 
@@ -192,7 +192,7 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsImpl w
     * $sumWidth
     * @group Bitwise
     */
-  def ##(that: Bits)(using sourceInfo: SourceInfo): UInt = _impl_##(that)
+  def ##(that: Bits)(using SourceInfo): UInt = _impl_##(that)
 }
 
 object Bits extends UIntFactory
@@ -214,7 +214,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
     * $constantWidth
     * @group Arithmetic
     */
-  def unary_-(using sourceInfo: SourceInfo): UInt = _impl_unary_-
+  def unary_-(using SourceInfo): UInt = _impl_unary_-
 
   /** Unary negation (constant width)
     *
@@ -222,7 +222,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
     * $constantWidth
     * @group Arithmetic
     */
-  def unary_-%(using sourceInfo: SourceInfo): UInt = _impl_unary_-%
+  def unary_-%(using SourceInfo): UInt = _impl_unary_-%
 
   override def +(that: UInt): UInt = _impl_+(that)
   override def -(that: UInt): UInt = _impl_-(that)
@@ -305,7 +305,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
 
   def abs: UInt = _absImpl
 
-  override def unary_~(using sourceInfo: SourceInfo): UInt = _impl_unary_~
+  override def unary_~(using SourceInfo): UInt = _impl_unary_~
 
   // REVIEW TODO: Can these be defined on Bits?
   /** Or reduction operator
@@ -327,7 +327,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
     * @return a hardware [[Bool]] resulting from every bit of this $coll xor'd together
     * @group Bitwise
     */
-  final def xorR(using sourceInfo: SourceInfo): Bool = _xorRImpl
+  final def xorR(using SourceInfo): Bool = _xorRImpl
 
   override def <(that:  UInt): Bool = _impl_<(that)
   override def >(that:  UInt): Bool = _impl_>(that)
@@ -340,7 +340,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
     * @return a hardware [[Bool]] asserted if this $coll is not equal to `that`
     * @group Comparison
     */
-  def =/=(that: UInt)(using sourceInfo: SourceInfo): Bool = _impl_=/=(that)
+  def =/=(that: UInt)(using SourceInfo): Bool = _impl_=/=(that)
 
   /** Dynamic equals operator
     *
@@ -348,40 +348,40 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
     * @return a hardware [[Bool]] asserted if this $coll is equal to `that`
     * @group Comparison
     */
-  def ===(that: UInt)(using sourceInfo: SourceInfo): Bool = _impl_===(that)
+  def ===(that: UInt)(using SourceInfo): Bool = _impl_===(that)
 
   /** Unary not
     *
     * @return a hardware [[Bool]] asserted if this $coll equals zero
     * @group Bitwise
     */
-  def unary_!(using sourceInfo: SourceInfo): Bool = _impl_unary_!
+  def unary_!(using SourceInfo): Bool = _impl_unary_!
 
-  override def <<(that: Int)(using sourceInfo:    SourceInfo): UInt = _impl_<<(that)
-  override def <<(that: BigInt)(using sourceInfo: SourceInfo): UInt = _impl_<<(that)
-  override def <<(that: UInt)(using sourceInfo:   SourceInfo): UInt = _impl_<<(that)
+  override def <<(that: Int)(using SourceInfo):    UInt = _impl_<<(that)
+  override def <<(that: BigInt)(using SourceInfo): UInt = _impl_<<(that)
+  override def <<(that: UInt)(using SourceInfo):   UInt = _impl_<<(that)
 
-  override def >>(that: Int)(using sourceInfo:    SourceInfo): UInt = _impl_>>(that)
-  override def >>(that: BigInt)(using sourceInfo: SourceInfo): UInt = _impl_>>(that)
-  override def >>(that: UInt)(using sourceInfo:   SourceInfo): UInt = _impl_>>(that)
+  override def >>(that: Int)(using SourceInfo):    UInt = _impl_>>(that)
+  override def >>(that: BigInt)(using SourceInfo): UInt = _impl_>>(that)
+  override def >>(that: UInt)(using SourceInfo):   UInt = _impl_>>(that)
 
   /**
     * Circular shift to the left
     * @param that number of bits to rotate
     * @return UInt of same width rotated left n bits
     */
-  def rotateLeft(n: Int)(using sourceInfo: SourceInfo): UInt = _rotateLeftImpl(n)
+  def rotateLeft(n: Int)(using SourceInfo): UInt = _rotateLeftImpl(n)
 
-  def rotateLeft(n: UInt)(using sourceInfo: SourceInfo): UInt = _rotateLeftImpl(n)
+  def rotateLeft(n: UInt)(using SourceInfo): UInt = _rotateLeftImpl(n)
 
   /**
     * Circular shift to the right
     * @param that number of bits to rotate
     * @return UInt of same width rotated right n bits
     */
-  def rotateRight(n: Int)(using sourceInfo: SourceInfo): UInt = _rotateRightImpl(n)
+  def rotateRight(n: Int)(using SourceInfo): UInt = _rotateRightImpl(n)
 
-  def rotateRight(n: UInt)(using sourceInfo: SourceInfo): UInt = _rotateRightImpl(n)
+  def rotateRight(n: UInt)(using SourceInfo): UInt = _rotateRightImpl(n)
 
   /** Conditionally set or clear a bit
     *
@@ -390,7 +390,7 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
     * @return a hrdware $coll with bit `off` set or cleared based on the value of `dat`
     * $unchangedWidth
     */
-  def bitSet(off: UInt, dat: Bool)(using sourceInfo: SourceInfo): UInt = _bitSetImpl(off, dat)
+  def bitSet(off: UInt, dat: Bool)(using SourceInfo): UInt = _bitSetImpl(off, dat)
 
   // TODO: this eventually will be renamed as toSInt, once the existing toSInt
   // completes its deprecation phase.
@@ -399,9 +399,9 @@ sealed class UInt private[chisel3] (width: Width) extends Bits(width) with UIntI
     * @return an [[SInt]] equal to this $coll with an additional zero in its most significant bit
     * @note The width of the returned [[SInt]] is `width of this` + `1`.
     */
-  def zext(using sourceInfo: SourceInfo): SInt = _zextImpl
+  def zext(using SourceInfo): SInt = _zextImpl
 
-  override def asSInt(using sourceInfo: SourceInfo): SInt = _asSIntImpl
+  override def asSInt(using SourceInfo): SInt = _asSIntImpl
 }
 
 object UInt extends UIntFactory
@@ -414,7 +414,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $constantWidth
     * @group Arithmetic
     */
-  final def unary_-(using sourceInfo: SourceInfo): SInt = _impl_unary_-
+  final def unary_-(using SourceInfo): SInt = _impl_unary_-
 
   /** Unary negation (constant width)
     *
@@ -422,7 +422,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $constantWidth
     * @group Arithmetic
     */
-  def unary_-%(using sourceInfo: SourceInfo): SInt = _impl_unary_-%
+  def unary_-%(using SourceInfo): SInt = _impl_unary_-%
 
   /** add (default - no growth) operator */
   override def +(that: SInt): SInt = _impl_+(that)
@@ -441,7 +441,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $singleCycleMul
     * @group Arithmetic
     */
-  def *(that: UInt)(using sourceInfo: SourceInfo): SInt = _impl_*(that)
+  def *(that: UInt)(using SourceInfo): SInt = _impl_*(that)
 
   /** Addition operator (expanding width)
     *
@@ -450,7 +450,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $maxWidthPlusOne
     * @group Arithmetic
     */
-  def +&(that: SInt)(using sourceInfo: SourceInfo): SInt = _impl_+&(that)
+  def +&(that: SInt)(using SourceInfo): SInt = _impl_+&(that)
 
   /** Addition operator (constant width)
     *
@@ -459,7 +459,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $maxWidth
     * @group Arithmetic
     */
-  def +%(that: SInt)(using sourceInfo: SourceInfo): SInt = _impl_+%(that)
+  def +%(that: SInt)(using SourceInfo): SInt = _impl_+%(that)
 
   /** Subtraction operator (increasing width)
     *
@@ -468,7 +468,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $maxWidthPlusOne
     * @group Arithmetic
     */
-  def -&(that: SInt)(using sourceInfo: SourceInfo): SInt = _impl_-&(that)
+  def -&(that: SInt)(using SourceInfo): SInt = _impl_-&(that)
 
   /** Subtraction operator (constant width)
     *
@@ -477,7 +477,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $maxWidth
     * @group Arithmetic
     */
-  def -%(that: SInt)(using sourceInfo: SourceInfo): SInt = _impl_-%(that)
+  def -%(that: SInt)(using SourceInfo): SInt = _impl_-%(that)
 
   /** Bitwise and operator
     *
@@ -486,7 +486,7 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $maxWidth
     * @group Bitwise
     */
-  def &(that: SInt)(using sourceInfo: SourceInfo): SInt = _impl_&(that)
+  def &(that: SInt)(using SourceInfo): SInt = _impl_&(that)
 
   /** Bitwise or operator
     *
@@ -504,9 +504,9 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
     * $maxWidth
     * @group Bitwise
     */
-  def ^(that: SInt)(using sourceInfo: SourceInfo): SInt = _impl_^(that)
+  def ^(that: SInt)(using SourceInfo): SInt = _impl_^(that)
 
-  override def unary_~(using sourceInfo: SourceInfo): SInt = _impl_unary_~
+  override def unary_~(using SourceInfo): SInt = _impl_unary_~
 
   override def <(that:  SInt): Bool = _impl_<(that)
   override def >(that:  SInt): Bool = _impl_>(that)
@@ -531,22 +531,22 @@ sealed class SInt private[chisel3] (width: Width) extends Bits(width) with SIntI
 
   def abs: SInt = _absImpl
 
-  override def <<(that: Int)(using sourceInfo:    SourceInfo): SInt = _impl_<<(that)
-  override def <<(that: BigInt)(using sourceInfo: SourceInfo): SInt = _impl_<<(that)
-  override def <<(that: UInt)(using sourceInfo:   SourceInfo): SInt = _impl_<<(that)
+  override def <<(that: Int)(using SourceInfo):    SInt = _impl_<<(that)
+  override def <<(that: BigInt)(using SourceInfo): SInt = _impl_<<(that)
+  override def <<(that: UInt)(using SourceInfo):   SInt = _impl_<<(that)
 
-  override def >>(that: Int)(using sourceInfo:    SourceInfo): SInt = _impl_>>(that)
-  override def >>(that: BigInt)(using sourceInfo: SourceInfo): SInt = _impl_>>(that)
-  override def >>(that: UInt)(using sourceInfo:   SourceInfo): SInt = _impl_>>(that)
+  override def >>(that: Int)(using SourceInfo):    SInt = _impl_>>(that)
+  override def >>(that: BigInt)(using SourceInfo): SInt = _impl_>>(that)
+  override def >>(that: UInt)(using SourceInfo):   SInt = _impl_>>(that)
 
-  override def asSInt(using sourceInfo: SourceInfo): SInt = _asSIntImpl
+  override def asSInt(using SourceInfo): SInt = _asSIntImpl
 }
 
 object SInt extends SIntFactory
 
 sealed trait Reset extends ResetImpl with ToBoolable {
-  def asAsyncReset(using sourceInfo: SourceInfo): AsyncReset
-  def asDisable(using sourceInfo:    SourceInfo): Disable = _asDisableImpl
+  def asAsyncReset(using SourceInfo): AsyncReset
+  def asDisable(using SourceInfo):    Disable = _asDisableImpl
 }
 
 object Reset {
@@ -559,9 +559,9 @@ object Reset {
   * super type due to Bool inheriting from abstract class UInt
   */
 final class ResetType(private[chisel3] val width: Width = Width(1)) extends Reset with ResetTypeImpl with ToBoolable {
-  def asAsyncReset(using sourceInfo: SourceInfo): AsyncReset = _asAsyncResetImpl
-  def asBool:                                     Bool = _asBoolImpl
-  def toBool:                                     Bool = asBool
+  def asAsyncReset(using SourceInfo): AsyncReset = _asAsyncResetImpl
+  def asBool:                         Bool = _asBoolImpl
+  def toBool:                         Bool = asBool
 }
 
 object AsyncReset {
@@ -575,10 +575,10 @@ object AsyncReset {
   * asychronously reset registers.
   */
 sealed class AsyncReset(private[chisel3] val width: Width = Width(1)) extends AsyncResetImpl with Reset {
-  override def toString:                          String = stringAccessor("AsyncReset")
-  def asAsyncReset(using sourceInfo: SourceInfo): AsyncReset = _asAsyncResetImpl
-  def asBool:                                     Bool = _asBoolImpl
-  def toBool:                                     Bool = _asBoolImpl
+  override def toString:              String = stringAccessor("AsyncReset")
+  def asAsyncReset(using SourceInfo): AsyncReset = _asAsyncResetImpl
+  def asBool:                         Bool = _asBoolImpl
+  def toBool:                         Bool = _asBoolImpl
 }
 
 // REVIEW TODO: Why does this extend UInt and not Bits? Does defining airth
@@ -599,7 +599,7 @@ sealed class Bool() extends UInt(1.W) with BoolImpl with Reset {
     * @return the bitwise and of  this $coll and `that`
     * @group Bitwise
     */
-  def &(that: Bool)(using sourceInfo: SourceInfo): Bool = _impl_&(that)
+  def &(that: Bool)(using SourceInfo): Bool = _impl_&(that)
 
   /** Bitwise or operator
     *
@@ -615,9 +615,9 @@ sealed class Bool() extends UInt(1.W) with BoolImpl with Reset {
     * @return the bitwise xor of this $coll and `that`
     * @group Bitwise
     */
-  def ^(that: Bool)(using sourceInfo: SourceInfo): Bool = _impl_^(that)
+  def ^(that: Bool)(using SourceInfo): Bool = _impl_^(that)
 
-  override def unary_~(using sourceInfo: SourceInfo): Bool = _impl_unary_~
+  override def unary_~(using SourceInfo): Bool = _impl_unary_~
 
   /** Logical or operator
     *
@@ -626,7 +626,7 @@ sealed class Bool() extends UInt(1.W) with BoolImpl with Reset {
     * @note this is equivalent to [[Bool!.|(that:chisel3\.Bool)* Bool.|)]]
     * @group Logical
     */
-  def ||(that: Bool)(using sourceInfo: SourceInfo): Bool = _impl_||(that)
+  def ||(that: Bool)(using SourceInfo): Bool = _impl_||(that)
 
   /** Logical and operator
     *
@@ -635,14 +635,14 @@ sealed class Bool() extends UInt(1.W) with BoolImpl with Reset {
     * @note this is equivalent to [[Bool!.&(that:chisel3\.Bool)* Bool.&]]
     * @group Logical
     */
-  def &&(that: Bool)(using sourceInfo: SourceInfo): Bool = _impl_&&(that)
+  def &&(that: Bool)(using SourceInfo): Bool = _impl_&&(that)
 
   override def asBool: Bool = _asBoolImpl
 
   /** Reinterprets this $coll as a clock */
-  def asClock(using sourceInfo: SourceInfo): Clock = _asClockImpl
+  def asClock(using SourceInfo): Clock = _asClockImpl
 
-  def asAsyncReset(using sourceInfo: SourceInfo): AsyncReset = _asAsyncResetImpl
+  def asAsyncReset(using SourceInfo): AsyncReset = _asAsyncResetImpl
 }
 
 object Bool extends BoolFactory

--- a/core/src/main/scala-3/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala-3/chisel3/ChiselEnum.scala
@@ -7,12 +7,12 @@ import chisel3.experimental.SourceInfo
 abstract class EnumType(factory: ChiselEnum, selfAnnotating: Boolean = true)
     extends EnumTypeImpl(factory, selfAnnotating) {
 
-  final def ===(that: EnumType)(using sourceInfo: SourceInfo): Bool = _impl_===(that)
-  final def =/=(that: EnumType)(using sourceInfo: SourceInfo): Bool = _impl_=/=(that)
-  final def <(that:   EnumType)(using sourceInfo: SourceInfo): Bool = _impl_<(that)
-  final def <=(that:  EnumType)(using sourceInfo: SourceInfo): Bool = _impl_>(that)
-  final def >(that:   EnumType)(using sourceInfo: SourceInfo): Bool = _impl_<=(that)
-  final def >=(that:  EnumType)(using sourceInfo: SourceInfo): Bool = _impl_>=(that)
+  final def ===(that: EnumType)(using SourceInfo): Bool = _impl_===(that)
+  final def =/=(that: EnumType)(using SourceInfo): Bool = _impl_=/=(that)
+  final def <(that:   EnumType)(using SourceInfo): Bool = _impl_<(that)
+  final def <=(that:  EnumType)(using SourceInfo): Bool = _impl_>(that)
+  final def >(that:   EnumType)(using SourceInfo): Bool = _impl_<=(that)
+  final def >=(that:  EnumType)(using SourceInfo): Bool = _impl_>=(that)
 }
 
 abstract class ChiselEnum extends ChiselEnumImpl

--- a/core/src/main/scala-3/chisel3/Clock.scala
+++ b/core/src/main/scala-3/chisel3/Clock.scala
@@ -12,5 +12,5 @@ object Clock {
 sealed class Clock extends ClockImpl {
 
   /** Returns the contents of the clock wire as a [[Bool]]. */
-  def asBool(using sourceInfo: SourceInfo): Bool = _asBoolImpl
+  def asBool(using SourceInfo): Bool = _asBoolImpl
 }

--- a/core/src/main/scala-3/chisel3/Data.scala
+++ b/core/src/main/scala-3/chisel3/Data.scala
@@ -22,7 +22,7 @@ abstract class Data extends DataImpl with SourceInfoDoc {
     * @note bit widths are NOT checked, may pad or drop bits from input
     * @note that should have known widths
     */
-  def asTypeOf[T <: Data](that: T)(using sourceInfo: SourceInfo): T = _asTypeOfImpl(that)
+  def asTypeOf[T <: Data](that: T)(using SourceInfo): T = _asTypeOfImpl(that)
 
   /** Reinterpret cast to UInt.
     *

--- a/core/src/main/scala-3/chisel3/Disable.scala
+++ b/core/src/main/scala-3/chisel3/Disable.scala
@@ -22,7 +22,7 @@ class Disable private[chisel3] (private[chisel3] val value: Bool) extends Disabl
     * @return invert the logical value of this `Disable`
     * @group Bitwise
     */
-  def unary_!(using sourceInfo: SourceInfo): Disable = new Disable(!this.value)
+  def unary_!(using SourceInfo): Disable = new Disable(!this.value)
 }
 
 object Disable extends ObectDisableImpl

--- a/core/src/main/scala-3/chisel3/Mem.scala
+++ b/core/src/main/scala-3/chisel3/Mem.scala
@@ -91,8 +91,8 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt, protected
     data: T,
     mask: Seq[Bool]
   )(
-    implicit evidence: T <:< Vec[_],
-    sourceInfo:        SourceInfo
+    using T <:< Vec[_],
+    SourceInfo
   ): Unit = _writeImpl(idx, data, mask)
 
   /** Creates a masked write accessor into the memory with a clock
@@ -112,8 +112,8 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt, protected
     mask:  Seq[Bool],
     clock: Clock
   )(
-    implicit evidence: T <:< Vec[_],
-    sourceInfo:        SourceInfo
+    using T <:< Vec[_],
+    SourceInfo
   ): Unit = _writeImpl(idx, data, mask, clock)
 }
 
@@ -277,8 +277,8 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
     en:        Bool,
     isWrite:   Bool
   )(
-    implicit evidence: T <:< Vec[_],
-    sourceInfo:        SourceInfo
+    using T <:< Vec[_],
+    SourceInfo
   ): T = _readWriteImpl(idx, writeData, mask, en, isWrite)
 
   /** Generates an explicit read-write port for this SyncReadMem, with a bytemask for
@@ -307,7 +307,7 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
     isWrite:   Bool,
     clock:     Clock
   )(
-    implicit evidence: T <:< Vec[_],
-    sourceInfo:        SourceInfo
+    using T <:< Vec[_],
+    SourceInfo
   ): T = _readWriteImpl(idx, writeData, mask, en, isWrite, clock)
 }

--- a/core/src/main/scala-3/chisel3/Mem.scala
+++ b/core/src/main/scala-3/chisel3/Mem.scala
@@ -15,7 +15,7 @@ object Mem extends ObjectMemImpl with SourceInfoDoc {
     size: BigInt,
     t:    T
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Mem[T] = _applyImpl(size, t)
 
   /** Creates a combinational/asynchronous-read, sequential/synchronous-write [[Mem]].
@@ -23,7 +23,7 @@ object Mem extends ObjectMemImpl with SourceInfoDoc {
     * @param size number of elements in the memory
     * @param t data type of memory element
     */
-  def apply[T <: Data](size: Int, t: T)(using sourceInfo: SourceInfo): Mem[T] = _applyImpl(size, t)
+  def apply[T <: Data](size: Int, t: T)(using SourceInfo): Mem[T] = _applyImpl(size, t)
 }
 
 sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt, protected val sourceInfo: SourceInfo)
@@ -35,38 +35,38 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt, protected
   /** Creates a read accessor into the memory with static addressing. See the
     * class documentation of the memory for more detailed information.
     */
-  def apply(idx: BigInt)(using sourceInfo: SourceInfo): T = _applyImpl(idx)
+  def apply(idx: BigInt)(using SourceInfo): T = _applyImpl(idx)
 
   /** Creates a read accessor into the memory with static addressing. See the
     * class documentation of the memory for more detailed information.
     */
-  def apply(idx: Int)(using sourceInfo: SourceInfo): T = _applyImpl(idx)
+  def apply(idx: Int)(using SourceInfo): T = _applyImpl(idx)
 
   /** Creates a read/write accessor into the memory with dynamic addressing.
     * See the class documentation of the memory for more detailed information.
     */
-  def apply(idx: UInt)(using sourceInfo: SourceInfo): T = _applyImpl(idx)
+  def apply(idx: UInt)(using SourceInfo): T = _applyImpl(idx)
 
-  def apply(idx: UInt, clock: Clock)(using sourceInfo: SourceInfo): T = _applyImpl(idx, clock)
+  def apply(idx: UInt, clock: Clock)(using SourceInfo): T = _applyImpl(idx, clock)
 
   /** Creates a read accessor into the memory with dynamic addressing. See the
     * class documentation of the memory for more detailed information.
     */
-  def read(idx: UInt)(using sourceInfo: SourceInfo): T = _readImpl(idx)
+  def read(idx: UInt)(using SourceInfo): T = _readImpl(idx)
 
   /** Creates a read accessor into the memory with dynamic addressing.
     * Takes a clock parameter to bind a clock that may be different
     * from the implicit clock. See the class documentation of the memory
     * for more detailed information.
     */
-  def read(idx: UInt, clock: Clock)(using sourceInfo: SourceInfo): T = _readImpl(idx, clock)
+  def read(idx: UInt, clock: Clock)(using SourceInfo): T = _readImpl(idx, clock)
 
   /** Creates a write accessor into the memory.
     *
     * @param idx memory element index to write into
     * @param data new data to write
     */
-  def write(idx: UInt, data: T)(using sourceInfo: SourceInfo): Unit = _writeImpl(idx, data)
+  def write(idx: UInt, data: T)(using SourceInfo): Unit = _writeImpl(idx, data)
 
   /** Creates a write accessor into the memory with a clock
     * that may be different from the implicit clock.
@@ -75,7 +75,7 @@ sealed abstract class MemBase[T <: Data](val t: T, val length: BigInt, protected
     * @param data new data to write
     * @param clock clock to bind to this accessor
     */
-  def write(idx: UInt, data: T, clock: Clock)(using sourceInfo: SourceInfo): Unit = _writeImpl(idx, data, clock)
+  def write(idx: UInt, data: T, clock: Clock)(using SourceInfo): Unit = _writeImpl(idx, data, clock)
 
   /** Creates a masked write accessor into the memory.
     *
@@ -141,7 +141,7 @@ object SyncReadMem extends ObjectSyncReadMemImpl {
     size: Int,
     t:    T
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): SyncReadMem[T] = _applyImpl(size, t)
 
   def apply[T <: Data](
@@ -149,7 +149,7 @@ object SyncReadMem extends ObjectSyncReadMemImpl {
     t:    T,
     ruw:  ReadUnderWrite = Undefined
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): SyncReadMem[T] = _applyImpl(size, t, ruw)
 }
 
@@ -171,11 +171,11 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
 ) extends MemBase[T](t, n, sourceInfo)
     with SyncReadMemImpl[T] {
 
-  override def read(idx: UInt)(using sourceInfo: SourceInfo): T = _readImpl(idx)
+  override def read(idx: UInt)(using SourceInfo): T = _readImpl(idx)
 
-  def read(idx: UInt, en: Bool)(using sourceInfo: SourceInfo): T = _readImpl(idx, en)
+  def read(idx: UInt, en: Bool)(using SourceInfo): T = _readImpl(idx, en)
 
-  def read(idx: UInt, en: Bool, clock: Clock)(using sourceInfo: SourceInfo): T = _readImpl(idx, en, clock)
+  def read(idx: UInt, en: Bool, clock: Clock)(using SourceInfo): T = _readImpl(idx, en, clock)
 
   /** Generates an explicit read-write port for this SyncReadMem. Note that this does not infer
     * port directionality based on connection semantics and the `when` context unlike SyncReadMem.apply(),
@@ -209,7 +209,7 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
     *
     * }}}
     */
-  def readWrite(idx: UInt, writeData: T, en: Bool, isWrite: Bool)(using sourceInfo: SourceInfo): T =
+  def readWrite(idx: UInt, writeData: T, en: Bool, isWrite: Bool)(using SourceInfo): T =
     _readWriteImpl(idx, writeData, en, isWrite)
 
   /** Generates an explicit read-write port for this SyncReadMem, using a clock that may be
@@ -232,7 +232,7 @@ sealed class SyncReadMem[T <: Data] private[chisel3] (
     isWrite: Bool,
     clock:   Clock
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T = _readWriteImpl(idx, data, en, isWrite, clock)
 
   /** Generates an explicit read-write port for this SyncReadMem, with a bytemask for

--- a/core/src/main/scala-3/chisel3/Mux.scala
+++ b/core/src/main/scala-3/chisel3/Mux.scala
@@ -22,6 +22,6 @@ object Mux extends MuxImpl with SourceInfoDoc {
     con:  T,
     alt:  T
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T = _applyImpl(cond, con, alt)
 }

--- a/core/src/main/scala-3/chisel3/Printf.scala
+++ b/core/src/main/scala-3/chisel3/Printf.scala
@@ -32,6 +32,6 @@ object printf extends PrintfImpl {
     * @see [[Printable]] documentation
     * @param pable [[Printable]] to print
     */
-  def apply(pable: Printable)(using sourceInfo: SourceInfo): chisel3.printf.Printf =
-    PrintfMacrosCompat.printfWithReset(pable)(using sourceInfo)
+  def apply(pable: Printable)(using SourceInfo): chisel3.printf.Printf =
+    PrintfMacrosCompat.printfWithReset(pable)
 }

--- a/core/src/main/scala-3/chisel3/PrintfMacros.scala
+++ b/core/src/main/scala-3/chisel3/PrintfMacros.scala
@@ -10,7 +10,7 @@ object PrintfMacrosCompat {
   private[chisel3] def printfWithReset(
     pable: Printable
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): chisel3.printf.Printf = {
     var printfId: chisel3.printf.Printf = null
     when(!Module.reset.asBool) {
@@ -22,14 +22,14 @@ object PrintfMacrosCompat {
   private[chisel3] def printfWithoutReset(
     pable: Printable
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): chisel3.printf.Printf = {
     val clock = Builder.forcedClock
     val printfId = new chisel3.printf.Printf(pable)
 
     Printable.checkScope(pable)
 
-    pushCommand(chisel3.internal.firrtl.ir.Printf(printfId, sourceInfo, clock.ref, pable))
+    pushCommand(chisel3.internal.firrtl.ir.Printf(printfId, summon[SourceInfo], clock.ref, pable))
     printfId
   }
 }

--- a/core/src/main/scala-3/chisel3/VerificationStatementMacros.scala
+++ b/core/src/main/scala-3/chisel3/VerificationStatementMacros.scala
@@ -23,7 +23,7 @@ object VerifStmtMacrosCompat {
     cond:     Bool,
     message:  Option[Printable]
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Printable = {
     val (filename, line) = lineInfo
     val lineMsg = s"$filename:$line".replaceAll("%", "%%")

--- a/core/src/main/scala-3/chisel3/probe/Probe.scala
+++ b/core/src/main/scala-3/chisel3/probe/Probe.scala
@@ -9,10 +9,10 @@ object Probe extends ProbeBase {
 
   /** Mark a Chisel type as with a probe modifier.
     */
-  def apply[T <: Data](source: => T)(using sourceInfo: SourceInfo): T =
+  def apply[T <: Data](source: => T)(using SourceInfo): T =
     super.apply(source, false, None)
 
-  def apply[T <: Data](source: => T, color: layer.Layer)(using sourceInfo: SourceInfo): T =
+  def apply[T <: Data](source: => T, color: layer.Layer)(using SourceInfo): T =
     super.apply(source, false, Some(color))
 }
 
@@ -20,5 +20,5 @@ object RWProbe extends ProbeBase with SourceInfoDoc {
 
   /** Mark a Chisel type with a writable probe modifier.
     */
-  def apply[T <: Data](source: => T)(using sourceInfo: SourceInfo): T = super.apply(source, true)
+  def apply[T <: Data](source: => T)(using SourceInfo): T = super.apply(source, true)
 }

--- a/core/src/main/scala-3/chisel3/probe/ProbeValue.scala
+++ b/core/src/main/scala-3/chisel3/probe/ProbeValue.scala
@@ -8,11 +8,11 @@ import chisel3.experimental.SourceInfo
 object ProbeValue extends ProbeValueBase with SourceInfoDoc {
 
   /** Create a read-only probe expression. */
-  def apply[T <: Data](source: T)(using sourceInfo: SourceInfo): T = super.apply(source, writable = false)
+  def apply[T <: Data](source: T)(using SourceInfo): T = super.apply(source, writable = false)
 }
 
 object RWProbeValue extends ProbeValueBase with SourceInfoDoc {
 
   /** Create a read/write probe expression. */
-  def apply[T <: Data](source: T)(using sourceInfo: SourceInfo): T = super.apply(source, writable = true)
+  def apply[T <: Data](source: T)(using SourceInfo): T = super.apply(source, writable = true)
 }

--- a/core/src/main/scala-3/chisel3/probe/package.scala
+++ b/core/src/main/scala-3/chisel3/probe/package.scala
@@ -11,5 +11,5 @@ package object probe extends ObjectProbeImpl {
     *
     * @param source probe whose value is getting accessed
     */
-  def read[T <: Data](source: T)(using sourceInfo: SourceInfo): T = _readImpl(source)
+  def read[T <: Data](source: T)(using SourceInfo): T = _readImpl(source)
 }

--- a/src/main/scala-3/chisel3/choice/ModuleChoice.scala
+++ b/src/main/scala-3/chisel3/choice/ModuleChoice.scala
@@ -30,6 +30,6 @@ object ModuleChoice extends ModuleChoiceImpl {
     default: => FixedIOBaseModule[T],
     choices: Seq[(Case, () => FixedIOBaseModule[T])]
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T = _applyImpl(default, choices)
 }

--- a/src/main/scala-3/chisel3/util/BitPat.scala
+++ b/src/main/scala-3/chisel3/util/BitPat.scala
@@ -9,8 +9,8 @@ import scala.util.hashing.MurmurHash3
 
 object BitPat extends ObjectBitPatImpl {
   implicit class fromUIntToBitPatComparable(x: UInt) {
-    def ===(that: BitPat)(using sourceInfo: SourceInfo): Bool = that === x
-    def =/=(that: BitPat)(using sourceInfo: SourceInfo): Bool = that =/= x
+    def ===(that: BitPat)(using SourceInfo): Bool = that === x
+    def =/=(that: BitPat)(using SourceInfo): Bool = that =/= x
   }
 }
 
@@ -18,9 +18,9 @@ sealed class BitPat(val value: BigInt, val mask: BigInt, val width: Int) extends
   import chisel3.util.experimental.BitSet
   def terms = Set(this)
 
-  def apply(x:  Int)(using sourceInfo:    SourceInfo):                        BitPat = _applyImpl(x)
-  def apply(x:  Int, y:                   Int)(using sourceInfo: SourceInfo): BitPat = _applyImpl(x, y)
-  def ===(that: UInt)(using sourceInfo:   SourceInfo):                        Bool = _impl_===(that)
-  def =/=(that: UInt)(using sourceInfo:   SourceInfo):                        Bool = _impl_=/=(that)
-  def ##(that:  BitPat)(using sourceInfo: SourceInfo):                        BitPat = _impl_##(that)
+  def apply(x:  Int)(using SourceInfo):         BitPat = _applyImpl(x)
+  def apply(x:  Int, y: Int)(using SourceInfo): BitPat = _applyImpl(x, y)
+  def ===(that: UInt)(using SourceInfo):        Bool = _impl_===(that)
+  def =/=(that: UInt)(using SourceInfo):        Bool = _impl_=/=(that)
+  def ##(that:  BitPat)(using SourceInfo):      BitPat = _impl_##(that)
 }

--- a/src/main/scala-3/chisel3/util/Bitwise.scala
+++ b/src/main/scala-3/chisel3/util/Bitwise.scala
@@ -25,13 +25,13 @@ object FillInterleaved extends FillInterleavedImpl {
     *
     * Output data-equivalent to in(size(in)-1) (n times) ## ... ## in(1) (n times) ## in(0) (n times)
     */
-  def apply(n: Int, in: UInt)(using sourceInfo: SourceInfo): UInt = _applyImpl(n, in)
+  def apply(n: Int, in: UInt)(using SourceInfo): UInt = _applyImpl(n, in)
 
   /** Creates n repetitions of each bit of x in order.
     *
     * Output data-equivalent to in(size(in)-1) (n times) ## ... ## in(1) (n times) ## in(0) (n times)
     */
-  def apply(n: Int, in: Seq[Bool])(using sourceInfo: SourceInfo): UInt = _applyImpl(n, in)
+  def apply(n: Int, in: Seq[Bool])(using SourceInfo): UInt = _applyImpl(n, in)
 }
 
 /** Returns the number of bits set (value is 1 or true) in the input signal.
@@ -47,8 +47,8 @@ object FillInterleaved extends FillInterleavedImpl {
   */
 object PopCount extends PopCountImpl {
 
-  def apply(in: Iterable[Bool])(using sourceInfo: SourceInfo): UInt = _applyImpl(in)
-  def apply(in: Bits)(using sourceInfo:           SourceInfo): UInt = _applyImpl(in)
+  def apply(in: Iterable[Bool])(using SourceInfo): UInt = _applyImpl(in)
+  def apply(in: Bits)(using SourceInfo):           UInt = _applyImpl(in)
 }
 
 /** Create repetitions of the input using a tree fanout topology.
@@ -66,7 +66,7 @@ object Fill extends FillImpl {
     * Output data-equivalent to x ## x ## ... ## x (n repetitions).
     * @throws java.lang.IllegalArgumentException if `n` is less than zero
     */
-  def apply(n: Int, x: UInt)(using sourceInfo: SourceInfo): UInt = _applyImpl(n, x)
+  def apply(n: Int, x: UInt)(using SourceInfo): UInt = _applyImpl(n, x)
 }
 
 /** Returns the input in bit-reversed order. Useful for little/big-endian conversion.
@@ -79,5 +79,5 @@ object Fill extends FillImpl {
   */
 object Reverse extends ReverseImpl {
 
-  def apply(in: UInt)(using sourceInfo: SourceInfo): UInt = _applyImpl(in)
+  def apply(in: UInt)(using SourceInfo): UInt = _applyImpl(in)
 }

--- a/src/main/scala-3/chisel3/util/Cat.scala
+++ b/src/main/scala-3/chisel3/util/Cat.scala
@@ -19,7 +19,7 @@ object Cat extends CatImpl {
   /** Concatenates the argument data elements, in argument order, together. The first argument
     * forms the most significant bits, while the last argument forms the least significant bits.
     */
-  def apply[T <: Bits](a: T, r: T*)(using sourceInfo: SourceInfo): UInt = _applyImpl(a, r: _*)
+  def apply[T <: Bits](a: T, r: T*)(using SourceInfo): UInt = _applyImpl(a, r: _*)
 
   /** Concatenates the data elements of the input sequence, in reverse sequence order, together.
     * The first element of the sequence forms the most significant bits, while the last element
@@ -28,5 +28,5 @@ object Cat extends CatImpl {
     * Equivalent to r(0) ## r(1) ## ... ## r(n-1).
     * @note This returns a `0.U` if applied to a zero-element `Vec`.
     */
-  def apply[T <: Bits](r: Seq[T])(using sourceInfo: SourceInfo): UInt = _applyImpl(r)
+  def apply[T <: Bits](r: Seq[T])(using SourceInfo): UInt = _applyImpl(r)
 }

--- a/src/main/scala-3/chisel3/util/Mux.scala
+++ b/src/main/scala-3/chisel3/util/Mux.scala
@@ -24,13 +24,13 @@ import chisel3.experimental.SourceInfo
   */
 object Mux1H extends Mux1HImpl {
 
-  def apply[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+  def apply[T <: Data](sel: Seq[Bool], in: Seq[T])(using SourceInfo): T = _applyImpl(sel, in)
 
-  def apply[T <: Data](in: Iterable[(Bool, T)])(implicit sourceInfo: SourceInfo): T = _applyImpl(in)
+  def apply[T <: Data](in: Iterable[(Bool, T)])(using SourceInfo): T = _applyImpl(in)
 
-  def apply[T <: Data](sel: UInt, in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+  def apply[T <: Data](sel: UInt, in: Seq[T])(using SourceInfo): T = _applyImpl(sel, in)
 
-  def apply(sel: UInt, in: UInt)(implicit sourceInfo: SourceInfo): Bool = _applyImpl(sel, in)
+  def apply(sel: UInt, in: UInt)(using SourceInfo): Bool = _applyImpl(sel, in)
 }
 
 /** Builds a Mux tree under the assumption that multiple select signals
@@ -48,11 +48,11 @@ object Mux1H extends Mux1HImpl {
   */
 object PriorityMux extends PriorityMuxImpl {
 
-  def apply[T <: Data](in: Seq[(Bool, T)])(implicit sourceInfo: SourceInfo): T = _applyImpl(in)
+  def apply[T <: Data](in: Seq[(Bool, T)])(using SourceInfo): T = _applyImpl(in)
 
-  def apply[T <: Data](sel: Seq[Bool], in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+  def apply[T <: Data](sel: Seq[Bool], in: Seq[T])(using SourceInfo): T = _applyImpl(sel, in)
 
-  def apply[T <: Data](sel: Bits, in: Seq[T])(implicit sourceInfo: SourceInfo): T = _applyImpl(sel, in)
+  def apply[T <: Data](sel: Bits, in: Seq[T])(using SourceInfo): T = _applyImpl(sel, in)
 }
 
 /** Creates a cascade of n Muxs to search for a key value. The Selector may be a UInt or an EnumType.
@@ -74,7 +74,7 @@ object MuxLookup extends MuxLookupImpl {
     default: T,
     mapping: Seq[(S, T)]
   )(
-    implicit sourceinfo: SourceInfo
+    using SourceInfo
   ): T = _applyEnumImpl(key, default, mapping)
 
   /** @param key a key to search for
@@ -82,6 +82,6 @@ object MuxLookup extends MuxLookupImpl {
     * @param mapping a sequence to search of keys and values
     * @return the value found or the default if not
     */
-  def apply[S <: UInt, T <: Data](key: S, default: T, mapping: Seq[(S, T)])(implicit sourceinfo: SourceInfo): T =
+  def apply[S <: UInt, T <: Data](key: S, default: T, mapping: Seq[(S, T)])(using SourceInfo): T =
     _applyImpl(key, default, mapping)
 }

--- a/src/main/scala-3/chisel3/util/Reg.scala
+++ b/src/main/scala-3/chisel3/util/Reg.scala
@@ -13,7 +13,7 @@ object RegEnable extends RegEnableImpl {
     * val regWithEnable = RegEnable(nextVal, ena)
     * }}}
     */
-  def apply[T <: Data](next: T, enable: Bool)(using sourceInfo: SourceInfo): T = _applyImpl(next, enable)
+  def apply[T <: Data](next: T, enable: Bool)(using SourceInfo): T = _applyImpl(next, enable)
 
   /** Returns a register with the specified next, update enable gate, and reset initialization.
     *
@@ -26,7 +26,7 @@ object RegEnable extends RegEnableImpl {
     init:   T,
     enable: Bool
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T = _applyImpl(next, init, enable)
 }
 
@@ -47,7 +47,7 @@ object ShiftRegister extends ShiftRegisterImpl {
     n:  Int,
     en: Bool = true.B
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T =
     _applyImpl(in, n, en)
 
@@ -62,7 +62,7 @@ object ShiftRegister extends ShiftRegisterImpl {
     * val regDelayTwo = ShiftRegister(nextVal, 2)
     * }}}
     */
-  def apply[T <: Data](in: T, n: Int)(using sourceInfo: SourceInfo): T =
+  def apply[T <: Data](in: T, n: Int)(using SourceInfo): T =
     _applyImpl(in, n)
 
   /** Returns the n-cycle delayed version of the input signal with reset initialization.
@@ -82,7 +82,7 @@ object ShiftRegister extends ShiftRegisterImpl {
     resetData: T,
     en:        Bool
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T = _applyImpl(in, n, resetData, en)
 
   /** Returns the n-cycle delayed version of the input signal (SyncReadMem-based ShiftRegister implementation).
@@ -100,7 +100,7 @@ object ShiftRegister extends ShiftRegisterImpl {
     useDualPortSram: Boolean,
     name:            Option[String]
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): T = _applyImplMem(in, n, en, useDualPortSram, name)
 }
 
@@ -117,7 +117,7 @@ object ShiftRegisters extends ShiftRegistersImpl {
     n:  Int,
     en: Bool
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Seq[T] = _applyImpl(in, n, en)
 
   /** Returns a sequence of delayed input signal registers from 1 to n.
@@ -127,7 +127,7 @@ object ShiftRegisters extends ShiftRegistersImpl {
     * @param in input to delay
     * @param n  number of cycles to delay
     */
-  def apply[T <: Data](in: T, n: Int)(using sourceInfo: SourceInfo): Seq[T] =
+  def apply[T <: Data](in: T, n: Int)(using SourceInfo): Seq[T] =
     _applyImpl(in, n)
 
   /** Returns delayed input signal registers with reset initialization from 1 to n.
@@ -143,6 +143,6 @@ object ShiftRegisters extends ShiftRegistersImpl {
     resetData: T,
     en:        Bool
   )(
-    using sourceInfo: SourceInfo
+    using SourceInfo
   ): Seq[T] = _applyImpl(in, n, resetData, en)
 }


### PR DESCRIPTION
They are not needed and add unnecessary noise to public APIs.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Only affects Scala 3 APIs which are not yet published

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
