### PR TITLE
[svsim] Fix VCS run_simulation function

### DIFF
--- a/svsim/src/main/scala/Workspace.scala
+++ b/svsim/src/main/scala/Workspace.scala
@@ -157,7 +157,7 @@ final class Workspace(
       l("    done = 0;")
       l("  endtask")
       l("  `else")
-      l("  import \"DPI-C\" function int run_simulation(int timesteps);")
+      l("  import \"DPI-C\" function void run_simulation(input int timesteps, output int done);")
       l("  `endif")
       l()
 


### PR DESCRIPTION
Fix an incorrect function signatures for the VCS implementation of `run_simulation`.  This is a task which has inputs and outputs.  This needs to be declared as having an `int *` argument for the output in C and have the input/outputs declared in Verilog.

This should fix an internal error when bumping Chisel w/ VCS-based tests (I haven't tested this, though. 😬)