### PR TITLE
Add safer Chisel annotation API, deprecate old ones

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -86,6 +86,7 @@ object v extends Module {
     "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
     "cat=deprecation&origin=chisel3\\.ltl.*:s",
+    "cat=deprecation&origin=chisel3\\.InstanceId:s",
     // Deprecated for external users, will eventually be removed.
     "cat=deprecation&msg=Looking up Modules is deprecated:s",
     // Only for testing of deprecated APIs

--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ lazy val warningSuppression = Seq(
     "cat=deprecation&origin=chisel3\\.util\\.experimental\\.BoringUtils.*:s",
     "cat=deprecation&origin=chisel3\\.experimental\\.IntrinsicModule:s",
     "cat=deprecation&origin=chisel3\\.ltl.*:s",
+    "cat=deprecation&origin=chisel3\\.InstanceId:s",
     "cat=deprecation&msg=Looking up Modules is deprecated:s",
   ).mkString(",")
 )

--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -3,8 +3,10 @@
 package chisel3.experimental
 
 import scala.language.existentials
+import scala.annotation.nowarn
 import chisel3.internal.Builder
-import chisel3.{Data, InstanceId, RawModule}
+import chisel3.{Data, HasTarget, InstanceId, RawModule}
+import chisel3.experimental.AnyTargetable
 import firrtl.annotations._
 import firrtl.options.Unserializable
 import firrtl.transforms.{DedupGroupAnnotation, NoDedupAnnotation}
@@ -13,6 +15,10 @@ import firrtl.transforms.{DedupGroupAnnotation, NoDedupAnnotation}
   *
   * Defines a conversion to a corresponding FIRRTL Annotation
   */
