### PR TITLE
[firrtl] Add, use dramaticMessage

### DIFF
--- a/firrtl/src/main/scala/firrtl/options/StageUtils.scala
+++ b/firrtl/src/main/scala/firrtl/options/StageUtils.scala
@@ -22,7 +22,7 @@ object StageUtils {
     * @param message error message
     */
   def dramaticWarning(message: String): Unit = {
-    println(Console.YELLOW + dramaticMessage(header=None, body=s"Warning: $message") + Console.RESET)
+    println(Console.YELLOW + dramaticMessage(header = None, body = s"Warning: $message") + Console.RESET)
   }
 
   /** Print an error message (in red)
@@ -30,7 +30,7 @@ object StageUtils {
     * @note This does not stop the Driver.
     */
   def dramaticError(message: String): Unit = {
-    println(Console.RED + dramaticMessage(header=None, body=s"Error: $message") + Console.RESET)
+    println(Console.RED + dramaticMessage(header = None, body = s"Error: $message") + Console.RESET)
   }
 
   /** Generate a message suggesting that the user look at the usage text.

--- a/firrtl/src/main/scala/firrtl/options/StageUtils.scala
+++ b/firrtl/src/main/scala/firrtl/options/StageUtils.scala
@@ -5,13 +5,24 @@ package firrtl.options
 /** Utilities related to working with a [[Stage]] */
 object StageUtils {
 
+  /** Construct a message with an optional header and body.  Demarcate the body
+    * with separators appropriate for most terminals.
+    *
+    * @param header an optional header to include before the separatot
+    * @param body the body of the message
+    * @return a string containing the complete message
+    */
+  def dramaticMessage(header: Option[String], body: String): String = {
+    s"""|${header.map(_ + "\n").getOrElse("")}${"-" * 78}
+        |$body
+        |${"-" * 78}""".stripMargin
+  }
+
   /** Print a warning message (in yellow)
     * @param message error message
     */
   def dramaticWarning(message: String): Unit = {
-    println(Console.YELLOW + "-" * 78)
-    println(s"Warning: $message")
-    println("-" * 78 + Console.RESET)
+    println(Console.YELLOW + dramaticMessage(header=None, body=s"Warning: $message") + Console.RESET)
   }
 
   /** Print an error message (in red)
@@ -19,9 +30,7 @@ object StageUtils {
     * @note This does not stop the Driver.
     */
   def dramaticError(message: String): Unit = {
-    println(Console.RED + "-" * 78)
-    println(s"Error: $message")
-    println("-" * 78 + Console.RESET)
+    println(Console.RED + dramaticMessage(header=None, body=s"Error: $message") + Console.RESET)
   }
 
   /** Generate a message suggesting that the user look at the usage text.

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -20,6 +20,7 @@ import firrtl.options.{
   StageOptionsView,
   Unserializable
 }
+import firrtl.options.StageUtils.dramaticMessage
 import firrtl.stage.{FirrtlOptions, FirrtlOptionsView}
 import firrtl.{annoSeqToSeq, seqToAnnoSeq, AnnotationSeq, EmittedVerilogCircuit, EmittedVerilogCircuitAnnotation}
 
@@ -78,18 +79,6 @@ private object Helpers {
 
 private[this] object Exceptions {
 
-  /** Wrap a message in colorful error text in the sytle of StageUtils.dramaticError.  That method prints to stdout and by
-    * extracting this to just a method that does the string wrapping, this enables the message to be sent to another
-    * file, e.g., stderr.
-    * @todo Remove/unify this with StageUtils.dramaticError once SFC code is migrated into Chisel3.
-    */
-  def dramaticError(header: String, body: String): String = {
-    s"""|$header
-        |${"-" * 78}
-        |$body
-        |${"-" * 78}""".stripMargin
-  }
-
   def versionAdvice: String =
     s"Note that this version of Chisel ($chiselVersion) was published against firtool version " +
       firtoolVersion.getOrElse("<unknown>") + "."
@@ -104,8 +93,8 @@ private[this] object Exceptions {
     */
   class FirtoolNonZeroExitCode(binary: String, exitCode: Int, stdout: String, stderr: String)
       extends RuntimeException(
-        dramaticError(
-          header = s"${binary} returned a non-zero exit code. $versionAdvice",
+        dramaticMessage(
+          header = Some(s"${binary} returned a non-zero exit code. $versionAdvice"),
           body = s"ExitCode:\n${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}"
         )
       )
@@ -118,8 +107,8 @@ private[this] object Exceptions {
     */
   class FirtoolNotFound(msg: String)
       extends RuntimeException(
-        dramaticError(
-          header = s"Error resolving firtool",
+        dramaticMessage(
+          header = Some(s"Error resolving firtool"),
           body = s"""|Chisel requires firtool, the MLIR-based FIRRTL Compiler (MFC), to generate Verilog.
                      |Something is wrong with your firtool installation, please see the following logging
                      |information.


### PR DESCRIPTION
Factor out a utility for constructing distinctive messages from the CIRCT phase and into the firrtl package.  This was always the plan, however, I forgot about it for years.

This is being moved and made public so that I can use it when constructing Chiselsim error messages.

#### Release Notes

- Add `firrtl.options.StageUtils.dramaticMessage` utility for constructing distinctive error messages that do not print to stdout.