### PR TITLE
[Chiselsim] Add WithTestingDirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ target/
 *.fir
 *.v
 test_run_dir
+build/
 *~
 \#*\#
 .\#*

--- a/build.mill
+++ b/build.mill
@@ -274,6 +274,8 @@ trait Chisel extends CrossSbtModule with HasScala2MacroAnno with HasScala2Plugin
 
   override def moduleDeps = super.moduleDeps ++ Seq(coreModule, svsimModule)
 
+  def compileIvyDeps = Agg(v.scalatest)
+
   object test extends SbtTests with TestModule.ScalaTest with ScalafmtModule {
     def ivyDeps = Agg(v.scalatest, v.scalacheck)
 

--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,7 @@ lazy val firrtl = (project in file("firrtl"))
 lazy val chiselSettings = Seq(
   name := "chisel",
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "3.2.19" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.19" % "provided",
     "org.scalatestplus" %% "scalacheck-1-18" % "3.2.19.0" % "test",
     "com.lihaoyi" %% "upickle" % "3.3.1",
     "org.chipsalliance" %% "firtool-resolver" % "2.0.0"

--- a/release.mill
+++ b/release.mill
@@ -62,6 +62,9 @@ trait Unipublish extends ScalaModule with ChiselPublishModule {
   /** Aggregated ivy deps to include as dependencies in POM */
   def ivyDeps = Task { Task.traverse(components)(_.ivyDeps)().flatten }
 
+  /** Aggregated compile (Maven provided scope) dependencies to be included in POM */
+  def compileIvyDeps = Task { Task.traverse(components)(_.compileIvyDeps)().flatten }
+
   /** Aggregated local classpath to include in jar */
   override def localClasspath = Task { Task.traverse(components)(_.localClasspath)().flatten }
 

--- a/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
@@ -32,7 +32,7 @@ trait WithTestingDirectory { self: TestSuite =>
     *
     * For different behavior, please override this in your test suite.
     */
-  def buildDir: String = "test-run-dir"
+  def buildDir: String = "build"
 
   // Assemble all the directories that should be created for this test.  This is
   // done by examining the test (via a fixture) and then setting a dynamic

--- a/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
@@ -15,11 +15,11 @@ import scala.util.DynamicVariable
   * <buildDir>
   * └── <suite-name>
   *     └── <scope-1-name>
-  *         └── <scope-2-name>
-  *             └── ...
-  *                 └── <scope-n-name>
-  *                     ├── <test-1-name>
-  *                     └── <test-2-name>
+  *         └── ...
+  *             └── <scope-n-name>
+  *                 ├── <test-1-name>
+  *                 ├── ...
+  *                 └── <test-n-name>
   * }}}
   *
   * You may change the `buildDir` by overridding a method of the same name in

--- a/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.simulator.scalatest
+
+import chisel3.simulator.HasTestingDirectory
+import java.nio.file.{FileSystems, Path}
+import org.scalatest.TestSuite
+import scala.util.DynamicVariable
+
+/** A mix-in for a Scalatest test suite that will setup the output directory for
+  * you.  E.g., this will create output directories for your tests like the
+  * following:
+  *
+  * {{{
+  * <buildDir>
+  * └── <suite-name>
+  *     └── <scope-1-name>
+  *         └── <scope-2-name>
+  *             └── ...
+  *                 └── <scope-n-name>
+  *                     ├── <test-1-name>
+  *                     └── <test-2-name>
+  * }}}
+  *
+  * You may change the `buildDir` by overridding a method of the same name in
+  * this trait.
+  *
+  */
+trait WithTestingDirectory { self: TestSuite =>
+
+  /** Return the name of the root test directory.
+    *
+    * For different behavior, please override this in your test suite.
+    */
+  def buildDir: String = "test_run_dir"
+
+  // Assemble all the directories that should be created for this test.  This is
+  // done by examining the test (via a fixture) and then setting a dynamic
+  // variable for that test.  The exacct structure of the test is extracted,
+  // including any nesting (Scalatest scopes) in the test.
+  private val testName: DynamicVariable[List[String]] = new DynamicVariable[List[String]](Nil)
+  override def withFixture(test: NoArgTest) = {
+    testName.withValue(test.scopes.toList :+ test.text) {
+      test()
+    }
+  }
+
+  /** Implementaton of [[HasTestingDirectory]] which sets up the test directory
+    * for you based on settings which make sense in Scalatest.
+    */
+  final implicit def implementation: HasTestingDirectory = new HasTestingDirectory {
+
+    /** Return the test name with some sanitization applied. */
+    final def getTestName = testName.value.map(_.replaceAll(" ", "_").replaceAll("\\W+", ""))
+
+    override def getDirectory(testClassName: String): Path = FileSystems
+      .getDefault()
+      .getPath(buildDir, self.suiteName +: getTestName: _*)
+
+  }
+
+}

--- a/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
@@ -32,7 +32,7 @@ trait WithTestingDirectory { self: TestSuite =>
     *
     * For different behavior, please override this in your test suite.
     */
-  def buildDir: String = "test_run_dir"
+  def buildDir: String = "test-run-dir"
 
   // Assemble all the directories that should be created for this test.  This is
   // done by examining the test (via a fixture) and then setting a dynamic
@@ -50,8 +50,13 @@ trait WithTestingDirectory { self: TestSuite =>
     */
   final implicit def implementation: HasTestingDirectory = new HasTestingDirectory {
 
-    /** Return the test name with some sanitization applied. */
-    final def getTestName = testName.value.map(_.replaceAll(" ", "_").replaceAll("\\W+", ""))
+    /** Return the test name with minimal sanitization applied:
+      *
+      *   - Replace all whitespace as this is incompatible with GNU make [1]
+      *
+      * [1]: https://savannah.gnu.org/bugs/?712
+      */
+    final def getTestName = testName.value.map(_.replaceAll("\\s", "-"))
 
     override def getDirectory(testClassName: String): Path = FileSystems
       .getDefault()

--- a/src/test/scala/chiselTests/simulator/scalatest/WithTestingDirectorySpec.scala
+++ b/src/test/scala/chiselTests/simulator/scalatest/WithTestingDirectorySpec.scala
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.simulator.scalatest
+
+import chisel3._
+import chisel3.simulator.scalatest.WithTestingDirectory
+import chisel3.simulator.DefaultSimulator._
+import java.nio.file.FileSystems
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import scala.reflect.io.Directory
+
+class WithTestingDirectorySpec extends AnyFunSpec with Matchers with WithTestingDirectory {
+
+  class Foo extends Module {
+    stop()
+  }
+
+  describe("A test suite mixing in WithTestingDirectory") {
+    it("should generate a directory structure derived from the suite and test name") {
+
+      val directory = Directory(
+        FileSystems
+          .getDefault()
+          .getPath(
+            "test_run_dir",
+            "WithTestingDirectorySpec",
+            "A_test_suite_mixing_in_WithTestingDirectory",
+            "should_generate_a_directory_structure_derived_from_the_suite_and_test_name"
+          )
+          .toFile()
+      )
+      directory.deleteRecursively()
+
+      simulate(new Foo()) { _ => }
+
+      info(s"found expected directory: '$directory'")
+      assert(directory.exists)
+      assert(directory.isDirectory)
+
+      val allFiles = directory.deepFiles.toSeq.map(_.toString).toSet
+      for (
+        file <- Seq(
+          directory.toFile.toString + "/workdir-default/Makefile",
+          directory.toFile.toString + "/primary-sources/Foo.sv"
+        )
+      ) {
+        info(s"found expected file: '$file'")
+        allFiles should contain(file)
+      }
+    }
+    it("should generate another directory, too") {
+      val directory = Directory(
+        FileSystems
+          .getDefault()
+          .getPath(
+            "test_run_dir",
+            "WithTestingDirectorySpec",
+            "A_test_suite_mixing_in_WithTestingDirectory",
+            "should_generate_another_directory_too"
+          )
+          .toFile()
+      )
+      directory.deleteRecursively()
+
+      simulate(new Foo()) { _ => }
+
+      info(s"found expected directory: '$directory'")
+      assert(directory.exists)
+      assert(directory.isDirectory)
+    }
+  }
+
+}

--- a/src/test/scala/chiselTests/simulator/scalatest/WithTestingDirectorySpec.scala
+++ b/src/test/scala/chiselTests/simulator/scalatest/WithTestingDirectorySpec.scala
@@ -50,7 +50,7 @@ class WithTestingDirectorySpec extends AnyFunSpec with Matchers with WithTesting
 
     it("should generate a directory structure derived from the suite and test name") {
       checkDirectoryStructure(
-        "test-run-dir",
+        "build",
         "WithTestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-generate-a-directory-structure-derived-from-the-suite-and-test-name"
@@ -61,7 +61,7 @@ class WithTestingDirectorySpec extends AnyFunSpec with Matchers with WithTesting
 
     it("should generate another directory, too") {
       checkDirectoryStructure(
-        "test-run-dir",
+        "build",
         "WithTestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-generate-another-directory,-too"
@@ -72,7 +72,7 @@ class WithTestingDirectorySpec extends AnyFunSpec with Matchers with WithTesting
 
     it("should handle emojis, e.g., 🚀") {
       checkDirectoryStructure(
-        "test-run-dir",
+        "build",
         "WithTestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-handle-emojis,-e.g.,-🚀"
@@ -83,7 +83,7 @@ class WithTestingDirectorySpec extends AnyFunSpec with Matchers with WithTesting
 
     it("should handle CJK characters, e.g., 好猫咪") {
       checkDirectoryStructure(
-        "test-run-dir",
+        "build",
         "WithTestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-handle-CJK-characters,-e.g.,-好猫咪"


### PR DESCRIPTION
Add a trait, `WithTestingDirectory`, that will automatically create a test directory structure based on Scalatest information.  This provides a type class implementation of `HasTestingDirectory`, but with better Scalatest-specific directories as opposed to generic timestamp-based ones.

This necessarily introduces a provided ("compile only" to Mill) dependency on Scalatest for Chisel.  This prevents making all of Chisel pull in Scalatest and relies on the user to load it.

E.g., the included test will create the following directory structure:

```
build
└── WithTestingDirectorySpec
    └── A-test-suite-mixing-in-WithTestingDirectory
        ├── should-generate-a-directory-structure-derived-from-the-suite-and-test-name
        ├── should-generate-another-directory,-too
        ├── should-handle-CJK-characters,-e.g.,-好猫咪
        └── should-handle-emojis,-e.g.,-🚀
```

#### Release Notes

Add `WithTestingDirectory` Scalatest suite mix-in that automatically sets up a Scalatest-specific directory structure for your tests.