### PR TITLE
[svsim] End Verilator simulation on $finish

### DIFF
--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -150,10 +150,12 @@ final class Workspace(
       l("  export \"DPI-C\" task run_simulation;")
       l("  task run_simulation;")
       l("    input int timesteps;")
+      l("    output int done;")
       l("    #timesteps;")
+      l("    done = 0;")
       l("  endtask")
       l("  `else")
-      l("  import \"DPI-C\" function void run_simulation(int timesteps);")
+      l("  import \"DPI-C\" function int run_simulation(int timesteps);")
       l("  `endif")
       l()
 

--- a/svsim/src/test/resources/Finish.sv
+++ b/svsim/src/test/resources/Finish.sv
@@ -1,0 +1,6 @@
+module Finish(input clock);
+
+  always @ (posedge clock)
+    $finish;
+
+endmodule

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -298,6 +298,39 @@ trait BackendSpec extends AnyFunSpec with Matchers {
           }
         }
       }
+
+      it("ends the simulation on '$finish' (#4700)") {
+        workspace.reset()
+        workspace.elaborateFinishTest()
+        workspace.generateAdditionalSources()
+        simulation = workspace.compile(
+          backend
+        )(
+          workingDirectoryTag = name,
+          commonSettings = CommonCompilationSettings(),
+          backendSpecificSettings = compilationSettings,
+          customSimulationWorkingDirectory = None,
+          verbose = false
+        )
+        simulation.run(
+          verbose = false,
+          executionScriptLimit = None
+        ) { controller =>
+          val clock = controller.port("clock")
+          clock.tick(
+            inPhaseValue = 0,
+            outOfPhaseValue = 1,
+            timestepsPerPhase = 1,
+            maxCycles = 8,
+            sentinel = None
+          )
+        }
+        val re = ".*Verilog \\$finish.*".r
+        new BufferedReader(new FileReader(s"${simulation.workingDirectoryPath}/simulation-log.txt")).lines
+          .filter(re.matches(_))
+          .toArray
+          .size must be(1)
+      }
     }
   }
 }

--- a/svsim/src/test/scala/Resources.scala
+++ b/svsim/src/test/scala/Resources.scala
@@ -131,5 +131,20 @@ object Resources {
         )
       )
     }
+    def elaborateFinishTest(): Unit = {
+      workspace.addPrimarySourceFromResource(getClass, "/Finish.sv")
+      workspace.elaborate(
+        ModuleInfo(
+          name = "Finish",
+          ports = Seq(
+            new ModuleInfo.Port(
+              name = "clock",
+              isSettable = true,
+              isGettable = false
+            )
+          )
+        )
+      )
+    }
   }
 }


### PR DESCRIPTION
Fix a bug in how Verilator simulations work in svsim where the simulation would _not_ terminate when a `$finish` was called.  This seems to be a bug in Verilator where it will not terminate the simulation (as mandated by the Verilog spec) unless you are running with time delays.

Fixes #4700.

#### Release Notes

Fix an svsim bug, which could manifest in Chiselsim, where when a simulation calls `$finish` that it does not immediately exit for Verilator backends.