### PR TITLE
[test] Partial Migration off of ChiselSepc

### DIFF
--- a/src/test/resources/chisel3/VerilogVendingMachine.v
+++ b/src/test/resources/chisel3/VerilogVendingMachine.v
@@ -41,6 +41,9 @@ module VerilogVendingMachine(
       sOk: begin
         state <= sIdle;
       end
+      default: begin
+        assert(1'b0) else $error("illegal state");
+      end
       endcase
     end
   end

--- a/src/test/scala-2/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsTapSpec.scala
@@ -54,7 +54,7 @@ object BoringUtilsTapSpec {
 
 }
 
-class BoringUtilsTapSpec extends ChiselFlatSpec with ChiselRunners with Utils with FileCheck {
+class BoringUtilsTapSpec extends ChiselFlatSpec with Utils with FileCheck {
   val args = Array("--throw-on-first-error", "--full-stacktrace")
   "Ready-only tap" should "work downwards from parent to child" in {
     class Foo extends RawModule {

--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -32,7 +32,7 @@ import java.util.Calendar
 import chisel3.reflect.DataMirror
 
 /** Common utility functions for Chisel unit tests. */
-trait ChiselRunners extends Assertions {
+sealed trait ChiselRunners extends Assertions {
   private val verilatorBackend = verilator.Backend.initializeFromProcessEnvironment()
   private val timeStampFormat = new SimpleDateFormat("yyyyMMddHHmmss")
   def runTester(

--- a/src/test/scala-2/chiselTests/ChiselTestUtilitiesSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselTestUtilitiesSpec.scala
@@ -5,7 +5,7 @@ package chiselTests
 import chisel3._
 import org.scalatest.exceptions.TestFailedException
 
-class ChiselTestUtilitiesSpec extends ChiselFlatSpec {
+class ChiselTestUtilitiesSpec extends ChiselFlatSpec with WidthHelpers {
   // Who tests the testers?
   "assertKnownWidth" should "error when the expected width is wrong" in {
     intercept[TestFailedException] {

--- a/src/test/scala-2/chiselTests/DedupSpec.scala
+++ b/src/test/scala-2/chiselTests/DedupSpec.scala
@@ -3,13 +3,18 @@
 package chiselTests
 
 import chisel3._
-import chisel3.util._
-import chisel3.experimental.{annotate, dedupGroup}
-import chisel3.experimental.hierarchy.Definition
-import chisel3.properties.Class
-import firrtl.transforms.DedupGroupAnnotation
 import chisel3.experimental.hierarchy._
+import chisel3.experimental.{annotate, dedupGroup}
+import chisel3.properties.Class
+import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.testers.TestUtils
 import chisel3.util.circt.PlusArgsValue
+import chisel3.util.{Counter, Decoupled, Queue}
+import circt.stage.ChiselStage
+import firrtl.EmittedVerilogCircuitAnnotation
+import firrtl.transforms.DedupGroupAnnotation
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class DedupIO extends Bundle {
   val in = Flipped(Decoupled(UInt(32.W)))
@@ -95,25 +100,25 @@ class ModuleWithClass extends Module {
   val cls = Definition(new Class)
 }
 
-class DedupSpec extends ChiselFlatSpec {
+class DedupSpec extends AnyFlatSpec with Matchers {
   private val ModuleRegex = """\s*module\s+(\w+)\b.*""".r
   def countModules(verilog: String): Int =
     (verilog.split("\n").collect { case ModuleRegex(name) => name }).filterNot(_.contains("ram_4x32")).size
 
   "Deduplication" should "occur" in {
-    assert(countModules(compile { new DedupQueues(4) }) === 2)
+    assert(countModules(ChiselStage.emitSystemVerilog(new DedupQueues(4))) === 2)
   }
 
   it should "properly dedup modules with deduped submodules" in {
-    assert(countModules(compile { new NestedDedup }) === 3)
+    assert(countModules(ChiselStage.emitSystemVerilog(new NestedDedup)) === 3)
   }
 
   it should "dedup modules that share a literal" in {
-    assert(countModules(compile { new SharedConstantValDedupTop }) === 2)
+    assert(countModules(ChiselStage.emitSystemVerilog(new SharedConstantValDedupTop)) === 2)
   }
 
   it should "not dedup modules that are in different dedup groups" in {
-    assert(countModules(compile {
+    assert(countModules(ChiselStage.emitSystemVerilog {
       val top = new SharedConstantValDedupTop
       dedupGroup(top.inst0, "inst0")
       dedupGroup(top.inst1, "inst1")
@@ -122,15 +127,28 @@ class DedupSpec extends ChiselFlatSpec {
   }
 
   it should "work natively for desiredNames" in {
-    assert(countModules(compile {
-      val top = new SharedConstantValDedupTopDesiredName
-      top
-    }) === 3)
+    // TODO: This test _should_ be able to use `ChiselStage$` methods, but there
+    // are problems with annotations and D/I.
+    //
+    // See: https://github.com/chipsalliance/chisel/issues/4730
+    val verilog = new ChiselStage()
+      .execute(
+        Array("--target", "systemverilog"),
+        Seq(ChiselGeneratorAnnotation(() => new SharedConstantValDedupTopDesiredName))
+      )
+      .collectFirst { case EmittedVerilogCircuitAnnotation(a) =>
+        a.value
+      }
+      .get
+
+    assert(
+      countModules(verilog) === 3
+    )
   }
 
   it should "error on conflicting dedup groups" in {
     a[Exception] should be thrownBy {
-      compile {
+      ChiselStage.emitSystemVerilog {
         val top = new SharedConstantValDedupTop
         dedupGroup(top.inst0, "inst0")
         dedupGroup(top.inst0, "anothergroup")
@@ -142,7 +160,7 @@ class DedupSpec extends ChiselFlatSpec {
   }
 
   it should "not add DedupGroupAnnotation to intrinsics" in {
-    val (_, annos) = getFirrtlAndAnnos(new ModuleWithIntrinsic)
+    val (_, annos) = TestUtils.getChirrtlAndAnnotations(new ModuleWithIntrinsic)
     val dedupGroupAnnos = annos.collect { case DedupGroupAnnotation(target, _) =>
       target.module
     }
@@ -150,7 +168,7 @@ class DedupSpec extends ChiselFlatSpec {
   }
 
   it should "not add DedupGroupAnnotation to classes" in {
-    val (_, annos) = getFirrtlAndAnnos(new ModuleWithClass)
+    val (_, annos) = TestUtils.getChirrtlAndAnnotations(new ModuleWithClass)
     val dedupGroupAnnos = annos.collect { case DedupGroupAnnotation(target, _) =>
       target.module
     }

--- a/src/test/scala-2/chiselTests/LTLSpec.scala
+++ b/src/test/scala-2/chiselTests/LTLSpec.scala
@@ -4,17 +4,17 @@ package chiselTests
 
 import chisel3._
 import chisel3.ltl._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testers.BasicTester
 import chisel3.experimental.SourceLine
-import _root_.circt.stage.ChiselStage
-import chiselTests.ChiselRunners
-
+import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import Sequence._
 
-class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
+class LTLSpec extends AnyFlatSpec with Matchers with ChiselSim {
   it should "allow booleans to be used as sequences" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val a = IO(Input(Bool()))
@@ -419,11 +419,13 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselRunners {
   }
 
   it should "fail correctly in verilator simulation" in {
-    assertTesterFails(new BasicTester {
-      withClockAndReset(clock, reset) {
-        AssertProperty(0.U === 1.U)
-      }
-    })
+    intercept[chisel3.simulator.Exceptions.AssertionFailed] {
+      simulate(new BasicTester {
+        withClockAndReset(clock, reset) {
+          AssertProperty(0.U === 1.U)
+        }
+      })(RunUntilFinished(3))
+    }
   }
 
   class LayerBlockMod extends RawModule {

--- a/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
+++ b/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
@@ -20,7 +20,7 @@ object ModulePrefixSpec {
   }
 }
 
-class ModulePrefixSpec extends ChiselFlatSpec with ChiselRunners with Utils with FileCheck {
+class ModulePrefixSpec extends ChiselFlatSpec with Utils with FileCheck {
   import ModulePrefixSpec._
   behavior.of("withModulePrefix")
 

--- a/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
+++ b/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
@@ -6,6 +6,7 @@ import circt.stage.ChiselStage
 
 import chisel3._
 import chisel3.experimental.{annotate, AnyTargetable}
+import chisel3.testers.TestUtils
 import chisel3.stage.ChiselGeneratorAnnotation
 import chiselTests.experimental.hierarchy.Utils
 
@@ -14,7 +15,7 @@ import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class NewAnnotationsSpec extends AnyFreeSpec with Matchers with ChiselRunners with Utils {
+class NewAnnotationsSpec extends AnyFreeSpec with Matchers with Utils {
 
   class MuchUsedModule extends Module {
     val io = IO(new Bundle {
@@ -75,7 +76,7 @@ class NewAnnotationsSpec extends AnyFreeSpec with Matchers with ChiselRunners wi
     }
 
     "It should be possible to annotate heterogeneous Targetable things" in {
-      val (_, annotations) = getFirrtlAndAnnos(new RawModule {
+      val (_, annotations) = TestUtils.getChirrtlAndAnnotations(new RawModule {
         override def desiredName: String = "Top"
         val in = IO(Input(UInt(8.W)))
         val out = IO(Output(UInt(8.W)))

--- a/src/test/scala-2/chiselTests/Stop.scala
+++ b/src/test/scala-2/chiselTests/Stop.scala
@@ -3,14 +3,17 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
-import _root_.circt.stage.ChiselStage
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class StopTester() extends BasicTester {
+class StopTester() extends Module {
   chisel3.stop()
 }
 
-class StopWithMessageTester() extends BasicTester {
+class StopWithMessageTester() extends Module {
   val cycle = RegInit(0.U(4.W))
   cycle := cycle + 1.U
   when(cycle === 4.U) {
@@ -18,7 +21,7 @@ class StopWithMessageTester() extends BasicTester {
   }
 }
 
-class StopImmediatelyTester extends BasicTester {
+class StopImmediatelyTester extends Module {
   val cycle = RegInit(0.asUInt(4.W))
   cycle := cycle + 1.U
   when(cycle === 4.U) {
@@ -27,9 +30,9 @@ class StopImmediatelyTester extends BasicTester {
   assert(cycle =/= 5.U, "Simulation did not exit upon executing stop()")
 }
 
-class StopSpec extends ChiselFlatSpec {
+class StopSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "stop()" should "stop and succeed the testbench" in {
-    assertTesterPasses { new StopTester }
+    simulate { new StopTester }(RunUntilFinished(3))
   }
 
   it should "emit an optional message with arguments" in {
@@ -38,6 +41,6 @@ class StopSpec extends ChiselFlatSpec {
   }
 
   it should "end the simulation immediately" in {
-    assertTesterPasses { new StopImmediatelyTester }
+    simulate { new StopImmediatelyTester }(RunUntilFinished(6))
   }
 }

--- a/src/test/scala-2/chiselTests/UIntOps.scala
+++ b/src/test/scala-2/chiselTests/UIntOps.scala
@@ -211,7 +211,7 @@ class UIntLitZeroWidthTester extends BasicTester {
   stop()
 }
 
-trait ShiftRightWidthBehavior { self: ChiselRunners =>
+trait ShiftRightWidthBehavior extends WidthHelpers {
   // The UInt and SInt objects don't share a type, so make one up that they can conform to structurally
   type BitsFactory[T <: Bits] = {
     def apply():         T

--- a/src/test/scala-2/chiselTests/UIntOps.scala
+++ b/src/test/scala-2/chiselTests/UIntOps.scala
@@ -4,8 +4,10 @@ package chiselTests
 
 import circt.stage.ChiselStage
 import chisel3._
-import chisel3.testers.BasicTester
-import chisel3.util._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.util.{is, log2Ceil, random, switch, Counter}
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatest.matchers.should.Matchers
 
 class UIntOps extends Module {
@@ -56,7 +58,7 @@ class UIntOps extends Module {
 }
 
 // Note a and b need to be "safe"
-class UIntOpsTester(a: Long, b: Long) extends BasicTester {
+class UIntOpsTester(a: Long, b: Long) extends Module {
   require(a >= 0 && b >= 0)
 
   val dut = Module(new UIntOps)
@@ -125,7 +127,7 @@ class NegativeShift(t: => Bits) extends Module {
   Reg(t) >> -1
 }
 
-class BasicRotate extends BasicTester {
+class BasicRotate extends Module {
   val shiftAmount = random.LFSR(4)
   val ctr = RegInit(0.U(4.W))
 
@@ -159,7 +161,7 @@ class BasicRotate extends BasicTester {
 /** rotating a w-bit word left by n should be equivalent to rotating it by w - n
   * to the left
   */
-class MatchedRotateLeftAndRight(w: Int = 13) extends BasicTester {
+class MatchedRotateLeftAndRight(w: Int = 13) extends Module {
   val initValue = BigInt(w, scala.util.Random)
   println(s"Initial value: ${initValue.toString(2)}")
 
@@ -183,7 +185,7 @@ class MatchedRotateLeftAndRight(w: Int = 13) extends BasicTester {
   }
 }
 
-class UIntLitExtractTester extends BasicTester {
+class UIntLitExtractTester extends Module {
   assert("b101010".U.extract(2) === false.B)
   assert("b101010".U.extract(3) === true.B)
   assert("b101010".U.extract(100) === false.B)
@@ -198,7 +200,7 @@ class UIntLitExtractTester extends BasicTester {
   stop()
 }
 
-class UIntLitZeroWidthTester extends BasicTester {
+class UIntLitZeroWidthTester extends Module {
   assert(-0.U(0.W) === 0.U)
   assert(~0.U(0.W) === 0.U)
   assert(0.U(0.W) + 0.U(0.W) === 0.U)
@@ -270,7 +272,7 @@ trait ShiftRightWidthBehavior extends WidthHelpers {
 
 }
 
-class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRightWidthBehavior {
+class UIntOpsSpec extends AnyPropSpec with Matchers with Utils with ShiftRightWidthBehavior with ChiselSim {
 
   // This is intentionally a val outside of any ScalaTest constructs to check that it is legal
   // to create a literal outside of a Chisel context and *before* any Chisel contexts have been created
@@ -282,15 +284,15 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
   }
 
   property("Bools cannot be created from 0 bit UInts") {
-    a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.emitCHIRRTL(new ZeroWidthBoolConversion) }
+    intercept[Exception] { ChiselStage.emitCHIRRTL(new ZeroWidthBoolConversion) }
   }
 
   property("Bools cannot be created from >1 bit UInts") {
-    a[Exception] should be thrownBy extractCause[Exception] { ChiselStage.emitCHIRRTL(new BadBoolConversion) }
+    intercept[Exception] { ChiselStage.emitCHIRRTL(new BadBoolConversion) }
   }
 
   property("Out-of-bounds extraction from known-width UInts") {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(2.W)))
         u(2, 1)
@@ -299,7 +301,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
   }
 
   property("Out-of-bounds single-bit extraction from known-width UInts") {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(2.W)))
         u(2)
@@ -308,7 +310,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
   }
 
   property("Out-of-bounds extraction from known-zero-width UInts") {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(0.W)))
         u(0, 0)
@@ -317,7 +319,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
   }
 
   property("Out-of-bounds single-bit extraction from known-zero-width UInts") {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new RawModule {
         val u = IO(Input(UInt(0.W)))
         u(0)
@@ -330,31 +332,31 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
   }
 
   property("UIntOpsTester should return the correct result") {
-    assertTesterPasses { new UIntOpsTester(123, 7) }
+    simulate { new UIntOpsTester(123, 7) }(RunUntilFinished(3))
   }
 
   property("Negative shift amounts are invalid") {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new NegativeShift(UInt()))
     }
   }
 
   property("rotateLeft and rotateRight should work for dynamic shift values") {
-    assertTesterPasses(new BasicRotate)
+    simulate(new BasicRotate)(RunUntilFinished(1024 * 10))
   }
 
   property(
     "rotateLeft and rotateRight should be consistent for dynamic shift values"
   ) {
-    assertTesterPasses(new MatchedRotateLeftAndRight)
+    simulate(new MatchedRotateLeftAndRight)(RunUntilFinished(1024 * 10))
   }
 
   property("Bit extraction on literals should work for all non-negative indices") {
-    assertTesterPasses(new UIntLitExtractTester)
+    simulate(new UIntLitExtractTester)(RunUntilFinished(3))
   }
 
   property("Basic arithmetic and bit operations with zero-width literals should return correct result (0)") {
-    assertTesterPasses(new UIntLitZeroWidthTester)
+    simulate(new UIntLitZeroWidthTester)(RunUntilFinished(3))
   }
 
   property("asBools should support chained apply") {
@@ -499,7 +501,7 @@ class UIntOpsSpec extends ChiselPropSpec with Matchers with Utils with ShiftRigh
       log should include("warn")
     }
 
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new RawModule {
         val in = IO(Input(UInt(0.W)))
         val index = IO(Input(UInt(1.W)))

--- a/src/test/scala-2/chiselTests/VectorPacketIO.scala
+++ b/src/test/scala-2/chiselTests/VectorPacketIO.scala
@@ -3,8 +3,11 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
-import chisel3.util._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.util.Counter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
   * This test used to fail when assignment statements were
@@ -50,7 +53,7 @@ class BrokenVectorPacketModule extends Module {
   io.outs.foreach(_.noenq())
 }
 
-class VectorPacketIOUnitTester extends BasicTester {
+class VectorPacketIOUnitTester extends Module {
   val dut = Module(new BrokenVectorPacketModule)
   dut.io <> DontCare
 
@@ -61,11 +64,11 @@ class VectorPacketIOUnitTester extends BasicTester {
   }
 }
 
-class VectorPacketIOUnitTesterSpec extends ChiselFlatSpec {
+class VectorPacketIOUnitTesterSpec extends AnyFlatSpec with ChiselSim {
   "a circuit using an io containing a vector of EnqIO wrapped packets" should
     "compile and run" in {
-      assertTesterPasses {
+      simulate {
         new VectorPacketIOUnitTester
-      }
+      }(RunUntilFinished(3))
     }
 }

--- a/src/test/scala-2/chiselTests/WhenSpec.scala
+++ b/src/test/scala-2/chiselTests/WhenSpec.scala
@@ -2,13 +2,16 @@
 
 package chiselTests
 
-import circt.stage.ChiselStage
 import chisel3._
-import chisel3.testers.BasicTester
-import chisel3.util._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.util.Counter
 import chisel3.experimental.{SourceInfo, SourceLine}
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class WhenTester() extends BasicTester {
+class WhenTester() extends Module {
   val cnt = Counter(4)
   when(true.B) { cnt.inc() }
 
@@ -30,7 +33,7 @@ class WhenTester() extends BasicTester {
   }
 }
 
-class OverlappedWhenTester() extends BasicTester {
+class OverlappedWhenTester() extends Module {
   val cnt = Counter(4)
   when(true.B) { cnt.inc() }
 
@@ -52,7 +55,7 @@ class OverlappedWhenTester() extends BasicTester {
   }
 }
 
-class NoOtherwiseOverlappedWhenTester() extends BasicTester {
+class NoOtherwiseOverlappedWhenTester() extends Module {
   val cnt = Counter(4)
   when(true.B) { cnt.inc() }
 
@@ -76,7 +79,7 @@ class NoOtherwiseOverlappedWhenTester() extends BasicTester {
   }
 }
 
-class SubmoduleWhenTester extends BasicTester {
+class SubmoduleWhenTester extends Module {
   val (cycle, done) = Counter(true.B, 3)
   when(done) { stop() }
   val children =
@@ -92,7 +95,7 @@ class SubmoduleWhenTester extends BasicTester {
   }
 }
 
-class WhenCondTester extends BasicTester {
+class WhenCondTester extends Module {
   val pred = Wire(Vec(4, Bool()))
   val (cycle, done) = Counter(true.B, 1 << pred.size)
   // Cycle through every predicate
@@ -128,25 +131,25 @@ class WhenCondTester extends BasicTester {
   when(done) { stop() }
 }
 
-class WhenSpec extends ChiselFlatSpec with Utils {
+class WhenSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "When, elsewhen, and otherwise with orthogonal conditions" should "work" in {
-    assertTesterPasses { new WhenTester }
+    simulate(new WhenTester)(RunUntilFinished(5))
   }
   "When, elsewhen, and otherwise with overlapped conditions" should "work" in {
-    assertTesterPasses { new OverlappedWhenTester }
+    simulate(new OverlappedWhenTester)(RunUntilFinished(5))
   }
   "When and elsewhen without otherwise with overlapped conditions" should "work" in {
-    assertTesterPasses { new NoOtherwiseOverlappedWhenTester }
+    simulate(new NoOtherwiseOverlappedWhenTester)(RunUntilFinished(5))
   }
   "Conditional connections to submodule ports" should "be handled properly" in {
-    assertTesterPasses(new SubmoduleWhenTester)
+    simulate(new SubmoduleWhenTester)(RunUntilFinished(4))
   }
   "when.cond" should "give the current when condition" in {
-    assertTesterPasses(new WhenCondTester)
+    simulate(new WhenCondTester)(RunUntilFinished(math.pow(2, 4).toInt + 1))
   }
 
   "Returning in a when scope" should "give a reasonable error message" in {
-    val e = the[ChiselException] thrownBy extractCause[ChiselException] {
+    val e = intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val foo = Input(UInt(8.W))

--- a/src/test/scala-2/chiselTests/WidthSpec.scala
+++ b/src/test/scala-2/chiselTests/WidthSpec.scala
@@ -44,7 +44,7 @@ class WidthSpec extends ChiselFlatSpec {
   }
 }
 
-abstract class WireRegWidthSpecImpl extends ChiselFlatSpec {
+abstract class WireRegWidthSpecImpl extends ChiselFlatSpec with WidthHelpers {
   def name:                     String
   def builder[T <: Data](x: T): T
 
@@ -126,7 +126,7 @@ class RegWidthSpec extends WireRegWidthSpecImpl {
   def builder[T <: Data](x: T): T = Reg(x)
 }
 
-abstract class WireDefaultRegInitSpecImpl extends ChiselFlatSpec {
+abstract class WireDefaultRegInitSpecImpl extends ChiselFlatSpec with WidthHelpers {
   def name:                            String
   def builder1[T <: Data](x: T):       T
   def builder2[T <: Data](x: T, y: T): T

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Utils.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Utils.scala
@@ -6,7 +6,7 @@ import _root_.firrtl.annotations._
 import chiselTests.ChiselRunners
 import org.scalatest.matchers.should.Matchers
 
-trait Utils extends ChiselRunners with chiselTests.Utils with Matchers {
+trait Utils extends chiselTests.Utils with Matchers {
   // TODO promote to standard API (in FIRRTL) and perhaps even implement with a macro
   implicit class Str2RefTarget(str: String) {
     def rt: ReferenceTarget = Target.deserialize(str).asInstanceOf[ReferenceTarget]

--- a/src/test/scala-2/chiselTests/util/PriorityMuxSpec.scala
+++ b/src/test/scala-2/chiselTests/util/PriorityMuxSpec.scala
@@ -2,13 +2,15 @@
 
 package chiselTests.util
 
-import chisel3._
-import chisel3.testers.BasicTester
-import chisel3.util.{Counter, PriorityMux}
-import chiselTests.ChiselFlatSpec
 import _root_.circt.stage.ChiselStage.emitCHIRRTL
+import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.util.{Counter, PriorityMux}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PriorityMuxTester extends BasicTester {
+class PriorityMuxTester extends Module {
 
   val sel = Wire(UInt(3.W))
   sel := 0.U // default
@@ -40,11 +42,11 @@ class PriorityMuxTester extends BasicTester {
   }
 }
 
-class PriorityMuxSpec extends ChiselFlatSpec {
+class PriorityMuxSpec extends AnyFlatSpec with Matchers with ChiselSim {
   behavior.of("PriorityMux")
 
   it should "be functionally correct" in {
-    assertTesterPasses(new PriorityMuxTester)
+    simulate(new PriorityMuxTester)(RunUntilFinished(9))
   }
 
   it should "be stack safe" in {

--- a/src/test/scala-2/chiselTests/util/experimental/DecoderTableSpec.scala
+++ b/src/test/scala-2/chiselTests/util/experimental/DecoderTableSpec.scala
@@ -1,12 +1,14 @@
 package chiselTests.util.experimental
 
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util.BitPat
 import chisel3.util.experimental.decode._
-import chisel3.testers.BasicTester
-import chiselTests.ChiselFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DecoderTableSpec extends ChiselFlatSpec {
+class DecoderTableSpec extends AnyFlatSpec with Matchers with ChiselSim {
   /*
    * Assuming a simple ALU instruction scheme
    *      | Name Width Register
@@ -76,12 +78,12 @@ class DecoderTableSpec extends ChiselFlatSpec {
   }
 
   "DecoderTable" should "decode every field" in {
-    assertTesterPasses(new BasicTester {
+    simulate(new Module {
       val input = "b1100".U(4.W)
       val dut = Module(new ExampleALUDecoder)
       dut.inst := input
       chisel3.assert(dut.isWideOp, "WRONG OUTPUT %b", dut.isWideOp)
       stop()
-    })
+    })(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/cookbook/Bundle2UInt.scala
+++ b/src/test/scala-2/cookbook/Bundle2UInt.scala
@@ -3,6 +3,7 @@
 package cookbook
 
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 
 /* ### How do I create a UInt from an instance of a Bundle?
  *
@@ -26,6 +27,6 @@ class Bundle2UInt extends CookbookTester(1) {
 
 class Bundle2UIntSpec extends CookbookSpec {
   "Bundle2UInt" should "work" in {
-    assertTesterPasses { new Bundle2UInt }
+    simulate(new Bundle2UInt)(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/cookbook/CookbookSpec.scala
+++ b/src/test/scala-2/cookbook/CookbookSpec.scala
@@ -3,20 +3,21 @@
 package cookbook
 
 import chisel3._
-import chisel3.util._
+import chisel3.util.Counter
+import chisel3.simulator.scalatest.ChiselSim
 import chisel3.testers.BasicTester
-
-import chiselTests.ChiselFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** Tester for concise cookbook tests
   *
   * Provides a length of test after which the test will pass
   */
-abstract class CookbookTester(length: Int) extends BasicTester {
+abstract class CookbookTester(length: Int) extends Module {
   require(length >= 0, "Simulation length must be non-negative!")
 
   val (cycle, done) = Counter(true.B, length + 1) // + 1 cycle because done is actually wrap
   when(done) { stop() }
 }
 
-abstract class CookbookSpec extends ChiselFlatSpec
+abstract class CookbookSpec extends AnyFlatSpec with Matchers with ChiselSim

--- a/src/test/scala-2/cookbook/FSM.scala
+++ b/src/test/scala-2/cookbook/FSM.scala
@@ -4,6 +4,7 @@ package cookbook
 
 import chisel3._
 import chisel3.util._
+import chisel3.simulator.stimulus.RunUntilFinished
 
 /* ### How do I create a finite state machine?
  *
@@ -61,6 +62,6 @@ class DetectTwoOnesTester extends CookbookTester(10) {
 
 class FSMSpec extends CookbookSpec {
   "DetectTwoOnes" should "work" in {
-    assertTesterPasses { new DetectTwoOnesTester }
+    simulate(new DetectTwoOnesTester)(RunUntilFinished(12))
   }
 }

--- a/src/test/scala-2/cookbook/RegOfVec.scala
+++ b/src/test/scala-2/cookbook/RegOfVec.scala
@@ -3,6 +3,7 @@
 package cookbook
 
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 
 /* ### How do I create a Reg of type Vec?
  *
@@ -28,6 +29,6 @@ class RegOfVec extends CookbookTester(2) {
 
 class RegOfVecSpec extends CookbookSpec {
   "RegOfVec" should "work" in {
-    assertTesterPasses { new RegOfVec }
+    simulate(new RegOfVec)(RunUntilFinished(4))
   }
 }

--- a/src/test/scala-2/cookbook/UInt2Bundle.scala
+++ b/src/test/scala-2/cookbook/UInt2Bundle.scala
@@ -3,6 +3,7 @@
 package cookbook
 
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 
 /* ### How do I create a Bundle from a UInt?
  *
@@ -25,6 +26,6 @@ class UInt2Bundle extends CookbookTester(1) {
 
 class UInt2BundleSpec extends CookbookSpec {
   "UInt2Bundle" should "work" in {
-    assertTesterPasses { new UInt2Bundle }
+    simulate(new UInt2Bundle)(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/cookbook/UInt2VecOfBool.scala
+++ b/src/test/scala-2/cookbook/UInt2VecOfBool.scala
@@ -3,6 +3,7 @@
 package cookbook
 
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 
 /* ### How do I create a Vec of Bools from a UInt?
  *
@@ -24,6 +25,6 @@ class UInt2VecOfBool extends CookbookTester(1) {
 
 class UInt2VecOfBoolSpec extends CookbookSpec {
   "UInt2VecOfBool" should "work" in {
-    assertTesterPasses { new UInt2VecOfBool }
+    simulate(new UInt2VecOfBool)(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/cookbook/VecOfBool2UInt.scala
+++ b/src/test/scala-2/cookbook/VecOfBool2UInt.scala
@@ -3,6 +3,7 @@
 package cookbook
 
 import chisel3._
+import chisel3.simulator.stimulus.RunUntilFinished
 
 /* ### How do I create a UInt from a Vec of Bool?
  *
@@ -23,6 +24,6 @@ class VecOfBool2UInt extends CookbookTester(1) {
 
 class VecOfBool2UIntSpec extends CookbookSpec {
   "VecOfBool2UInt" should "work" in {
-    assertTesterPasses { new VecOfBool2UInt }
+    simulate(new VecOfBool2UInt)(RunUntilFinished(3))
   }
 }

--- a/src/test/scala-2/examples/ImplicitStateVendingMachine.scala
+++ b/src/test/scala-2/examples/ImplicitStateVendingMachine.scala
@@ -2,8 +2,12 @@
 
 package examples
 
-import chiselTests.ChiselFlatSpec
 import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chiselTests.ChiselFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 // Vending machine implemented with an implicit state machine
 class ImplicitStateVendingMachine extends SimpleVendingMachine {
@@ -24,8 +28,8 @@ class ImplicitStateVendingMachine extends SimpleVendingMachine {
   io.dispense := doDispense
 }
 
-class ImplicitStateVendingMachineSpec extends ChiselFlatSpec {
+class ImplicitStateVendingMachineSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "An vending machine implemented with implicit state" should "work" in {
-    assertTesterPasses { new SimpleVendingMachineTester(new ImplicitStateVendingMachine) }
+    simulate { new SimpleVendingMachineTester(new ImplicitStateVendingMachine) }(RunUntilFinished(11))
   }
 }

--- a/src/test/scala-2/examples/SimpleVendingMachine.scala
+++ b/src/test/scala-2/examples/SimpleVendingMachine.scala
@@ -2,10 +2,13 @@
 
 package examples
 
-import chiselTests.ChiselFlatSpec
-import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3._
-import chisel3.util._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.util.{is, switch, Counter, Enum, HasBlackBoxResource}
+import chiselTests.ChiselFlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class SimpleVendingMachineIO extends Bundle {
   val nickel = Input(Bool())
@@ -48,12 +51,14 @@ class FSMVendingMachine extends SimpleVendingMachine {
   io.dispense := (state === sOk)
 }
 
-class VerilogVendingMachine extends BlackBox {
+class VerilogVendingMachine extends BlackBox with HasBlackBoxResource {
   // Because this is a blackbox, we must explicitly add clock and reset
   val io = IO(new SimpleVendingMachineIO {
     val clock = Input(Clock())
     val reset = Input(Reset())
   })
+
+  addResource("/chisel3/VerilogVendingMachine.v")
 }
 
 // Shim because Blackbox io is slightly different than normal Chisel Modules
@@ -68,12 +73,12 @@ class VerilogVendingMachineWrapper extends SimpleVendingMachine {
 
 // Accept a reference to a SimpleVendingMachine so it can be constructed inside
 // the tester (in a call to Module.apply as required by Chisel
-class SimpleVendingMachineTester(mod: => SimpleVendingMachine) extends BasicTester {
+class SimpleVendingMachineTester(mod: => SimpleVendingMachine) extends Module {
 
   val dut = Module(mod)
 
   val (cycle, done) = Counter(true.B, 10)
-  when(done) { stop(); stop() } // Stop twice because of Verilator
+  when(done) { stop() }
 
   val nickelInputs = VecInit(true.B, true.B, true.B, true.B, true.B, false.B, false.B, false.B, true.B, false.B)
   val dimeInputs = VecInit(false.B, false.B, false.B, false.B, false.B, true.B, true.B, false.B, false.B, true.B)
@@ -84,14 +89,13 @@ class SimpleVendingMachineTester(mod: => SimpleVendingMachine) extends BasicTest
   assert(dut.io.dispense === expected(cycle))
 }
 
-class SimpleVendingMachineSpec extends ChiselFlatSpec {
+class SimpleVendingMachineSpec extends AnyFlatSpec with Matchers with ChiselSim {
   "An FSM implementation of a vending machine" should "work" in {
-    assertTesterPasses { new SimpleVendingMachineTester(new FSMVendingMachine) }
+    simulate(new SimpleVendingMachineTester(new FSMVendingMachine))(RunUntilFinished(12))
   }
   "An Verilog implementation of a vending machine" should "work" in {
-    assertTesterPasses(
-      new SimpleVendingMachineTester(new VerilogVendingMachineWrapper),
-      List("/chisel3/VerilogVendingMachine.v")
-    )
+    simulate(
+      new SimpleVendingMachineTester(new VerilogVendingMachineWrapper)
+    )(RunUntilFinished(12))
   }
 }


### PR DESCRIPTION
Move more tests to not depend on `ChiselSpec` (`ChiselRunners`). This is a check-in PR to make sure I'm still good with CI.