### PR TITLE
Add formal contracts

### DIFF
--- a/core/src/main/scala-2/chisel3/FormalContractIntf.scala
+++ b/core/src/main/scala-2/chisel3/FormalContractIntf.scala
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import chisel3.experimental.SourceInfo
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+private[chisel3] trait FormalContract$Intf extends FormalContract$VirtualMethods {
+
+  /** Create a `contract` block with one or more arguments and results. */
+  def apply(head: Data, tail: Data*): (Any => Unit) => Any =
+    macro FormalContractMacro.apply_impl
+}
+
+private[chisel3] object FormalContractMacro {
+
+  /** A macro for `FormalContract` to allow for contracts with a single argument
+    * and contracts with a tuple of arguments to be created. The macro packages
+    * the sequence of arguments up into a tuple (`Tuple1` for single arguments,
+    * and the corresponding `TupleN` for multiple arguments). Without this
+    * macro, the contracts would always operate on tuples (`Product`), forcing
+    * the user to use
+    * {{{
+    * val Tuple1(a) = FormalContract(Tuple1(b)) { case Tuple1(x) => ... }
+    * }}}
+    * for contracts with only a single argument.
+    *
+    * A call to `FormalContract(a: T)` becomes:
+    * {{{
+    * FormalContract.mapped(
+    *   Seq(a),
+    *   (values => values(0).asInstanceOf[T])
+    * )
+    * }}}
+    *
+    * A call to `FormalContract(a: A, b: B, c: C)` becomes:
+    * {{{
+    * FormalContract.mapped(
+    *   Seq(a, b, c),
+    *   (values => (
+    *     values(0).asInstanceOf[A],
+    *     values(1).asInstanceOf[B],
+    *     values(2).asInstanceOf[C]
+    *   ))
+    * )
+    * }}}
+    */
+  def apply_impl(c: whitebox.Context)(head: c.Expr[Data], tail: c.Expr[Data]*): c.Expr[(Any => Unit) => Any] = {
+    import c.universe._
+    val args = head +: tail
+    val mapping =
+      q"(values => (..${args.zipWithIndex.map { case (arg, i) => q"values(${i}).asInstanceOf[${arg.tree.tpe}]" }}))"
+    val result = q"FormalContract.mapped(Seq(..${args.map(_.tree)}), $mapping)(_)"
+    c.Expr[(Any => Unit) => Any](result)
+  }
+}

