### PR TITLE
[chiselsim] Improve error behavior

### DIFF
--- a/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
+++ b/src/main/scala/chisel3/simulator/PeekPokeAPI.scala
@@ -5,12 +5,22 @@ import chisel3._
 
 import chisel3.experimental.{SourceInfo, SourceLine}
 import chisel3.internal.ExceptionHelpers
+import firrtl.options.StageUtils.dramaticMessage
+import scala.util.control.NoStackTrace
 
 object PeekPokeAPI extends PeekPokeAPI
 
 trait PeekPokeAPI {
   case class FailedExpectationException[T](observed: T, expected: T, message: String)
-      extends Exception(s"Failed Expectation: Observed value '$observed' != $expected. $message")
+      extends RuntimeException(
+        dramaticMessage(
+          header = Some("Failed Expectation"),
+          body = s"""|Observed value: '$observed'
+                     |Expected value: '$expected'
+                     |$message""".stripMargin
+        )
+      )
+      with NoStackTrace
   object FailedExpectationException {
     def apply[T](
       observed:     T,

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -37,7 +37,6 @@ final object Simulator {
 
   final case class SimulationDigest[T](simulationStartTime: Long, simulationEndTime: Long, outcome: Try[T])
       extends BackendInvocationOutcome[T]
-
 }
 
 trait Simulator[T <: Backend] {
@@ -127,7 +126,7 @@ trait Simulator[T <: Backend] {
     // post-process the log to figure out what happened.  This post-processing
     // occurs in _both_ the success and failure modes for multiple reasons:
     //
-    // 1. svsim returns a vague UnexpectedEndOfMessage on failure
+    // 1. svsim returns a vague `UnexpectedEndOfMessage` on failure.
     // 2. svsim assumes that simulators will either exit on an assertion failure
     //    or can be compile-time configured to do so.  This is _not_ the case
     //    for VCS as VCS requires runtime configuration to do and svsim

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -64,12 +64,10 @@ trait Simulator[T <: Backend] {
       .fromFile(log)
       .getLines()
       .zipWithIndex
-      .filter { case (line, lineNo) => backend.assertionFailed.matches(line) }
+      .filter { case (line, _) => backend.assertionFailed.matches(line) }
       .toSeq
-    if (lines.isEmpty)
-      return None
 
-    Some(
+    Option.when(lines.nonEmpty)(
       new Exceptions.AssertionFailed(
         message = s"""|The following assertion failures were extracted from the log file:
                       |

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -60,7 +60,12 @@ trait Simulator[T <: Backend] {
     */
   private def postProcessLog: Option[Throwable] = {
     val log = Paths.get(workspacePath, s"workdir-${tag}", "simulation-log.txt").toFile
-    val lines = scala.io.Source.fromFile(log).getLines().zipWithIndex.filter { case (line, lineNo) => backend.assertionFailed.matches(line) }.toSeq
+    val lines = scala.io.Source
+      .fromFile(log)
+      .getLines()
+      .zipWithIndex
+      .filter { case (line, lineNo) => backend.assertionFailed.matches(line) }
+      .toSeq
     if (lines.isEmpty)
       return None
 

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -9,8 +9,6 @@ import svsim._
 
 private[this] object Exceptions {
 
-  case object CompilationFailed extends Exception
-
   class AssertionFailed(message: String)
       extends RuntimeException(
         dramaticMessage(

--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -31,7 +31,6 @@ trait SimulatorAPI {
         stimulus(module.wrapped)
       }
       .result
-
   }
 
   /** Simulate a [[Module]] using a standard initialization procedure that is
@@ -105,6 +104,7 @@ trait SimulatorAPI {
         stimulus(dut)
       }
       .result
+
   }
 
 }

--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -3,11 +3,8 @@
 package chisel3.simulator
 
 import chisel3.{Module, RawModule}
-import chisel3.simulator.Simulator.{BackendInvocationOutcome, CompilationFailed, SimulationDigest}
 import chisel3.util.simpleClassName
 import java.nio.file.Files
-import scala.util.{Failure, Success}
-import svsim.Backend
 
 trait SimulatorAPI {
 
@@ -108,7 +105,6 @@ trait SimulatorAPI {
         stimulus(dut)
       }
       .result
-
   }
 
 }

--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -3,8 +3,11 @@
 package chisel3.simulator
 
 import chisel3.{Module, RawModule}
+import chisel3.simulator.Simulator.{BackendInvocationOutcome, CompilationFailed, SimulationDigest}
 import chisel3.util.simpleClassName
 import java.nio.file.Files
+import scala.util.{Failure, Success}
+import svsim.Backend
 
 trait SimulatorAPI {
 
@@ -31,6 +34,7 @@ trait SimulatorAPI {
         stimulus(module.wrapped)
       }
       .result
+
   }
 
   /** Simulate a [[Module]] using a standard initialization procedure that is

--- a/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -64,6 +64,5 @@ class DefaultSimulatorSpec extends AnyFunSpec with Matchers with FileCheck {
            |""".stripMargin
       }
     }
-
   }
 }

--- a/src/test/scala-2/chiselTests/simulator/EphemeralSimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/EphemeralSimulatorSpec.scala
@@ -32,18 +32,18 @@ class EphemeralSimulatorSpec extends AnyFunSpec with Matchers {
           }
         }
         it("should enable all layers by default") {
-          intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
+          intercept[Exception] {
             simulate(new Foo) { dut =>
               dut.clock.step()
             }
-          }
+          }.getMessage must include("Assertion failed")
         }
         it("should enable all layers when provied with EnableAll") {
-          intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
+          intercept[Exception] {
             simulate(new Foo, layerControl = LayerControl.EnableAll) { dut =>
               dut.clock.step()
             }
-          }
+          }.getMessage must include("Assertion failed")
         }
         it("should disable all layers when provided with Enable()") {
           simulate(new Foo, layerControl = LayerControl.Enable()) { dut =>
@@ -51,11 +51,11 @@ class EphemeralSimulatorSpec extends AnyFunSpec with Matchers {
           }
         }
         it("should enable specific layers with Enable") {
-          intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
+          intercept[Exception] {
             simulate(new Foo, layerControl = LayerControl.Enable(A)) { dut =>
               dut.clock.step()
             }
-          }
+          }.getMessage must include("Assertion failed")
         }
       }
       describe("for inline layers") {
@@ -67,18 +67,18 @@ class EphemeralSimulatorSpec extends AnyFunSpec with Matchers {
           }
         }
         it("should enable all layers by default") {
-          intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
+          intercept[Exception] {
             simulate(new Foo) { dut =>
               dut.clock.step()
             }
-          }
+          }.getMessage must include("Assertion failed")
         }
         it("should enable all layers when provied with EnableAll") {
-          intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
+          intercept[Exception] {
             simulate(new Foo, layerControl = LayerControl.EnableAll) { dut =>
               dut.clock.step()
             }
-          }
+          }.getMessage must include("Assertion failed")
         }
         it("should disable all layers when provided with Enable()") {
           simulate(new Foo, layerControl = LayerControl.Enable()) { dut =>
@@ -86,11 +86,11 @@ class EphemeralSimulatorSpec extends AnyFunSpec with Matchers {
           }
         }
         it("should enable specific layers with Enable") {
-          intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
+          intercept[Exception] {
             simulate(new Foo, layerControl = LayerControl.Enable(A)) { dut =>
               dut.clock.step()
             }
-          }
+          }.getMessage must include("Assertion failed")
         }
         it("should error if an enabled layer does not exist") {
           intercept[IllegalArgumentException] {

--- a/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
@@ -89,7 +89,7 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
           }
           .result
       }
