### PR TITLE
Speedup Computation for whether Aggregates containsProbe

### DIFF
--- a/core/src/main/scala/chisel3/AggregateImpl.scala
+++ b/core/src/main/scala/chisel3/AggregateImpl.scala
@@ -82,6 +82,9 @@ private[chisel3] trait AggregateImpl extends Data { thiz: Aggregate =>
     */
   def getElements: Seq[Data]
 
+  /** Amortize this result, as it can be very expensive to determine this otherwise */
+  private[chisel3] lazy val containsProbe: Boolean = elementsIterator.exists(d => chisel3.internal.containsProbe(d))
+
   /** Similar to [[getElements]] but allows for more optimized use */
   private[chisel3] def elementsIterator: Iterator[Data]
 

--- a/core/src/main/scala/chisel3/AggregateImpl.scala
+++ b/core/src/main/scala/chisel3/AggregateImpl.scala
@@ -82,7 +82,7 @@ private[chisel3] trait AggregateImpl extends Data { thiz: Aggregate =>
     */
   def getElements: Seq[Data]
 
-  /** Amortize this result, as it can be very expensive to determine this otherwise */
+  /** Save this result, as it can be very expensive to determine this otherwise */
   private[chisel3] lazy val containsProbe: Boolean = elementsIterator.exists(d => chisel3.internal.containsProbe(d))
 
   /** Similar to [[getElements]] but allows for more optimized use */

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -163,8 +163,7 @@ package object internal {
   }
 
   private[chisel3] def containsProbe(data: Data): Boolean = data match {
-    case a: Aggregate =>
-      a.elementsIterator.foldLeft(false)((res: Boolean, d: Data) => res || containsProbe(d))
+    case a: Aggregate => a.containsProbe
     case leaf => leaf.probeInfo.nonEmpty
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [N/A] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Performance improvement


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Add a private containsProbe var to Aggregate and use it to speed up containsProbe checks.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
