### PR TITLE
Add ElaboratedCircuit and deprecate use of internal ir Circuit

### DIFF
--- a/core/src/main/scala/chisel3/ElaboratedCircuit.scala
+++ b/core/src/main/scala/chisel3/ElaboratedCircuit.scala
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+import firrtl.annotations.Annotation
+import firrtl.ir.{CircuitWithAnnos, Serializer}
+import firrtl.options.{CustomFileEmission, Unserializable}
+import chisel3.experimental.{BaseModule, SourceInfo, UnlocatableSourceInfo}
+import chisel3.experimental.hierarchy.Definition
+import chisel3.internal.firrtl.ir.Circuit
+import chisel3.internal.firrtl.Converter
+
+/** The result of running Chisel elaboration
+  *
+  * Provides limited APIs for inspection of the resulting circuit.
+  */
+// This is an important interface so let's keep it separate from the implementation.
+sealed trait ElaboratedCircuit {
+
+  /** The name of the circuit, also the name of the top public module */
+  def name: String
+
+  /** The circuit and annotations as a string of FIRRTL IR
+    *
+    * This will include annotations passed to Chisel to build the circuit and those created during elaboration.
+    * For large circuits (> 2 GiB of text) use [[lazilySerialize]].
+    */
+  def serialize: String
+
+  /** The circuit and annotations as a string of FIRRTL IR
+    *
+    * For large circuits (> 2 GiB of text) use [[lazilySerialize]]
+    *
+    * @param annotations annotations to include in the FIRRTL IR. No other annotations will be included.
+    */
+  def serialize(annotations: Iterable[Annotation]): String
+
+  /** The circuit and annotations as a lazy buffer of strings of FIRRTL IR
+    *
+    * This will include annotations passed to Chisel to build the circuit and those created during elaboration.
+    * Serialized lazily to reduce peak memory use and support cicuits larger than 2 GiB.
+    */
+  def lazilySerialize: Iterable[String]
+
+  /** The circuit and annotations as a lazy buffer of strings of FIRRTL IR
+    *
+    * Serialized lazily to reduce peak memory use and support cicuits larger than 2 GiB.
+    *
+    * @param annotations annotations to include in the FIRRTL IR. No other annotations will be included.
+    */
+  def lazilySerialize(annotations: Iterable[Annotation]): Iterable[String]
+
+  /** The annotations created during elaboration of this circuit
+    *
+    * This does not include annotations passed to elaboration.
+    */
+  def annotations: Iterable[Annotation]
+
+  /** The Definition of the top module in the elaborated circuit */
+  def topDefinition: Definition[BaseModule]
+
+  /** The underlying circuit, for private use only */
+  private[chisel3] def _circuit: Circuit
+}
+
+private class ElaboratedCircuitImpl(circuit: Circuit, initialAnnotations: Seq[Annotation]) extends ElaboratedCircuit {
+
+  // Source locator needed for toDefinition
+  private implicit def sourceInfo: SourceInfo = UnlocatableSourceInfo
+
+  override def name: String = circuit.name
+
+  override def serialize: String = lazilySerialize.mkString
+
+  override def serialize(annotations: Iterable[Annotation]): String = lazilySerialize(annotations).mkString
+
+  override def lazilySerialize: Iterable[String] = {
+    val annotations = (initialAnnotations.view ++ circuit.firrtlAnnotations).flatMap {
+      case _: Unserializable     => None
+      case _: CustomFileEmission => None
+      case a => Some(a)
+    }.toVector
+    lazilySerialize(annotations)
+  }
+
+  override def lazilySerialize(annotations: Iterable[Annotation]): Iterable[String] = {
+    val prelude = {
+      val dummyCircuit = circuit.copy(components = Nil)
+      val converted = Converter.convert(dummyCircuit)
+      val withAnnos = CircuitWithAnnos(converted, annotations.toVector)
+      Serializer.lazily(withAnnos)
+    }
+    val typeAliases: Seq[String] = circuit.typeAliases.map(_.name)
+    val modules = circuit.components.iterator.map(c => Converter.convert(c, typeAliases))
+    val moduleStrings = modules.flatMap { m =>
+      Serializer.lazily(m, 1) ++ Seq("\n\n")
+    }
+    prelude ++ moduleStrings
+  }
+
+  override def annotations: Iterable[Annotation] = circuit.firrtlAnnotations
+
+  // TODO come up with a better way to figure this out than "last"
+  override def topDefinition: Definition[BaseModule] = circuit.components.last.id.toDefinition
+
+  private[chisel3] override def _circuit: Circuit = circuit
+}
+
+object ElaboratedCircuit {
+  private[chisel3] def apply(circuit: Circuit, initialAnnotations: Seq[Annotation]): ElaboratedCircuit =
+    new ElaboratedCircuitImpl(circuit, initialAnnotations)
+}

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -122,8 +122,8 @@ object Definition extends SourceInfoDoc {
     }
     dynamicContext.inDefinition = true
     val (ir, module) = Builder.build(Module(proto), dynamicContext)
