### PR TITLE
Selective view renaming

### DIFF
--- a/core/src/main/scala/chisel3/Annotation.scala
+++ b/core/src/main/scala/chisel3/Annotation.scala
@@ -22,7 +22,11 @@ object annotate {
     */
   def apply(targets: AnyTargetable*)(mkAnnos: => Seq[Annotation]): Unit = {
     targets.map(_.a).foreach {
-      case d: Data => requireIsAnnotatable(d, "Data marked with annotation")
+      case d: Data =>
+        requireIsAnnotatable(d, "Data marked with annotation")
+        if (dataview.isView(d)) {
+          dataview.recordViewForRenaming(d)
+        }
       case _ => ()
     }
     Builder.annotations += (() => mkAnnos)

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -331,20 +331,6 @@ object Lookupable {
       case _ => throw new InternalErrorException(s"Match error: data.topBinding=${data.topBinding}")
     }
 
-    // TODO Unify the following with `.viewAs`
-    // We must also mark any non-identity Aggregates as unnammed
-    newBinding match {
-      case _: ViewBinding => // Do nothing
-      case AggregateViewBinding(childMap, _) =>
-        // TODO we could do reifySingleTarget instead of just marking non-identity mappings
-        getRecursiveFields.lazily(result, "_").foreach {
-          case (agg: Aggregate, _) if !childMap.contains(agg) =>
-            Builder.unnamedViews += agg
-          case _ => ()
-        }
-      case _ => throw new InternalErrorException(s"Match error: newBinding=$newBinding")
-    }
-
     result.bind(newBinding)
     result.setAllParents(Some(ViewParent))
     result.forceName("view", Builder.viewNamespace)


### PR DESCRIPTION
Now depends on https://github.com/chipsalliance/chisel/pull/4717.

Because views may not map 1-1 to FIRRTL targets and that annotations are so heavily exposed to the user (esp. via Stage/Phase), we have to generate a RenameMap for any views that are annotated. Previously, we couldn't know what views might be annotated (the `.toTarget` call is after Chisel elaboration) so we had to conservatively generate a `RenameMap` for all views that don't map 1-1. This is **ludicriously** expensive.

With #4643, we now require that annotations report what Data will be annotated up front, so now we only need to rename views that are actually annotated. Much more elegant and efficient at the cost of a minor API change.

I guess technically we shouldn't merge this until the deprecated APIs are removed... 🙈 

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Performance improvement


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
