### PR TITLE
Partial Migration from ChiselSpec to ChiselSim

### DIFF
--- a/src/main/scala/chisel3/simulator/HasSimulator.scala
+++ b/src/main/scala/chisel3/simulator/HasSimulator.scala
@@ -39,19 +39,25 @@ object HasSimulator {
   object simulators {
 
     /** A [[HasSimulator]] implementation for a Verilator simulator. */
-    def verilator: HasSimulator = new HasSimulator {
+    def verilator(
+      compilationSettings: svsim.CommonCompilationSettings = svsim.CommonCompilationSettings(),
+      verilatorSettings:   svsim.verilator.Backend.CompilationSettings = svsim.verilator.Backend.CompilationSettings()
+    ): HasSimulator = new HasSimulator {
       override def getSimulator(implicit testingDirectory: HasTestingDirectory): Simulator[svsim.verilator.Backend] =
         new Simulator[svsim.verilator.Backend] {
           override val backend = svsim.verilator.Backend.initializeFromProcessEnvironment()
           override val tag = "verilator"
-          override val commonCompilationSettings = svsim.CommonCompilationSettings()
-          override val backendSpecificCompilationSettings = svsim.verilator.Backend.CompilationSettings()
+          override val commonCompilationSettings = compilationSettings
+          override val backendSpecificCompilationSettings = verilatorSettings
           override val workspacePath = Files.createDirectories(testingDirectory.getDirectory).toString
         }
     }
 
     /** A [[HasSimulator]] implementation for a VCS simulator. */
-    def vcs: HasSimulator = new HasSimulator {
+    def vcs(
+      compilationSettings: svsim.CommonCompilationSettings = svsim.CommonCompilationSettings(),
+      vcsSettings:         svsim.vcs.Backend.CompilationSettings = svsim.vcs.Backend.CompilationSettings()
+    ): HasSimulator = new HasSimulator {
       override def getSimulator(implicit testingDirectory: HasTestingDirectory): Simulator[svsim.vcs.Backend] =
         new Simulator[svsim.vcs.Backend] {
           override val backend = svsim.vcs.Backend.initializeFromProcessEnvironment().getOrElse {
@@ -60,8 +66,8 @@ object HasSimulator {
             )
           }
           override val tag = "vcs"
-          override val commonCompilationSettings = svsim.CommonCompilationSettings()
-          override val backendSpecificCompilationSettings = svsim.vcs.Backend.CompilationSettings()
+          override val commonCompilationSettings = compilationSettings
+          override val backendSpecificCompilationSettings = vcsSettings
           override val workspacePath = Files.createDirectories(testingDirectory.getDirectory).toString
         }
     }
@@ -72,6 +78,6 @@ object HasSimulator {
     * This is the default that will be used if the user does provide an
     * alternative.
     */
-  implicit def default: HasSimulator = simulators.verilator
+  implicit def default: HasSimulator = simulators.verilator()
 
 }

--- a/src/main/scala/chisel3/simulator/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/WithTestingDirectory.scala
@@ -52,7 +52,7 @@ trait WithTestingDirectory { self: TestSuite =>
 
     // A sequence of regular expressions and their replacements that should be
     // applied to the test name.
-    val res = Seq("\\s|\\(|\\)|\\$".r -> "-", "\"|\'|#".r -> "")
+    val res = Seq("\\s|\\(|\\)|\\$".r -> "-", "\"|\'|#|:".r -> "")
 
     /** Return the test name with minimal sanitization applied:
       *

--- a/src/test/resources/chisel3/BlackBoxTest.v
+++ b/src/test/resources/chisel3/BlackBoxTest.v
@@ -45,7 +45,7 @@ module BlackBoxConstant #(
 ) (
   output [WIDTH-1:0] out
 );
-  assign out = VALUE;
+  assign out = VALUE[WIDTH-1:0];
 endmodule
 
 module BlackBoxStringParam #(
@@ -70,5 +70,5 @@ module BlackBoxTypeParam #(
 ) (
   output T out
 );
-  assign out = 32'hdeadbeef;
+  assign out = {32'hdeadbeef}[$bits(out)-1:0];
 endmodule

--- a/src/test/scala-2/chiselTests/BitwiseOps.scala
+++ b/src/test/scala-2/chiselTests/BitwiseOps.scala
@@ -3,9 +3,11 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import org.scalatest.propspec.AnyPropSpec
 
-class BitwiseOpsTester(w: Int, _a: Int, _b: Int) extends BasicTester {
+class BitwiseOpsTester(w: Int, _a: Int, _b: Int) extends Module {
   val mask = (1 << w) - 1
   val a = _a.asUInt(w.W)
   val b = _b.asUInt(w.W)
@@ -18,10 +20,10 @@ class BitwiseOpsTester(w: Int, _a: Int, _b: Int) extends BasicTester {
   stop()
 }
 
-class BitwiseOpsSpec extends ChiselPropSpec {
+class BitwiseOpsSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
   property("All bit-wise ops should return the correct result") {
     forAll(safeUIntPair) { case (w: Int, a: Int, b: Int) =>
-      assertTesterPasses { new BitwiseOpsTester(w, a, b) }
+      simulate { new BitwiseOpsTester(w, a, b) }(RunUntilFinished(2))
     }
   }
 }

--- a/src/test/scala-2/chiselTests/BlackBox.scala
+++ b/src/test/scala-2/chiselTests/BlackBox.scala
@@ -234,12 +234,10 @@ class BlackBoxSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "A BlackBoxed register" should "work" in {
     simulate(new BlackBoxWithClockTester)(RunUntilFinished(16))
   }
-  // TODO: SFC->MFC, this test is ignored because the parameters have undesired quotes around values in verilog in MFC
-  "BlackBoxes with simpler parameters" should "work" ignore {
+  "BlackBoxes with simpler parameters" should "work" in {
     simulate(new SimplerBlackBoxWithParamsTester)(RunUntilFinished(5))
   }
-  // TODO: SFC->MFC, this test is ignored because the parameters have undesired quotes around values in verilog in MFC
-  "BlackBoxes with parameters" should "work" ignore {
+  "BlackBoxes with parameters" should "work" in {
     simulate(new BlackBoxWithParamsTester)(RunUntilFinished(5))
   }
   "DataMirror.modulePorts" should "work with BlackBox" in {

--- a/src/test/scala-2/chiselTests/BundleWire.scala
+++ b/src/test/scala-2/chiselTests/BundleWire.scala
@@ -2,7 +2,9 @@
 
 package chiselTests
 import chisel3._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import org.scalatest.propspec.AnyPropSpec
 
 class Coord extends Bundle {
   val x = UInt(32.W)
@@ -21,7 +23,7 @@ class BundleWire(n: Int) extends Module {
   }
 }
 
-class BundleToUnitTester extends BasicTester {
+class BundleToUnitTester extends Module {
   val bundle1 = Wire(new Bundle {
     val a = UInt(4.W)
     val b = UInt(4.W)
@@ -42,7 +44,7 @@ class BundleToUnitTester extends BasicTester {
   stop()
 }
 
-class BundleWireTester(n: Int, x: Int, y: Int) extends BasicTester {
+class BundleWireTester(n: Int, x: Int, y: Int) extends Module {
   val dut = Module(new BundleWire(n))
   dut.io.in.x := x.asUInt
   dut.io.in.y := y.asUInt
@@ -53,17 +55,17 @@ class BundleWireTester(n: Int, x: Int, y: Int) extends BasicTester {
   stop()
 }
 
-class BundleWireSpec extends ChiselPropSpec {
+class BundleWireSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
 
   property("All vec elems should match the inputs") {
     forAll(vecSizes, safeUInts, safeUInts) { (n: Int, x: Int, y: Int) =>
-      assertTesterPasses { new BundleWireTester(n, x, y) }
+      simulate { new BundleWireTester(n, x, y) }(RunUntilFinished(3))
     }
   }
 }
 
-class BundleToUIntSpec extends ChiselPropSpec {
+class BundleToUIntSpec extends AnyPropSpec with ChiselSim {
   property("Bundles with same data but different, underlying elements should compare as UInt") {
-    assertTesterPasses(new BundleToUnitTester)
+    simulate(new BundleToUnitTester)(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/chiselTests/ClockSpec.scala
+++ b/src/test/scala-2/chiselTests/ClockSpec.scala
@@ -3,10 +3,13 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import circt.stage.ChiselStage
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
 
-class ClockAsUIntTester extends BasicTester {
+class ClockAsUIntTester extends Module {
   assert(true.B.asClock.asUInt === 1.U)
   assert(true.B.asClock.asBool === true.B)
   stop()
@@ -24,9 +27,9 @@ class WithClockAndNoReset extends RawModule {
   out := a
 }
 
-class ClockSpec extends ChiselPropSpec {
+class ClockSpec extends AnyPropSpec with Matchers with ChiselSim {
   property("Bool.asClock.asUInt should pass a signal through unaltered") {
-    assertTesterPasses { new ClockAsUIntTester }
+    simulate { new ClockAsUIntTester }(RunUntilFinished(3))
   }
 
   property("Should be able to use withClock in a module with no reset") {

--- a/src/test/scala-2/chiselTests/ComplexAssign.scala
+++ b/src/test/scala-2/chiselTests/ComplexAssign.scala
@@ -3,8 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util._
+import org.scalatest.propspec.AnyPropSpec
 
 class Complex[T <: Data](val re: T, val im: T) extends Bundle
 
@@ -25,7 +27,7 @@ class ComplexAssign(w: Int) extends Module {
   }
 }
 
-class ComplexAssignTester(enList: List[Boolean], re: Int, im: Int) extends BasicTester {
+class ComplexAssignTester(enList: List[Boolean], re: Int, im: Int) extends Module {
   val (cnt, wrap) = Counter(true.B, enList.size)
   val dut = Module(new ComplexAssign(32))
   dut.io.in.re := re.asUInt
@@ -39,10 +41,10 @@ class ComplexAssignTester(enList: List[Boolean], re: Int, im: Int) extends Basic
   }
 }
 
-class ComplexAssignSpec extends ChiselPropSpec {
+class ComplexAssignSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
   property("All complex assignments should return the correct result") {
     forAll(enSequence(2), safeUInts, safeUInts) { (en: List[Boolean], re: Int, im: Int) =>
-      assertTesterPasses { new ComplexAssignTester(en, re, im) }
+      simulate { new ComplexAssignTester(en, re, im) }(RunUntilFinished(en.size + 1))
     }
   }
 }

--- a/src/test/scala-2/chiselTests/ConnectSpec.scala
+++ b/src/test/scala-2/chiselTests/ConnectSpec.scala
@@ -4,8 +4,11 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.Analog
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import circt.stage.ChiselStage
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
 
 abstract class CrossCheck extends Bundle {
   val in:  Data
@@ -31,77 +34,61 @@ class PipeInternalWires extends Module {
   pipe.io.enq.bits <> io.b
 }
 
-class CrossConnectTester(inType: Data, outType: Data) extends BasicTester {
+class CrossConnectTester(inType: Data, outType: Data) extends Module {
   val dut = Module(new CrossConnects(inType, outType))
   dut.io := DontCare
   stop()
 }
 
-class ConnectSpec extends ChiselPropSpec with Utils {
+class ConnectSpec extends AnyPropSpec with Matchers with ChiselSim {
   property("SInt := SInt should succeed") {
-    assertTesterPasses { new CrossConnectTester(SInt(16.W), SInt(16.W)) }
+    simulate { new CrossConnectTester(SInt(16.W), SInt(16.W)) }(RunUntilFinished(3))
   }
   property("SInt := UInt should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(UInt(16.W), SInt(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(UInt(16.W), SInt(16.W)) }
     }
   }
   property("UInt := UInt should succeed") {
-    assertTesterPasses { new CrossConnectTester(UInt(16.W), UInt(16.W)) }
+    simulate { new CrossConnectTester(UInt(16.W), UInt(16.W)) }(RunUntilFinished(3))
   }
   property("UInt := SInt should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(SInt(16.W), UInt(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(SInt(16.W), UInt(16.W)) }
     }
   }
   property("Clock := Clock should succeed") {
-    assertTesterPasses { new CrossConnectTester(Clock(), Clock()) }
+    simulate { new CrossConnectTester(Clock(), Clock()) }(RunUntilFinished(3))
   }
   property("Clock := UInt should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(Clock(), UInt(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(Clock(), UInt(16.W)) }
     }
   }
 
   property("Analog := Analog should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), Analog(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), Analog(16.W)) }
     }
   }
   property("Analog := UInt should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), UInt(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), UInt(16.W)) }
     }
   }
   property("Analog := SInt should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), SInt(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(Analog(16.W), SInt(16.W)) }
     }
   }
   property("UInt := Analog should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(UInt(16.W), Analog(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(UInt(16.W), Analog(16.W)) }
     }
   }
   property("SInt := Analog should fail") {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL { new CrossConnectTester(SInt(16.W), Analog(16.W)) }
-      }
+      ChiselStage.emitCHIRRTL { new CrossConnectTester(SInt(16.W), Analog(16.W)) }
     }
   }
   property("Pipe internal connections should succeed") {

--- a/src/test/scala-2/chiselTests/EnumSpec.scala
+++ b/src/test/scala-2/chiselTests/EnumSpec.scala
@@ -3,17 +3,20 @@
 package chiselTests
 
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util.Enum
-import chisel3.testers.BasicTester
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class EnumSpec extends ChiselFlatSpec {
+class EnumSpec extends AnyFlatSpec with ChiselSim {
 
   "1-entry Enums" should "work" in {
-    assertTesterPasses(new BasicTester {
+    simulate(new Module {
       val onlyState :: Nil = Enum(1)
       val wire = WireDefault(onlyState)
       chisel3.assert(wire === onlyState)
       stop()
-    })
+    })(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/chiselTests/GCD.scala
+++ b/src/test/scala-2/chiselTests/GCD.scala
@@ -3,8 +3,12 @@
 package chiselTests
 
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.propspec.AnyPropSpec
 
 class GCD extends Module {
   val io = IO(new Bundle {
@@ -35,7 +39,7 @@ class GCDTester(a: Int, b: Int, z: Int) extends BasicTester {
   }
 }
 
-class GCDSpec extends ChiselPropSpec {
+class GCDSpec extends AnyPropSpec with ScalaCheckPropertyChecks with ChiselSim {
 
   // TODO: use generators and this function to make z's
   def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
@@ -53,7 +57,7 @@ class GCDSpec extends ChiselPropSpec {
 
   property("GCDTester should return the correct result") {
     forAll(gcds) { (a: Int, b: Int, z: Int) =>
-      assertTesterPasses { new GCDTester(a, b, z) }
+      simulate(new GCDTester(a, b, z))(RunUntilFinished(1024 * 10))
     }
   }
 }

--- a/src/test/scala-2/chiselTests/IntegerMathSpec.scala
+++ b/src/test/scala-2/chiselTests/IntegerMathSpec.scala
@@ -3,7 +3,10 @@
 package chiselTests
 
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testers.BasicTester
+import org.scalatest.propspec.AnyPropSpec
 
 class IntegerMathTester extends BasicTester {
 
@@ -25,8 +28,8 @@ class IntegerMathTester extends BasicTester {
   stop()
 }
 
-class IntegerMathSpec extends ChiselPropSpec {
+class IntegerMathSpec extends AnyPropSpec with ChiselSim {
   property("All integer ops should return the correct result") {
-    assertTesterPasses { new IntegerMathTester }
+    simulate { new IntegerMathTester }(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/chiselTests/LiteralExtractorSpec.scala
+++ b/src/test/scala-2/chiselTests/LiteralExtractorSpec.scala
@@ -4,13 +4,14 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental.BundleLiterals._
-import chisel3.experimental._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import circt.stage.ChiselStage
-
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.collection.immutable.ListMap
 
-class LiteralExtractorSpec extends ChiselFlatSpec {
+class LiteralExtractorSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "litValue" should "return the literal value" in {
     assert(0.U.litValue === BigInt(0))
     assert(1.U.litValue === BigInt(1))
@@ -79,7 +80,7 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
       val y = UInt(88.W)
     }
 
-    class LitInsideOutsideTester(outsideLiteral: InsideBundle) extends BasicTester {
+    class LitInsideOutsideTester(outsideLiteral: InsideBundle) extends Module {
       val insideLiteral = (new InsideBundle).Lit(_.x -> 7.S, _.y -> 7777.U)
 
       // the following errors with "assertion failed"
@@ -98,7 +99,7 @@ class LiteralExtractorSpec extends ChiselFlatSpec {
     }
 
     val outsideLiteral = (new InsideBundle).Lit(_.x -> 7.S, _.y -> 7777.U)
-    assertTesterPasses { new LitInsideOutsideTester(outsideLiteral) }
+    simulate(new LitInsideOutsideTester(outsideLiteral))(RunUntilFinished(3))
 
   }
 

--- a/src/test/scala-2/chiselTests/MulLookup.scala
+++ b/src/test/scala-2/chiselTests/MulLookup.scala
@@ -3,7 +3,10 @@
 package chiselTests
 
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testers.BasicTester
+import org.scalatest.propspec.AnyPropSpec
 
 class MulLookup(val w: Int) extends Module {
   val io = IO(new Bundle {
@@ -28,11 +31,11 @@ class MulLookupTester(w: Int, x: Int, y: Int) extends BasicTester {
   stop()
 }
 
-class MulLookupSpec extends ChiselPropSpec {
+class MulLookupSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
 
   property("Mul lookup table should return the correct result") {
     forAll(smallPosInts, smallPosInts) { (x: Int, y: Int) =>
-      assertTesterPasses { new MulLookupTester(3, x, y) }
+      simulate { new MulLookupTester(3, x, y) }(RunUntilFinished(3))
     }
   }
 }

--- a/src/test/scala-2/chiselTests/MultiAssign.scala
+++ b/src/test/scala-2/chiselTests/MultiAssign.scala
@@ -2,12 +2,15 @@
 
 package chiselTests
 
-import circt.stage.ChiselStage
 import chisel3._
-import chisel3.testers.BasicTester
-import chisel3.util._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.util.Counter
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class LastAssignTester() extends BasicTester {
+class LastAssignTester() extends Module {
   val countOnClockCycles = true.B
   val (cnt, wrap) = Counter(countOnClockCycles, 2)
 
@@ -25,20 +28,18 @@ class LastAssignTester() extends BasicTester {
   }
 }
 
-class MultiAssignSpec extends ChiselFlatSpec {
+class MultiAssignSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "The last assignment" should "be used when multiple assignments happen" in {
-    assertTesterPasses { new LastAssignTester }
+    simulate { new LastAssignTester }(RunUntilFinished(3))
   }
 }
 
-class IllegalAssignSpec extends ChiselFlatSpec with Utils {
+class IllegalAssignSpec extends AnyFlatSpec with Matchers with Utils {
   "Reassignments to literals" should "be disallowed" in {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL {
-          new BasicTester {
-            15.U := 7.U
-          }
+      ChiselStage.emitCHIRRTL {
+        new Module {
+          15.U := 7.U
         }
       }
     }
@@ -46,11 +47,9 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
 
   "Reassignments to ops" should "be disallowed" in {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL {
-          new BasicTester {
-            (15.U + 1.U) := 7.U
-          }
+      ChiselStage.emitCHIRRTL {
+        new Module {
+          (15.U + 1.U) := 7.U
         }
       }
     }
@@ -58,11 +57,9 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
 
   "Reassignments to bit slices" should "be disallowed" in {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL {
-          new BasicTester {
-            (15.U)(1, 0) := 7.U
-          }
+      ChiselStage.emitCHIRRTL {
+        new Module {
+          (15.U)(1, 0) := 7.U
         }
       }
     }
@@ -70,11 +67,9 @@ class IllegalAssignSpec extends ChiselFlatSpec with Utils {
 
   "Bulk-connecting two read-only nodes" should "be disallowed" in {
     intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL {
-          new BasicTester {
-            (15.U + 1.U) <> 7.U
-          }
+      ChiselStage.emitCHIRRTL {
+        new Module {
+          (15.U + 1.U) <> 7.U
         }
       }
     }

--- a/src/test/scala-2/chiselTests/MuxSpec.scala
+++ b/src/test/scala-2/chiselTests/MuxSpec.scala
@@ -3,11 +3,15 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util.{log2Ceil, MuxLookup}
 import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 
-class MuxTester extends BasicTester {
+class MuxTester extends Module {
   assert(Mux(0.B, 1.U, 2.U) === 2.U)
   assert(Mux(1.B, 1.U, 2.U) === 1.U)
   val dontCareMux1 = Wire(UInt())
@@ -29,9 +33,9 @@ class MuxBetween[A <: Data, B <: Data](genA: A, genB: B) extends RawModule {
   val result = Mux(sel, in0, in1)
 }
 
-class MuxSpec extends ChiselFlatSpec {
+class MuxSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "Mux" should "pass basic checks" in {
-    assertTesterPasses { new MuxTester }
+    simulate(new MuxTester)(RunUntilFinished(3))
   }
 
   it should "give reasonable error messages for mismatched user-defined types" in {
@@ -49,7 +53,7 @@ class MuxSpec extends ChiselFlatSpec {
 
 }
 
-class MuxLookupEnumTester extends BasicTester {
+class MuxLookupEnumTester extends Module {
   object TestEnum extends ChiselEnum {
     val a = Value
     val b = Value(7.U)
@@ -70,9 +74,9 @@ class MuxLookupEnumTester extends BasicTester {
   stop()
 }
 
-class MuxLookupEnumSpec extends ChiselFlatSpec {
+class MuxLookupEnumSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "MuxLookup with enum selector" should "pass basic checks" in {
-    assertTesterPasses { new MuxLookupEnumTester }
+    simulate(new MuxLookupEnumTester)(RunUntilFinished(3))
   }
 }
 
@@ -83,7 +87,7 @@ class MuxLookupWrapper(keyWidth: Int, default: Int, mapping: () => Seq[(UInt, UI
   output := MuxLookup(key, default.U)(mapping())
 }
 
-class MuxLookupExhaustiveSpec extends ChiselPropSpec {
+class MuxLookupExhaustiveSpec extends AnyPropSpec with Matchers {
   val keyWidth = 2
   val default = 9 // must be less than 10 to avoid hex/decimal mismatches
   val firrtlLit = s"""UInt<4>(0h$default)"""

--- a/src/test/scala-2/chiselTests/OneHotMuxSpec.scala
+++ b/src/test/scala-2/chiselTests/OneHotMuxSpec.scala
@@ -3,28 +3,28 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util.{Mux1H, UIntToOH}
-import _root_.circt.stage.ChiselStage.emitCHIRRTL
-import org.scalatest._
+import circt.stage.ChiselStage.emitCHIRRTL
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselRunners {
+class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselSim {
   "simple one hot mux with uint should work" in {
-    assertTesterPasses(new SimpleOneHotTester)
+    simulate(new SimpleOneHotTester)(RunUntilFinished(3))
   }
   "simple one hot mux with sint should work" in {
-    assertTesterPasses(new SIntOneHotTester)
+    simulate(new SIntOneHotTester)(RunUntilFinished(3))
   }
   "simple one hot mux with all same parameterized sint values should work" in {
-    assertTesterPasses(new ParameterizedOneHotTester)
+    simulate(new ParameterizedOneHotTester)(RunUntilFinished(3))
   }
   "UIntToOH with output width greater than 2^(input width)" in {
-    assertTesterPasses(new UIntToOHTester)
+    simulate(new UIntToOHTester)(RunUntilFinished(3))
   }
   "UIntToOH should accept width of zero" in {
-    assertTesterPasses(new ZeroWidthOHTester)
+    simulate(new ZeroWidthOHTester)(RunUntilFinished(3))
   }
   "Mux1H should give a decent error when given an empty Seq" in {
     val e = intercept[IllegalArgumentException] {
@@ -52,7 +52,7 @@ class OneHotMuxSpec extends AnyFreeSpec with Matchers with ChiselRunners {
   }
 }
 
-class SimpleOneHotTester extends BasicTester {
+class SimpleOneHotTester extends Module {
   val out = Wire(UInt())
   out := Mux1H(
     Seq(
@@ -68,7 +68,7 @@ class SimpleOneHotTester extends BasicTester {
   stop()
 }
 
-class SIntOneHotTester extends BasicTester {
+class SIntOneHotTester extends Module {
   val out = Wire(SInt())
   out := Mux1H(
     Seq(
@@ -84,7 +84,7 @@ class SIntOneHotTester extends BasicTester {
   stop()
 }
 
-class ParameterizedOneHotTester extends BasicTester {
+class ParameterizedOneHotTester extends Module {
   val values: Seq[Int] = Seq(-3, -5, -7, -11)
   for ((v, i) <- values.zipWithIndex) {
     val dut = Module(new ParameterizedOneHot(values.map(_.S), SInt(8.W)))
@@ -121,7 +121,7 @@ class ParameterizedAggregateOneHot[T <: Data](valGen: HasMakeLit[T], outGen: T) 
   io.out := Mux1H(terms)
 }
 
-class UIntToOHTester extends BasicTester {
+class UIntToOHTester extends Module {
   val out = UIntToOH(1.U, 3)
   require(out.getWidth == 3)
   assert(out === 2.U)
@@ -133,7 +133,7 @@ class UIntToOHTester extends BasicTester {
   stop()
 }
 
-class ZeroWidthOHTester extends BasicTester {
+class ZeroWidthOHTester extends Module {
   val out = UIntToOH(0.U, 0)
   assert(out === 0.U(0.W))
   stop()

--- a/src/test/scala-2/chiselTests/ParameterizedModule.scala
+++ b/src/test/scala-2/chiselTests/ParameterizedModule.scala
@@ -3,7 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class ParameterizedModule(invert: Boolean) extends Module {
   val io = IO(new Bundle {
@@ -21,7 +24,7 @@ class ParameterizedModule(invert: Boolean) extends Module {
   * modules with the same name but different contents aren't aliased). Doesn't
   * check that deduplication actually happens, though.
   */
-class ParameterizedModuleTester() extends BasicTester {
+class ParameterizedModuleTester() extends Module {
   val invert = Module(new ParameterizedModule(true))
   val noninvert = Module(new ParameterizedModule(false))
 
@@ -33,8 +36,8 @@ class ParameterizedModuleTester() extends BasicTester {
   stop()
 }
 
-class ParameterizedModuleSpec extends ChiselFlatSpec {
+class ParameterizedModuleSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "Different parameterized modules" should "have different behavior" in {
-    assertTesterPasses(new ParameterizedModuleTester())
+    simulate(new ParameterizedModuleTester())(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/chiselTests/PopCount.scala
+++ b/src/test/scala-2/chiselTests/PopCount.scala
@@ -3,10 +3,13 @@
 package chiselTests
 
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util.PopCount
-import chisel3.testers.BasicTester
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatest.matchers.should.Matchers
 
-class PopCountTester(n: Int) extends BasicTester {
+class PopCountTester(n: Int) extends Module {
   val x = RegInit(0.U(n.W))
   x := x + 1.U
   when(RegNext(x === ~0.U(n.W))) { stop() }
@@ -18,8 +21,8 @@ class PopCountTester(n: Int) extends BasicTester {
   require(result.getWidth == BigInt(n).bitLength)
 }
 
-class PopCountSpec extends ChiselPropSpec {
+class PopCountSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
   property("Mul lookup table should return the correct result") {
-    forAll(smallPosInts) { (n: Int) => assertTesterPasses { new PopCountTester(n) } }
+    forAll(smallPosInts) { (n: Int) => simulate(new PopCountTester(n))(RunUntilFinished(math.pow(2, n).toInt + 2)) }
   }
 }

--- a/src/test/scala-2/chiselTests/ReduceTreeSpec.scala
+++ b/src/test/scala-2/chiselTests/ReduceTreeSpec.scala
@@ -3,8 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.util._
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.util.{is, switch, DecoupledIO, Enum}
+import org.scalatest.propspec.AnyPropSpec
 
 class Arbiter[T <: Data: Manifest](n: Int, private val gen: T) extends Module {
   val io = IO(new Bundle {
@@ -59,7 +61,7 @@ class Arbiter[T <: Data: Manifest](n: Int, private val gen: T) extends Module {
   io.out <> io.in.reduceTree(arbitrateTwo)
 }
 
-class ReduceTreeBalancedTester(nodes: Int) extends BasicTester {
+class ReduceTreeBalancedTester(nodes: Int) extends Module {
 
   val cnt = RegInit(0.U(8.W))
   val min = RegInit(99.U(8.W))
@@ -92,15 +94,15 @@ class ReduceTreeBalancedTester(nodes: Int) extends BasicTester {
   }
 }
 
-class ReduceTreeBalancedSpec extends ChiselPropSpec {
+class ReduceTreeBalancedSpec extends AnyPropSpec with ChiselSim {
   property("Tree shall be fair and shall have a maximum difference of one hop for each node") {
 
     // This test will fail for 5 nodes due to an unbalanced tree.
     // A fix is on the way.
     for (n <- 1 to 5) {
-      assertTesterPasses {
+      simulate {
         new ReduceTreeBalancedTester(n)
-      }
+      }(RunUntilFinished(12))
     }
   }
 }

--- a/src/test/scala-2/chiselTests/Reg.scala
+++ b/src/test/scala-2/chiselTests/Reg.scala
@@ -5,13 +5,16 @@ package chiselTests
 import circt.stage.ChiselStage
 import chisel3._
 import chisel3.reflect.DataMirror
-import chisel3.testers.BasicTester
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util._
 import org.scalacheck.Gen
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class RegSpec extends ChiselFlatSpec {
   "Reg" should "be of the same type and width as t" in {
-    class RegOutTypeWidthTester extends BasicTester {
+    class RegOutTypeWidthTester extends Module {
       val reg = Reg(UInt(2.W))
       DataMirror.widthOf(reg) should be(2.W)
     }
@@ -19,7 +22,7 @@ class RegSpec extends ChiselFlatSpec {
   }
 
   "RegNext" should "be of unknown width" in {
-    class RegUnknownWidthTester extends BasicTester {
+    class RegUnknownWidthTester extends Module {
       val reg1 = RegNext(2.U(3.W))
       DataMirror.widthOf(reg1).known should be(false)
       val reg2 = RegNext(2.U(3.W), 4.U)
@@ -31,7 +34,7 @@ class RegSpec extends ChiselFlatSpec {
   }
 
   "RegInit" should "have width only if specified in the literal" in {
-    class RegForcedWidthTester extends BasicTester {
+    class RegForcedWidthTester extends Module {
       val reg1 = RegInit(20.U)
       DataMirror.widthOf(reg1).known should be(false)
       val reg2 = RegInit(20.U(7.W))
@@ -41,7 +44,7 @@ class RegSpec extends ChiselFlatSpec {
   }
 }
 
-class ShiftTester(n: Int) extends BasicTester {
+class ShiftTester(n: Int) extends Module {
   val (cntVal, done) = Counter(true.B, n)
   val start = 23.U
   val sr = ShiftRegister(cntVal + start, n)
@@ -51,7 +54,7 @@ class ShiftTester(n: Int) extends BasicTester {
   }
 }
 
-class ShiftResetTester(n: Int) extends BasicTester {
+class ShiftResetTester(n: Int) extends Module {
   val (cntVal, done) = Counter(true.B, n - 1)
   val start = 23.U
   val sr = ShiftRegister(cntVal + 23.U, n, 1.U, true.B)
@@ -61,17 +64,17 @@ class ShiftResetTester(n: Int) extends BasicTester {
   }
 }
 
-class ShiftRegisterSpec extends ChiselPropSpec {
+class ShiftRegisterSpec extends AnyPropSpec with ScalaCheckPropertyChecks with ChiselSim {
   property("ShiftRegister should shift") {
-    forAll(Gen.choose(0, 4)) { (shift: Int) => assertTesterPasses { new ShiftTester(shift) } }
+    forAll(Gen.choose(0, 4)) { (shift: Int) => simulate { new ShiftTester(shift) }(RunUntilFinished(shift + 2)) }
   }
 
   property("ShiftRegister should reset all values inside") {
-    forAll(Gen.choose(0, 4)) { (shift: Int) => assertTesterPasses { new ShiftResetTester(shift) } }
+    forAll(Gen.choose(0, 4)) { (shift: Int) => simulate { new ShiftResetTester(shift) }(RunUntilFinished(shift + 2)) }
   }
 }
 
-class ShiftsTester(n: Int) extends BasicTester {
+class ShiftsTester(n: Int) extends Module {
   val (cntVal, done) = Counter(true.B, n)
   val start = 23.U
   val srs = ShiftRegisters(cntVal + start, n)
@@ -83,8 +86,8 @@ class ShiftsTester(n: Int) extends BasicTester {
   }
 }
 
-class ShiftRegistersSpec extends ChiselPropSpec {
+class ShiftRegistersSpec extends AnyPropSpec with ScalaCheckPropertyChecks with ChiselSim {
   property("ShiftRegisters should shift") {
-    forAll(Gen.choose(0, 4)) { (shift: Int) => assertTesterPasses { new ShiftsTester(shift) } }
+    forAll(Gen.choose(0, 4)) { (shift: Int) => simulate { new ShiftsTester(shift) }(RunUntilFinished(shift + 2)) }
   }
 }


### PR DESCRIPTION
Bounce this off CI and make sure the migration is still good.

#### Release Notes

Add arguments to `HasSimulator` type class factories to allow for the creation of Verilator or VCS simulators with specific common or backend-specific compilation settings.