### PR TITLE
Add UnitTest marker and test discovery utility

### DIFF
--- a/src/main/scala/chisel3/UnitTest.scala
+++ b/src/main/scala/chisel3/UnitTest.scala
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.test
+
+import chisel3.experimental.BaseModule
+import chisel3.experimental.hierarchy.Definition
+import chisel3.RawModule
+import java.io.File
+import java.util.jar.JarFile
+import scala.collection.JavaConverters._
+
+/** All classes and objects marked as [[UnitTest]] are automatically
+  * discoverable by the `DiscoverUnitTests` helper.
+  */
+trait UnitTest
+
+/** Helper to discover all subtypes of [[UnitTest]] in the class path, and call
+  * their constructors (if they are a class) or ensure that the singleton is
+  * constructed (if they are an object).
+  *
+  * This code is loosely based on the test suite discovery in scalatest, which
+  * performs the same scan over the classpath JAR files and directories, and
+  * guesses class names based on the encountered directory structure.
+  */
+private[chisel3] object DiscoverUnitTests {
+
+  /** The callback invoked for each unit test class name and unit test
+    * constructor.
+    */
+  type Callback = (String, () => Unit) => Unit
+
+  /** Discover all tests in the classpath and call `cb` for each. */
+  def apply(cb: Callback): Unit = classpath().foreach(discoverFile(_, cb))
+
+  /** Return the a sequence of files or directories on the classpath. */
+  private def classpath(): Iterable[File] = System
+    .getProperty("java.class.path")
+    .split(File.pathSeparator)
+    .map(s => if (s.trim.length == 0) "." else s)
+    .map(new File(_))
+
+  /** Discover all tests in a given file. If this is a JAR file, looks through
+    * its contents and tries to find its classes.
+    */
+  private def discoverFile(file: File, cb: Callback): Unit = file match {
+    // Unzip JAR files and process the class files they contain.
+    case _ if file.getPath.toLowerCase.endsWith(".jar") =>
+      val jarFile = new java.util.jar.JarFile(file)
+      jarFile.entries.asScala.foreach { jarEntry =>
+        val name = jarEntry.getName
+        if (!jarEntry.isDirectory && name.endsWith(".class"))
+          discoverClass(pathToClassName(name), cb)
+      }
+
+    // Recursively collect any class files contained in directories.
+    case _ if file.isDirectory =>
+      def visit(prefix: String, file: File): Unit = {
+        val name = prefix + "/" + file.getName
+        if (file.isDirectory) {
+          for (entry <- file.listFiles)
+            visit(name, entry)
+        } else if (name.endsWith(".class")) {
+          discoverClass(pathToClassName(name), cb)
+        }
+      }
+      for (entry <- file.listFiles)
+        visit("", entry)
+
+    // Ignore any other files that aren't directories.
+    case _ => ()
+  }
+
+  /** Convert a file path to a class */
+  private def pathToClassName(path: String): String =
+    path.replace('/', '.').replace('\\', '.').stripPrefix(".").stripSuffix(".class")
+
+  /** Load the given class and check whether it is a subtype of [[UnitTest]]. If
+    * it is, call the user-provided callback with a function that either calls
+    * the loaded class' constructor or ensures the loaded object is constructed.
+    */
+  private def discoverClass(className: String, cb: Callback): Unit = {
+    val clazz =
+      try {
+        classOf[UnitTest].getClassLoader.loadClass(className)
+      } catch {
+        case _: ClassNotFoundException       => return
+        case _: NoClassDefFoundError         => return
+        case _: ClassCastException           => return
+        case _: UnsupportedClassVersionError => return
+      }
+
+    // Check if it is a subtype of `UnitTest` (and also not the definition of
+    // `UnitTest` itself).
+    if (clazz == classOf[UnitTest] || !classOf[UnitTest].isAssignableFrom(clazz))
+      return
+
+    // Check if this is a `BaseModule`, in which case we implicitly wrap its
+    // constructor in a `Definition(...)` call.
+    val isModule = classOf[BaseModule].isAssignableFrom(clazz)
+
+    // Handle singleton objects by ensuring they are constructed.
+    try {
+      val field = clazz.getField("MODULE$")
+      if (isModule)
+        cb(className, () => Definition(field.get(null).asInstanceOf[BaseModule]))
+      else
+        cb(className, () => field.get(null))
+      return
+    } catch {
+      case e: NoSuchFieldException => ()
+    }
+
+    // Handle classes by calling their constructor.
+    try {
+      val ctor = clazz.getConstructor()
+      if (isModule)
+        cb(className, () => Definition(ctor.newInstance().asInstanceOf[BaseModule]))
+      else
+        cb(className, () => ctor.newInstance())
+      return
+    } catch {
+      case e: NoSuchMethodException  => ()
+      case e: IllegalAccessException => ()
+    }
+  }
+}
+
+/** A Chisel module that discovers and constructs all [[UnitTest]] subtypes
+  * discovered in the classpath. This is just here as a convenience top-level
+  * generator to collect all unit tests. In practice you would likely want to
+  * use a command line utility that offers some additional filtering capability.
+  */
+class AllUnitTests extends RawModule {
+  DiscoverUnitTests((_, gen) => gen())
+}