-    Builder.components ++= ir.components
-    Builder.annotations ++= ir.annotations: @nowarn // this will go away when firrtl is merged
+    Builder.components ++= ir._circuit.components
+    Builder.annotations ++= ir._circuit.annotations
     Builder.layers ++= dynamicContext.layers
     Builder.options ++= dynamicContext.options
     module._circuit = Builder.currentModule

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1041,7 +1041,7 @@ private[chisel3] object Builder extends LazyLogging {
   private[chisel3] def build[T <: BaseModule](
     f:              => T,
     dynamicContext: DynamicContext
-  ): (Circuit, T) = {
+  ): (ElaboratedCircuit, T) = {
     // Logger has its own context separate from Chisel's dynamic context
     _root_.logger.Logger.makeScope(dynamicContext.loggerOptions) {
       buildImpl(f, dynamicContext)
@@ -1051,7 +1051,7 @@ private[chisel3] object Builder extends LazyLogging {
   private def buildImpl[T <: BaseModule](
     f:              => T,
     dynamicContext: DynamicContext
-  ): (Circuit, T) = {
+  ): (ElaboratedCircuit, T) = {
     dynamicContextVar.withValue(Some(dynamicContext)) {
       // Must initialize the singleton in a Builder context or weird things can happen
       // in tiny designs/testcases that never access anything in chisel3.internal.
@@ -1129,7 +1129,7 @@ private[chisel3] object Builder extends LazyLogging {
         case _ =>
       }
 
-      (
+      val circuit =
         Circuit(
           components.last.name,
           components.toSeq,
@@ -1139,9 +1139,8 @@ private[chisel3] object Builder extends LazyLogging {
           typeAliases,
           layerAdjacencyList(layer.Layer.Root).map(foldLayers).toSeq,
           optionDefs
-        ),
-        mod
-      )
+        )
+      (ElaboratedCircuit(circuit, dynamicContext.annotationSeq.toSeq), mod)
     }
   }
 

--- a/docs/src/cookbooks/hierarchy.md
+++ b/docs/src/cookbooks/hierarchy.md
@@ -161,12 +161,8 @@ class Top extends Module {
 ```
 ```scala mdoc:passthrough
 println("```")
-val chiselCircuit = (new chisel3.stage.phases.Elaborate)
-  .transform(Seq(chisel3.stage.ChiselGeneratorAnnotation(() => new Top)))
-  .collectFirst { case chisel3.stage.ChiselCircuitAnnotation(a) =>
-    a
-  }.get
-  println(chiselCircuit)
+// Run elaboration so that the println above shows up
+circt.stage.ChiselStage.convert(new Top)
 println("```")
 ```
 

--- a/docs/src/explanations/chisel-type-vs-scala-type.md
+++ b/docs/src/explanations/chisel-type-vs-scala-type.md
@@ -61,12 +61,7 @@ class MyModule(gen: () => MyBundle) extends Module {
 ```scala mdoc:invisible
 // Just here to compile check the above
 def elaborate(module: => chisel3.RawModule) = {
-  (new chisel3.stage.phases.Elaborate)
-    .transform(Seq(chisel3.stage.ChiselGeneratorAnnotation(() => module)))
-    .collectFirst { case chisel3.stage.ChiselCircuitAnnotation(circuit) =>
-      circuit
-    }
-    .get
+  circt.stage.ChiselStage.convert(module)
 }
 elaborate(new MyModule(() => new MyBundle(3)))
 ```

--- a/src/main/scala/chisel3/stage/ChiselAnnotations.scala
+++ b/src/main/scala/chisel3/stage/ChiselAnnotations.scala
@@ -14,7 +14,7 @@ import firrtl.options.{
 }
 import firrtl.options.internal.WriteableCircuitAnnotation
 import firrtl.options.Viewer.view
-import chisel3.{deprecatedMFCMessage, ChiselException, Module}
+import chisel3.{deprecatedMFCMessage, ChiselException, ElaboratedCircuit, Module}
 import chisel3.RawModule
 import chisel3.layer.Layer
 import chisel3.internal.{Builder, WarningFilter}
@@ -297,11 +297,56 @@ object ChiselGeneratorAnnotation extends HasShellOptions {
 /** Stores a Chisel Circuit
   * @param circuit a Chisel Circuit
   */
-case class ChiselCircuitAnnotation(circuit: Circuit) extends NoTargetAnnotation with ChiselOption with Unserializable {
+class ChiselCircuitAnnotation private (private[chisel3] val _circuit: Either[Circuit, ElaboratedCircuit])
+    extends NoTargetAnnotation
+    with ChiselOption
+    with Unserializable
+    with Product
+    with Serializable {
+
+  @deprecated("Use factory method with ElaboratedCircuit instead.", "Chisel 6.7.0")
+  def this(circuit: Circuit) = this(Left(circuit))
+
+  @deprecated("Use elaboratedCircuit instead.", "Chisel 6.7.0")
+  def circuit: Circuit = _circuit.map(_._circuit).merge
+
+  // If constructed from a Circuit, we fake an ElaboratedCircuit with no annotations
+  def elaboratedCircuit: ElaboratedCircuit = _circuit.left.map(ElaboratedCircuit(_, Nil)).merge
+
+  def canEqual(that: Any): Boolean = that.isInstanceOf[ChiselCircuitAnnotation]
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: ChiselCircuitAnnotation => this._circuit == that._circuit
+    case _ => false
+  }
+
+  def productArity: Int = 1
+
+  def productElement(n: Int): Any = n match {
+    case 0 => _circuit
+    case _ => throw new IndexOutOfBoundsException(s"Invalid index $n")
+  }
+
   /* Caching the hashCode for a large circuit is necessary due to repeated queries.
    * Not caching the hashCode will cause severe performance degredations for large [[Circuit]]s.
    */
-  override lazy val hashCode: Int = circuit.hashCode
+  override lazy val hashCode: Int = _circuit.hashCode
+
+  @deprecated("Don't copy, just create a new one.", "Chisel 6.7.0")
+  def copy(circuit: Circuit = this.circuit): ChiselCircuitAnnotation = new ChiselCircuitAnnotation(Left(circuit))
+}
+
+object ChiselCircuitAnnotation extends scala.runtime.AbstractFunction1[ElaboratedCircuit, ChiselCircuitAnnotation] {
+
+  @deprecated("Construct with ElaboratedCircuit instead.", "Chisel 6.7.0")
+  def apply(circuit: Circuit): ChiselCircuitAnnotation = new ChiselCircuitAnnotation(Left(circuit))
+
+  def apply(elaboratedCircuit: ElaboratedCircuit): ChiselCircuitAnnotation = new ChiselCircuitAnnotation(
+    Right(elaboratedCircuit)
+  )
+
+  @deprecated("Unapply is deprecated, access fields directly.", "Chisel 6.7.0")
+  def unapply(c: ChiselCircuitAnnotation): Option[Circuit] = Some(c.circuit)
 }
 
 object CircuitSerializationAnnotation {
@@ -311,23 +356,68 @@ object CircuitSerializationAnnotation {
   case object FirrtlFileFormat extends Format {
     def extension = ".fir"
   }
+
+  @deprecated("Construct with ElaboratedCircuit instead.", "Chisel 6.7.0")
+  def apply(circuit: Circuit, filename: String, format: Format): CircuitSerializationAnnotation =
+    new CircuitSerializationAnnotation(Left(circuit), filename, format)
+
+  def apply(elaboratedCircuit: ElaboratedCircuit, filename: String): CircuitSerializationAnnotation =
+    new CircuitSerializationAnnotation(Right(elaboratedCircuit), filename, FirrtlFileFormat)
+
+  @deprecated("Unapply is deprecated, access fields directly.", "Chisel 6.7.0")
+  def unapply(c: CircuitSerializationAnnotation): Option[(Circuit, String, Format)] = Some(
+    (c.circuit, c.filename, FirrtlFileFormat)
+  )
 }
 
-import CircuitSerializationAnnotation._
+import CircuitSerializationAnnotation.{FirrtlFileFormat, Format}
 
 /** Wraps a `Circuit` for serialization via `CustomFileEmission`
   * @param circuit a Chisel Circuit
   * @param filename name of destination file (excludes file extension)
   * @param format serialization file format (sets file extension)
   */
-case class CircuitSerializationAnnotation(circuit: Circuit, filename: String, format: Format)
-    extends NoTargetAnnotation
+class CircuitSerializationAnnotation private (
+  private val _circuit: Either[Circuit, ElaboratedCircuit],
+  val filename:         String,
+  val format:           Format
+) extends NoTargetAnnotation
     with BufferedCustomFileEmission
-    with WriteableCircuitAnnotation {
+    with WriteableCircuitAnnotation
+    with Product
+    with Serializable {
+
+  @deprecated("Construct with ElaboratedCircuit instead", "Chisel 6.7.0")
+  def this(circuit: Circuit, filename: String, format: Format) = this(Left(circuit), filename, format)
+
+  @deprecated("Use elaboratedCircuit instead", "Chisel 6.7.0")
+  def circuit: Circuit = _circuit.map(_._circuit).merge
+
+  def elaboratedCircuit: ElaboratedCircuit = _circuit.toOption.getOrElse(
+    throw new Exception("This object was built with the deprecated Circuit constructor, cannot get elaboratedCircuit.")
+  )
+
   /* Caching the hashCode for a large circuit is necessary due to repeated queries.
    * Not caching the hashCode will cause severe performance degredations for large [[Circuit]]s.
    */
-  override lazy val hashCode: Int = circuit.hashCode
+  override lazy val hashCode: Int = _circuit.hashCode
+
+  override def canEqual(that: Any): Boolean = that.isInstanceOf[CircuitSerializationAnnotation]
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: CircuitSerializationAnnotation =>
+      this._circuit == that._circuit && this.filename == that.filename && this.format == that.format
+    case _ => false
+  }
+
+  override def productArity: Int = 3
+
+  def productElement(n: Int): Any = n match {
+    case 0 => _circuit
+    case 1 => filename
+    case 2 => format
+    case _ => throw new IndexOutOfBoundsException(s"Invalid index $n")
+  }
 
   protected def baseFileName(annotations: AnnotationSeq): String = filename
 
@@ -350,23 +440,16 @@ case class CircuitSerializationAnnotation(circuit: Circuit, filename: String, fo
     *
     * @note This API is lazy to improve performance and enable emitting circuits larger than 2 GiB
     */
-  def emitLazily(annos: Seq[Annotation]): Iterable[String] = {
-    // First emit all circuit logic without modules
-    val prelude = {
-      val dummyCircuit = circuit.copy(components = Nil)
-      val converted = Converter.convert(dummyCircuit)
-      val withAnnos = CircuitWithAnnos(converted, annos)
-      Serializer.lazily(withAnnos)
-    }
-    val typeAliases: Seq[String] = circuit.typeAliases.map(_.name)
-    val modules = circuit.components.iterator.map(c => Converter.convert(c, typeAliases))
-    val moduleStrings = modules.flatMap { m =>
-      Serializer.lazily(m, 1) ++ Seq("\n\n")
-    }
-    prelude ++ moduleStrings
+  def emitLazily(annos: Seq[Annotation]): Iterable[String] = _circuit match {
+    case Left(c)   => ElaboratedCircuit(c, Nil).lazilySerialize(annos)
+    case Right(ec) => ec.lazilySerialize(annos)
   }
 
   override def getBytesBuffered: Iterable[Array[Byte]] = emitLazily(Nil).map(_.getBytes)
+
+  @deprecated("Don't copy, just create a new one.", "Chisel 6.7.0")
+  def copy(circuit: Circuit = this.circuit, filename: String = this.filename, format: Format = this.format) =
+    new CircuitSerializationAnnotation(Left(circuit), filename, format)
 }
 
 case class ChiselOutputFileAnnotation(file: String) extends NoTargetAnnotation with ChiselOption with Unserializable

--- a/src/main/scala/chisel3/stage/ChiselOptions.scala
+++ b/src/main/scala/chisel3/stage/ChiselOptions.scala
@@ -5,45 +5,52 @@ package chisel3.stage
 import chisel3.internal.firrtl.ir.Circuit
 import chisel3.internal.WarningFilter
 import chisel3.layer.Layer
+import chisel3.ElaboratedCircuit
 import java.io.File
 
 class ChiselOptions private[stage] (
   val printFullStackTrace: Boolean = false,
   val throwOnFirstError:   Boolean = false,
   val outputFile:          Option[String] = None,
-  val chiselCircuit:       Option[Circuit] = None,
+  _chiselCircuit:          Option[Circuit] = None,
   val sourceRoots:         Vector[File] = Vector.empty,
   val warningFilters:      Vector[WarningFilter] = Vector.empty,
   val useLegacyWidth:      Boolean = false,
   val layerMap:            Map[Layer, Layer] = Map.empty,
   val includeUtilMetadata: Boolean = false,
-  val useSRAMBlackbox:     Boolean = false
+  val useSRAMBlackbox:     Boolean = false,
+  val elaboratedCircuit:   Option[ElaboratedCircuit] = None
 ) {
+
+  @deprecated("Use elaboratedCircuit instead", "Chisel 6.7.0")
+  def chiselCircuit: Option[Circuit] = _chiselCircuit
 
   private[stage] def copy(
     printFullStackTrace: Boolean = printFullStackTrace,
     throwOnFirstError:   Boolean = throwOnFirstError,
     outputFile:          Option[String] = outputFile,
-    chiselCircuit:       Option[Circuit] = chiselCircuit,
+    chiselCircuit:       Option[Circuit] = _chiselCircuit,
     sourceRoots:         Vector[File] = sourceRoots,
     warningFilters:      Vector[WarningFilter] = warningFilters,
     useLegacyWidth:      Boolean = useLegacyWidth,
     layerMap:            Map[Layer, Layer] = layerMap,
     includeUtilMetadata: Boolean = includeUtilMetadata,
-    useSRAMBlackbox:     Boolean = useSRAMBlackbox
+    useSRAMBlackbox:     Boolean = useSRAMBlackbox,
+    elaboratedCircuit:   Option[ElaboratedCircuit] = elaboratedCircuit
   ): ChiselOptions = {
 
     new ChiselOptions(
       printFullStackTrace = printFullStackTrace,
       throwOnFirstError = throwOnFirstError,
       outputFile = outputFile,
-      chiselCircuit = chiselCircuit,
+      _chiselCircuit = _chiselCircuit,
       sourceRoots = sourceRoots,
       warningFilters = warningFilters,
       useLegacyWidth = useLegacyWidth,
       layerMap = layerMap,
       includeUtilMetadata = includeUtilMetadata,
-      useSRAMBlackbox = useSRAMBlackbox
+      useSRAMBlackbox = useSRAMBlackbox,
+      elaboratedCircuit = elaboratedCircuit
     )
 
   }

--- a/src/main/scala/chisel3/stage/package.scala
+++ b/src/main/scala/chisel3/stage/package.scala
@@ -14,7 +14,7 @@ package object stage {
 
   final val pleaseSwitchToCIRCT = deprecatedMFCMessage + " Please switch to circt.stage.ChiselStage."
 
-  @nowarn("cat=deprecation&msg=WarnReflectiveNamingAnnotation")
+  @nowarn("cat=deprecation&msg=Use elaboratedCircuit instead")
   implicit object ChiselOptionsView extends OptionsView[ChiselOptions] {
 
     def view(options: AnnotationSeq): ChiselOptions = options.collect { case a: ChiselOption => a }
@@ -25,8 +25,9 @@ package object stage {
           case WarningsAsErrorsAnnotation =>
             c.copy(warningFilters = c.warningFilters :+ WarningsAsErrorsAnnotation.asFilter)
           case ChiselOutputFileAnnotation(f) => c.copy(outputFile = Some(f))
-          case ChiselCircuitAnnotation(a)    => c.copy(chiselCircuit = Some(a))
-          case SourceRootAnnotation(s)       => c.copy(sourceRoots = c.sourceRoots :+ s)
+          case a: ChiselCircuitAnnotation =>
+            c.copy(chiselCircuit = Some(a.circuit), elaboratedCircuit = a._circuit.toOption)
+          case SourceRootAnnotation(s) => c.copy(sourceRoots = c.sourceRoots :+ s)
           case a: WarningConfigurationAnnotation     => c.copy(warningFilters = c.warningFilters ++ a.filters)
           case a: WarningConfigurationFileAnnotation => c.copy(warningFilters = c.warningFilters ++ a.filters)
           case UseLegacyWidthBehavior         => c.copy(useLegacyWidth = true)

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -20,7 +20,7 @@ class AddDedupGroupAnnotations extends Phase {
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val chiselOptions = view[ChiselOptions](annotations)
-    val circuit = chiselOptions.chiselCircuit.getOrElse {
+    val elaboratedCircuit = chiselOptions.elaboratedCircuit.getOrElse {
       throw new ChiselException(
         s"Unable to locate the elaborated circuit, did ${classOf[Elaborate].getName} run correctly"
       )
@@ -28,7 +28,7 @@ class AddDedupGroupAnnotations extends Phase {
 
     val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }.toSet
 
-    val annos = circuit.components.filter {
+    val annos = elaboratedCircuit._circuit.components.filter {
       case x @ DefBlackBox(id, _, _, _, _)   => !id._isImportedDefinition
       case DefIntrinsicModule(_, _, _, _, _) => false
       case DefClass(_, _, _, _)              => false

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputAnnotationFile.scala
@@ -20,8 +20,9 @@ class AddImplicitOutputAnnotationFile extends Phase {
     case _: OutputAnnotationFileAnnotation => annotations
   }.getOrElse {
 
+    // We are assuming these annotations are in sync
     val x: Option[AnnotationSeq] = annotations.collectFirst { case a: ChiselCircuitAnnotation =>
-      OutputAnnotationFileAnnotation(a.circuit.name) +: annotations
+      OutputAnnotationFileAnnotation(a.elaboratedCircuit.name) +: annotations
     }
 
     x.getOrElse(annotations)

--- a/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
+++ b/src/main/scala/chisel3/stage/phases/AddImplicitOutputFile.scala
@@ -21,7 +21,7 @@ class AddImplicitOutputFile extends Phase {
     annotations.collectFirst { case _: ChiselOutputFileAnnotation => annotations }.getOrElse {
 
       val x: Option[AnnotationSeq] = annotations.collectFirst { case a: ChiselCircuitAnnotation =>
-        ChiselOutputFileAnnotation(a.circuit.name) +: annotations
+        ChiselOutputFileAnnotation(a.elaboratedCircuit.name) +: annotations
       }
 
       x.getOrElse(annotations)

--- a/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddSerializationAnnotations.scala
@@ -21,12 +21,12 @@ class AddSerializationAnnotations extends Phase {
 
   def transform(annotations: AnnotationSeq): AnnotationSeq = {
     val chiselOptions = view[ChiselOptions](annotations)
-    val circuit = chiselOptions.chiselCircuit.getOrElse {
+    val circuit = chiselOptions.elaboratedCircuit.getOrElse {
       throw new ChiselException(
         s"Unable to locate the elaborated circuit, did ${classOf[Elaborate].getName} run correctly"
       )
     }
     val filename = chiselOptions.outputFile.getOrElse(circuit.name).stripSuffix(".fir")
-    CircuitSerializationAnnotation(circuit, filename, FirrtlFileFormat) +: annotations
+    CircuitSerializationAnnotation(circuit, filename) +: annotations
   }
 }

--- a/src/main/scala/chisel3/stage/phases/Convert.scala
+++ b/src/main/scala/chisel3/stage/phases/Convert.scala
@@ -8,8 +8,6 @@ import firrtl.{annoSeqToSeq, seqToAnnoSeq, AnnotationSeq}
 import firrtl.options.{Dependency, Phase}
 import firrtl.stage.FirrtlCircuitAnnotation
 
-import scala.annotation.nowarn
-
 /** This prepares a `ChiselCircuitAnnotation for compilation with FIRRTL. This does three things:
   *   - Uses `chisel3.internal.firrtl.Converter` to generate a FirrtlCircuitAnnotation`
   *   - Extracts all `firrtl.annotations.Annotation`s from the `chisel3.internal.firrtl.Circuit`
@@ -22,15 +20,13 @@ class Convert extends Phase {
   override def optionalPrerequisiteOf = Seq.empty
   override def invalidates(a: Phase) = false
 
-  @nowarn("msg=Do not use annotations val of Circuit directly")
   def transform(annotations: AnnotationSeq): AnnotationSeq = annotations.flatMap {
     case a: ChiselCircuitAnnotation =>
       Some(a) ++
         /* Convert this Chisel Circuit to a FIRRTL Circuit */
-        Some(FirrtlCircuitAnnotation(Converter.convert(a.circuit))) ++
+        Some(FirrtlCircuitAnnotation(Converter.convert(a.elaboratedCircuit._circuit))) ++
         /* Convert all Chisel Annotations to FIRRTL Annotations */
-        // TODO: clean up this code when firrtl is merged
-        a.circuit.firrtlAnnotations
+        a.elaboratedCircuit.annotations
     case a => Some(a)
   }
 

--- a/src/main/scala/chisel3/stage/phases/Elaborate.scala
+++ b/src/main/scala/chisel3/stage/phases/Elaborate.scala
@@ -21,6 +21,7 @@ import firrtl.options.Viewer.view
 import logger.{LoggerOptions, LoggerOptionsView}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.annotation.nowarn
 
 /** Elaborate all [[chisel3.stage.ChiselGeneratorAnnotation]]s into [[chisel3.stage.ChiselCircuitAnnotation]]s.
   */
@@ -54,7 +55,7 @@ class Elaborate extends Phase {
             BuilderContextCache.empty,
             chiselOptions.layerMap
           )
-        val (circuit, dut) = {
+        val (elaboratedCircuit, dut) = {
           Builder.build(Module(gen()), context)
         }
 
@@ -63,7 +64,10 @@ class Elaborate extends Phase {
           layer.children.foldLeft(layers :+ layer.chiselLayer) { case (acc, x) => walkLayers(x, acc) }
         }
 
-        Seq(ChiselCircuitAnnotation(circuit), DesignAnnotation(dut, layers = circuit.layers.flatMap(walkLayers(_))))
+        Seq(
+          ChiselCircuitAnnotation(elaboratedCircuit),
+          DesignAnnotation(dut, layers = elaboratedCircuit._circuit.layers.flatMap(walkLayers(_)))
+        )
       } catch {
         /* if any throwable comes back and we're in "stack trace trimming" mode, then print an error and trim the stack trace
          */

--- a/src/main/scala/chisel3/stage/phases/Emitter.scala
+++ b/src/main/scala/chisel3/stage/phases/Emitter.scala
@@ -35,7 +35,7 @@ class Emitter extends Phase {
     annotations.flatMap {
       case a: ChiselCircuitAnnotation if copts.outputFile.isDefined =>
         val filename = sopts.getBuildFileName(copts.outputFile.get, Some(".fir"))
-        val csa = CircuitSerializationAnnotation(a.circuit, filename, FirrtlFileFormat)
+        val csa = CircuitSerializationAnnotation(a.elaboratedCircuit, filename)
         csa.doWriteToFile(new File(filename), Nil)
         Some(a)
       case a => Some(a)

--- a/src/main/scala/chisel3/testers/TesterDriver.scala
+++ b/src/main/scala/chisel3/testers/TesterDriver.scala
@@ -111,11 +111,14 @@ object TesterDriver extends BackendCompilationUtilities {
     override def invalidates(a: Phase) = false
 
     override def transform(a: AnnotationSeq) = a.flatMap {
-      case a @ ChiselCircuitAnnotation(circuit) =>
+      case a: ChiselCircuitAnnotation =>
         Seq(
           a,
           TargetDirAnnotation(
-            firrtl.util.BackendCompilationUtilities.createTestDirectory(circuit.name).getAbsolutePath.toString
+            firrtl.util.BackendCompilationUtilities
+              .createTestDirectory(a.elaboratedCircuit.name)
+              .getAbsolutePath
+              .toString
           )
         )
       case a => Seq(a)

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -2,7 +2,7 @@
 
 package circt.stage
 
-import chisel3.RawModule
+import chisel3.{ElaboratedCircuit, RawModule}
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, CircuitSerializationAnnotation}
 import chisel3.stage.CircuitSerializationAnnotation.FirrtlFileFormat
 import firrtl.{annoSeqToSeq, seqToAnnoSeq, AnnotationSeq, EmittedVerilogCircuitAnnotation}
@@ -76,16 +76,16 @@ object ChiselStage {
 
     val resultAnnos = phase.transform(annos)
 
-    var circuitAnno: Option[CircuitSerializationAnnotation] = None
+    var elaboratedCircuit: Option[ElaboratedCircuit] = None
     val inFileAnnos = resultAnnos.flatMap {
       case a: ChiselCircuitAnnotation =>
-        circuitAnno = Some(CircuitSerializationAnnotation(a.circuit, "", FirrtlFileFormat))
+        elaboratedCircuit = Some(a.elaboratedCircuit)
         None
       case _: Unserializable     => None
       case _: CustomFileEmission => None
       case a => Some(a)
     }
-    circuitAnno.get.emitLazily(inFileAnnos).mkString
+    elaboratedCircuit.get.serialize(inFileAnnos)
   }
 
   /** Elaborates a Chisel circuit and emits it to a file

--- a/src/test/scala-2/chisel3/stage/ChiselOptionsViewSpec.scala
+++ b/src/test/scala-2/chisel3/stage/ChiselOptionsViewSpec.scala
@@ -5,6 +5,7 @@ package chisel3.stage
 import firrtl.options.Viewer.view
 import firrtl.RenameMap
 
+import chisel3.ElaboratedCircuit
 import chisel3.stage._
 import chisel3.internal.firrtl.ir.Circuit
 import org.scalatest.flatspec.AnyFlatSpec
@@ -16,10 +17,11 @@ class ChiselOptionsViewSpec extends AnyFlatSpec with Matchers {
 
   it should "construct a view from an AnnotationSeq" in {
     val bar = Circuit("bar", Seq.empty, Seq.empty, RenameMap())
+    val circuit = ElaboratedCircuit(bar, Seq.empty)
     val annotations = Seq(
       PrintFullStackTraceAnnotation,
       ChiselOutputFileAnnotation("foo"),
-      ChiselCircuitAnnotation(bar)
+      ChiselCircuitAnnotation(circuit)
     )
     val out = view[ChiselOptions](annotations)
 
@@ -29,8 +31,8 @@ class ChiselOptionsViewSpec extends AnyFlatSpec with Matchers {
     info("outputFile was set to 'foo'")
     out.outputFile should be(Some("foo"))
 
-    info("chiselCircuit was set to circuit 'bar'")
-    out.chiselCircuit should be(Some(bar))
+    info("elaboratedCircuit was set to circuit 'circuit'")
+    out.elaboratedCircuit should be(Some(circuit))
 
   }
 

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -4,6 +4,7 @@ package chiselTests.experimental.hierarchy
 
 import chiselTests.ChiselFunSpec
 import chisel3._
+import chisel3.aop.Select
 import chisel3.experimental.BaseModule
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, DesignAnnotation}
 import chisel3.experimental.hierarchy.{Definition, Instance}
@@ -50,7 +51,8 @@ class SeparateElaborationSpec extends ChiselFunSpec with Utils {
     annos.flatMap { a =>
       a match {
         case a: ChiselCircuitAnnotation =>
-          a.circuit.components.map { c => ImportDefinitionAnnotation(c.id.toDefinition) }
+          val allDefns = Select.allDefinitionsOf[BaseModule](a.elaboratedCircuit.topDefinition)
+          allDefns.map(ImportDefinitionAnnotation(_))
         case _ => Seq.empty
       }
     }

--- a/src/test/scala-2/chiselTests/stage/phases/AddSerializationAnnotationsSpec.scala
+++ b/src/test/scala-2/chiselTests/stage/phases/AddSerializationAnnotationsSpec.scala
@@ -29,7 +29,7 @@ class AddSerializationAnnotationsSpec extends AnyFlatSpec with Matchers {
 
     manager
       .transform(annotations)
-      .collect { case CircuitSerializationAnnotation(_, filename, format) => (filename, format) }
+      .collect { case a: CircuitSerializationAnnotation => (a.filename, a.format) }
       .toSeq should be(Seq(("Bar", FirrtlFileFormat)))
   }
 
@@ -39,7 +39,7 @@ class AddSerializationAnnotationsSpec extends AnyFlatSpec with Matchers {
 
     manager
       .transform(annotations)
-      .collect { case CircuitSerializationAnnotation(_, filename, format) => (filename, format) }
+      .collect { case a: CircuitSerializationAnnotation => (a.filename, a.format) }
       .toSeq should be(Seq(("Bar.pb", FirrtlFileFormat)))
   }
 

--- a/src/test/scala-2/chiselTests/stage/phases/ElaborateSpec.scala
+++ b/src/test/scala-2/chiselTests/stage/phases/ElaborateSpec.scala
@@ -38,7 +38,7 @@ class ElaborateSpec extends AnyFlatSpec with Matchers {
     out.collect { case a: ChiselGeneratorAnnotation => a } should be(empty)
 
     info("circuits created with the expected names")
-    out.collect { case a: ChiselCircuitAnnotation => a.circuit.name } should be(Seq("Foo", "Bar"))
+    out.collect { case a: ChiselCircuitAnnotation => a.elaboratedCircuit.name } should be(Seq("Foo", "Bar"))
   }
 
 }

--- a/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
@@ -1111,8 +1111,8 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.Utils {
           new ChiselStageSpec.Bar,
           args
         )
-        .collectFirst { case CircuitSerializationAnnotation(_, filename, _) =>
-          filename
+        .collectFirst { case a: CircuitSerializationAnnotation =>
+          a.filename
         }
         .get should be("Bar")
 


### PR DESCRIPTION

When I tried out https://github.com/chipsalliance/chisel/pull/4643 internally at SiFive, I realized that despite `chisel3.internal.firrtl.ir` being a package private object, `ir.Circuit` still leaks out via `ChiselCircuitAnnotation` and it can be used freely. This leaks full access to the Chisel internal IR in a way that makes it really hard to change things.

This is my attempt to "spackle" that leak by providing the new `ElaboratedCircuit` API as the intended public interface to give to users to let them do what they want to do, while letting us muck with the internals. I think we should feel free to add and deprecate then remove APIs from `ElaboratedCircuit` as long as we take care to keep the actual internals private.

Before merging this, I intend to test it internally and redo https://github.com/chipsalliance/chisel/pull/4643 on top of it because I still want to backport the annotation deprecations as well. Technically https://github.com/chipsalliance/chisel/pull/4643 does not need this, but I think this makes the story of what changes I want to make in 7.0 a lot cleaner without having to worry about changes to `ir.Circuit` accidentally breaking user code.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Change ChiselCircuitAnnotation and CircuitSerializationAnnotation to no longer be case classes to help with the transition to ElaboratedCircuit.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
