### PR TITLE
[svsim][chiselsim] Do not compile extract layery directories

### DIFF
--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -98,7 +98,10 @@ trait Simulator[T <: Backend] {
           elaboratedModule
         ),
       fileFilter =
-        commonCompilationSettings.fileFilter.orElse(chiselSettings.verilogLayers.shouldIncludeFile(elaboratedModule))
+        commonCompilationSettings.fileFilter.orElse(chiselSettings.verilogLayers.shouldIncludeFile(elaboratedModule)),
+      directoryFilter = commonCompilationSettings.directoryFilter.orElse(
+        chiselSettings.verilogLayers.shouldIncludeDirectory(elaboratedModule, workspace.primarySourcesPath)
+      )
     )
 
     // Compile the design.  Early exit if the compilation fails for any reason.

--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -63,7 +63,8 @@ trait ChiselRunners extends Assertions {
             VerilogPreprocessorDefine("STOP_COND", s"!${Workspace.testbenchModuleName}.reset")
           ) ++ layerControl.preprocessorDefines(elaboratedModule),
           includeDirs = Some(Seq(workspace.primarySourcesPath)),
-          fileFilter = layerControl.shouldIncludeFile(elaboratedModule)
+          fileFilter = layerControl.shouldIncludeFile(elaboratedModule),
+          directoryFilter = layerControl.shouldIncludeDirectory(elaboratedModule, workspace.primarySourcesPath)
         )
       },
       verilator.Backend

--- a/src/test/scala-2/chiselTests/simulator/LayerControlSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/LayerControlSpec.scala
@@ -108,7 +108,7 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
       }
 
       info("build/B is excluded")
-        layerControl.shouldIncludeDirectory(elaboratedModule, "build")(new File("build/B")) should be(false)
+      layerControl.shouldIncludeDirectory(elaboratedModule, "build")(new File("build/B")) should be(false)
     }
   }
 }

--- a/src/test/scala-2/chiselTests/simulator/LayerControlSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/LayerControlSpec.scala
@@ -30,10 +30,17 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
 
       info("non-layer files are ignored")
       layerControl.shouldIncludeFile(elaboratedModule).isDefinedAt(new File("Foo.sv")) should be(false)
+      layerControl.shouldIncludeDirectory(elaboratedModule, "build").isDefinedAt(new File("build/foo")) should be(false)
 
+      info("layer ABI files are included")
       Seq("layers-Foo-A.sv", "layers-Foo-B.sv", "layers-Foo-B-C.sv").map(new File(_)).foreach { case filename =>
         info(s"$filename is included")
         layerControl.shouldIncludeFile(elaboratedModule)(filename) should be(true)
+      }
+      info("layer directories are included")
+      Seq("build/A", "build/B", "build/B/C").map(new File(_)).foreach { case directory =>
+        info(s"$directory is included")
+        layerControl.shouldIncludeDirectory(elaboratedModule, "build")(directory) should be(true)
       }
     }
   }
@@ -43,10 +50,17 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
 
       info("non-layer files are ignored")
       layerControl.shouldIncludeFile(elaboratedModule).isDefinedAt(new File("Foo.sv")) should be(false)
+      layerControl.shouldIncludeDirectory(elaboratedModule, "build").isDefinedAt(new File("build/foo")) should be(false)
 
+      info("layer ABI files are excluded")
       Seq("layers-Foo-A.sv", "layers-Foo-B.sv", "layers-Foo-B-C.sv").map(new File(_)).foreach { case filename =>
         info(s"$filename is excluded")
         layerControl.shouldIncludeFile(elaboratedModule)(filename) should be(false)
+      }
+      info("layer directories are excluded")
+      Seq("build/A", "build/B", "build/B/C").map(new File(_)).foreach { case directory =>
+        info(s"$directory is excluded")
+        layerControl.shouldIncludeDirectory(elaboratedModule, "build")(directory) should be(false)
       }
     }
   }
@@ -56,10 +70,17 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
 
       info("non-layer files are ignored")
       layerControl.shouldIncludeFile(elaboratedModule).isDefinedAt(new File("Foo.sv")) should be(false)
+      layerControl.shouldIncludeDirectory(elaboratedModule, "build").isDefinedAt(new File("build/foo")) should be(false)
 
+      info("layer ABI files are excluded")
       Seq("layers-Foo-A.sv", "layers-Foo-B.sv", "layers-Foo-B-C.sv").map(new File(_)).foreach { case filename =>
         info(s"$filename is excluded")
         layerControl.shouldIncludeFile(elaboratedModule)(filename) should be(false)
+      }
+      info("layer directories are excluded")
+      Seq("build/A", "build/B", "build/B/C").map(new File(_)).foreach { case directory =>
+        info(s"$directory is excluded")
+        layerControl.shouldIncludeDirectory(elaboratedModule, "build")(directory) should be(false)
       }
     }
   }
@@ -69,7 +90,9 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
 
       info("non-layer files are ignored")
       layerControl.shouldIncludeFile(elaboratedModule).isDefinedAt(new File("foo")) should be(false)
