### PR TITLE
Revert "Add publish flow for panama modules"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,8 +131,6 @@ jobs:
           echo \`\`\` >> $GITHUB_STEP_SUMMARY
           $CHISEL_FIRTOOL_PATH/firtool -version >> $GITHUB_STEP_SUMMARY
           echo \`\`\` >> $GITHUB_STEP_SUMMARY
-      - name: Publish Chisel locally for Panama modules
-        run: ./mill unipublish.publishLocal
       - name: Compile with Mill
         run: ./mill compileAll
 

--- a/circtpanamabinding/package.mill
+++ b/circtpanamabinding/package.mill
@@ -5,15 +5,12 @@ import mill.scalalib._
 import mill.scalalib.scalafmt._
 
 import build._
-import build_.release
 
 object `package` extends RootModule with CIRCTPanamaBinding
 
 // Java Codegen for all declared functions.
 // All of these functions are not private API which is subject to change.
-trait CIRCTPanamaBinding extends HasJextractGeneratedSources with release.ChiselPublishModule {
-  override def javadocOptions = Task(super.javadocOptions() ++ Seq("--enable-preview", "--release", "21"))
-
+trait CIRCTPanamaBinding extends HasJextractGeneratedSources {
   object utils extends Module {
     val architecture = System.getProperty("os.arch")
     val operationSystem = System.getProperty("os.name")

--- a/panamaconverter/package.mill
+++ b/panamaconverter/package.mill
@@ -6,7 +6,6 @@ import mill.scalalib.scalafmt._
 import mill.define.Cross
 
 import build._
-import build_.release
 
 object `package` extends RootModule {
   // https://github.com/com-lihaoyi/mill/issues/3693
@@ -18,13 +17,12 @@ trait PanamaConverter
     with HasPanamaOMModule
     with CrossModuleBase
     with HasScala2Plugin
-    with ScalafmtModule
-    with release.ChiselPublishModule {
+    with ScalafmtModule {
   def millSourcePath = super.millSourcePath / os.up
 
   def panamaOMModule = panamaom.cross(crossScalaVersion)
+  def chiselModule = chisel(crossScalaVersion)
   def pluginModule = plugin.cross(crossScalaVersion)
 
-  // depend published chisel artifact for publishing
-  override def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.chipsalliance::chisel::${publishVersion()}")
+  override def moduleDeps = super.moduleDeps ++ Some(chiselModule)
 }

--- a/panamalib/package.mill
+++ b/panamalib/package.mill
@@ -6,7 +6,6 @@ import mill.scalalib.scalafmt._
 import mill.define.Cross
 
 import build._
-import build_.release
 
 object `package` extends RootModule {
   // https://github.com/com-lihaoyi/mill/issues/3693
@@ -14,12 +13,7 @@ object `package` extends RootModule {
 }
 
 // The Scala API for PanamaBinding, API here is experimentally public to all developers
-trait PanamaLib
-    extends ScalaModule
-    with HasCIRCTPanamaBindingModule
-    with CrossModuleBase
-    with ScalafmtModule
-    with release.ChiselPublishModule {
+trait PanamaLib extends ScalaModule with HasCIRCTPanamaBindingModule with CrossModuleBase with ScalafmtModule {
   def millSourcePath = super.millSourcePath / os.up
 
   def circtPanamaBindingModule = circtpanamabinding

--- a/panamaom/package.mill
+++ b/panamaom/package.mill
@@ -6,19 +6,13 @@ import mill.scalalib.scalafmt._
 import mill.define.Cross
 
 import build._
-import build_.release
 
 object `package` extends RootModule {
   // https://github.com/com-lihaoyi/mill/issues/3693
   object cross extends Cross[PanamaOM](v.scalaCrossVersions)
 }
 
-trait PanamaOM
-    extends ScalaModule
-    with HasPanamaLibModule
-    with CrossModuleBase
-    with ScalafmtModule
-    with release.ChiselPublishModule {
+trait PanamaOM extends ScalaModule with HasPanamaLibModule with CrossModuleBase with ScalafmtModule {
   def millSourcePath = super.millSourcePath / os.up
 
   def panamaLibModule = panamalib.cross(crossScalaVersion)

--- a/plugin/package.mill
+++ b/plugin/package.mill
@@ -6,7 +6,7 @@ import mill.scalalib.scalafmt._
 import mill.define.Cross
 
 import build._
-import build_.release
+import $file.release
 
 object `package` extends RootModule {
   // https://github.com/com-lihaoyi/mill/issues/3693


### PR DESCRIPTION
Reverts chipsalliance/chisel#4661

Breaks publishing CI so revert for now, @unlsycn and @sequencer to fix and re-PR.