### PR TITLE
[ci] Speed up tests with testForkGrouping

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -283,6 +283,8 @@ trait Chisel extends CrossSbtModule with HasScala2MacroAnno with HasScala2Plugin
     // Suppress Scala 3 behavior requiring explicit types on implicit definitions
     // Note this must come before the -Wconf is warningSuppression
     override def scalacOptions = Task { super.scalacOptions() :+ "-Wconf:cat=other-implicit-type:s" }
+
+    override def testForkGrouping = discoveredTestClasses().grouped(8).toSeq
   }
 }
 

--- a/integration-tests/package.mill
+++ b/integration-tests/package.mill
@@ -22,5 +22,7 @@ trait IntegrationTests extends CrossSbtModule with HasScala2Plugin with HasCommo
   object test extends SbtTests with TestModule.ScalaTest with ScalafmtModule {
     override def moduleDeps = super.moduleDeps :+ chisel().test
     def ivyDeps = Agg(v.scalatest, v.scalacheck)
+
+    override def testForkGrouping = discoveredTestClasses().grouped(8).toSeq
   }
 }


### PR DESCRIPTION
See docs: https://mill-build.org/mill/javalib/testing.html#_test_grouping

We could possibly do something more intelligent, but this speeds things up quite a bit on my MBP (~7.5 min to run `chisel[].test.test` vs. 15 min without this change), should speed up CI a bit too.

I tried using ScalaTest's parallelism (by overriding [def test](https://github.com/com-lihaoyi/mill/blob/07da626f5516b574586592f6083e872ead7d9752/scalalib/src/mill/scalalib/TestModule.scala#L70) passing `-P<nprocs>`) but it was slower.

I also tried `.grouped(1)` but that was much slower. `.grouped(8)` at least seems to speed things up a bit. It would be nice if the parallelism could be dynamically scheduled (the grouping is basically a static separating out tests to JVM forks so you really want to avoid putting all of the slow specs on a single JVM). That being said, we should probably just ensure that no spec is too slow.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)`, clean up the commit message, and label with `Please Merge`.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