+@deprecated(
+  "Avoid custom annotations. If you must use annotations, use annotate.apply method that takes Data",
+  "Chisel 6.7.0"
+)
 trait ChiselAnnotation {
 
   /** Conversion to FIRRTL Annotation */
@@ -23,16 +29,45 @@ trait ChiselAnnotation {
   *
   *  Defines a conversion to corresponding FIRRTL Annotation(s)
   */
+@deprecated(
+  "Avoid custom annotations. If you must use annotations, use annotate.apply method that takes Data",
+  "Chisel 6.7.0"
+)
 trait ChiselMultiAnnotation {
   def toFirrtl: Seq[Annotation]
 }
 
+@nowarn("msg=Avoid custom annotations")
 object annotate {
-  def apply(anno: ChiselAnnotation): Unit = {
+  @deprecated(
+    "Avoid custom annotations. If you must use annotations, use annotate.apply method that takes Data",
+    "Chisel 6.7.0"
+  )
+  def apply(anno: ChiselAnnotation): Unit =
     Builder.annotations += anno
-  }
-  def apply(annos: ChiselMultiAnnotation): Unit = {
+
+  @deprecated(
+    "Avoid custom annotations. If you must use annotations, use annotate.apply method that takes Data",
+    "Chisel 6.7.0"
+  )
+  def apply(annos: ChiselMultiAnnotation): Unit =
     Builder.newAnnotations += annos
+
+  /** Create annotations.
+    *
+    * Avoid this API if possible.
+    *
+    * Anything being annotated must be passed as arguments so that Chisel can do safety checks.
+    * The caller is still responsible for calling .toTarget on those arguments in mkAnnos.
+    */
+  def apply(targets: AnyTargetable*)(mkAnnos: => Seq[Annotation]): Unit = {
+    targets.map(_.a).foreach {
+      case d: Data => requireIsAnnotatable(d, "Data marked with annotation")
+      case _ => ()
+    }
+    Builder.newAnnotations += new ChiselMultiAnnotation {
+      def toFirrtl: Seq[Annotation] = mkAnnos
+    }
   }
 }
 
@@ -76,7 +111,7 @@ object doNotDedup {
     * @return Unmodified signal `module`
     */
   def apply[T <: RawModule](module: T): Unit = {
-    annotate(new ChiselAnnotation { def toFirrtl: NoDedupAnnotation = NoDedupAnnotation(module.toNamed) })
+    annotate(module)(Seq(NoDedupAnnotation(module.toNamed)))
   }
 }
 
@@ -89,6 +124,6 @@ object dedupGroup {
     * @return Unmodified signal `module`
     */
   def apply[T <: BaseModule](module: T, group: String): Unit = {
-    annotate(new ChiselAnnotation { def toFirrtl: DedupGroupAnnotation = DedupGroupAnnotation(module.toTarget, group) })
+    annotate(module)(Seq(DedupGroupAnnotation(module.toTarget, group)))
   }
 }

--- a/core/src/main/scala/chisel3/ChiselEnumImpl.scala
+++ b/core/src/main/scala/chisel3/ChiselEnumImpl.scala
@@ -3,6 +3,7 @@
 package chisel3
 
 import scala.language.existentials
+import scala.annotation.nowarn
 import scala.collection.mutable
 import chisel3.experimental.{annotate, requireIsHardware, ChiselAnnotation, SourceInfo, UnlocatableSourceInfo}
 import chisel3.internal.Builder.pushOp
@@ -13,6 +14,9 @@ import chisel3.internal.binding.{Binding, ChildBinding, ConstrainedBinding}
 
 import chisel3.experimental.EnumAnnotations._
 
+// Rather than refactoring the annotation work here, we should just remove ChiselEnum annotations
+@nowarn("msg=Avoid custom annotations")
+@nowarn("msg=Enum annotations will be removed")
 private[chisel3] abstract class EnumTypeImpl(private[chisel3] val factory: ChiselEnum, selfAnnotating: Boolean = true)
     extends Element { self: EnumType =>
 
@@ -231,10 +235,15 @@ private[chisel3] abstract class EnumTypeImpl(private[chisel3] val factory: Chise
   }
 }
 
+// Rather than refactoring the annotation work here, we should just remove ChiselEnum annotations
+@nowarn("msg=Avoid custom annotations")
 private[chisel3] object ChiselEnumImpl {
   private[chisel3] case object CacheKey extends BuilderContextCache.Key[mutable.HashSet[ChiselAnnotation]]
 }
 
+// Rather than refactoring the annotation work here, we should just remove ChiselEnum annotations
+@nowarn("msg=Avoid custom annotations")
+@nowarn("msg=Enum annotations will be removed")
 private[chisel3] trait ChiselEnumImpl { self: ChiselEnum =>
   class Type extends EnumType(this)
   object Type {

--- a/core/src/main/scala/chisel3/ModuleImpl.scala
+++ b/core/src/main/scala/chisel3/ModuleImpl.scala
@@ -10,7 +10,7 @@ import chisel3.internal._
 import chisel3.internal.binding._
 import chisel3.internal.Builder._
 import chisel3.internal.firrtl.ir._
-import chisel3.experimental.{requireIsChiselType, BaseModule, SourceInfo, UnlocatableSourceInfo}
+import chisel3.experimental.{requireIsChiselType, BaseModule, SourceInfo, Targetable, UnlocatableSourceInfo}
 import chisel3.properties.{Class, Property}
 import chisel3.reflect.DataMirror
 import _root_.firrtl.annotations.{
@@ -980,13 +980,10 @@ private case class ModulePrefixAnnotation(target: IsMember, prefix: String) exte
 }
 
 private object ModulePrefixAnnotation {
-  def annotate[T <: HasId](target: T): Unit = {
+  def annotate[T <: HasId: Targetable](target: T): Unit = {
     val prefix = Builder.getModulePrefix
     if (prefix != "") {
-      val annotation: ChiselAnnotation = new ChiselAnnotation {
-        def toFirrtl: Annotation = ModulePrefixAnnotation(target.toTarget, prefix)
-      }
-      chisel3.experimental.annotate(annotation)
+      chisel3.experimental.annotate(target)(Seq(ModulePrefixAnnotation(target.toTarget, prefix)))
     }
   }
 }

--- a/core/src/main/scala/chisel3/dontTouch.scala
+++ b/core/src/main/scala/chisel3/dontTouch.scala
@@ -39,8 +39,7 @@ object dontTouch {
       case d if DataMirror.hasProbeTypeModifier(d) => ()
       case _:   Property[_] => ()
       case agg: Aggregate   => agg.getElements.foreach(dontTouch.apply)
-      case _:   Element =>
-        annotate(new ChiselAnnotation { def toFirrtl: DontTouchAnnotation = DontTouchAnnotation(data.toNamed) })
+      case _:   Element     => annotate(data)(Seq(DontTouchAnnotation(data.toNamed)))
       case _ => throw new ChiselException("Non-hardware dontTouch")
     }
     data

--- a/core/src/main/scala/chisel3/experimental/EnumAnnotations.scala
+++ b/core/src/main/scala/chisel3/experimental/EnumAnnotations.scala
@@ -2,9 +2,11 @@
 
 package chisel3.experimental
 
+import scala.annotation.nowarn
 import chisel3._
 import firrtl.annotations._
 
+@nowarn("msg=Avoid custom annotations")
 object EnumAnnotations {
 
   /** An annotation for strong enum instances that are ''not'' inside of Vecs
@@ -12,10 +14,12 @@ object EnumAnnotations {
     * @param target the enum instance being annotated
     * @param enumTypeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
     */
+  @deprecated("Enum annotations will be removed in Chisel 7.0.", "Chisel 6.7.0")
   case class EnumComponentAnnotation(target: Named, enumTypeName: String) extends SingleTargetAnnotation[Named] {
     def duplicate(n: Named): EnumComponentAnnotation = this.copy(target = n)
   }
 
+  @deprecated("Enum annotations will be removed in Chisel 7.0.", "Chisel 6.7.0")
   case class EnumComponentChiselAnnotation(target: InstanceId, enumTypeName: String) extends ChiselAnnotation {
     def toFirrtl: EnumComponentAnnotation = EnumComponentAnnotation(target.toNamed, enumTypeName)
   }
@@ -40,11 +44,13 @@ object EnumAnnotations {
     * @param typeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
     * @param fields a list of all chains of elements leading from the Vec instance to its inner enum fields.
     */
+  @deprecated("Enum annotations will be removed in Chisel 7.0.", "Chisel 6.7.0")
   case class EnumVecAnnotation(target: Named, typeName: String, fields: Seq[Seq[String]])
       extends SingleTargetAnnotation[Named] {
     def duplicate(n: Named): EnumVecAnnotation = this.copy(target = n)
   }
 
+  @deprecated("Enum annotations will be removed in Chisel 7.0.", "Chisel 6.7.0")
   case class EnumVecChiselAnnotation(target: InstanceId, typeName: String, fields: Seq[Seq[String]])
       extends ChiselAnnotation {
     override def toFirrtl: EnumVecAnnotation = EnumVecAnnotation(target.toNamed, typeName, fields)
@@ -55,8 +61,10 @@ object EnumAnnotations {
     * @param typeName the name of the enum's type (e.g. ''"mypackage.MyEnum"'')
     * @param definition a map describing which integer values correspond to which enum names
     */
+  @deprecated("Enum annotations will be removed in Chisel 7.0.", "Chisel 6.7.0")
   case class EnumDefAnnotation(typeName: String, definition: Map[String, BigInt]) extends NoTargetAnnotation
 
+  @deprecated("Enum annotations will be removed in Chisel 7.0.", "Chisel 6.7.0")
   case class EnumDefChiselAnnotation(typeName: String, definition: Map[String, BigInt]) extends ChiselAnnotation {
     override def toFirrtl: Annotation = EnumDefAnnotation(typeName, definition)
   }

--- a/core/src/main/scala/chisel3/experimental/Targetable.scala
+++ b/core/src/main/scala/chisel3/experimental/Targetable.scala
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.experimental
+
+import scala.language.implicitConversions
+
+import chisel3.HasTarget
+import chisel3.experimental.hierarchy.Hierarchy
+import chisel3.internal.NamedComponent
+import firrtl.annotations.IsMember
+
+/** Type class for types that can be converted to a Target
+  *
+  * See [[AnyTargetable]] for type-erased containers of Targetables
+  *
+  * @note This uses type classes instead of inheritance because Hierarchy does not constrain its type parameter
+  *       and thus not all instances of Hierarchy are Targetable.
+  */
+sealed trait Targetable[A] {
+
+  /** Returns a FIRRTL IsMember that refers to this object in the elaborated hardware graph */
+  def toTarget(a: A): IsMember
+
+  /** Returns a FIRRTL IsMember that refers to the absolute path to this object in the elaborated hardware graph */
+  def toAbsoluteTarget(a: A): IsMember
+
+  /** Returns a FIRRTL IsMember that references this object, relative to an optional root.
+    *
+    * If `root` is defined, the target is a hierarchical path starting from `root`.
+    *
+    * If `root` is not defined, the target is a hierarchical path equivalent to `toAbsoluteTarget`.
+    *
+    * @note If `root` is defined, and has not finished elaboration, this must be called within `atModuleBodyEnd`.
+    * @note The Targetable must be a descendant of `root`, if it is defined.
+    * @note This doesn't have special handling for Views.
+    */
+  def toRelativeTarget(a: A, root: Option[BaseModule]): IsMember
+
+  /** Returns a FIRRTL IsMember that references this object, relative to an optional root.
+    *
+    * If `root` is defined, the target is a hierarchical path starting from `root`.
+    *
+    * If `root` is not defined, the target is a hierarchical path equivalent to `toAbsoluteTarget`.
+    *
+    * @note If `root` is defined, and has not finished elaboration, this must be called within `atModuleBodyEnd`.
+    * @note The Targetable must be a descendant of `root`, if it is defined.
+    * @note This doesn't have special handling for Views.
+    */
+  def toRelativeTargetToHierarchy(a: A, root: Option[Hierarchy[BaseModule]]): IsMember
+}
+
+object Targetable {
+
+  // Extension methods for using Targetable as the user expects
+  implicit class TargetableSyntax[A](a: A)(implicit targetable: Targetable[A]) {
+    def toTarget:                                   IsMember = targetable.toTarget(a)
+    def toAbsoluteTarget:                           IsMember = targetable.toAbsoluteTarget(a)
+    def toRelativeTarget(root: Option[BaseModule]): IsMember = targetable.toRelativeTarget(a, root)
+    def toRelativeTargetToHierarchy(root: Option[Hierarchy[BaseModule]]): IsMember =
+      targetable.toRelativeTargetToHierarchy(a, root)
+  }
+
+  /** NamedComponent is an awkward private API for all HasId except BaseModule
+    *
+    * This instance works for [[Data]], [[MemBase]], and [[SramTarget]]
+    */
+  implicit def forNamedComponent[A <: NamedComponent]: Targetable[A] = new Targetable[A] {
+    def toTarget(a:         A):                           IsMember = a.toTarget
+    def toAbsoluteTarget(a: A):                           IsMember = a.toAbsoluteTarget
+    def toRelativeTarget(a: A, root: Option[BaseModule]): IsMember = a.toRelativeTarget(root)
+    def toRelativeTargetToHierarchy(a: A, root: Option[Hierarchy[BaseModule]]): IsMember =
+      a.toRelativeTargetToHierarchy(root)
+  }
+
+  implicit def forBaseModule[A <: BaseModule]: Targetable[A] = new Targetable[A] {
+    def toTarget(a:         A):                           IsMember = a.toTarget
+    def toAbsoluteTarget(a: A):                           IsMember = a.toAbsoluteTarget
+    def toRelativeTarget(a: A, root: Option[BaseModule]): IsMember = a.toRelativeTarget(root)
+    def toRelativeTargetToHierarchy(a: A, root: Option[Hierarchy[BaseModule]]): IsMember =
+      a.toRelativeTargetToHierarchy(root)
+  }
+
+  implicit def forHierarchy[A <: BaseModule, H[A] <: Hierarchy[A]]: Targetable[H[A]] = new Targetable[H[A]] {
+    def toTarget(b:         H[A]):                           IsMember = b.toTarget
+    def toAbsoluteTarget(b: H[A]):                           IsMember = b.toAbsoluteTarget
+    def toRelativeTarget(b: H[A], root: Option[BaseModule]): IsMember = b.toRelativeTarget(root)
+    def toRelativeTargetToHierarchy(b: H[A], root: Option[Hierarchy[BaseModule]]): IsMember =
+      b.toRelativeTargetToHierarchy(root)
+  }
+
+  implicit def forHasTarget: Targetable[HasTarget] = new Targetable[HasTarget] {
+    def toTarget(a:         HasTarget):                           IsMember = a.toTarget
+    def toAbsoluteTarget(a: HasTarget):                           IsMember = a.toAbsoluteTarget
+    def toRelativeTarget(a: HasTarget, root: Option[BaseModule]): IsMember = a.toRelativeTarget(root)
+    def toRelativeTargetToHierarchy(a: HasTarget, root: Option[Hierarchy[BaseModule]]): IsMember =
+      a.toRelativeTargetToHierarchy(root)
+  }
+}
+
+/** Existential Type class for types that can be converted to a Target
+  *
+  * This is useful for containers of Targetables.
+  */
+sealed trait AnyTargetable {
+  type A
+  def a:          A
+  def targetable: Targetable[A]
+
+  // Convenience methods
+  def toTarget:                                   IsMember = targetable.toTarget(a)
+  def toAbsoluteTarget:                           IsMember = targetable.toAbsoluteTarget(a)
+  def toRelativeTarget(root: Option[BaseModule]): IsMember = targetable.toRelativeTarget(a, root)
+  def toRelativeTargetToHierarchy(root: Option[Hierarchy[BaseModule]]): IsMember =
+    targetable.toRelativeTargetToHierarchy(a, root)
+}
+
+object AnyTargetable {
+
+  /** Implicit conversion making working with Targetables easier */
+  implicit def toAnyTargetable[A](a: A)(implicit targetable: Targetable[A]): AnyTargetable = {
+    type _A = A
+    val _a = a
+    val _targetable = targetable
+    new AnyTargetable {
+      type A = _A
+      val a:          A = _a
+      val targetable: Targetable[A] = _targetable
+    }
+  }
+}

--- a/core/src/main/scala/chisel3/experimental/Trace.scala
+++ b/core/src/main/scala/chisel3/experimental/Trace.scala
@@ -23,9 +23,7 @@ object Trace {
 
   /** Trace a Instance name. */
   def traceName(x: RawModule): Unit = {
-    annotate(new ChiselAnnotation {
-      def toFirrtl: Annotation = TraceAnnotation(x.toAbsoluteTarget, x.toAbsoluteTarget)
-    })
+    annotate(x)(Seq(TraceAnnotation(x.toAbsoluteTarget, x.toAbsoluteTarget)))
   }
 
   /** Trace a Data name. This does NOT add "don't touch" semantics to the traced data. If you want this behavior, use an explicit [[chisel3.dontTouch]]. */
@@ -34,9 +32,7 @@ object Trace {
       case aggregate: Aggregate =>
         aggregate.elementsIterator.foreach(traceName)
       case element: Element =>
-        annotate(new ChiselAnnotation {
-          def toFirrtl: Annotation = TraceAnnotation(element.toAbsoluteTarget, element.toAbsoluteTarget)
-        })
+        annotate(element)(Seq(TraceAnnotation(element.toAbsoluteTarget, element.toAbsoluteTarget)))
     }
   }
 

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -124,6 +124,7 @@ object Definition extends SourceInfoDoc {
     val (ir, module) = Builder.build(Module(proto), dynamicContext)
     Builder.components ++= ir._circuit.components
     Builder.annotations ++= ir._circuit.annotations
+    Builder.newAnnotations ++= ir._circuit.newAnnotations
     Builder.layers ++= dynamicContext.layers
     Builder.options ++= dynamicContext.options
     module._circuit = Builder.currentModule

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -23,7 +23,7 @@ import chisel3.internal.Builder.Prefix
 import logger.{LazyLogging, LoggerOption}
 
 import scala.collection.mutable
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import java.io.File
 import scala.util.control.NonFatal
 import chisel3.ChiselException
@@ -476,6 +476,7 @@ private[chisel3] class ChiselContext() {
   var modulePrefixStack: List[(String, Boolean)] = Nil
 }
 
+@nowarn("msg=Avoid custom annotations")
 private[chisel3] class DynamicContext(
   val annotationSeq:       AnnotationSeq,
   val throwOnFirstError:   Boolean,
@@ -570,6 +571,7 @@ private[chisel3] class DynamicContext(
   var inDefinition: Boolean = false
 }
 
+@nowarn("msg=Avoid custom annotations")
 private[chisel3] object Builder extends LazyLogging {
 
   // Represents the current state of the prefixes given

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -567,6 +567,7 @@ private[chisel3] object ir {
 
   case class DefClass(id: Class, name: String, ports: Seq[Port], block: Block) extends Component
 
+  @nowarn("msg=Avoid custom annotations")
   case class Circuit(
     name:           String,
     components:     Seq[Component],
@@ -595,6 +596,7 @@ private[chisel3] object ir {
       )
   }
 
+  @nowarn("msg=Avoid custom annotations")
   object Circuit
       extends scala.runtime.AbstractFunction7[String, Seq[Component], Seq[ChiselAnnotation], RenameMap, Seq[
         DefTypeAlias

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -151,6 +151,7 @@ package object chisel3 {
     * currently, the node's name, the full path name, and references to its parent Module and component.
     * These are only valid once the design has been elaborated, and should not be used during its construction.
     */
+  @deprecated("User-defined annotations are not supported in CIRCT, use Targetable if you must.", "Chisel 6.7.0")
   trait InstanceId {
     def instanceName:   String
     def pathName:       String

--- a/docs/src/cookbooks/hierarchy.md
+++ b/docs/src/cookbooks/hierarchy.md
@@ -379,19 +379,13 @@ There are seven hierarchy-specific functions, which (with the exception of `ios`
  - `allDefinitionsOf[type]`: Return all definitions of instances of provided `type` directly and indirectly instantiated, locally and deeply, starting from `root`
  - `ios`: Returns all the I/Os of the provided definition or instance.
 
-To demonstrate this, consider the following. We mock up an example where we are using the `Select.allInstancesOf` and `Select.allDefinitionsOf` to annotate instances and the definition of `EmptyModule`. When converting the `ChiselAnnotation` to firrtl's `Annotation`, we print out the resulting `Target`. As shown, despite `EmptyModule` actually only being elaborated once, we still provide different targets depending on how the instance or definition is selected.
+To demonstrate this, consider the following. We mock up an example where we are using the `Select.allInstancesOf` and `Select.allDefinitionsOf` to annotate instances and the definition of `EmptyModule`.
+When the annotation logic is execute after elaboration, we print the resulting `Target`.
+As shown, despite `EmptyModule` actually only being elaborated once, we still provide different targets depending on how the instance or definition is selected.
 
 ```scala mdoc:reset
 import chisel3._
 import chisel3.experimental.hierarchy.{Definition, Instance, Hierarchy, instantiable, public}
-import firrtl.annotations.{IsModule, NoTargetAnnotation}
-case object EmptyAnnotation extends NoTargetAnnotation
-case class MyChiselAnnotation(m: Hierarchy[RawModule], tag: String) extends experimental.ChiselAnnotation {
-  def toFirrtl = {
-    println(tag + ": " + m.toTarget)
-    EmptyAnnotation
-  }
-}
 
 @instantiable
 class EmptyModule extends Module {
@@ -409,10 +403,16 @@ class Top extends Module {
   val definition = Definition(new TwoEmptyModules)
   val instance   = Instance(definition)
   aop.Select.allInstancesOf[EmptyModule](instance).foreach { i =>
-    experimental.annotate(MyChiselAnnotation(i, "instance"))
+    experimental.annotate(i) {
+      println("instance: " + i.toTarget)
+      Nil
+    }
   }
   aop.Select.allDefinitionsOf[EmptyModule](instance).foreach { d =>
-    experimental.annotate(MyChiselAnnotation(d, "definition"))
+    experimental.annotate(d) {
+      println("definition: " + d.toTarget)
+      Nil
+    }
   }
 }
 ```
@@ -425,13 +425,6 @@ println("```")
 You can also use `Select.ios` on either a `Definition` or an `Instance` to annotate the I/Os appropriately:
 
 ```scala mdoc
-case class MyIOAnnotation(m: Data, tag: String) extends experimental.ChiselAnnotation {
-  def toFirrtl = {
-    println(tag + ": " + m.toTarget)
-    EmptyAnnotation
-  }
-}
-
 @instantiable
 class InOutModule extends Module {
   @public val in = IO(Input(Bool()))
@@ -456,12 +449,20 @@ class InOutTop extends Module {
   val instance   = Instance(definition)
   aop.Select.allInstancesOf[InOutModule](instance).foreach { i =>
     aop.Select.ios(i).foreach { io =>
-      experimental.annotate(MyIOAnnotation(io, "instance io"))
-  }}
+      experimental.annotate(io) {
+        println("instance io: " + io.toTarget)
+        Nil
+      }
+    }
+  }
   aop.Select.allDefinitionsOf[InOutModule](instance).foreach { d =>
-    aop.Select.ios(d).foreach {io =>
-      experimental.annotate(MyIOAnnotation(io, "definition io"))
-  }}
+    aop.Select.ios(d).foreach { io =>
+      experimental.annotate(io) {
+        println("definition io: " + io.toTarget)
+        Nil
+      }
+    }
+  }
 }
 ```
 ```scala mdoc:passthrough

--- a/src/main/scala/chisel3/util/AttributeAnnotation.scala
+++ b/src/main/scala/chisel3/util/AttributeAnnotation.scala
@@ -35,9 +35,6 @@ object addAttribute {
     * @param annoString attribute string to add to target.
     */
   def apply(target: Data, annoString: String): Unit = {
-    requireIsAnnotatable(target, "target must be annotatable")
-    annotate(new ChiselAnnotation {
-      def toFirrtl = AttributeAnnotation(target.toNamed, annoString)
-    })
+    annotate(target)(Seq(AttributeAnnotation(target.toNamed, annoString)))
   }
 }

--- a/src/main/scala/chisel3/util/BlackBoxUtils.scala
+++ b/src/main/scala/chisel3/util/BlackBoxUtils.scala
@@ -45,10 +45,7 @@ trait HasBlackBoxResource extends BlackBox {
     * }}}
     */
   def addResource(blackBoxResource: String): Unit = {
-    val anno = new ChiselAnnotation {
-      def toFirrtl = BlackBoxInlineAnno.fromResource(blackBoxResource, self.toNamed)
-    }
-    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(self)(Seq(BlackBoxInlineAnno.fromResource(blackBoxResource, self.toNamed)))
   }
 }
 
@@ -61,10 +58,7 @@ trait HasBlackBoxInline extends BlackBox {
     * @param blackBoxInline The black box contents
     */
   def setInline(blackBoxName: String, blackBoxInline: String): Unit = {
-    val anno = new ChiselAnnotation {
-      def toFirrtl = BlackBoxInlineAnno(self.toNamed, blackBoxName, blackBoxInline)
-    }
-    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(self)(Seq(BlackBoxInlineAnno(self.toNamed, blackBoxName, blackBoxInline)))
   }
 }
 
@@ -78,9 +72,6 @@ trait HasBlackBoxPath extends BlackBox {
     * target directory.
     */
   def addPath(blackBoxPath: String): Unit = {
-    val anno = new ChiselAnnotation {
-      def toFirrtl = BlackBoxPathAnno(self.toNamed, blackBoxPath)
-    }
-    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(self)(Seq(BlackBoxPathAnno(self.toNamed, blackBoxPath)))
   }
 }

--- a/src/main/scala/chisel3/util/ExtModuleUtils.scala
+++ b/src/main/scala/chisel3/util/ExtModuleUtils.scala
@@ -19,10 +19,7 @@ trait HasExtModuleResource extends ExtModule {
     * }}}
     */
   def addResource(blackBoxResource: String): Unit = {
-    val anno = new ChiselAnnotation {
-      def toFirrtl = BlackBoxInlineAnno.fromResource(blackBoxResource, self.toNamed)
-    }
-    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(self)(Seq(BlackBoxInlineAnno.fromResource(blackBoxResource, self.toNamed)))
   }
 }
 
@@ -35,10 +32,7 @@ trait HasExtModuleInline extends ExtModule {
     * @param blackBoxInline The black box contents
     */
   def setInline(blackBoxName: String, blackBoxInline: String): Unit = {
-    val anno = new ChiselAnnotation {
-      def toFirrtl = BlackBoxInlineAnno(self.toNamed, blackBoxName, blackBoxInline)
-    }
-    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(self)(Seq(BlackBoxInlineAnno(self.toNamed, blackBoxName, blackBoxInline)))
   }
 }
 
@@ -52,9 +46,6 @@ trait HasExtModulePath extends ExtModule {
     * target directory.
     */
   def addPath(blackBoxPath: String): Unit = {
-    val anno = new ChiselAnnotation {
-      def toFirrtl = BlackBoxPathAnno(self.toNamed, blackBoxPath)
-    }
-    chisel3.experimental.annotate(anno)
+    chisel3.experimental.annotate(self)(Seq(BlackBoxPathAnno(self.toNamed, blackBoxPath)))
   }
 }

--- a/src/main/scala/chisel3/util/experimental/ForceNames.scala
+++ b/src/main/scala/chisel3/util/experimental/ForceNames.scala
@@ -15,12 +15,7 @@ object forceName {
     * @param instance Instance to name
     */
   def apply(instance: chisel3.experimental.BaseModule, name: String): Unit = {
-    annotate(new ChiselAnnotation {
-      def toFirrtl = {
-        val t = instance.toAbsoluteTarget
-        ForceNameAnnotation(t, name)
-      }
-    })
+    annotate(instance)(Seq(ForceNameAnnotation(instance.toAbsoluteTarget, name)))
   }
 
   /** Force the name of this instance to the name its given during Chisel compilation
@@ -29,12 +24,7 @@ object forceName {
     * @param instance Signal to name
     */
   def apply(instance: chisel3.experimental.BaseModule): Unit = {
-    annotate(new ChiselAnnotation {
-      def toFirrtl = {
-        val t = instance.toAbsoluteTarget
-        ForceNameAnnotation(t, instance.instanceName)
-      }
-    })
+    annotate(instance)(Seq(ForceNameAnnotation(instance.toAbsoluteTarget, instance.instanceName)))
   }
 }
 

--- a/src/main/scala/chisel3/util/experimental/Inline.scala
+++ b/src/main/scala/chisel3/util/experimental/Inline.scala
@@ -39,26 +39,14 @@ import firrtl.annotations.Annotation
   * }}}
   */
 trait InlineInstance { self: BaseModule =>
-  Seq(
-    new ChiselAnnotation {
-      def toFirrtl: Annotation = InlineAnnotation(self.toNamed)
-    },
-    new ChiselAnnotation {
-      def toFirrtl: Annotation = NoDedupAnnotation(self.toNamed)
-    }
-  )
-    .map(chisel3.experimental.annotate(_))
+  chisel3.experimental.annotate(self)(Seq(InlineAnnotation(self.toNamed), NoDedupAnnotation(self.toNamed)))
 }
 
 /** Inlines all instances of a module. If this module dedups with any other
   * module, instances of that other module will also be inlined.
   */
 trait InlineInstanceAllowDedup { self: BaseModule =>
-  chisel3.experimental.annotate(
-    new ChiselAnnotation {
-      def toFirrtl: Annotation = InlineAnnotation(self.toNamed)
-    }
-  )
+  chisel3.experimental.annotate(self)(Seq(InlineAnnotation(self.toNamed)))
 }
 
 /** Flattens an instance of a module
@@ -88,13 +76,5 @@ trait InlineInstanceAllowDedup { self: BaseModule =>
   * }}}
   */
 trait FlattenInstance { self: BaseModule =>
-  Seq(
-    new ChiselAnnotation {
-      def toFirrtl: Annotation = FlattenAnnotation(self.toNamed)
-    },
-    new ChiselAnnotation {
-      def toFirrtl: Annotation = NoDedupAnnotation(self.toNamed)
-    }
-  )
-    .map(chisel3.experimental.annotate(_))
+  chisel3.experimental.annotate(self)(Seq(FlattenAnnotation(self.toNamed), NoDedupAnnotation(self.toNamed)))
 }

--- a/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
+++ b/src/main/scala/chisel3/util/experimental/LoadMemoryTransform.scala
@@ -8,30 +8,6 @@ import firrtl.annotations.{ComponentName, LoadMemoryAnnotation, MemoryFileInline
 
 import scala.collection.mutable
 
-/** This is the annotation created when using [[loadMemoryFromFile]], it records the memory, the load file
-  * and the format of the file.
-  * @param target        memory to load
-  * @param fileName      name of input file
-  * @param hexOrBinary   use \$readmemh or \$readmemb, i.e. hex or binary text input, default is hex
-  */
-private case class ChiselLoadMemoryAnnotation[T <: Data](
-  target:      MemBase[T],
-  fileName:    String,
-  hexOrBinary: MemoryLoadFileType.FileType = MemoryLoadFileType.Hex
-) extends ChiselAnnotation {
-
-  if (fileName.isEmpty) {
-    throw new Exception(
-      s"""LoadMemory from file annotations file empty file name"""
-    )
-  }
-
-  def toFirrtl: LoadMemoryAnnotation = {
-    val tx = target.toNamed.asInstanceOf[ComponentName]
-    LoadMemoryAnnotation(tx, fileName, hexOrBinary, Some(tx.name))
-  }
-}
-
 /** [[loadMemoryFromFile]] is an annotation generator that helps with loading a memory from a text file as a bind module. This relies on
   * Verilator and Verilog's `\$readmemh` or `\$readmemb`.
   *
@@ -102,7 +78,16 @@ object loadMemoryFromFile {
     fileName:    String,
     hexOrBinary: MemoryLoadFileType.FileType = MemoryLoadFileType.Hex
   ): Unit = {
-    annotate(ChiselLoadMemoryAnnotation(memory, fileName, hexOrBinary))
+    if (fileName.isEmpty) {
+      throw new Exception(
+        s"""LoadMemory from file annotations file empty file name"""
+      )
+    }
+    annotate(memory)({
+      // Note this is a by-name thunk, not executed until end of elaboration
+      val tx = memory.toNamed.asInstanceOf[ComponentName]
+      Seq(LoadMemoryAnnotation(tx, fileName, hexOrBinary, Some(tx.name)))
+    })
   }
 }
 
@@ -177,8 +162,6 @@ object loadMemoryFromFileInline {
     fileName:    String,
     hexOrBinary: MemoryLoadFileType.FileType = MemoryLoadFileType.Hex
   ): Unit = {
-    annotate(new ChiselAnnotation {
-      override def toFirrtl = MemoryFileInlineAnnotation(memory.toTarget, fileName, hexOrBinary)
-    })
+    annotate(memory)(Seq(MemoryFileInlineAnnotation(memory.toTarget, fileName, hexOrBinary)))
   }
 }

--- a/src/main/scala/chisel3/util/experimental/decode/decoder.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/decoder.scala
@@ -31,11 +31,7 @@ object decoder extends LazyLogging {
       val (plaInput, plaOutput) =
         pla(minimizedTable.table.toSeq, BitPat(minimizedTable.default.value.U(minimizedTable.default.getWidth.W)))
 
-      requireIsAnnotatable(plaOutput, "DecodeTableAnnotation target")
-      annotate(new ChiselAnnotation {
-        override def toFirrtl: Annotation =
-          DecodeTableAnnotation(plaOutput.toTarget, truthTable.toString, minimizedTable.toString)
-      })
+      annotate(plaOutput)(Seq(DecodeTableAnnotation(plaOutput.toTarget, truthTable.toString, minimizedTable.toString)))
 
       plaInput := input
       plaOutput

--- a/src/main/scala/circt/Convention.scala
+++ b/src/main/scala/circt/Convention.scala
@@ -32,9 +32,7 @@ case class ConventionAnnotation(target: ModuleTarget, convention: String) extend
   */
 object convention {
   private def apply[T <: BaseModule](data: T, convention: String): Unit =
-    annotate(new ChiselAnnotation {
-      def toFirrtl = ConventionAnnotation(data.toTarget, convention)
-    })
+    annotate(data)(Seq(ConventionAnnotation(data.toTarget, convention)))
 
   /** Annotate a module as having the "scalarized" port convention.
     * With this port convention, the aggregate ports of the module will be

--- a/src/main/scala/circt/OutputDirAnnotation.scala
+++ b/src/main/scala/circt/OutputDirAnnotation.scala
@@ -26,9 +26,7 @@ case class OutputDirAnnotation(target: ModuleTarget, dirname: String) extends Si
   */
 object outputDir {
   def apply[T <: BaseModule](data: T, dirname: String): T = {
-    annotate(new ChiselAnnotation {
-      def toFirrtl = OutputDirAnnotation(data.toTarget, dirname)
-    })
+    annotate(data)(Seq(OutputDirAnnotation(data.toTarget, dirname)))
     data
   }
 }

--- a/src/test/scala-2/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala-2/chiselTests/AnnotatingDiamondSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.experimental.{annotate, ChiselAnnotation}
+import chisel3.experimental.{annotate, AnyTargetable}
 import chisel3.stage.ChiselGeneratorAnnotation
 import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
@@ -19,14 +19,9 @@ case class IdentityAnnotation(target: Target, value: String) extends SingleTarge
   def duplicate(n: Target): IdentityAnnotation = this.copy(target = n)
 }
 
-/** ChiselAnnotation that corresponds to the above FIRRTL annotation */
-case class IdentityChiselAnnotation(target: InstanceId, value: String) extends ChiselAnnotation {
-  def toFirrtl: IdentityAnnotation = IdentityAnnotation(target.toNamed, value)
-}
 object identify {
-  def apply(component: InstanceId, value: String): Unit = {
-    val anno = IdentityChiselAnnotation(component, value)
-    annotate(anno)
+  def apply(component: AnyTargetable, value: String): Unit = {
+    annotate(component)(Seq(IdentityAnnotation(component.toTarget, value)))
   }
 }
 

--- a/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
@@ -5,7 +5,7 @@ package chiselTests
 import chisel3._
 import chisel3.util.Counter
 import chisel3.testers._
-import chisel3.experimental.{BaseModule, ChiselAnnotation, OpaqueType}
+import chisel3.experimental.{BaseModule, OpaqueType}
 import chisel3.probe._
 import chisel3.properties.Property
 import chisel3.util.experimental.BoringUtils
@@ -43,10 +43,7 @@ class BoringUtilsSpec extends ChiselFlatSpec with ChiselRunners with Utils with 
   }
 
   trait WireX { this: BaseModule =>
-    val x = Wire(UInt(4.W))
-    chisel3.experimental.annotate(new ChiselAnnotation {
-      def toFirrtl: Annotation = DontTouchAnnotation(x.toNamed)
-    })
+    val x = dontTouch(Wire(UInt(4.W)))
   }
 
   class Source extends RawModule with WireX {

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -12,6 +12,8 @@ import org.scalatest.Assertion
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.annotation.nowarn
+
 object EnumExample extends ChiselEnum {
   val e0, e1, e2 = Value
 
@@ -749,6 +751,7 @@ class ChiselEnumAnnotatorWithChiselName extends Module {
   val indexed2 = vec_of_bundles(cycle)
 }
 
+@nowarn("msg=Enum annotations will be removed")
 class ChiselEnumAnnotationSpec extends AnyFreeSpec with Matchers {
   import chisel3.experimental.EnumAnnotations._
   import firrtl.annotations.{Annotation, ComponentName}

--- a/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
+++ b/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
@@ -1,6 +1,6 @@
 package chiselTests
 import chisel3._
-import chisel3.experimental.{annotate, ChiselMultiAnnotation}
+import chisel3.experimental.annotate
 import chisel3.stage.ChiselGeneratorAnnotation
 import circt.stage.ChiselStage
 import firrtl.stage.FirrtlCircuitAnnotation
@@ -37,14 +37,13 @@ class NewAnnotationsSpec extends AnyFreeSpec with Matchers {
     io.out := mod3.io.out
 
     // Give two annotations as single element of the seq - ensures previous API works by wrapping into a seq.
-    annotate(new ChiselMultiAnnotation { def toFirrtl = Seq(new NoDedupAnnotation(mod2.toNamed)) })
-    annotate(new ChiselMultiAnnotation { def toFirrtl = Seq(new NoDedupAnnotation(mod3.toNamed)) })
+    annotate(mod2)(Seq(new NoDedupAnnotation(mod2.toNamed)))
+    annotate(mod3)(Seq(new NoDedupAnnotation(mod3.toNamed)))
 
     // Pass multiple annotations in the same seq - should get emitted out correctly.
-    annotate(new ChiselMultiAnnotation {
-      def toFirrtl =
-        Seq(new DontTouchAnnotation(mod1.io.in.toNamed), new DontTouchAnnotation(mod1.io.out.toNamed))
-    })
+    annotate(mod1.io.in, mod1.io.out)(
+      Seq(new DontTouchAnnotation(mod1.io.in.toNamed), new DontTouchAnnotation(mod1.io.out.toNamed))
+    )
   }
 
   val stage = new ChiselStage

--- a/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.experimental.dataview._
 import chisel3.experimental.conversions._
-import chisel3.experimental.{annotate, ChiselAnnotation}
+import chisel3.experimental.annotate
 import chiselTests.ChiselFlatSpec
 
 object DataViewTargetSpec {
@@ -14,15 +14,10 @@ object DataViewTargetSpec {
   private case class DummyAnno(target: ReferenceTarget, id: Int) extends SingleTargetAnnotation[ReferenceTarget] {
     override def duplicate(n: ReferenceTarget) = this.copy(target = n)
   }
-  private def mark(d: Data, id: Int) = annotate(new ChiselAnnotation {
-    override def toFirrtl: Annotation = DummyAnno(d.toTarget, id)
-  })
-  private def markAbs(d: Data, id: Int) = annotate(new ChiselAnnotation {
-    override def toFirrtl: Annotation = DummyAnno(d.toAbsoluteTarget, id)
-  })
-  private def markRel(d: Data, root: Option[BaseModule], id: Int) = annotate(new ChiselAnnotation {
-    override def toFirrtl: Annotation = DummyAnno(d.toRelativeTarget(root), id)
-  })
+  private def mark(d:    Data, id: Int) = annotate(d)(Seq(DummyAnno(d.toTarget, id)))
+  private def markAbs(d: Data, id: Int) = annotate(d)(Seq(DummyAnno(d.toAbsoluteTarget, id)))
+  private def markRel(d: Data, root: Option[BaseModule], id: Int) =
+    annotate(d)(Seq(DummyAnno(d.toRelativeTarget(root), id)))
 }
 
 class DataViewTargetSpec extends ChiselFlatSpec {

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Annotations.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Annotations.scala
@@ -3,7 +3,7 @@
 package chiselTests.experimental.hierarchy
 
 import _root_.firrtl.annotations._
-import chisel3.experimental.{annotate, BaseModule}
+import chisel3.experimental.{annotate, BaseModule, Targetable}
 import chisel3.{Data, HasTarget, MemBase}
 import chisel3.experimental.hierarchy.{Definition, Hierarchy, Instance}
 
@@ -12,26 +12,10 @@ private[hierarchy] object Annotations {
   case class MarkAnnotation(target: IsMember, tag: String) extends SingleTargetAnnotation[IsMember] {
     def duplicate(n: IsMember): Annotation = this.copy(target = n)
   }
-  case class MarkChiselHierarchyAnnotation[B <: BaseModule](d: Hierarchy[B], tag: String, isAbsolute: Boolean)
-      extends chisel3.experimental.ChiselAnnotation {
-    def toFirrtl = MarkAnnotation(d.toTarget, tag)
-  }
-  case class MarkChiselAnnotation(d: Data, tag: String, isAbsolute: Boolean)
-      extends chisel3.experimental.ChiselAnnotation {
-    def toFirrtl = if (isAbsolute) MarkAnnotation(d.toAbsoluteTarget, tag) else MarkAnnotation(d.toTarget, tag)
-  }
-  case class MarkChiselMemAnnotation[T <: Data](m: MemBase[T], tag: String, isAbsolute: Boolean)
-      extends chisel3.experimental.ChiselAnnotation {
-    def toFirrtl = if (isAbsolute) MarkAnnotation(m.toAbsoluteTarget, tag) else MarkAnnotation(m.toTarget, tag)
-  }
-  case class MarkChiselHasTargetAnnotation(d: HasTarget, tag: String, isAbsolute: Boolean)
-      extends chisel3.experimental.ChiselAnnotation {
-    def toFirrtl = if (isAbsolute) MarkAnnotation(d.toAbsoluteTarget, tag) else MarkAnnotation(d.toTarget, tag)
-  }
-  def mark(d:                  Data, tag:         String): Unit = annotate(MarkChiselAnnotation(d, tag, false))
-  def mark[T <: Data](d:       MemBase[T], tag:   String): Unit = annotate(MarkChiselMemAnnotation(d, tag, false))
-  def mark(d:                  HasTarget, tag:    String): Unit = annotate(MarkChiselHasTargetAnnotation(d, tag, false))
-  def mark[B <: BaseModule](d: Hierarchy[B], tag: String): Unit = annotate(MarkChiselHierarchyAnnotation(d, tag, true))
-  def amark(d:                 Data, tag:         String): Unit = annotate(MarkChiselAnnotation(d, tag, true))
-  def amark[B <: BaseModule](d: Hierarchy[B], tag: String): Unit = annotate(MarkChiselHierarchyAnnotation(d, tag, true))
+  def mark(d:                  Data, tag:         String): Unit = annotate(d)(Seq(MarkAnnotation(d.toTarget, tag)))
+  def mark[T <: Data](d:       MemBase[T], tag:   String): Unit = annotate(d)(Seq(MarkAnnotation(d.toTarget, tag)))
+  def mark(d:                  HasTarget, tag:    String): Unit = annotate(d)(Seq(MarkAnnotation(d.toTarget, tag)))
+  def mark[B <: BaseModule](d: Hierarchy[B], tag: String): Unit = annotate(d)(Seq(MarkAnnotation(d.toTarget, tag)))
+  def amark(d: Data, tag: String): Unit = annotate(d)(Seq(MarkAnnotation(d.toAbsoluteTarget, tag)))
+  def amark[B <: BaseModule](d: Hierarchy[B], tag: String): Unit = annotate(d)(Seq(MarkAnnotation(d.toTarget, tag)))
 }

--- a/src/test/scala-2/chiselTests/stage/phases/ConvertSpec.scala
+++ b/src/test/scala-2/chiselTests/stage/phases/ConvertSpec.scala
@@ -3,7 +3,6 @@
 package chiselTests.stage.phases
 
 import chisel3._
-import chisel3.experimental.ChiselAnnotation
 import chisel3.stage.ChiselGeneratorAnnotation
 import chisel3.stage.phases.{Convert, Elaborate}
 
@@ -16,17 +15,13 @@ import org.scalatest.matchers.should.Matchers
 
 case class ConvertSpecFirrtlAnnotation(name: String) extends NoTargetAnnotation
 
-case class ConvertSpecChiselAnnotation(name: String) extends ChiselAnnotation {
-  def toFirrtl: Annotation = ConvertSpecFirrtlAnnotation(name)
-}
-
 class ConvertSpecFoo extends RawModule {
   override val desiredName: String = "foo"
 
   val in = IO(Input(Bool()))
   val out = IO(Output(Bool()))
 
-  experimental.annotate(ConvertSpecChiselAnnotation("bar"))
+  chisel3.experimental.annotate()(Seq(ConvertSpecFirrtlAnnotation("bar")))
 }
 
 class ConvertSpec extends AnyFlatSpec with Matchers {

--- a/src/test/scala-2/chiselTests/util/SRAMSpec.scala
+++ b/src/test/scala-2/chiselTests/util/SRAMSpec.scala
@@ -5,7 +5,7 @@ package chiselTests.util
 import _root_.circt.stage.ChiselStage.{emitCHIRRTL, emitSystemVerilog}
 import _root_.circt.stage.{CIRCTTarget, CIRCTTargetAnnotation, ChiselStage}
 import chisel3._
-import chisel3.experimental.{annotate, ChiselAnnotation, OpaqueType}
+import chisel3.experimental.{annotate, OpaqueType}
 import chisel3.stage.{ChiselGeneratorAnnotation, IncludeUtilMetadata, UseSRAMBlackbox}
 import chisel3.util.{MemoryReadWritePort, SRAM}
 import chiselTests.ChiselFlatSpec
@@ -32,9 +32,7 @@ class SRAMSpec extends ChiselFlatSpec {
         numReadwritePorts = 1
       )
       require(sram.underlying.nonEmpty)
-      annotate(new ChiselAnnotation {
-        override def toFirrtl: Annotation = DummyAnno(sram.underlying.get.toTarget)
-      })
+      annotate(sram.underlying.get)(Seq(DummyAnno(sram.underlying.get.toTarget)))
     }
     val (chirrtlCircuit, annos) = getFirrtlAndAnnos(new Top, providedAnnotations = Seq(IncludeUtilMetadata))
     val chirrtl = chirrtlCircuit.serialize
@@ -76,9 +74,7 @@ class SRAMSpec extends ChiselFlatSpec {
       )
       require(sramInterface.underlying.nonEmpty)
       sramInterface.underlying.get.suggestName("carrot")
-      annotate(new ChiselAnnotation {
-        override def toFirrtl: Annotation = DummyAnno(sramInterface.underlying.get.toTarget)
-      })
+      annotate(sramInterface.underlying.get)(Seq(DummyAnno(sramInterface.underlying.get.toTarget)))
     }
     val (chirrtlCircuit, annos) = getFirrtlAndAnnos(new Top)
     val chirrtl = chirrtlCircuit.serialize

--- a/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
@@ -76,9 +76,7 @@ object ChiselStageSpec {
     val a = IO(Input(Bool()))
     val b = IO(Output(Bool()))
     b := a
-    chisel3.experimental.annotate(new chisel3.experimental.ChiselAnnotation {
-      def toFirrtl = DummyAnnotation
-    })
+    chisel3.experimental.annotate()(Seq(DummyAnnotation))
   }
 
   class UserAssertionModule extends RawModule {
@@ -593,7 +591,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       val lines = stdout.split("\n")
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines(0) should include(
-        "src/test/scala-2/circtTests/stage/ChiselStageSpec.scala 97:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala-2/circtTests/stage/ChiselStageSpec.scala 95:9: Negative shift amounts are illegal (got -1)"
       )
       lines(1) should include("    3.U >> -1")
       lines(2) should include("        ^")
@@ -614,7 +612,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
       // Fuzzy includes aren't ideal but there is ANSI color in these strings that is hard to match
       lines.size should equal(2)
       lines(0) should include(
-        "src/test/scala-2/circtTests/stage/ChiselStageSpec.scala 97:9: Negative shift amounts are illegal (got -1)"
+        "src/test/scala-2/circtTests/stage/ChiselStageSpec.scala 95:9: Negative shift amounts are illegal (got -1)"
       )
       (lines(1) should not).include("3.U >> -1")
     }


### PR DESCRIPTION
Note that I tested that the deprecated versions of `annotate` work by updating them first, making sure all tests pass, then removing all uses of ChiselAnnotation and ChiselMultiAnnotation except in ChiselEnum. The ones in ChiselEnum have duplication checking that I could replicate with the annotations, but is annoying. I figure we'd rather just remove those (and roll out firrtl enums? 🙏) so I just left them. They also do help test the deprecated APIs.

This PR has two purposes:
1. Make it possible to check that any data being annotated are annotatable. You can see we've done that for some annotations but not all--this new API enforces it for all annotations (or at least encourages enforcement).
2. By [softly] requiring the user to record what Data are being annotated up front, we can improve the view renaming logic. Rather than having to conservatively rename tons and tons of views, we only do so for those that are actually annotated. This should be a huge performance improvement for designs that use lots of views.

(2) will be in a follow on PR.

One weirdness in the PR that I would appreciate review of is that the new API asks the caller to "report" all `InstanceIds` that will be annotated. We really only currently care about `Data` but I figure in the future we may want checks for other things. The awkwardness though, is that `InstanceId` includes `Data`, `BaseModule`, and `MemBase`, but not `Hierarchy` nor the new SRAM targets. So if we wanted more checks, we might need to change the API anyway in the future since users can't currently report `Hierarchy` or `SRAM` targets being annotated. I could take a step back and try to find a way to unify all of these, or just leave it, or switch the API to `Data` to make it more clear that that is all we're checking. WDYT?



### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Creating annotations in Chisel now requires reporting what `InstanceIds` are going to be annotated so that Chisel can do some safety checks.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
