### PR TITLE
Add RequireProperty and EnsureProperty

### DIFF
--- a/src/main/scala-2/chisel3/ltl/LTL.scala
+++ b/src/main/scala-2/chisel3/ltl/LTL.scala
@@ -504,3 +504,37 @@ object AssumeProperty extends AssertPropertyLike(defaultLayer = layers.Verificat
 object CoverProperty extends AssertPropertyLike(defaultLayer = layers.Verification.Cover) {
   protected def createIntrinsic(label: Option[String])(implicit sourceInfo: SourceInfo) = VerifCoverIntrinsic(label)
 }
+
+/** Require that a property holds as a pre-condition of a contract. Behaves like
+  * an `AssertProperty` if used outside of a contract. When used inside of a
+  * contract, the behavior differs depending on how the contract is used in a
+  * formal proof:
+  *
+  * - During a proof that the contract is upheld by the surrounding circuit, the
+  *   property given to `RequireProperty` is assumed to hold.
+  * - During a larger proof where the contract is already assumed to be proven,
+  *   the property given to `RequireProperty` is asserted to hold.
+  *
+  * Use like `RequireProperty(p)`. See `AssertPropertyLike.apply` for optional
+  * clock, disable_iff, and label parameters.
+  */
+object RequireProperty extends AssertPropertyLike(defaultLayer = layers.Verification.Assume) {
+  protected def createIntrinsic(label: Option[String])(implicit sourceInfo: SourceInfo) = VerifRequireIntrinsic(label)
+}
+
+/** Ensure that a property holds as a post-condition of a contract. Behaves like
+  * an `AssertProperty` if used outside of a contract. When used inside of a
+  * contract, the behavior differs depending on how the contract is used in a
+  * formal proof:
+  *
+  * - During a proof that the contract is upheld by the surrounding circuit, the
+  *   property given to `EnsureProperty` is asserted to hold.
+  * - During a larger proof where the contract is already assumed to be proven,
+  *   the property given to `EnsureProperty` is assumed to hold.
+  *
+  * Use like `EnsureProperty(p)`. See `AssertPropertyLike.apply` for optional
+  * clock, disable_iff, and label parameters.
+  */
+object EnsureProperty extends AssertPropertyLike(defaultLayer = layers.Verification.Assert) {
+  protected def createIntrinsic(label: Option[String])(implicit sourceInfo: SourceInfo) = VerifEnsureIntrinsic(label)
+}

--- a/src/main/scala-2/chisel3/util/circt/LTLIntrinsics.scala
+++ b/src/main/scala-2/chisel3/util/circt/LTLIntrinsics.scala
@@ -169,3 +169,15 @@ private[chisel3] object VerifCoverIntrinsic {
   def apply(label: Option[String] = None)(prop: Bool, enable: Option[Bool])(implicit sourceInfo: SourceInfo) =
     VerifAssertLikeIntrinsic("cover", label)(prop, enable)
 }
+
+/** A wrapper intrinsic for the CIRCT `verif.require` operation. */
+private[chisel3] object VerifRequireIntrinsic {
+  def apply(label: Option[String] = None)(prop: Bool, enable: Option[Bool])(implicit sourceInfo: SourceInfo) =
+    VerifAssertLikeIntrinsic("require", label)(prop, enable)
+}
+
+/** A wrapper intrinsic for the CIRCT `verif.ensure` operation. */
+private[chisel3] object VerifEnsureIntrinsic {
+  def apply(label: Option[String] = None)(prop: Bool, enable: Option[Bool])(implicit sourceInfo: SourceInfo) =
+    VerifAssertLikeIntrinsic("ensure", label)(prop, enable)
+}

--- a/src/test/scala-2/chiselTests/LTLSpec.scala
+++ b/src/test/scala-2/chiselTests/LTLSpec.scala
@@ -255,6 +255,8 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     AssertProperty(a)
     AssumeProperty(a)
     CoverProperty(a)
+    RequireProperty(a)
+    EnsureProperty(a)
   }
   it should "support simple property asserts/assumes/covers and put them in layer blocks" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new BasicVerifMod)
@@ -268,8 +270,14 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     chirrtl should include("layerblock Verification")
     chirrtl should include("layerblock Cover")
     chirrtl should include(f"intrinsic(circt_verif_cover, a) $sourceLoc")
+    chirrtl should include("layerblock Verification")
+    chirrtl should include("layerblock Assume")
+    chirrtl should include(f"intrinsic(circt_verif_require, a) $sourceLoc")
+    chirrtl should include("layerblock Verification")
+    chirrtl should include("layerblock Assert")
+    chirrtl should include(f"intrinsic(circt_verif_ensure, a) $sourceLoc")
   }
-  it should "compile simple property asserts/assumes/covers" in {
+  it should "compile simple property checks" in {
     ChiselStage.emitSystemVerilog(new BasicVerifMod)
   }
   it should "not create layer blocks if already in a layer block" in {
@@ -290,7 +298,9 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     val properties = Seq(
       AssertProperty -> ("VerifAssertIntrinsic", "assert"),
       AssumeProperty -> ("VerifAssumeIntrinsic", "assume"),
-      CoverProperty -> ("VerifCoverIntrinsic", "cover")
+      CoverProperty -> ("VerifCoverIntrinsic", "cover"),
+      RequireProperty -> ("VerifRequireIntrinsic", "require"),
+      EnsureProperty -> ("VerifEnsureIntrinsic", "ensure")
     )
 
     for ((prop, (intrinsic, op)) <- properties) {
@@ -313,12 +323,16 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
     AssertProperty(a, label = Some("foo0"))
     AssumeProperty(a, label = Some("foo1"))
     CoverProperty(a, label = Some("foo2"))
+    RequireProperty(a, label = Some("foo3"))
+    EnsureProperty(a, label = Some("foo4"))
   }
   it should "support labeled property asserts/assumes/covers" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new LabeledVerifMod)
     chirrtl should include("intrinsic(circt_verif_assert<label = \"foo0\">, a)")
     chirrtl should include("intrinsic(circt_verif_assume<label = \"foo1\">, a")
     chirrtl should include("intrinsic(circt_verif_cover<label = \"foo2\">, a)")
+    chirrtl should include("intrinsic(circt_verif_require<label = \"foo3\">, a)")
+    chirrtl should include("intrinsic(circt_verif_ensure<label = \"foo4\">, a)")
   }
   it should "compile labeled property asserts/assumes/covers" in {
     ChiselStage.emitSystemVerilog(new LabeledVerifMod)


### PR DESCRIPTION
Add support for CIRCT's `circt_verif_require` and `circt_verif_ensure` intrinsics. These interact with the formal contracts implemented in CIRCT and translate to asserts or assumes depending on whether the contract is checked or applied. They lower to asserts if used outside of a contract.

Chisel itself has no support for contracts yet, such that these two additions behave like `AssertProperty` in practice. As soon as contracts are added to Chisel though, they can be used to formulate the pre- and post-conditions of those contracts.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
