### PR TITLE
[chiselsim] Remove test class name from directory

### DIFF
--- a/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
+++ b/src/main/scala-2/chisel3/simulator/DefaultSimulator.scala
@@ -31,10 +31,8 @@ object DefaultSimulator extends PeekPokeAPI {
     layerControl: LayerControl.Type = LayerControl.EnableAll
   )(body: (T) => Unit)(implicit testingDirectory: HasTestingDirectory): Unit = {
 
-    val testClassName = simpleClassName(getClass())
-
     val simulator = new DefaultSimulator(
-      workspacePath = Files.createDirectories(testingDirectory.getDirectory(testClassName)).toString
+      workspacePath = Files.createDirectories(testingDirectory.getDirectory).toString
     )
 
     simulator.simulate(module, layerControl)({ module => body(module.wrapped) }).result

--- a/src/main/scala-2/chisel3/simulator/HasTestingDirectory.scala
+++ b/src/main/scala-2/chisel3/simulator/HasTestingDirectory.scala
@@ -11,7 +11,7 @@ import scala.reflect.io.Directory
 trait HasTestingDirectory {
 
   /** Return the directory where tests should be placed. */
-  def getDirectory(testClassName: String): Path
+  def getDirectory: Path
 
 }
 
@@ -26,17 +26,17 @@ object HasTestingDirectory {
     * something like:
     *
     * {{{
-    * test_run_dir/
-    * └── DefaultSimulator
+    * test_run_dir
+    * └── chiselsim
     *     ├── 2025-02-05T16-58-02.175175
     *     ├── 2025-02-05T16-58-11.941263
     *     └── 2025-02-05T16-58-17.721776
     * }}}
     */
   val timestamp: HasTestingDirectory = new HasTestingDirectory {
-    override def getDirectory(testClassName: String) = FileSystems
+    override def getDirectory = FileSystems
       .getDefault()
-      .getPath("test_run_dir/", testClassName, LocalDateTime.now().toString().replace(':', '-'))
+      .getPath("test_run_dir", "chiselsim", LocalDateTime.now().toString().replace(':', '-'))
   }
 
   /** An implementation generator of [[HasTestingDirectory]] which will use an
@@ -46,13 +46,15 @@ object HasTestingDirectory {
     * @param deleteOnExit if true, delete the temporary directory when the JVM exits
     */
   def temporary(deleteOnExit: Boolean = true): HasTestingDirectory = new HasTestingDirectory {
-    override def getDirectory(testClassName: String) = {
+    override def getDirectory = {
       val path = FileSystems
         .getDefault()
         .getPath(
-          Files.createTempDirectory(s"${testClassName}-${LocalDateTime.now().toString().replace(':', '-')}").toString
+          Files.createTempDirectory(s"chiselsim-${LocalDateTime.now().toString().replace(':', '-')}").toString
         )
+      println(s"Creating: ${path.toString}")
       if (deleteOnExit) {
+        println(s"Deleting: ${path.toString}")
         sys.addShutdownHook(new Directory(path.toFile).deleteRecursively())
       }
       path

--- a/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala-2/chisel3/simulator/scalatest/WithTestingDirectory.scala
@@ -58,7 +58,7 @@ trait WithTestingDirectory { self: TestSuite =>
       */
     final def getTestName = testName.value.map(_.replaceAll("\\s", "-"))
 
-    override def getDirectory(testClassName: String): Path = FileSystems
+    override def getDirectory: Path = FileSystems
       .getDefault()
       .getPath(buildDir, self.suiteName +: getTestName: _*)
 

--- a/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -20,11 +20,11 @@ class DefaultSimulatorSpec extends AnyFunSpec with Matchers {
 
       /** An implementation that always writes to the subdirectory "test_run_dir/<class-name>/foo/" */
       implicit val fooDirectory = new HasTestingDirectory {
-        override def getDirectory(testClassName: String) =
-          FileSystems.getDefault().getPath("test_run_dir", testClassName, "foo")
+        override def getDirectory =
+          FileSystems.getDefault().getPath("test_run_dir", "foo")
       }
 
-      val directory = Directory(FileSystems.getDefault().getPath("test_run_dir", "DefaultSimulator", "foo").toFile())
+      val directory = Directory(FileSystems.getDefault().getPath("test_run_dir", "foo").toFile())
       directory.deleteRecursively()
 
       simulate(new Foo()) { _ => }
@@ -36,8 +36,8 @@ class DefaultSimulatorSpec extends AnyFunSpec with Matchers {
       val allFiles = directory.deepFiles.toSeq.map(_.toString).toSet
       for (
         file <- Seq(
-          "test_run_dir/DefaultSimulator/foo/workdir-default/Makefile",
-          "test_run_dir/DefaultSimulator/foo/primary-sources/Foo.sv"
+          "test_run_dir/foo/workdir-default/Makefile",
+          "test_run_dir/foo/primary-sources/Foo.sv"
         )
       ) {
         info(s"found expected file: '$file'")


### PR DESCRIPTION
Remove an argument from the `getDirectory` method of the `HasTestingDirectory` type class.  This was intended to capture the name of the class.  However, this didn't actually work.  Remove this as it is both: (1) not necessary as if users of this are likely using the Scalatest type class implementation which does support this and (2) it simplifies downstream methods as this doesn't need to be routed around.

This is changing a public method that was never in a release. Hence, there are no release notes.