--- a/src/main/scala/chisel3/UnitTestMain.scala
+++ b/src/main/scala/chisel3/UnitTestMain.scala
@@ -1,0 +1,116 @@
+package chisel3
+
+import chisel3.test.DiscoverUnitTests
+import circt.stage.ChiselStage
+import java.io.File
+import java.io.PrintStream
+import scala.util.matching.Regex
+import scopt.OptionParser
+
+/** Utility to discover and generate all unit tests in the classpath. */
+object UnitTests {
+
+  /** Command line configuration options. */
+  case class Config(
+    outputFile: Option[File] = None,
+    list:       Boolean = false,
+    verbose:    Boolean = false,
+    filters:    List[Regex] = List(),
+    excludes:   List[Regex] = List()
+  )
+
+  def main(args: Array[String]): Unit = {
+    var shouldExit = false
+    val parser = new OptionParser[Config]("chisel3.UnitTests") {
+      head("Chisel Unit Test Utility")
+      help("help").abbr("h")
+
+      opt[File]('o', "output")
+        .text("Output file name (\"-\" for stdout)")
+        .action((x, c) => c.copy(outputFile = if (!x.getPath.isEmpty && x.getPath != "-") Some(x) else None))
+
+      opt[Unit]('l', "list")
+        .text("List tests instead of building them")
+        .action((_, c) => c.copy(list = true))
+
+      opt[Unit]('v', "verbose")
+        .text("Print verbose information to stderr")
+        .action((_, c) => c.copy(verbose = true))
+
+      opt[Seq[String]]('f', "filter")
+        .text("Only consider tests which match at least one filter regex")
+        .unbounded()
+        .action((x, c) => c.copy(filters = c.filters ++ x.map(_.r)))
+
+      opt[Seq[String]]('x', "exclude")
+        .text("Ignore tests which match at least one exclusion regex")
+        .unbounded()
+        .action((x, c) => c.copy(excludes = c.excludes ++ x.map(_.r)))
+
+      // Do not `sys.exit` on `help` to facilitate testing.
+      override def terminate(exitState: Either[String, Unit]): Unit = {
+        shouldExit = true
+      }
+    }
+
+    // Parse the command line options.
+    val config = parser.parse(args, Config()) match {
+      case Some(config) => config
+      case None         => return
+    }
+    if (shouldExit)
+      return
+
+    // Define the handler that will be called for each discovered unit test, and
+    // which will decide whether the test is generated or not.
+    def handler(className: String, gen: () => Unit): Unit = {
+      // If none of the inclusion filters match, skip this test.
+      if (!config.filters.isEmpty && !config.filters.exists(_.findFirstMatchIn(className).isDefined)) {
+        Console.err.println(f"Skipping ${className} (does not match filter)")
+        return
+      }
+
+      // If any of the exclusion filters match, skip this test.
+      if (config.excludes.exists(_.findFirstMatchIn(className).isDefined)) {
+        Console.err.println(f"Skipping ${className} (matches exclude filter)")
+        return
+      }
+
+      // If we are just listing tests, print the class name and skip this test.
+      if (config.list) {
+        println(className)
+        return
+      }
+
+      // Otherwise generate the test.
+      if (config.verbose)
+        Console.err.println(f"Building ${className}")
+      gen()
+    }
+
+    // If the user only asked for a list of tests, run test discovery without
+    // setting up any of the Chisel builder stuff in the background. The handler
+    // will never actually call the Chisel generators in this mode.
+    if (config.list) {
+      DiscoverUnitTests(handler)
+      return
+    }
+
+    // Generate the unit tests.
+    class AllUnitTests extends RawModule {
+      DiscoverUnitTests(handler)
+    }
+    val chirrtl = ChiselStage.emitCHIRRTL(new AllUnitTests)
+
+    // Write the result to the output.
+    val output: PrintStream = config.outputFile match {
+      case Some(file) => new PrintStream(file)
+      case None       => Console.out
+    }
+    try {
+      output.print(chirrtl)
+    } finally {
+      output.close()
+    }
+  }
+}

--- a/src/test/scala/chiselTests/ChiselSpec.scala
+++ b/src/test/scala/chiselTests/ChiselSpec.scala
@@ -238,7 +238,7 @@ trait FileCheck extends BeforeAndAfterEachTestData { this: Suite =>
     // Filecheck needs the thing to check in a file
     os.write.over(checkFile.get, check)
     val extraArgs = os.Shellable(fileCheckArgs)
-    os.proc("FileCheck", checkFile.get, extraArgs).call(stdin = in)
+    os.proc("FileCheck", "--allow-empty", checkFile.get, extraArgs).call(stdin = in)
   }
 
   /** Elaborate a Module to FIRRTL and check the FIRRTL with FileCheck */

