### PR TITLE
Re-land #4702

### DIFF
--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -152,10 +152,12 @@ final class Workspace(
       l("  export \"DPI-C\" task run_simulation;")
       l("  task run_simulation;")
       l("    input int timesteps;")
+      l("    output int done;")
       l("    #timesteps;")
+      l("    done = 0;")
       l("  endtask")
       l("  `else")
-      l("  import \"DPI-C\" function void run_simulation(int timesteps);")
+      l("  import \"DPI-C\" function int run_simulation(int timesteps);")
       l("  `endif")
       l()
 

--- a/svsim/src/test/resources/Finish.sv
+++ b/svsim/src/test/resources/Finish.sv
@@ -1,0 +1,6 @@
+module Finish(input clock);
+
+  always @ (posedge clock)
+    $finish;
+
+endmodule

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -298,6 +298,39 @@ trait BackendSpec extends AnyFunSpec with Matchers {
           }
         }
       }
+
+      it("ends the simulation on '$finish' (#4700)") {
+        workspace.reset()
+        workspace.elaborateFinishTest()
+        workspace.generateAdditionalSources()
+        simulation = workspace.compile(
+          backend
+        )(
+          workingDirectoryTag = name,
+          commonSettings = CommonCompilationSettings(),
+          backendSpecificSettings = compilationSettings,
+          customSimulationWorkingDirectory = None,
+          verbose = false
+        )
+        simulation.run(
+          verbose = false,
+          executionScriptLimit = None
+        ) { controller =>
+          val clock = controller.port("clock")
+          clock.tick(
+            inPhaseValue = 0,
+            outOfPhaseValue = 1,
+            timestepsPerPhase = 1,
+            maxCycles = 8,
+            sentinel = None
+          )
+        }
+        val re = ".*Verilog \\$finish.*".r
+        new BufferedReader(new FileReader(s"${simulation.workingDirectoryPath}/simulation-log.txt")).lines
+          .filter(re.matches(_))
+          .toArray
+          .size must be(1)
+      }
     }
   }
 }

--- a/svsim/src/test/scala/Resources.scala
+++ b/svsim/src/test/scala/Resources.scala
@@ -131,5 +131,20 @@ object Resources {
         )
       )
     }
+    def elaborateFinishTest(): Unit = {
+      workspace.addPrimarySourceFromResource(getClass, "/Finish.sv")
+      workspace.elaborate(
+        ModuleInfo(
+          name = "Finish",
+          ports = Seq(
+            new ModuleInfo.Port(
+              name = "clock",
+              isSettable = true,
+              isGettable = false
+            )
+          )
+        )
+      )
+    }
   }
 }


### PR DESCRIPTION
Re-land #4702.

The commit to fix this looks like a brittle fix as it narrowly handles the observed exception. (See: https://github.com/chipsalliance/chisel/actions/runs/13418015449/job/37483578519#step:11:1377) However, I think this is actually correct. The details are in the commit message and copied below:

Fix an issue that can occur now that the simulation will aggressively try
to shut themselves down when they see a `$finish`.  The problem occurs
because svsim is assuming that it can check if the simulation process is
alive and then shut it down.  However, this occurs in a critical region.
Just because the process is alive when checked, doesn't mean it _will_ be
alive when you try to shut it down.

I considered an alternative solutoin here which would put the simulation
into a "finish" state and then respond with a new "finish" message which
the controller would then need to handle. (It would just throw exceptions
if you tried to interact with the simulation after it ended.)  This
approach can be revived.  However, it needs to _also_ figure out what to
do with VCS.

The Verilog spec (1800-2023 Section 20.2) states:

> The `$finish` system task causes the simulator to exit and pass control
> back to the host operating system.

My read of this is that the simulation, if it is allowed to call
`$finish`, can terminate at essentially any time.  Verilator diverges from
this and will allow multiple `$finish` system tasks in the same block,
without time delays, to execute.  Based on how we construct the testbench
for Verilator, we run into this bug.  (If we use time delays, I think
Verilator will behave the same as VCS.)  Adapting the simulation to use a
"finish" message is therefore aligning the simulation with the expectation
of how Verilator behaves and is likely _not_ going to work for VCS.
Therefore, I rejected this approach.

If we want to move in this direction in the future, a change to the
testbench to use a `final` block, or some way of keeping the simulation
alive after a `$finish` to still respond to the controller, may work.

#### Release Notes

Fix an svsim bug, which could manifest in Chiselsim, where when a simulation calls `$finish` that it does not immediately exit for Verilator backends.