### PR TITLE
[svsim] Use 2-state variable for ports

### DIFF
--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -97,7 +97,7 @@ final class Workspace(
       l("module ", Workspace.testbenchModuleName, ";")
       for ((port, index) <- ports) {
         if (port.isSettable) {
-      l("  reg  [$bits(", dut.instanceName, ".",  port.name, ")-1:0] ", port.name, " = '0;")
+      l("  bit  [$bits(", dut.instanceName, ".",  port.name, ")-1:0] ", port.name, " = '0;")
         } else {
       l("  wire [$bits(", dut.instanceName, ".",  port.name, ")-1:0] ", port.name, ";")
         }


### PR DESCRIPTION
Fix an apparent additional problem with svsim and VCS xprop.  For reasons that I am unable to comprehend, this change gets xprop simulations to pass.  Without them, I am continuing to see spurious clock toggles causing assertions to fire.

This is a follow-on to a77eee6.  This is a bit of a game of whack-a-mole at this point...

#### Release Notes

Use 2-state logic in svsim variables used to drive ports to (hopefully) fix lingering problems with VCS and xprop.