### PR TITLE
[chiselsim] Add ChiselSim APIs

### DIFF
--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -10,6 +10,21 @@ import firrtl.{annoSeqToSeq, seqToAnnoSeq}
 
 package object simulator {
 
+  /** A trait that provides the minimal set of ChiselSim APIs.
+    *
+    * Example usage:
+    * {{{
+    * import chisel3.simulator.ChiselSim
+    *
+    * class Foo extends ChiselSim {
+    *   /** This has access to all ChiselSim APIs like `simulate`, `peek`, and `poke`. */
+    * }
+    * }}}
+    *
+    * @see [[chisel3.simulator.scalatest.ChiselSim]]
+    */
+  trait ChiselSim extends PeekPokeAPI with SimulatorAPI
+
   /**
     * An opaque class that can be passed to `Simulation.run` to get access to a `SimulatedModule` in the simulation body.
     */

--- a/src/main/scala/chisel3/simulator/scalatest/package.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/package.scala
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.simulator
+
+import org.scalatest.TestSuite
+
+package object scalatest {
+
+  /** A trait that provides ChiselSim APIs and integration with Scalatest.
+    *
+    * Example usage:
+    * {{{
+    * import chisel3.simulator.scalatestChiselSim
+    * import org.scalatest.funspec.AnyFunSpec
+    * import org.scalatest.matches.should.Matchers
+    *
+    * class Foo extends AnyFunSpec with Matchers with ChiselSim {
+    *   /** This has access to all ChiselSim APIs like `simulate`, `peek`, and `poke`. */
+    * }
+    * }}}
+    *
+    * @see [[chisel3.simulator.ChiselSim]]
+    */
+  trait ChiselSim extends PeekPokeAPI with SimulatorAPI with WithTestingDirectory { self: TestSuite => }
+
+}


### PR DESCRIPTION
Add two flavors of APIs for working with `ChiselSim`. This provides both the "trait mix-in" pattern and the "wildcard object import" pattern.

#### Release Notes

- Add `ChiselSim` APIs. This as the main entry points to `ChiselSim` and should be used in favor of the `EphemeralSimulator`.