### PR TITLE
[testers] Fix BasicTester `finish`, port to ChiselSim

### DIFF
--- a/src/main/scala/chisel3/testers/BasicTester.scala
+++ b/src/main/scala/chisel3/testers/BasicTester.scala
@@ -27,4 +27,6 @@ class BasicTester extends Module() {
     * add flow control logic for a decoupled io port of a device under test
     */
   def finish(): Unit = {}
+
+  atModuleBodyEnd(finish())
 }

--- a/src/test/scala-2/chiselTests/TesterDriverSpec.scala
+++ b/src/test/scala-2/chiselTests/TesterDriverSpec.scala
@@ -3,8 +3,12 @@
 package chiselTests
 
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testers.BasicTester
-import chisel3.util._
+import chisel3.util.Counter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** Extend BasicTester with a simple circuit and finish method.  TesterDriver will call the
   * finish method after the FinishTester's constructor has completed, which will alter the
@@ -34,11 +38,11 @@ class FinishTester extends BasicTester {
   }
 }
 
-class TesterDriverSpec extends ChiselFlatSpec {
+class TesterDriverSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "TesterDriver calls BasicTester's finish method which" should
     "allow modifications of test circuit after the tester's constructor is done" in {
-      assertTesterPasses {
+      simulate {
         new FinishTester
-      }
+      }(RunUntilFinished(3))
     }
 }


### PR DESCRIPTION
Fix what appears to be a longstanding bug where `BasicTester.finish` never did anything unless used with the `BackendCompilationUtilities` trait. This trait has been deprecated for four years before being made private.

I plan to deprecate and remove `BasicTester`, as it has no value over a straight `Module`. However, this is an intermediate step that is necessary to port its associated test to `ChiselSim`. (This test wasn't actually working before and would assert and finish on the same cycle without applying the body of the `finish`.)

Port the associated test to ChiselSim.

I'm breaking this out from the other porting effort as this may break something.

#### Release Notes

Fix a bug where the `BasicTester.finish` would never be called.