### PR TITLE
[chiselsim] Add, use HasSimulator type class

### DIFF
--- a/src/main/scala/chisel3/simulator/DefaultSimulator.scala
+++ b/src/main/scala/chisel3/simulator/DefaultSimulator.scala
@@ -19,23 +19,11 @@ import java.nio.file.Files
   */
 object DefaultSimulator extends PeekPokeAPI {
 
-  private class DefaultSimulator(val workspacePath: String) extends Simulator[verilator.Backend] {
-    override val backend = verilator.Backend.initializeFromProcessEnvironment()
-    override val tag = "default"
-    override val commonCompilationSettings = CommonCompilationSettings()
-    override val backendSpecificCompilationSettings = verilator.Backend.CompilationSettings()
-  }
-
   def simulate[T <: RawModule](
     module:       => T,
     layerControl: LayerControl.Type = LayerControl.EnableAll
-  )(body: (T) => Unit)(implicit testingDirectory: HasTestingDirectory): Unit = {
-
-    val simulator = new DefaultSimulator(
-      workspacePath = Files.createDirectories(testingDirectory.getDirectory).toString
-    )
-
-    simulator.simulate(module, layerControl)({ module => body(module.wrapped) }).result
+  )(body: (T) => Unit)(implicit hasSimulator: HasSimulator, testingDirectory: HasTestingDirectory): Unit = {
+    hasSimulator.getSimulator.simulate(module, layerControl)({ module => body(module.wrapped) }).result
   }
 
 }

--- a/src/main/scala/chisel3/simulator/HasSimulator.scala
+++ b/src/main/scala/chisel3/simulator/HasSimulator.scala
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.simulator
+
+import java.nio.file.Files
+
+/** Type class for providing a simulator. */
+trait HasSimulator {
+
+  /** Return a simulator.  This require providing a type class implementation of
+    * [[HasTestingDirectory]].
+    */
+  def getSimulator(implicit testingDirectory: HasTestingDirectory): Simulator[_]
+
+}
+
+/** Type class implementations of [[HasSimulator]]. */
+object HasSimulator {
+
+  /** This object provides implementations of [[HasSimulator]].  To set the
+    * simulator in your test, please import one of the implementations.
+    *
+    * E.g., to use Verilator import:
+    *
+    * {{{
+    * import chisel3.simulator.HasSimulator.simulators.verilator
+    * }}}
+    *
+    * Or, to use VCS import:
+    *
+    * {{{
+    * import chisel3.simulator.HasSimulator.simulators.vcs
+    * }}}
+    *
+    * Note: if you do _not_ import one of these, the default will be to use
+    * Verilator due to the low-priority implicit default
+    * [[HasSimulator.default]].
+    */
+  object simulators {
+
+    /** A [[HasSimulator]] implementation for a Verilator simulator. */
+    def verilator: HasSimulator = new HasSimulator {
+      override def getSimulator(implicit testingDirectory: HasTestingDirectory): Simulator[svsim.verilator.Backend] =
+        new Simulator[svsim.verilator.Backend] {
+          override val backend = svsim.verilator.Backend.initializeFromProcessEnvironment()
+          override val tag = "verilator"
+          override val commonCompilationSettings = svsim.CommonCompilationSettings()
+          override val backendSpecificCompilationSettings = svsim.verilator.Backend.CompilationSettings()
+          override val workspacePath = Files.createDirectories(testingDirectory.getDirectory).toString
+        }
+    }
+
+    /** A [[HasSimulator]] implementation for a VCS simulator. */
+    def vcs: HasSimulator = new HasSimulator {
+      override def getSimulator(implicit testingDirectory: HasTestingDirectory): Simulator[svsim.vcs.Backend] =
+        new Simulator[svsim.vcs.Backend] {
+          override val backend = svsim.vcs.Backend.initializeFromProcessEnvironment().getOrElse {
+            throw new Exception(
+              "Unable to load VCS from the environment. (Did you forget to set VCS_HOME and LM_LICENSE_FILE?)"
+            )
+          }
+          override val tag = "vcs"
+          override val commonCompilationSettings = svsim.CommonCompilationSettings()
+          override val backendSpecificCompilationSettings = svsim.vcs.Backend.CompilationSettings()
+          override val workspacePath = Files.createDirectories(testingDirectory.getDirectory).toString
+        }
+    }
+
+  }
+
+  /** Low-priority default implementation of [[HasSimulator]] that uses Verilator.
+    * This is the default that will be used if the user does provide an
+    * alternative.
+    */
+  implicit def default: HasSimulator = simulators.verilator
+
+}