--- a/core/src/main/scala-3/chisel3/FormalContractIntf.scala
+++ b/core/src/main/scala-3/chisel3/FormalContractIntf.scala
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import scala.quoted.*
+
+private[chisel3] trait FormalContract$Intf extends FormalContract$VirtualMethods {
+
+  /** Create a `contract` block with one or more arguments and results. */
+  transparent inline def apply[T <: Data](inline args: T*): Any =
+    ${ FormalContractMacro('args) }
+}
+
+private[chisel3] object FormalContractMacro {
+
+  /** A macro for `FormalContract` that allows for contracts to be built while
+    * preserving the types of individual elements passed to the contract. This
+    * allows the types of the contract's results to match the type of the
+    * arguments passed to the contract.
+    *
+    * A call to `FormalContract(a: T)` becomes:
+    * {{{
+    * FormalContract.mapped(
+    *   Seq(a),
+    *   (values => values(0).asInstanceOf[T])
+    * )
+    * }}}
+    *
+    * A call to `FormalContract(a: A, b: B, c: C)` becomes:
+    * {{{
+    * FormalContract.mapped(
+    *   Seq(a, b, c),
+    *   (values => (
+    *     values(0).asInstanceOf[A],
+    *     values(1).asInstanceOf[B],
+    *     values(2).asInstanceOf[C]
+    *   ))
+    * )
+    * }}}
+    */
+  def apply(args: Expr[Seq[Data]])(using Type[Seq[Data]])(using Quotes): Expr[Any] = {
+    val elements = args match {
+      case Varargs(elements) => elements
+      case _                 => quotes.reflect.report.errorAndAbort("Expected a compile-time known list of arguments")
+    }
+    // In the following we use a `match case '{ _: t}` to bind the type of the
+    // left-hand side of the match to `t`, which we can then refer to within the
+    // match to cast elements to the appropriate type. This allows us to get the
+    // type of the element if there's only one, or we construct a tuple out of
+    // all the elements as a way to construct the corresponding tuple type.
+    if (elements.size == 0) {
+      quotes.reflect.report.errorAndAbort("use `FormalContract` without `()` instead")
+    } else if (elements.size == 1) {
+      // Calls of the form `apply(x: T)` require a mapping like:
+      // ```
+      // (values: Seq[Data]) => values.last.asInstanceOf[T]
+      // ```
+      elements.last match {
+        case '{ $x: t } =>
+          val mapping = '{ (values: Seq[Data]) => values.last.asInstanceOf[t] }
+          '{ FormalContract.mapped(${ Expr.ofSeq(elements) }, $mapping) }
+      }
+    } else {
+      // Calls of the form `apply(x0: T0, x1: T1, ..., xi: Ti)` require a
+      // mapping like:
+      // ```
+      // (values: Seq[Data]) => (
+      //   values(0).asInstanceOf[T0],
+      //   values(1).asInstanceOf[T1],
+      //   ...,
+      //   values(i).asInstanceOf[Ti],
+      // )
+      // ```
+      Expr.ofTupleFromSeq(elements) match {
+        case '{ $x: t } =>
+          val mapping = '{ (values: Seq[Data]) =>
+            ${
+              Expr.ofTupleFromSeq((0 until elements.size).map(i => '{ values(${ Expr(i) }) }))
+            }.asInstanceOf[t]
+          }
+          '{ FormalContract.mapped(${ Expr.ofSeq(elements) }, $mapping) }
+      }
+    }
+  }
+}

--- a/core/src/main/scala/chisel3/FormalContract.scala
+++ b/core/src/main/scala/chisel3/FormalContract.scala
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import chisel3.experimental.SourceInfo
+import chisel3.internal._
+import chisel3.internal.Builder.pushCommand
+import chisel3.internal.firrtl.ir._
+
+/** Create a `contract` block.
+  *
+  * Outside of verification uses, the arguments passed to the contract are
+  * simply returned as contract results. During formal verification, the
+  * contract may act as a cutpoint by returning symbolic values for its
+  * results and using the contract body as constraint.
+  *
+  * Within the contract body, `RequireProperty` and `EnsureProperty` can be
+  * used to describe the pre and post-conditions of the contract. During
+  * formal verification, contracts can be used to divide large formal checks
+  * into smaller pieces by first asserting some local properties hold, and
+  * then assuming those properties hold in the context of the larger proof.
+  *
+  * @example
+  * The following is a contract with no arguments.
+  * {{{
+  * FormalContract {
+  *   RequireProperty(a >= 1)
+  *   EnsureProperty(a + a >= 2)
+  * }
+  * }}}
+  *
+  * The following is a contract with a single argument. It expresses the fact
+  * that the hardware implementation `(a << 3) + a` is equivalent to `a * 9`.
+  * During formal verification, this contract is interpreted as:
+  *
+  * - `assert((a << 3) + a === a * 9)` as a proof that the contract holds.
+  * - `assume(b === a * 9)` on a new symbolic value `b` as a simplification of
+  *   other proofs.
+  *
+  * {{{
+  * val b = FormalContract((a << 3) + a) { b =>
+  *   EnsureProperty(b === a * 9)
+  * }
+  * }}}
+  *
+  * The following is a contract with multiple arguments. It expresses the fact
+  * that a carry-save adder with `p`, `q`, and `r` as inputs reduces the number
+  * of sum terms from `p + q + r` to `c + s` but doesn't change the sum of the
+  * terms. During formal verification, this contract is interpreted as:
+  *
+  * - `assert(c + s === p + q + r)` as a proof that the carry-save adder indeed
+  *   compresses the three terms down to only two terms which have the same sum.
+  * - `assume(u + v === p + q + r)` on new symbolic values `u` and `v` as a
+  *   simplification of other proofs.
+  *
+  * {{{
+  * val s = p ^ q ^ r
+  * val c = (p & q | (p ^ q) & r) << 1
+  * val (u, v) = FormalContract(c, s) { case (u, v) =>
+  *   EnsureProperty(u + v === p + q + r)
+  * }
+  * }}}
+  */
+object FormalContract extends FormalContract$Intf {
+
+  /** Create a formal contract from a sequence of expressions.
+    *
+    * The `mapping` function is used to convert the `Seq[Data]` to a
+    * user-defined type `R`, which is then passed to the contract body and
+    * returned as a result.
+    *
+    * This function is mainly intended for internal use, where the `mapping`
+    * function can be used to map the args sequence to a tuple that is more
+    * convenient for a user to work with.
+    *
+    * @example
+    * Example with identity mapping. The `Seq(a, b)` is passed to `withSeqArgs`
+    * unmodified, and the contract returns a `Seq[Data]` result.
+    * {{{
+    * def withSeqArgs(args: Seq[Data]): Unit = ...
+    * val seqResult: Seq[Data] =
+    *   FormalContract.mapping(Seq(a, b), _ => _)(withSeqArgs)
+    * }}}
+    *
+    * Example with a mapping from sequence to a tuple. The `Seq(a, b)` is mapped
+    * to a `(UInt, UInt)` tuple through `mapToTuple`, which is then passed to
+    * `withTupleArgs`, and the contract returns a corresponding `(UInt, UInt)`
+    * result.
+    * {{{
+    * def mapToTuple(args: Seq[Data]): (UInt, UInt) = {
+    *   // check number of args and types, convert to tuple
+    * }
+    * def withTupleArgs(args: (UInt, UInt)): Unit = ...
+    * val tupleResult: (UInt, UInt) =
+    *   FormalContract.mapping(Seq(a, b), mapToTuple)(withTupleArgs)
+    * }}}
+    */
+  override def mapped[R](args: Seq[Data], mapping: Seq[Data] => R)(
+    body: R => Unit
+  )(implicit sourceInfo: SourceInfo): R = {
+    // Create a sequence of contract results, one for each argument.
+    val results = args.map { arg =>
+      val result = arg.cloneTypeFull
+      experimental.requireIsChiselType(result, "contract result type")
+      result.bind(binding.OpBinding(Builder.forcedUserModule, Builder.currentBlock))
+      result
+    }
+
+    // Create the contract.
+    val contract = Builder.pushCommand(new DefContract(sourceInfo, results, args.map(_.ref(sourceInfo))))
+
+    // Map the sequence of results to the user-defined type `R`, pass it to the
+    // body to build the contract body, and also return it as the result of the
+    // contract as a whole.
+    val mapped = mapping(results)
+    Builder.forcedUserModule.withRegion(contract.region)(layer.elideBlocks(body(mapped)))
+    mapped
+  }
+
+  /** Create a `contract` block with no arguments and results. */
+  def apply(body: => Unit)(implicit sourceInfo: SourceInfo): Unit = {
+    mapped[Unit](Seq(), _ => ())(_ => body)
+  }
+}
+
+// Virtual methods to tell scala-2 and scala-3 private interface traits what methods will be implemented by the public API.
+private[chisel3] trait FormalContract$VirtualMethods {
+  def mapped[R](args: Seq[Data], mapping: Seq[Data] => R)(body: R => Unit)(implicit sourceInfo: SourceInfo): R
+}

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -266,6 +266,8 @@ private[chisel3] object Converter {
       )
     case LayerBlock(info, layer, region) =>
       fir.LayerBlock(convert(info), layer, convert(region, ctx, typeAliases))
+    case DefContract(info, ids, exprs) =>
+      fir.EmptyStmt // dummy until the converter removed
     case Placeholder(info, block) =>
       convert(block, ctx, typeAliases)
   }

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -481,6 +481,10 @@ private[chisel3] object ir {
     }
   }
 
+  case class DefContract(sourceInfo: SourceInfo, ids: Seq[Data], exprs: Seq[Arg]) extends Command {
+    val region = new Block(sourceInfo)
+  }
+
   case class DefOption(sourceInfo: SourceInfo, name: String, cases: Seq[DefOptionCase])
   case class DefOptionCase(sourceInfo: SourceInfo, name: String)
 

--- a/src/test/scala/chiselTests/FormalContractSpec.scala
+++ b/src/test/scala/chiselTests/FormalContractSpec.scala
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests
+
+import chisel3._
+import chisel3.ltl._
+import chisel3.testing.scalatest.FileCheck
+import _root_.circt.stage.ChiselStage
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import Sequence._
+
+class FormalContractSpec extends AnyFlatSpec with Matchers with FileCheck {
+  behavior.of("FormalContract")
+
+  def check(gen: => RawModule)(fc: String): Unit =
+    ChiselStage.emitCHIRRTL(gen).fileCheck("--strict-whitespace", "--match-full-lines")(fc)
+
+  it should "support contracts with no operands" in {
+    class Foo extends RawModule {
+      val a = IO(Input(Bool()))
+      FormalContract {
+        EnsureProperty(a)
+      }
+    }
+    check(new Foo)("""
+      // CHECK-LABEL:  public module Foo : {{@.*}}
+      //  CHECK-NEXT:    input a : UInt<1> {{@.*}}
+      //       CHECK:    contract : {{@.*}}
+      //  CHECK-NEXT:      intrinsic(circt_verif_ensure, a) {{@.*}}
+      """)
+  }
+
+  it should "support contracts with a single operand" in {
+    class Foo extends RawModule {
+      val a = IO(Input(Bool()))
+      val b = FormalContract(a) { x =>
+        EnsureProperty(a)
+        EnsureProperty(x)
+      }
+      layer.elideBlocks {
+        AssumeProperty(b)
+      }
+    }
+    check(new Foo)("""
+      // CHECK-LABEL:  public module Foo : {{@.*}}
+      //  CHECK-NEXT:    input a : UInt<1> {{@.*}}
+      //       CHECK:    contract b = a : {{@.*}}
+      //  CHECK-NEXT:      intrinsic(circt_verif_ensure, a) {{@.*}}
+      //  CHECK-NEXT:      intrinsic(circt_verif_ensure, b) {{@.*}}
+      //       CHECK:    intrinsic(circt_verif_assume, b) {{@.*}}
+      """)
+  }
+
+  it should "support contracts with multiple operands" in {
+    class Foo extends RawModule {
+      val a = IO(Input(Bool()))
+      val b = IO(Input(Bool()))
+      val (c, d) = FormalContract(a, b) { case (x, y) =>
+        EnsureProperty(a)
+        EnsureProperty(b)
+        EnsureProperty(x)
+        EnsureProperty(y)
+      }
+      layer.elideBlocks {
+        AssumeProperty(c)
+        AssumeProperty(d)
+      }
+    }
+    check(new Foo)("""
+      // CHECK-LABEL:  public module Foo : {{@.*}}
+      //  CHECK-NEXT:    input a : UInt<1> {{@.*}}
+      //  CHECK-NEXT:    input b : UInt<1> {{@.*}}
+      //       CHECK:    contract [[C:.+]], [[D:.+]] = a, b : {{@.*}}
+      //  CHECK-NEXT:      intrinsic(circt_verif_ensure, a) {{@.*}}
+      //  CHECK-NEXT:      intrinsic(circt_verif_ensure, b) {{@.*}}
+      //  CHECK-NEXT:      intrinsic(circt_verif_ensure, [[C]]) {{@.*}}
+      //  CHECK-NEXT:      intrinsic(circt_verif_ensure, [[D]]) {{@.*}}
+      //       CHECK:    intrinsic(circt_verif_assume, [[C]]) {{@.*}}
+      //  CHECK-NEXT:    intrinsic(circt_verif_assume, [[D]]) {{@.*}}
+      """)
+  }
+
+  it should "support nested contracts" in {
+    class Foo extends RawModule {
+      val a = IO(Input(Bool()))
+      val b = FormalContract(a) { x =>
+        val c = FormalContract(x) { y =>
+          EnsureProperty(y)
+        }
+      }
+    }
+    check(new Foo)("""
+      // CHECK-LABEL:  public module Foo : {{@.*}}
+      //  CHECK-NEXT:    input a : UInt<1> {{@.*}}
+      //       CHECK:    contract [[B:.+]] = a : {{@.*}}
+      //  CHECK-NEXT:      contract [[C:.+]] = [[B]] : {{@.*}}
+      //  CHECK-NEXT:        intrinsic(circt_verif_ensure, [[C]]) {{@.*}}
+      """)
+  }
+}


### PR DESCRIPTION
Add the `Contract` API which allows users to express the pre and post-conditions of a piece of hardware. These can be used during formal verification to prove that the hardware upholds the conditions laid out in the contract. Additionally, contracts may be used to implement a divide-and-conquer strategy to simplify larger proofs since they act like a cutpoint and an assume-guarantee substitution.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Feature (or new API)

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
