### PR TITLE
[Chiselsim] Replace Chiselspec w/ ChiselSim

### DIFF
--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -7,7 +7,7 @@ import scala.util.{Failure, Success, Try}
 import scala.util.control.NoStackTrace
 import svsim._
 
-private[this] object Exceptions {
+private[simulator] object Exceptions {
 
   class AssertionFailed(message: String)
       extends RuntimeException(

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -18,6 +18,15 @@ private[this] object Exceptions {
       )
       with NoStackTrace
 
+  class Timeout(timesteps: BigInt, message: String)
+      extends RuntimeException(
+        dramaticMessage(
+          header = Some(s"A timeout occurred after $timesteps timesteps"),
+          body = message
+        )
+      )
+      with NoStackTrace
+
 }
 
 final object Simulator {

--- a/src/main/scala/chisel3/simulator/stimulus/RunUntilFinished.scala
+++ b/src/main/scala/chisel3/simulator/stimulus/RunUntilFinished.scala
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.simulator.stimulus
+
+import chisel3.{Clock, Module}
+import chisel3.simulator.AnySimulatedModule
+import chisel3.simulator.Exceptions
+
+/** Stimulus that will run a simulation, expecting a [[chisel3.stop]] (a Verilog
+  * `$finish`) to occur before a maximum number of cycles has elapsed.
+  */
+trait RunUntilFinished[A] extends Stimulus.Type[A] {
+
+  /** The maximum number of cycles. */
+  protected def _maxCycles: Int
+
+  /** A function that returns the clock to tick. */
+  protected def _getClock: (A) => Clock
+
+  /** Apply stimulus to the unit
+    *
+    * @param the unit to apply stimulus to
+    */
+  override final def apply(dut: A): Unit = {
+    AnySimulatedModule.current
+      .port(_getClock(dut))
+      .tick(
+        timestepsPerPhase = 1,
+        maxCycles = _maxCycles,
+        inPhaseValue = 1,
+        outOfPhaseValue = 0,
+        sentinel = None,
+        checkElapsedCycleCount = (count: BigInt) => {
+          if (count == _maxCycles)
+            throw new Exceptions.Timeout(_maxCycles, "Expected a $finish, but none received")
+        }
+      )
+  }
+
+}
+
+/** Factory of [[RunUntilFinished]] stimulus for different kinds of modules. */
+object RunUntilFinished {
+
+  /** Return stimulus for a [[Module]].  This uses the default clock of the module to apply stimulus.
+    *
+    * @param maxCycles the maximum number of cycles to run the unit for before a timeout
+    */
+  def module(maxCycles: Int): RunUntilFinished[Module] = new RunUntilFinished[Module] {
+
+    override protected final val _maxCycles = maxCycles
+
+    override protected final val _getClock = _.clock
+
+  }
+
+  /** Return stimulus for any type.  This requires the user to specify how to extract the clock from the type.
+    * @param maxCycles the maximum number of cycles to run the unit for before a timeout
+    * @param getClock a function to return a clock from the unit
+    */
+  def any[A](maxCycles: Int, getClock: A => Clock): RunUntilFinished[A] = new RunUntilFinished[A] {
+
+    override protected final val _maxCycles = maxCycles
+
+    override protected final val _getClock = getClock
+
+  }
+
+  /** Return default stimulus.  This is the same as [[module]].
+    *
+    * @param maxCycles the maximum number of cycles to run the unit for before a timeout
+    */
+  def apply(maxCycles: Int): RunUntilFinished[Module] = module(maxCycles)
+
+}

--- a/src/main/scala/chisel3/simulator/stimulus/Stimulus.scala
+++ b/src/main/scala/chisel3/simulator/stimulus/Stimulus.scala
@@ -1,0 +1,9 @@
+package chisel3.simulator.stimulus
+
+/** Types and utility functions related to the [[stimulus]] package. */
+object Stimulus {
+
+  /** The type of stimulus.  This takes a type and applies some stimulus to it.  Nothing is returned. */
+  type Type[A] = (A) => Unit
+
+}

--- a/src/test/scala-2/chiselTests/Assert.scala
+++ b/src/test/scala-2/chiselTests/Assert.scala
@@ -4,6 +4,8 @@ package chiselTests
 
 import chisel3._
 import circt.stage.ChiselStage
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testers.BasicTester
 import chisel3.util._
 
@@ -142,9 +144,11 @@ class PrintableWhenScopeTester extends Module {
   }
 }
 
-class AssertSpec extends ChiselFlatSpec with Utils {
+class AssertSpec extends ChiselFlatSpec with Utils with ChiselSim {
   "A failing assertion" should "fail the testbench" in {
-    assert(!runTester { new FailingAssertTester })
+    intercept[Exception] {
+      simulate(new FailingAssertTester)(RunUntilFinished(3))
+    }.getMessage() should include("One or more assertions failed")
   }
   "A succeeding assertion" should "not fail the testbench" in {
     assertTesterPasses { new SucceedingAssertTester }

--- a/src/test/scala-2/chiselTests/ProbeSpec.scala
+++ b/src/test/scala-2/chiselTests/ProbeSpec.scala
@@ -6,10 +6,14 @@ import chisel3._
 import chisel3.layer.{Layer, LayerConfig}
 import chisel3.probe._
 import chisel3.util.Counter
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testers.{BasicTester, TesterDriver}
 import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ProbeSpec extends ChiselFlatSpec with FileCheck with Utils {
+class ProbeSpec extends AnyFlatSpec with Matchers with FileCheck with Utils with ChiselSim {
   // Strip SourceInfos and split into lines
   private def processChirrtl(chirrtl: String): Array[String] =
     chirrtl.split('\n').map(line => line.takeWhile(_ != '@').trim())
@@ -657,7 +661,7 @@ class ProbeSpec extends ChiselFlatSpec with FileCheck with Utils {
       define(b.refs.out, RWProbeValue(out))
       define(b.refs.reg, RWProbeValue(r))
     }
-    runTester(new BasicTester {
+    simulate(new BasicTester {
       layer.enable(layers.Verification)
       layer.enable(layers.Verification.Assert)
       val dut = Module(new Top)
@@ -701,7 +705,7 @@ class ProbeSpec extends ChiselFlatSpec with FileCheck with Utils {
       }
 
       when(done) { stop() }
-    }) should be(true)
+    })(RunUntilFinished(21))
   }
 
   "Enum probe" should "work" in {


### PR DESCRIPTION
Add timeout exception and `runUntilFinished`. Use this to replace some usages of `ChiselSpec`.

This is stacked on #4699. This PR is intended to show where I am going with this and to get buy-in on how tests will look before rolling this out everywhere (to replace more widely used `ChiselSpec` methods like `assertTesterPasses` and `assertTesterFails`.

#### Release Notes

Add `Stimulus` object to `SimulatorAPI` which is intended to contain basic, common stimulus that should be applied to a circuit.  These can be chained together in series if desired. For now, only add `runUntilFinished` which is stimulus that runs for a number of cycles and then throws an exception if the simulation doesn't finish before the timeout.