### PR TITLE
Remove unused Builder methods

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -777,6 +777,7 @@ private[chisel3] object Builder extends LazyLogging {
     dynamicContext.blockStack = s
   }
 
+  def blockDepth: Int = dynamicContext.blockStack.length
   def pushBlock(b: Block): Unit = {
     dynamicContext.blockStack = b :: dynamicContext.blockStack
   }


### PR DESCRIPTION
Remove some Builder methods which have no users.  These methods may be useful, however, they can be added back if necessary.