-      thrown.getMessage must include("Observed value '12' != 5.")
+      thrown.getMessage must include("observed value 12 != 5")
       (thrown.getMessage must include).regex(
         """ @\[src/test/scala-2/chiselTests/simulator/SimulatorSpec\.scala:\d+:\d+\]"""
       )
@@ -288,7 +288,7 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
           chisel3.assert(a, "a must be true")
         }
       }
-      intercept[svsim.Simulation.UnexpectedEndOfMessages.type] {
+      intercept[Exception] {
         new VerilatorSimulator("test_run_dir/simulator/has_layers_enabled")
           .simulate(new Foo) { module =>
             import PeekPokeAPI._
@@ -297,7 +297,7 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
             dut.clock.step(1)
           }
           .result
-      }
+      }.getMessage should include("Assertion failed")
     }
   }
 }

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -10,7 +10,7 @@ import chiselTests.FileCheck
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileCheck {
+class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileCheck with WithTestingDirectory {
 
   describe("scalatest.ChiselSim") {
 
@@ -55,7 +55,11 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
         """|CHECK:      One or more assertions failed during Chiselsim simulation
            |CHECK-NEXT: ---
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
-           |CHECK-NEXT:   - {{.+}} foo assertion
+           |CHECK:      lineNo  line
+           |CHECK-NEXT: ---
+           |CHECK-NEXT:      0  [5] %Error:
+           |CHECK:      For more information, see the complete log file:
+           |CHECK:        build/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3.assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )
@@ -76,7 +80,11 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
         """|CHECK:      One or more assertions failed during Chiselsim simulation
            |CHECK-NEXT: ---
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
-           |CHECK-NEXT:   - {{.+$}}
+           |CHECK:      lineNo  line
+           |CHECK-NEXT: ---
+           |CHECK-NEXT:      0  [5] %Error:
+           |CHECK:      For more information, see the complete log file:
+           |CHECK:        build/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl.AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.simulator.scalatest
+
+import chisel3._
+import chisel3.simulator.PeekPokeAPI.FailedExpectationException
+import chisel3.simulator.ChiselSim
+import chisel3.simulator.scalatest.WithTestingDirectory
+import chiselTests.FileCheck
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+
+class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileCheck {
+
+  describe("scalatest.ChiselSim") {
+
+    it("should work correctly for poke and expect") {
+      class Foo extends RawModule {
+        val a = IO(Input(Bool()))
+        val b = IO(Output(Bool()))
+
+        b :<= !a
+      }
+
+      info("poke and expect work")
+      simulateRaw(new Foo) { foo =>
+        foo.a.poke(true.B)
+        foo.b.expect(false.B)
+
+        foo.a.poke(false.B)
+        foo.b.expect(true.B)
+      }
+
+      info("an expect throws an exception")
+      intercept[FailedExpectationException[_]] {
+        simulateRaw(new Foo) { foo =>
+          foo.a.poke(false.B)
+          foo.b.expect(false.B)
+        }
+      }
+    }
+
+    it("should error if a chisel3.assert fires during the simulation") {
+      class Foo extends Module {
+        chisel3.assert(false.B, "foo assertion")
+      }
+
+      val message = intercept[Exception] {
+        simulate(new Foo) { foo =>
+          foo.clock.step(4)
+        }
+      }.getMessage
+
+      fileCheckString(message)(
+        """|CHECK:      One or more assertions failed during Chiselsim simulation
+           |CHECK-NEXT: ---
+           |CHECK-NEXT: The following assertion failures were extracted from the log file:
+           |CHECK-NEXT:   - {{.+}} foo assertion
+           |CHECK-NEXT: ---
+           |""".stripMargin
+      )
+    }
+
+    it("should error if an ltl.AssertProperty fires during the simulation") {
+      class Foo extends Module {
+        ltl.AssertProperty(false.B)
+      }
+
+      val message = intercept[Exception] {
+        simulate(new Foo) { foo =>
+          foo.clock.step(4)
+        }
+      }.getMessage
+
+      fileCheckString(message)(
+        """|CHECK:      One or more assertions failed during Chiselsim simulation
+           |CHECK-NEXT: ---
+           |CHECK-NEXT: The following assertion failures were extracted from the log file:
+           |CHECK-NEXT:   - {{.+$}}
+           |CHECK-NEXT: ---
+           |""".stripMargin
+      )
+    }
+  }
+
+}

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -1,6 +1,7 @@
 package svsim
 
 import java.io.File
+import java.nio.file.Path
 
 // -- Compilation Settings
 
@@ -82,6 +83,14 @@ trait Backend {
     * parse defines and require different escaping.
     */
   def escapeDefine(string: String): String
+
+  /** Process a log file and return a sequence of lines which indicate that there
+    * were assertion failures.
+    *
+    * @param log the log file to process
+    * @return lines that indicate an assertion fired
+    */
+  def assertionFailed(log: Path): Seq[String]
 }
 
 final object Backend {

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -1,7 +1,6 @@
 package svsim
 
 import java.io.File
-import java.nio.file.Path
 import scala.util.matching.Regex
 
 // -- Compilation Settings

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -2,6 +2,7 @@ package svsim
 
 import java.io.File
 import java.nio.file.Path
+import scala.util.matching.Regex
 
 // -- Compilation Settings
 
@@ -84,13 +85,11 @@ trait Backend {
     */
   def escapeDefine(string: String): String
 
-  /** Process a log file and return a sequence of lines which indicate that there
-    * were assertion failures.
-    *
-    * @param log the log file to process
-    * @return lines that indicate an assertion fired
+  /** A regular expression that indicates lines in a log file which indicate
+    * assertion failure.
     */
-  def assertionFailed(log: Path): Seq[String]
+  def assertionFailed: Regex
+
 }
 
 final object Backend {

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -3,8 +3,6 @@
 package svsim.vcs
 
 import svsim._
-import java.nio.file.Path
-import scala.util.matching.Regex
 
 object Backend {
   object CompilationSettings {
@@ -222,6 +220,6 @@ final class Backend(
     */
   override def escapeDefine(string: String): String = string.replace("$", "\\$")
 
-  override def assertionFailed: Regex =
+  override val assertionFailed =
     "^((Assertion failed:)|(Error: )|(Fatal: )|(.* started at .* failed at .*)|(.*Offending)).*$".r
 }

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -220,7 +220,8 @@ final class Backend(
   /** VCS seems to require that dollar signs in arguments are escaped.  This is
     * different from Verilator.
     */
-  override def escapeDefine(string: String): String = string.replace("$", "\\$").q2
+  override def escapeDefine(string: String): String = string.replace("$", "\\$
+
   override def assertionFailed: Regex =
     "^((Assertion failed:)|(Error: )|(Fatal: )|(.* started at .* failed at .*)|(.*Offending)).*$".r
 }

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -4,6 +4,7 @@ package svsim.vcs
 
 import svsim._
 import java.nio.file.Path
+import scala.util.matching.Regex
 
 object Backend {
   object CompilationSettings {
@@ -221,5 +222,6 @@ final class Backend(
     */
   override def escapeDefine(string: String): String = string.replace("$", "\\$")
 
-  override def assertionFailed(file: Path): Seq[String] = ???
+  override def assertionFailed: Regex =
+    "^((Assertion failed:)|(Error: )|(.* started at .* failed at .*)|( *Offending)).*$".r
 }

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -3,6 +3,7 @@
 package svsim.vcs
 
 import svsim._
+import java.nio.file.Path
 
 object Backend {
   object CompilationSettings {
@@ -219,4 +220,6 @@ final class Backend(
     * different from Verilator.
     */
   override def escapeDefine(string: String): String = string.replace("$", "\\$")
+
+  override def assertionFailed(file: Path): Seq[String] = ???
 }

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -220,8 +220,7 @@ final class Backend(
   /** VCS seems to require that dollar signs in arguments are escaped.  This is
     * different from Verilator.
     */
-  override def escapeDefine(string: String): String = string.replace("$", "\\$")
-
+  override def escapeDefine(string: String): String = string.replace("$", "\\$").q2
   override def assertionFailed: Regex =
-    "^((Assertion failed:)|(Error: )|(.* started at .* failed at .*)|( *Offending)).*$".r
+    "^((Assertion failed:)|(Error: )|(Fatal: )|(.* started at .* failed at .*)|(.*Offending)).*$".r
 }

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -220,7 +220,7 @@ final class Backend(
   /** VCS seems to require that dollar signs in arguments are escaped.  This is
     * different from Verilator.
     */
-  override def escapeDefine(string: String): String = string.replace("$", "\\$
+  override def escapeDefine(string: String): String = string.replace("$", "\\$")
 
   override def assertionFailed: Regex =
     "^((Assertion failed:)|(Error: )|(Fatal: )|(.* started at .* failed at .*)|(.*Offending)).*$".r

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import svsim._
 import scala.sys.process._
 import scala.collection.mutable
+import scala.util.matching.Regex
 
 object Backend {
   object CompilationSettings {
@@ -171,8 +172,6 @@ final class Backend(executablePath: String) extends svsim.Backend {
 
   override def escapeDefine(string: String): String = string
 
-  override def assertionFailed(file: Path): Seq[String] = {
-    val re = "^.*Assertion failed in.*".r
-    scala.io.Source.fromFile(file.toFile).getLines().filter(re.matches).toSeq
-  }
+  override val assertionFailed: Regex = "^.*Assertion failed in.*".r
+
 }

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -2,11 +2,9 @@
 
 package svsim.verilator
 
-import java.nio.file.Path
 import svsim._
 import scala.sys.process._
 import scala.collection.mutable
-import scala.util.matching.Regex
 
 object Backend {
   object CompilationSettings {
@@ -172,6 +170,6 @@ final class Backend(executablePath: String) extends svsim.Backend {
 
   override def escapeDefine(string: String): String = string
 
-  override val assertionFailed: Regex = "^.*Assertion failed in.*".r
+  override val assertionFailed = "^.*Assertion failed in.*".r
 
 }

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -2,6 +2,7 @@
 
 package svsim.verilator
 
+import java.nio.file.Path
 import svsim._
 import scala.sys.process._
 import scala.collection.mutable
@@ -15,7 +16,7 @@ object Backend {
   }
 
   case class CompilationSettings(
-    traceStyle:                 Option[CompilationSettings.TraceStyle] = None,
+    traceStyle: Option[CompilationSettings.TraceStyle] = Some(CompilationSettings.TraceStyle.Vcd(filename = "foo.vcd")),
     outputSplit:                Option[Int] = None,
     outputSplitCFuncs:          Option[Int] = None,
     disabledWarnings:           Seq[String] = Seq(),
@@ -169,4 +170,9 @@ final class Backend(executablePath: String) extends svsim.Backend {
   }
 
   override def escapeDefine(string: String): String = string
+
+  override def assertionFailed(file: Path): Seq[String] = {
+    val re = "^.*Assertion failed in.*".r
+    scala.io.Source.fromFile(file.toFile).getLines().filter(re.matches).toSeq
+  }
 }

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -48,10 +48,7 @@ case class CustomVerilatorBackend(actualBackend: verilator.Backend) extends Back
 
   override def escapeDefine(string: String): String = string
 
-  override def assertionFailed(file: Path): Seq[String] = {
-    val re = "^.*Assertion failed in.*".r
-    scala.io.Source.fromFile(file.toFile).getLines().filter(re.matches).toSeq
-  }
+  override val assertionFailed = "^.*Assertion failed in.*".r
 }
 
 class VerilatorSpec extends BackendSpec {

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import svsim._
 import java.io.{BufferedReader, FileReader}
+import java.nio.file.Path
 import svsimTests.Resources.TestWorkspace
 
 class VCSSpec extends BackendSpec {
@@ -46,6 +47,11 @@ case class CustomVerilatorBackend(actualBackend: verilator.Backend) extends Back
   }
 
   override def escapeDefine(string: String): String = string
+
+  override def assertionFailed(file: Path): Seq[String] = {
+    val re = "^.*Assertion failed in.*".r
+    scala.io.Source.fromFile(file.toFile).getLines().filter(re.matches).toSeq
+  }
 }
 
 class VerilatorSpec extends BackendSpec {


### PR DESCRIPTION
Fix longstanding problems in Chiselsim where the result of a failing simulation (e.g., an assertion firing) would result in an obtuse `UnexpectedEndOfMessages` assertion.  This then forces any Chiselsim user to catch this and then figure out what went wrong.  See the unpublished ChiselSpec for an example.

Fix this with an abstract method for the Backend that forces it to describe (via a RegEx) how to find interesting parts of the log file which indicate certain failures (the aforementioned assertion failures).  This then allows for the default simulate method to substitute a _better_ assertion where possible.

This is not as good as a more advanced alternative which actually hooks into the simulation to do something when an assertion fires.  However, this is a larger effort that requires changing the Verilog that is emitted for CIRCT-compiled FIRRTL (or defining an ABI for assertions).  We definitely want to move in this direction, though.

#### Release Notes

- Improve the behavior of Chiselsim on an expectation or assertion failure.  This will no longer require the user to catch an `UnexpectedEndOfMessage` assertion and reconstruct what happened.