+      layerControl.shouldIncludeDirectory(elaboratedModule, "build").isDefinedAt(new File("build/foo")) should be(false)
 
+      info("layer ABI files are excluded or excluded appropriately")
       Seq("layers-Foo-A.sv", "layers-Foo-B-C.sv").map(new File(_)).foreach { case filename =>
         info(s"$filename is included")
         layerControl.shouldIncludeFile(elaboratedModule)(filename) should be(true)
@@ -77,6 +100,15 @@ class LayerControlSpec extends AnyFunSpec with Matchers {
 
       info("layers-Foo-A-B.sv is excluded")
       layerControl.shouldIncludeFile(elaboratedModule)(new File("layers-Foo-A-B.sv")) should be(false)
+
+      info("layer directories are excluded or excluded appropriately")
+      Seq("build/A", "build/B/C").map(new File(_)).foreach { case directory =>
+        info(s"$directory is included")
+        layerControl.shouldIncludeDirectory(elaboratedModule, "build")(directory) should be(true)
+      }
+
+      info("build/B is excluded")
+        layerControl.shouldIncludeDirectory(elaboratedModule, "build")(new File("build/B")) should be(false)
     }
   }
 }

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -16,7 +16,8 @@ case class CommonCompilationSettings(
   libraryExtensions: Option[Seq[String]] = None,
   libraryPaths:      Option[Seq[String]] = None,
   includeDirs:       Option[Seq[String]] = None,
-  fileFilter:        PartialFunction[File, Boolean] = PartialFunction.empty
+  fileFilter:        PartialFunction[File, Boolean] = PartialFunction.empty,
+  directoryFilter:   PartialFunction[File, Boolean] = PartialFunction.empty
 )
 object CommonCompilationSettings {
   object VerilogPreprocessorDefine {

--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -1,7 +1,9 @@
 package svsim
 
 import java.io.{BufferedReader, BufferedWriter, File, FileWriter, InputStreamReader, PrintWriter}
-import java.nio.file.{Files, Paths}
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, FileVisitor}
+import java.nio.file.{FileVisitor, Files, Path, Paths}
 import java.lang.ProcessBuilder.Redirect
 import scala.annotation.meta.param
 import scala.jdk.CollectionConverters._
@@ -317,12 +319,43 @@ final class Workspace(
       commonSettings = commonSettings,
       backendSpecificSettings = backendSpecificSettings
     )
-    val sourceFiles = Seq(primarySourcesPath, generatedSourcesPath)
-      .flatMap(p => Files.walk(Paths.get(p)).iterator().asScala.toSeq)
-      .map(_.toFile)
-      .filter(_.isFile)
-      .filter(commonSettings.fileFilter.orElse { case _ => true })
-      .map { file => workingDirectory.toPath().relativize(file.toPath()).toString() }
+
+    // Find all the source files by walking the build directory.  The behavior
+    // of which directories are visited and which files are included is
+    // controlled by fields in `CommonCompilationSettings`.
+    val sourceFiles = scala.collection.mutable.ArrayBuffer.empty[String]
+    val fileFilter: PartialFunction[File, Boolean] = commonSettings.fileFilter.orElse { case _ => true }
+    val directoryFilter: PartialFunction[File, Boolean] = commonSettings.directoryFilter.orElse { case _: File =>
+      true
+    }
+    class DirectoryVisitor extends FileVisitor[Path] {
+
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        if (fileFilter(file.toFile))
+          sourceFiles += workingDirectory.toPath().relativize(file).toString()
+        FileVisitResult.CONTINUE
+      }
+
+      override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        if (directoryFilter(dir.toFile))
+          FileVisitResult.CONTINUE
+        else
+          FileVisitResult.SKIP_SUBTREE
+      }
+
+      override def postVisitDirectory(dir: Path, ioe: java.io.IOException): FileVisitResult = {
+        FileVisitResult.CONTINUE
+      }
+
+      override def visitFileFailed(file: Path, ioe: java.io.IOException): FileVisitResult = {
+        throw ioe
+      }
+
+    }
+
+    for (dir <- Seq(primarySourcesPath, generatedSourcesPath)) {
+      Files.walkFileTree(Paths.get(dir), new DirectoryVisitor)
+    }
 
     val traceFileStem = (backendSpecificSettings match {
       case s: verilator.Backend.CompilationSettings =>


### PR DESCRIPTION
Only compile what is needed for extract layers. Previously, all files would be compiled and the layer would be enabled using the ABI bind file. Change this to, for extract layers, only visit directories which the layer says it is writing to.

Note: this can cause problems if the user is using weird combinations of layer directory control and module-level control. However, if a user is doing this, they should know what they are doing and the limitations of the tooling.

Fixes #4676. Individual commits should be reviewed separately.

#### Release Notes

Stop compiling all extract layer collateral. Instead, only compile what is specified from those directories. This avoids a problem where LTL constructs (unsupported by Verilator) would cause compilation failure even though they would never be bound in.