### PR TITLE
[chiselsim] Add FIRRTL macro control

### DIFF
--- a/src/main/scala/chisel3/simulator/ChiselSettings.scala
+++ b/src/main/scala/chisel3/simulator/ChiselSettings.scala
@@ -149,13 +149,13 @@ object ChiselSettings {
     * must invoke this method like:
     *
     * {{{
-    * ChiselSettings.default[Foo]
+    * ChiselSettings.defaultRaw[Foo]
     * }}}
     *
     * If you invoke this method like the following, you will get an error:
     *
     * {{{
-    * ChiselSettings.default
+    * ChiselSettings.defaultRaw
     * }}}
     */
   final def defaultRaw[A <: RawModule]: ChiselSettings[A] = new ChiselSettings[A](

--- a/src/main/scala/chisel3/simulator/ChiselSettings.scala
+++ b/src/main/scala/chisel3/simulator/ChiselSettings.scala
@@ -70,9 +70,14 @@ object MacroText {
   * compilation itself or the Verilog compilation and simulation.
   *
   * @param layerControl determines which [[chisel3.layer.Layer]]s should be
+  * @param assertVerboseCond a condition that guards the printing of assert
+  * messages created from `circt_chisel_ifelsefatal` intrinsics
+  * @param printfCond a condition that guards printing of [[chisel3.printf]]s
+  * @param stopCond a condition that guards terminating the simulation (via
+  * `$fatal`) for asserts created from `circt_chisel_ifelsefatal` intrinsics
   * enabled _during Verilog elaboration_.
   */
-final class ChiselSettings[A <: RawModule](
+final class ChiselSettings[A <: RawModule] private[simulator] (
   /** Layers to turn on/off during Verilog elaboration */
   val verilogLayers:     LayerControl.Type,
   val assertVerboseCond: Option[MacroText.Type[A]],
@@ -158,6 +163,31 @@ object ChiselSettings {
     assertVerboseCond = None,
     printfCond = None,
     stopCond = None
+  )
+
+  /** Simple factory for construcing a [[ChiselSettings]] from arguments.
+    *
+    * This method primarily exists as a way to make future refactors that add
+    * options to [[ChiselSettings]] easier.
+    *
+    * @param layerControl determines which [[chisel3.layer.Layer]]s should be
+    * @param assertVerboseCond a condition that guards the printing of assert
+    * messages created from `circt_chisel_ifelsefatal` intrinsics
+    * @param printfCond a condition that guards printing of [[chisel3.printf]]s
+    * @param stopCond a condition that guards terminating the simulation (via
+    * `$fatal`) for asserts created from `circt_chisel_ifelsefatal` intrinsics
+    * @return a [[ChiselSettings]] with the provided parameters set
+    */
+  def apply[A <: RawModule](
+    verilogLayers:     LayerControl.Type,
+    assertVerboseCond: Option[MacroText.Type[A]],
+    printfCond:        Option[MacroText.Type[A]],
+    stopCond:          Option[MacroText.Type[A]]
+  ): ChiselSettings[A] = new ChiselSettings(
+    verilogLayers = verilogLayers,
+    assertVerboseCond = assertVerboseCond,
+    printfCond = printfCond,
+    stopCond = stopCond
   )
 
 }

--- a/src/main/scala/chisel3/simulator/ChiselSettings.scala
+++ b/src/main/scala/chisel3/simulator/ChiselSettings.scala
@@ -139,11 +139,11 @@ object ChiselSettings {
     stopCond = Some(MacroText.NotSignal(get = _.reset))
   )
 
-  /** Retun a default [[ChiselSettings]] for a [[Module]].
+  /** Retun a default [[ChiselSettings]] for a [[RawModule]].
     *
-    *  This differs from [[default]] in that it cannot set default values for
-    *  macros because a [[RawModule]] has no defined reset port.  You will
-    *  likely want to override the macros after using this factory.
+    * This differs from [[default]] in that it cannot set default values for
+    * macros because a [[RawModule]] has no defined reset port.  You will likely
+    * want to override the macros after using this factory.
     *
     * Note: this _requires_ that an explicit type parameter is provided.  You
     * must invoke this method like:

--- a/src/main/scala/chisel3/simulator/ChiselSettings.scala
+++ b/src/main/scala/chisel3/simulator/ChiselSettings.scala
@@ -2,6 +2,67 @@
 
 package chisel3.simulator
 
+import chisel3.{Data, Module, RawModule}
+import svsim.CommonCompilationSettings.VerilogPreprocessorDefine
+import svsim.Workspace
+
+/** This object implements an enumeration of classes that can be used to
+  * generate macros for use in [[ChiselSettings]].
+  */
+object MacroText {
+
+  /** The type of all enumerations for macros */
+  sealed trait Type[A <: RawModule] {
+
+    /** Return the preprocessor define associated with this macro.
+      *
+      * @param macroName the macros name
+      * @param elaboratedModule a Chisel module to use to resolve substitutions
+      * @return the macro string
+      */
+    private[simulator] def toPreprocessorDefine(
+      macroName:        String,
+      elaboratedModule: ElaboratedModule[A]
+    ): VerilogPreprocessorDefine
+
+  }
+
+  /** A macro that will return macro text with the name of a signal in the design
+    * under test
+    *
+    * @param get a function that accesses a singal in the design under test
+    */
+  case class Signal[A <: RawModule](get: (A) => Data) extends Type[A] {
+
+    override private[simulator] def toPreprocessorDefine(
+      macroName:        String,
+      elaboratedModule: ElaboratedModule[A]
+    ) = {
+      val port = elaboratedModule.portMap(get(elaboratedModule.wrapped)).name
+      VerilogPreprocessorDefine(macroName, s"${Workspace.testbenchModuleName}.$port")
+    }
+
+  }
+
+  /** A macro that will return macro text with the logical inversion a signal in
+    * the design under test
+    *
+    * @param get a function that accesses a singal in the design under test
+    */
+  case class NotSignal[A <: RawModule](get: (A) => Data) extends Type[A] {
+
+    override private[simulator] def toPreprocessorDefine(
+      macroName:        String,
+      elaboratedModule: ElaboratedModule[A]
+    ) = {
+      val port = elaboratedModule.portMap(get(elaboratedModule.wrapped)).name
+      VerilogPreprocessorDefine(macroName, s"!${Workspace.testbenchModuleName}.$port")
+    }
+
+  }
+
+}
+
 /** This struct describes settings related to controlling a Chisel simulation.  Thes
   *
   * These setings are only intended to be associated with Chisel, FIRRTL, and
@@ -11,15 +72,92 @@ package chisel3.simulator
   * @param layerControl determines which [[chisel3.layer.Layer]]s should be
   * enabled _during Verilog elaboration_.
   */
-final class ChiselSettings(
+final class ChiselSettings[A <: RawModule](
   /** Layers to turn on/off during Verilog elaboration */
-  val verilogLayers: LayerControl.Type
-)
+  val verilogLayers:     LayerControl.Type,
+  val assertVerboseCond: Option[MacroText.Type[A]],
+  val printfCond:        Option[MacroText.Type[A]],
+  val stopCond:          Option[MacroText.Type[A]]
+) {
 
+  def copy(
+    verilogLayers:     LayerControl.Type = verilogLayers,
+    assertVerboseCond: Option[MacroText.Type[A]] = assertVerboseCond,
+    printfCond:        Option[MacroText.Type[A]] = printfCond,
+    stopCond:          Option[MacroText.Type[A]] = stopCond
+  ) =
+    new ChiselSettings(verilogLayers, assertVerboseCond, printfCond, stopCond)
+
+  private[simulator] def preprocessorDefines(
+    elaboratedModule: ElaboratedModule[A]
+  ): Seq[VerilogPreprocessorDefine] = {
+
+    Seq(
+      (assertVerboseCond -> "ASSERT_VERBOSE_COND"),
+      (printfCond -> "PRINTF_COND"),
+      (stopCond -> "STOP_COND")
+    ).flatMap {
+      case (Some(a), macroName) => Some(a.toPreprocessorDefine(macroName, elaboratedModule))
+      case (None, _)            => None
+    } ++ verilogLayers.preprocessorDefines(elaboratedModule)
+
+  }
+
+}
+
+/** This object contains factories of [[ChiselSettings]].
+  *
+  */
 object ChiselSettings {
 
-  final def default: ChiselSettings = new ChiselSettings(
-    verilogLayers = LayerControl.EnableAll
+  /** Retun a default [[ChiselSettings]] for a [[Module]].  Macros will be set to
+    * disable [[chisel3.assert]]-style assertions using the [[Module]]'s reset
+    * port.
+    *
+    * Note: this _requires_ that an explicit type parameter is provided.  You
+    * must invoke this method like:
+    *
+    * {{{
+    * ChiselSettings.default[Foo]
+    * }}}
+    *
+    * If you invoke this method like the following, you will get an error:
+    *
+    * {{{
+    * ChiselSettings.default
+    * }}}
+    */
+  final def default[A <: Module]: ChiselSettings[A] = new ChiselSettings[A](
+    verilogLayers = LayerControl.EnableAll,
+    assertVerboseCond = Some(MacroText.NotSignal(get = _.reset)),
+    printfCond = Some(MacroText.NotSignal(get = _.reset)),
+    stopCond = Some(MacroText.NotSignal(get = _.reset))
+  )
+
+  /** Retun a default [[ChiselSettings]] for a [[Module]].
+    *
+    *  This differs from [[default]] in that it cannot set default values for
+    *  macros because a [[RawModule]] has no defined reset port.  You will
+    *  likely want to override the macros after using this factory.
+    *
+    * Note: this _requires_ that an explicit type parameter is provided.  You
+    * must invoke this method like:
+    *
+    * {{{
+    * ChiselSettings.default[Foo]
+    * }}}
+    *
+    * If you invoke this method like the following, you will get an error:
+    *
+    * {{{
+    * ChiselSettings.default
+    * }}}
+    */
+  final def defaultRaw[A <: RawModule]: ChiselSettings[A] = new ChiselSettings[A](
+    verilogLayers = LayerControl.EnableAll,
+    assertVerboseCond = None,
+    printfCond = None,
+    stopCond = None
   )
 
 }

--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -22,7 +22,10 @@ object EphemeralSimulator extends PeekPokeAPI {
     layerControl: LayerControl.Type = LayerControl.EnableAll
   )(body: (T) => Unit): Unit = {
     implicit val temporary = HasTestingDirectory.temporary(deleteOnExit = true)
-    DefaultSimulator.simulateRaw(module, new ChiselSettings(verilogLayers = layerControl))(body)
+    DefaultSimulator.simulateRaw(
+      module,
+      ChiselSettings.defaultRaw[T].copy(verilogLayers = layerControl)
+    )(body)
   }
 
 }

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -81,7 +81,7 @@ trait Simulator[T <: Backend] {
 
   final def simulate[T <: RawModule, U](
     module:         => T,
-    chiselSettings: ChiselSettings = ChiselSettings.default
+    chiselSettings: ChiselSettings[T] = ChiselSettings.defaultRaw[T]
   )(body: (SimulatedModule[T]) => U): Simulator.BackendInvocationDigest[U] = {
     val workspace = new Workspace(path = workspacePath, workingDirectoryPrefix = workingDirectoryPrefix)
     workspace.reset()
@@ -94,9 +94,7 @@ trait Simulator[T <: Backend] {
       // ensures that `` `include `` directives can be resolved.
       includeDirs = Some(commonCompilationSettings.includeDirs.getOrElse(Seq.empty) :+ workspace.primarySourcesPath),
       verilogPreprocessorDefines =
-        commonCompilationSettings.verilogPreprocessorDefines ++ chiselSettings.verilogLayers.preprocessorDefines(
-          elaboratedModule
-        ),
+        commonCompilationSettings.verilogPreprocessorDefines ++ chiselSettings.preprocessorDefines(elaboratedModule),
       fileFilter =
         commonCompilationSettings.fileFilter.orElse(chiselSettings.verilogLayers.shouldIncludeFile(elaboratedModule)),
       directoryFilter = commonCompilationSettings.directoryFilter.orElse(

--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -23,7 +23,7 @@ trait SimulatorAPI {
     */
   def simulateRaw[T <: RawModule](
     module:         => T,
-    chiselSettings: ChiselSettings = ChiselSettings.default
+    chiselSettings: ChiselSettings[T] = ChiselSettings.defaultRaw[T]
   )(stimulus: (T) => Unit)(implicit hasSimulator: HasSimulator, testingDirectory: HasTestingDirectory): Unit = {
 
     hasSimulator.getSimulator
@@ -74,7 +74,7 @@ trait SimulatorAPI {
     */
   def simulate[T <: Module](
     module:                => T,
-    chiselSettings:        ChiselSettings = ChiselSettings.default,
+    chiselSettings:        ChiselSettings[T] = ChiselSettings.default[T],
     additionalResetCycles: Int = 0
   )(stimulus: (T) => Unit)(implicit hasSimulator: HasSimulator, testingDirectory: HasTestingDirectory): Unit = {
 

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -32,7 +32,11 @@ package object simulator {
     private[simulator] val wrapped: T,
     private[simulator] val ports:   Seq[(Data, ModuleInfo.Port)],
     private[simulator] val layers:  Seq[chisel3.layer.Layer]
-  )
+  ) {
+
+    private[chisel3] val portMap = ports.toMap
+
+  }
 
   /**
     * A class that enables using a Chisel module to control an `svsim.Simulation`.

--- a/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
@@ -312,13 +312,13 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
       info("illegal constructs cause compilation failure")
       intercept[Exception] {
         new VerilatorSimulator("test_run_dir/simulator/does_not_compile_disabled_layers-enabledf")
-          .simulate(new Foo, new ChiselSettings(verilogLayers = LayerControl.EnableAll)) { _ => }
+          .simulate(new Foo, ChiselSettings.default[Foo].copy(verilogLayers = LayerControl.EnableAll)) { _ => }
           .result
       }.getMessage() should include("Unsupported: s_eventually")
 
       info("disabling unsupported constracts causes compilation to succeed")
       new VerilatorSimulator("test_run_dir/simulator/does_not_compile_disabled_layers-disabled")
-        .simulate(new Foo, new ChiselSettings(verilogLayers = LayerControl.DisableAll)) { _ => }
+        .simulate(new Foo, ChiselSettings.default[Foo].copy(verilogLayers = LayerControl.DisableAll)) { _ => }
         .result
 
     }


### PR DESCRIPTION
Change SimulatorAPI methods to use the ChiselSettings class instead of
directly communicating layerControl.  This will enable us to lump together
more options that all are associated with Chisel/FIRRTL/the Verilog ABI.

Extend ChiselSettings with three macros which were currently being set by
ChiselRunners:

- ASSERT_VERBOSE_COND
- PRINTF_COND
- STOP_COND

Make this work in such a way that the user can specify a function that
will return the _signal_ that they want to use to set this macro in one of
several predefined ways.

This is working towards replacing this part of ChiselSpec: https://github.com/chipsalliance/chisel/blob/main/src/test/scala-2/chiselTests/ChiselSpec.scala#L60

#### Release Notes

- Add FIRRTL/Verilog ABI macro control to Chiselsim.