### PR TITLE
[chiselsim] Add Default (non-Ephemeral) Simulator

### DIFF
--- a/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
+++ b/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
@@ -3,11 +3,8 @@ package chisel3.simulator
 import svsim._
 import chisel3.RawModule
 import chisel3.util.simpleClassName
-import java.io.File
 import java.nio.file.{FileSystems, Files, Path}
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import scala.reflect.io.Directory
 
 /** This is a trait that can be mixed into a class to determine where
   * compilation should happen and where simulation artifacts should be written.

--- a/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
+++ b/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chisel3.simulator
 
 import svsim._

--- a/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
+++ b/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
@@ -1,0 +1,87 @@
+package chisel3.simulator
+
+import svsim._
+import chisel3.RawModule
+import chisel3.util.simpleClassName
+import java.io.File
+import java.nio.file.{FileSystems, Files, Path}
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import scala.reflect.io.Directory
+
+/** This is a trait that can be mixed into a class to determine where
+  * compilation should happen and where simulation artifacts should be written.
+  */
+trait HasTestingDirectory {
+
+  /** Return the directory where tests should be placed. */
+  def getDirectory(testClassName: String): Path
+
+}
+
+/** This provides some default implementations of the [[HasTestingDirectory]]
+  * type class.
+  */
+object HasTestingDirectory {
+
+  /** An implementation of [[HasTestingDirectory]] which will use the class name
+    * timestamp.  When this implementation is used, everything is put in a
+    * `test_run_dir/<class-name>/<timestamp>/`.  E.g., this may produce
+    * something like:
+    *
+    * {{{
+    * test_run_dir/
+    * └── DefaultSimulator
+    *     ├── 2025-02-05T16-58-02.175175
+    *     ├── 2025-02-05T16-58-11.941263
+    *     └── 2025-02-05T16-58-17.721776
+    * }}}
+    */
+  val timestamp: HasTestingDirectory = new HasTestingDirectory {
+    override def getDirectory(testClassName: String) = FileSystems
+      .getDefault()
+      .getPath("test_run_dir/", testClassName, LocalDateTime.now().toString().replace(':', '-'))
+  }
+
+  /** The default testing directory behavior.  If the user does _not_ provide an
+    * alternative type class implementation of [[HasTestingDirectory]], then
+    * this will be what is used.
+    */
+  implicit val default: HasTestingDirectory = timestamp
+
+}
+
+/** Provides a simple API for running simulations.  This will write temporary
+  * outputs to a directory derived from the class name of the test.
+  *
+  * @example
+  * {{{
+  * import chisel3.simulator.DefaultSimulator._
+  * ...
+  * simulate(new MyChiselModule()) { module => ... }
+  * }}}
+  */
+object DefaultSimulator extends PeekPokeAPI {
+
+  private class DefaultSimulator(val workspacePath: String) extends SingleBackendSimulator[verilator.Backend] {
+    val backend = verilator.Backend.initializeFromProcessEnvironment()
+    val tag = "default"
+    val commonCompilationSettings = CommonCompilationSettings()
+    val backendSpecificCompilationSettings = verilator.Backend.CompilationSettings()
+  }
+
+  def simulate[T <: RawModule](
+    module:       => T,
+    layerControl: LayerControl.Type = LayerControl.EnableAll
+  )(body: (T) => Unit)(implicit testingDirectory: HasTestingDirectory): Unit = {
+
+    val testClassName = simpleClassName(getClass())
+
+    val simulator = new DefaultSimulator(
+      workspacePath = Files.createDirectories(testingDirectory.getDirectory(testClassName)).toString
+    )
+
+    simulator.simulate(module, layerControl)({ module => body(module.wrapped) }).result
+  }
+
+}

--- a/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -1,0 +1,48 @@
+package chiselTests.simulator
+
+import chisel3._
+import chisel3.layer.{block, Layer, LayerConfig}
+import chisel3.ltl.AssertProperty
+import chisel3.simulator.{HasTestingDirectory, LayerControl}
+import chisel3.simulator.DefaultSimulator._
+import java.nio.file.FileSystems
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import scala.reflect.io.Directory
+
+class DefaultSimulatorSpec extends AnyFunSpec with Matchers {
+  class Foo extends Module {
+    stop()
+  }
+
+  describe("DefaultSimulator") {
+    it("writes files to a permanent directory on disk") {
+
+      /** An implementation that always writes to the subdirectory "test_run_dir/<class-name>/foo/" */
+      implicit val fooDirectory = new HasTestingDirectory {
+        override def getDirectory(testClassName: String) =
+          FileSystems.getDefault().getPath("test_run_dir", testClassName, "foo")
+      }
+
+      val directory = Directory(FileSystems.getDefault().getPath("test_run_dir", "DefaultSimulator", "foo").toFile())
+      directory.deleteRecursively()
+
+      simulate(new Foo()) { _ => }
+
+      info(s"found expected directory: '$directory'")
+      assert(directory.exists)
+      assert(directory.isDirectory)
+
+      val allFiles = directory.deepFiles.toSeq.map(_.toString).toSet
+      for (
+        file <- Seq(
+          "test_run_dir/DefaultSimulator/foo/workdir-default/Makefile",
+          "test_run_dir/DefaultSimulator/foo/primary-sources/Foo.sv"
+        )
+      ) {
+        info(s"found expected file: '$file'")
+        allFiles should contain(file)
+      }
+    }
+  }
+}

--- a/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -1,9 +1,7 @@
 package chiselTests.simulator
 
 import chisel3._
-import chisel3.layer.{block, Layer, LayerConfig}
-import chisel3.ltl.AssertProperty
-import chisel3.simulator.{HasTestingDirectory, LayerControl}
+import chisel3.simulator.HasTestingDirectory
 import chisel3.simulator.DefaultSimulator._
 import java.nio.file.FileSystems
 import org.scalatest.funspec.AnyFunSpec

--- a/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package chiselTests.simulator
 
 import chisel3._


### PR DESCRIPTION
Add a new simulator, DefaultSimulator, to Chiselsim.  This fills a major, long-standing hole in this API by adding a simulator that does not delete all the files that it creates after a test runs.

This uses a type class, `HasTestingDirectory`, to allow for control over where the directory is created.  A default implementation is provided which uses a nanosecond resolution timestamp to differentiate the tests. E.g., example output from running the new test included in this commit multiple times is:

    test_run_dir/
    └── DefaultSimulator
        ├── 2025-02-05T16-58-02.175175
        ├── 2025-02-05T16-58-11.941263
        └── 2025-02-05T16-58-17.721776

Note: a Scalatest-based type class implementation is intentionally _not_ provided as part of this PR.  This will be provided in a follow-on in such a way that Chiselsim does not inherit a dependency on Scalatest.  Ideally, users of Scalatest will use the future Scalatest-based type class implementation to get a subdirectory which is not a timestamp, but derived from the name of that part of the test.  I.e., a directory like:

    test_run_dir/
    └── DefaultSimulator
        ├── writes_files_to_a_permanent_directory_on_disk
        └── doesnt_delete_the_root_directory

#### Release Notes

Add `DefaultSimulator` to Chiselsim to provide a simulator which doesn't delete its build directory. This fills a long-standing hole where only the `EphemeralSimulator` was provided which will delete the build directory. The current directory structure is timestamp-based.