### PR TITLE
Use DedupGroup Phase in ChiselStage$

### DIFF
--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -57,6 +57,7 @@ object ChiselStage {
     Seq(
       Dependency[chisel3.stage.phases.Elaborate],
       Dependency[chisel3.stage.phases.Convert],
+      Dependency[chisel3.stage.phases.AddDedupGroupAnnotations],
       Dependency[circt.stage.phases.AddImplicitOutputFile],
       Dependency[chisel3.stage.phases.AddImplicitOutputAnnotationFile],
       Dependency[circt.stage.phases.Checks],

--- a/src/test/scala-2/chiselTests/DedupSpec.scala
+++ b/src/test/scala-2/chiselTests/DedupSpec.scala
@@ -3,10 +3,11 @@
 package chiselTests
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.{Counter, Decoupled, Queue}
 import chisel3.experimental.{annotate, dedupGroup}
 import chisel3.experimental.hierarchy.Definition
 import chisel3.properties.Class
+import circt.stage.ChiselStage
 import firrtl.transforms.DedupGroupAnnotation
 import chisel3.experimental.hierarchy._
 import chisel3.util.circt.PlusArgsValue
@@ -121,8 +122,15 @@ class DedupSpec extends ChiselFlatSpec {
     }) === 3)
   }
 
-  it should "work natively for desiredNames" in {
+  it should "work natively for desiredNames with ChiselStage (the class)" in {
     assert(countModules(compile {
+      val top = new SharedConstantValDedupTopDesiredName
+      top
+    }) === 3)
+  }
+
+  it should "work natively for desiredNames with ChiselStage$ (the object)" in {
+    assert(countModules(ChiselStage.emitSystemVerilog {
       val top = new SharedConstantValDedupTopDesiredName
       top
     }) === 3)


### PR DESCRIPTION
Fix a bug where the dedup group phase was only run for the ChiselStage class and not its companion object.  Add this phase.

#### Release Notes

Fix bug where dedup groups would have no effect if methods of `ChiselStage$` (the object), e.g., `ChiselStage.emitSystemVerilog`, were used.