--- a/src/test/scala/chiselTests/UnitTestMainSpec.scala
+++ b/src/test/scala/chiselTests/UnitTestMainSpec.scala
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.test._
+import java.io.{ByteArrayOutputStream, PrintStream}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class UnitTestMainSpec extends AnyFlatSpec with Matchers with FileCheck {
+  def check(args: Seq[String])(checkOut: String, checkErr: String): Unit = {
+    val outStream = new ByteArrayOutputStream()
+    val errStream = new ByteArrayOutputStream()
+    Console.withOut(new PrintStream(outStream)) {
+      Console.withErr(new PrintStream(errStream)) {
+        UnitTests.main(args.toArray)
+      }
+    }
+    if (!checkOut.isEmpty) fileCheckString(outStream.toString)(checkOut)
+    if (!checkErr.isEmpty) fileCheckString(errStream.toString)(checkErr)
+  }
+
+  def checkOutAndErr(args: String*)(checkOut: String, checkErr: String): Unit = check(args)(checkOut, checkErr)
+
+  def checkOut(args: String*)(checkOut: String): Unit = check(args)(checkOut, "")
+  def checkErr(args: String*)(checkErr: String): Unit = check(args)("", checkErr)
+
+  it should "print a help page" in {
+    checkOut("-h")("""
+      // CHECK: Chisel Unit Test Utility
+      // CHECK: Usage:
+      // CHECK: -h, --help
+      """)
+  }
+
+  it should "list unit tests" in {
+    checkOutAndErr("-l", "-f", "^chiselTests\\.sampleTests\\.")(
+      """
+      // CHECK-DAG: chiselTests.sampleTests.ClassTest
+      // CHECK-DAG: chiselTests.sampleTests.ObjectTest
+      // CHECK-DAG: chiselTests.sampleTests.ModuleTest
+      """,
+      """
+      // CHECK-NOT: Hello from
+      """
+    )
+  }
+
+  it should "execute unit test constructors" in {
+    checkErr("-f", "^chiselTests\\.sampleTests\\.")("""
+      // CHECK-DAG: Hello from class test
+      // CHECK-DAG: Hello from object test
+      // CHECK-DAG: Hello from module test
+      """)
+  }
+
+  it should "generate unit test FIRRTL" in {
+    checkOut("-f", "^chiselTests\\.sampleTests\\.")("""
+      // CHECK: module ModuleTest :
+      """)
+  }
+}
+
+package sampleTests {
+  class ClassTest extends UnitTest {
+    Console.err.println("Hello from class test")
+  }
+  object ObjectTest extends UnitTest {
+    Console.err.println("Hello from object test")
+  }
+  class ModuleTest extends RawModule with UnitTest {
+    Console.err.println("Hello from module test")
+  }
+}


### PR DESCRIPTION
Add the `UnitTest` trait as a marker for classes and objects that should be automatically discovered and constructed/executed as unit tests for hardware written in Chisel.

Also add a new `chisel3.UnitTests` main which discovers all unit tests in the classpath and generates the FIRRTL output for them. The discovery mechanism is roughly the same as implemented in ScalaTest, which scans the classpath for JAR files and directories and then tries to guess class names based on the encountered file structure. This feels pretty brittle, but has been working reliably for ScalaTest for a long time, so chances are this will work for Chisel too.

The utility offers a few options to list all available unit tests, or filter them according to inclusion or exclusion regular expressions. This allows unit tests of only the current package or a subset of the current project to be discovered and built. This is particularly useful if a Chisel project depends on libraries such as rocket-chip or by necessesity Chisel itself, whose unit tests are likely not of interest to that project.

Classes and objects can be marked as unit tests as follows:

    package magic

    class TestA extends UnitTest {
      Definition(new MyAdder(1))
      Definition(new MyAdder(42))
      // ...
    }

    object TestB extends UnitTest {
      for (i <- 1 to 4)
        Definition(new MyMultiplier(i))
      // ...
    }

The `chisel3.UnitTests` utility can then be execute, for example through mill or a standalone binary:

    # List all unit tests:
    > mill chisel[].runMain chisel3.UnitTests -l
    magic.TestA
    magic.TestB
    some.other.package.TestX

    # Produce FIRRTL output for all unit tests:
    > mill chisel[].runMain chisel3.UnitTests -o tests.fir

    # Filter tests according to a regex:
    > mill chisel[].runMain chisel3.UnitTests -l -f '^magic\.' -x TestA
    magic.TestB

As a convenience, Chisel modules can directly be marked as unit test as long as they do not have any constructor arguments. Doing so will automatically create a new `Definition` of the module without instantiating it. This can be useful for modules marked as public that serve as test harness, or by using a `FormalTest` marker to execute the module as a formal test.

    class MyTestHarness extends RawModule with UnitTest with Public {
      // ...
    }

    class MyFormalTest extends RawModule with UnitTest {
      // ...
      FormalTest(this)
    }

This is a first building block towards adding hardware unit tests to Chisel in a similar style as `AnyFlatSpec` and friends in ScalaTest, `#[test]` in Rust, lit tests in LLVM, or gtest in C++.

At a later stage, we may want to automate the execution of unit tests as formal or simulation checks, similar to how we have helper methods to run a Chisel generator all the way through to Verilog.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
