### PR TITLE
[svsim] Wait after destroying simulator process

### DIFF
--- a/svsim/src/main/scala/Simulation.scala
+++ b/svsim/src/main/scala/Simulation.scala
@@ -78,8 +78,8 @@ final class Simulation private[svsim] (
     // Because the process may _not_ terminate immediately, use `waitFor` to
     // ensure that it is dead.  If this is _not_ done, then `exitValue` may
     // throw an exception.
-    process.destroyForcibly()
     process.waitFor()
+    process.destroyForcibly()
 
     // Exceptions thrown from `body` have the highest priority
     val result = bodyOutcome.get

--- a/svsim/src/main/scala/Simulation.scala
+++ b/svsim/src/main/scala/Simulation.scala
@@ -71,12 +71,15 @@ final class Simulation private[svsim] (
       if (process.isAlive()) {
         controller.sendCommand(Simulation.Command.Done)
         controller.completeInFlightCommands()
-        process.waitFor()
       }
     }
 
-    // Ensure process is destroyed prior to returning or throwing an exception
+    // Ensure process is destroyed prior to returning or throwing an exception.
+    // Because the process may _not_ terminate immediately, use `waitFor` to
+    // ensure that it is dead.  If this is _not_ done, then `exitValue` may
+    // throw an exception.
     process.destroyForcibly()
+    process.waitFor()
 
     // Exceptions thrown from `body` have the highest priority
     val result = bodyOutcome.get


### PR DESCRIPTION
Attempt to workaround an observed CI failure [1] where calling `exitValue` on a process throws an exception.  Require that `waitFor` is called after the process is destroyed so that it will block until it _is_ destroyed.

[1]: https://github.com/chipsalliance/chisel/actions/runs/13476120281/job/37655532844

#### Release Notes

Fix a possible `IllegalThreadStateException` that could be raised during `svsim.Simulation.run`.