--- a/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -36,7 +36,7 @@ class DefaultSimulatorSpec extends AnyFunSpec with Matchers {
       val allFiles = directory.deepFiles.toSeq.map(_.toString).toSet
       for (
         file <- Seq(
-          "test_run_dir/foo/workdir-default/Makefile",
+          "test_run_dir/foo/workdir-verilator/Makefile",
           "test_run_dir/foo/primary-sources/Foo.sv"
         )
       ) {

--- a/src/test/scala-2/chiselTests/simulator/HasSimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/HasSimulatorSpec.scala
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.simulator
+
+import chisel3.simulator.{HasSimulator, HasTestingDirectory, Simulator}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class HasSimulatorSpec extends AnyFunSpec with Matchers {
+
+  /** Return a field from the simulator so that we can check its type. */
+  def foo(implicit a: HasSimulator): String = a.getSimulator.tag
+
+  describe("HasSimulator") {
+
+    it("should use Verilator as a low-priority default") {
+
+      foo should be("verilator")
+
+    }
+
+    it("should allow overriding via an implicit val") {
+
+      implicit val bar: HasSimulator = new HasSimulator {
+        override def getSimulator(implicit testingDirectory: HasTestingDirectory): Simulator[svsim.verilator.Backend] =
+          new Simulator[svsim.verilator.Backend] {
+            override val backend = svsim.verilator.Backend.initializeFromProcessEnvironment()
+            override val tag = "still-verilator"
+            override val commonCompilationSettings = svsim.CommonCompilationSettings()
+            override val backendSpecificCompilationSettings = svsim.verilator.Backend.CompilationSettings()
+            override val workspacePath = ""
+          }
+      }
+
+      foo should be("still-verilator")
+
+    }
+
+  }
+
+}

--- a/src/test/scala-2/chiselTests/simulator/scalatest/WithTestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/WithTestingDirectorySpec.scala
@@ -32,7 +32,7 @@ class WithTestingDirectorySpec extends AnyFunSpec with Matchers with WithTesting
     val allFiles = directory.deepFiles.toSeq.map(_.toString).toSet
     for (
       file <- Seq(
-        directory.toFile.toString + "/workdir-default/Makefile",
+        directory.toFile.toString + "/workdir-verilator/Makefile",
         directory.toFile.toString + "/primary-sources/Foo.sv"
       )
     ) {


### PR DESCRIPTION
Add a new type class, `HasSimulator`, which provides a method to get a
simulator.  Provide two implementations: one for Verilator and one for
VCS.  Additionally, provide a low-priority default that maps to Verilator.

This is working towards refactoring Chiselsim to improve the
customizability of its APIs while not dramatically changing how a user
interacts with it.  Additionally, this is trying to work towards providing
Scalatest-specific implementations of `HasSimulator` which allow the
simulator to be chosen on the command line.  Much of the code for this is
currently sequestered in either ChiselSpec (part of the tests which are
not published) or in internal code.

Refactor the Chiselsim's `DefaultSimulator` to no longer create an
instance of a private Verilator simulator class.  Instead, use what is
provided by a `HasSimulator` type class implementation.

This is done to slim down `DefaultSimulator` (and transitively
`EphemeralSimulator`) to essentially nothing other than objects that
define convenience APIs for running simulation like the existing
`simulate` method.

#### Release Notes

- Add `HasSimulator` type class to Chiselsim. This allows for customization of the simulator used by `DefaultSimulator`.