### PR TITLE
[test] Batched cleanups

### DIFF
--- a/src/test/scala-2/chisel3/internal/NameCollisionSpec.scala
+++ b/src/test/scala-2/chisel3/internal/NameCollisionSpec.scala
@@ -9,7 +9,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
   behavior.of("Builder")
 
   it should "error on duplicated names with a correct message" in {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL(
         new Module {
           val foo, bar = IO(Input(UInt(8.W)))
@@ -30,7 +30,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
 
   it should "error on sanitization resulting in duplicated names with a helpful message" in {
     // Case one: An unsanitary name that results in a collision with an existing name once sanitized
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL(
         new Module {
           val foo, bar = IO(Input(UInt(8.W)))
@@ -64,7 +64,7 @@ class NameCollisionSpec extends ChiselFlatSpec with Utils {
   }
 
   it should "error on nameless ports being assigned default names" in {
-    ((the[ChiselException] thrownBy extractCause[ChiselException] {
+    ((the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL(
         new Module {
           // Write to an output port that isn't assigned to a val, and so doesn't get prefixed

--- a/src/test/scala-2/chiselTests/AnalogSpec.scala
+++ b/src/test/scala-2/chiselTests/AnalogSpec.scala
@@ -98,7 +98,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
   behavior.of("Analog")
 
   it should "NOT be bindable to registers" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})
@@ -109,7 +109,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
   }
 
   it should "NOT be bindable to a direction" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
@@ -118,7 +118,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
         }
       }
     }
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
@@ -142,7 +142,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
   // There is no binding on the type of a memory
   // Should this be an error?
   ignore should "NOT be a legal type for Mem" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})
@@ -153,7 +153,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
   }
 
   it should "NOT be bindable to Mem ports" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})
@@ -189,7 +189,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
   }
 
   it should "error if any bulk connected more than once" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val wires = List.fill(3)(Wire(Analog(32.W)))
@@ -197,7 +197,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
         wires(0) <> wires(2)
       })
     }
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val wires = List.fill(2)(Wire(Analog(32.W)))

--- a/src/test/scala-2/chiselTests/AutoClonetypeSpec.scala
+++ b/src/test/scala-2/chiselTests/AutoClonetypeSpec.scala
@@ -232,7 +232,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Aliased fields" should "be caught" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       emitCHIRRTL {
         new Module {
           val bundleFieldType = UInt(8.W)
@@ -246,7 +246,7 @@ class AutoClonetypeSpec extends ChiselFlatSpec with Utils {
   }
 
   "Aliased fields from inadequate autoclonetype" should "be caught" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       class BadBundle(val typeTuple: (Data, Int)) extends Bundle {
         val a = typeTuple._1
       }

--- a/src/test/scala-2/chiselTests/BundleSpec.scala
+++ b/src/test/scala-2/chiselTests/BundleSpec.scala
@@ -72,17 +72,17 @@ class BundleSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
   }
 
   "Bulk connect on Bundles" should "check that the fields match" in {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL { new MyModule(new BundleFooBar, new BundleFoo) }
     }).getMessage should include("Right Record missing field")
 
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL { new MyModule(new BundleFoo, new BundleFooBar) }
     }).getMessage should include("Left Record missing field")
   }
 
   "Bundles" should "not be able to use Seq for constructing hardware" in {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
@@ -130,7 +130,7 @@ class BundleSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
       val d = c
     }
 
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(Output(new AliasedBundle))
@@ -142,7 +142,7 @@ class BundleSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
   }
 
   "Bundles" should "not have bound hardware" in {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           class MyBundle(val foo: UInt) extends Bundle
@@ -155,7 +155,7 @@ class BundleSpec extends AnyFlatSpec with Matchers with Utils with ChiselSim {
     }).getMessage should include("MyBundle contains hardware fields: foo: UInt<7>(123)")
   }
   "Bundles" should "not recursively contain aggregates with bound hardware" in {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           class MyBundle(val foo: UInt) extends Bundle

--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -256,43 +256,4 @@ trait Utils {
     }
     (baos.toString, ret)
   }
-
-  /** Run some code and rethrow an exception with a specific type if an exception of that type occurs anywhere in the
-    * stack trace.
-    *
-    * This is useful for "extracting" one exception that may be wrapped by other exceptions.
-    *
-    * Example usage:
-    * {{{
-    * a [ChiselException] should be thrownBy extractCause[ChiselException] { /* ... */ }
-    * }}}
-    *
-    * @param thunk some code to run
-    * @tparam A the type of the exception to extract
-    * @return nothing
-    */
-  def extractCause[A <: Throwable: ClassTag](thunk: => Any): Unit = {
-    def unrollCauses(a: Throwable): Seq[Throwable] = a match {
-      case null => Seq.empty
-      case _    => a +: unrollCauses(a.getCause)
-    }
-
-    val exceptions: Seq[_ <: Throwable] =
-      try {
-        thunk
-        Seq.empty
-      } catch {
-        case a: Throwable => unrollCauses(a)
-      }
-
-    exceptions.collectFirst { case a: A => a } match {
-      case Some(a) => throw a
-      case None =>
-        exceptions match {
-          case Nil    => ()
-          case h :: t => throw h
-        }
-    }
-
-  }
 }

--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -257,11 +257,6 @@ trait Utils {
     (baos.toString, ret)
   }
 
-  /** Encodes a System.exit exit code
-    * @param status the exit code
-    */
-  private case class ExitException(status: Int) extends SecurityException(s"Found a sys.exit with code $status")
-
   /** Run some code and rethrow an exception with a specific type if an exception of that type occurs anywhere in the
     * stack trace.
     *

--- a/src/test/scala-2/chiselTests/Direction.scala
+++ b/src/test/scala-2/chiselTests/Direction.scala
@@ -53,10 +53,10 @@ class DirectionSpec extends ChiselPropSpec with Matchers with Utils {
   }
 
   property("Inputs should not be assignable") {
-    a[Exception] should be thrownBy extractCause[Exception] {
+    a[Exception] should be thrownBy {
       ChiselStage.emitCHIRRTL(new BadDirection)
     }
-    a[Exception] should be thrownBy extractCause[Exception] {
+    a[Exception] should be thrownBy {
       ChiselStage.emitCHIRRTL(new BadSubDirection)
     }
   }

--- a/src/test/scala-2/chiselTests/IOCompatibility.scala
+++ b/src/test/scala-2/chiselTests/IOCompatibility.scala
@@ -51,7 +51,7 @@ class IOCompatibilitySpec extends ChiselPropSpec with Matchers with Utils {
   }
 
   property("Unwrapped IO should generate an exception") {
-    a[BindingException] should be thrownBy extractCause[BindingException] {
+    a[BindingException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new IOUnwrapped)
     }
   }

--- a/src/test/scala-2/chiselTests/IllegalRefSpec.scala
+++ b/src/test/scala-2/chiselTests/IllegalRefSpec.scala
@@ -59,13 +59,13 @@ class IllegalRefSpec extends ChiselFlatSpec with Utils {
 
   variants.foreach { case (k, v) =>
     s"Illegal cross-module references in ${k}" should "fail" in {
-      a[ChiselException] should be thrownBy extractCause[ChiselException] {
+      a[ChiselException] should be thrownBy {
         ChiselStage.emitCHIRRTL { new IllegalRefOuter(v) }
       }
     }
 
     s"Using a signal that has escaped its enclosing when scope in ${k}" should "fail" in {
-      a[ChiselException] should be thrownBy extractCause[ChiselException] {
+      a[ChiselException] should be thrownBy {
         ChiselStage.emitCHIRRTL { new CrossWhenConnect(v) }
       }
     }

--- a/src/test/scala-2/chiselTests/InvalidateAPISpec.scala
+++ b/src/test/scala-2/chiselTests/InvalidateAPISpec.scala
@@ -87,9 +87,7 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
       DontCare := io.in
     }
     val exception = intercept[ChiselException] {
-      extractCause[ChiselException] {
-        ChiselStage.emitCHIRRTL(new ModuleWithDontCareSink)
-      }
+      ChiselStage.emitCHIRRTL(new ModuleWithDontCareSink)
     }
     exception.getMessage should include("DontCare cannot be a connection sink")
   }
@@ -100,9 +98,7 @@ class InvalidateAPISpec extends ChiselPropSpec with Matchers with Utils {
       DontCare <> io.in
     }
     val exception = intercept[BiConnectException] {
-      extractCause[BiConnectException] {
-        circt.stage.ChiselStage.emitCHIRRTL(new ModuleWithDontCareSink)
-      }
+      circt.stage.ChiselStage.emitCHIRRTL(new ModuleWithDontCareSink)
     }
     exception.getMessage should include("DontCare cannot be a connection sink (LHS)")
   }

--- a/src/test/scala-2/chiselTests/MixedVecSpec.scala
+++ b/src/test/scala-2/chiselTests/MixedVecSpec.scala
@@ -10,21 +10,21 @@ import chisel3.util.MixedVec
 class MixedVecSpec extends ChiselPropSpec with Utils {
 
   property("MixedVecs should not be able to take hardware types") {
-    a[ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
+    a[ExpectedChiselTypeException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val hw = Wire(MixedVec(Seq(UInt(8.W), Bool())))
         val illegal = MixedVec(hw)
       })
     }
-    a[ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
+    a[ExpectedChiselTypeException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val hw = Reg(MixedVec(Seq(UInt(8.W), Bool())))
         val illegal = MixedVec(hw)
       })
     }
-    a[ExpectedChiselTypeException] should be thrownBy extractCause[ExpectedChiselTypeException] {
+    a[ExpectedChiselTypeException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val v = Input(MixedVec(Seq(UInt(8.W), Bool())))
@@ -35,7 +35,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
   }
 
   property("Connecting a MixedVec and something of different size should report a ChiselException") {
-    an[IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+    an[IllegalArgumentException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val out = Output(MixedVec(Seq(UInt(8.W), Bool())))
@@ -44,7 +44,7 @@ class MixedVecSpec extends ChiselPropSpec with Utils {
         io.out := seq
       })
     }
-    an[IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+    an[IllegalArgumentException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val out = Output(MixedVec(Seq(UInt(8.W), Bool())))

--- a/src/test/scala-2/chiselTests/ModuleSpec.scala
+++ b/src/test/scala-2/chiselTests/ModuleSpec.scala
@@ -105,25 +105,25 @@ class ModuleSpec extends ChiselPropSpec with Utils {
   ignore("ModuleWhenTester should return the correct result") {}
 
   property("Forgetting a Module() wrapper should result in an error") {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL { new ModuleForgetWrapper }
     }).getMessage should include("attempted to instantiate a Module without wrapping it")
   }
 
   property("Double wrapping a Module should result in an error") {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL { new ModuleDoubleWrap }
     }).getMessage should include("Called Module() twice without instantiating a Module")
   }
 
   property("Rewrapping an already instantiated Module should result in an error") {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL { new ModuleRewrap }
     }).getMessage should include("This is probably due to rewrapping a Module instance")
   }
 
   property("Wrapping a Class in Module() should result in an error") {
-    (the[ChiselException] thrownBy extractCause[ChiselException] {
+    (the[ChiselException] thrownBy {
       ChiselStage.emitCHIRRTL { new RawModule { Module(new Class {}) } }
     }).getMessage should include("Module() cannot be called on a Class")
   }
@@ -282,7 +282,7 @@ class ModuleSpec extends ChiselPropSpec with Utils {
     ChiselStage.emitCHIRRTL(new ModuleWrapper(new ModuleWire)) should include("module ModuleWireWrapper")
   }
   property("A name generating a null pointer exception should provide a good error message") {
-    (the[ChiselException] thrownBy extractCause[ChiselException](
+    (the[ChiselException] thrownBy (
       ChiselStage.emitCHIRRTL(new NullModuleWrapper)
     )).getMessage should include("desiredName of chiselTests.NullModuleWrapper is null")
   }

--- a/src/test/scala-2/chiselTests/PrintableSpec.scala
+++ b/src/test/scala-2/chiselTests/PrintableSpec.scala
@@ -270,9 +270,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers with Utils {
       printf(cf"This should error out for sure because of % - it should be %%")
     }
     a[java.util.UnknownFormatConversionException] should be thrownBy {
-      extractCause[java.util.UnknownFormatConversionException] {
-        ChiselStage.emitCHIRRTL { new MyModule }
-      }
+      ChiselStage.emitCHIRRTL { new MyModule }
     }
   }
 
@@ -295,18 +293,14 @@ class PrintableSpec extends AnyFlatSpec with Matchers with Utils {
       printf(cf"%")
     }
     a[java.util.UnknownFormatConversionException] should be thrownBy {
-      extractCause[java.util.UnknownFormatConversionException] {
-        ChiselStage.emitCHIRRTL { new MyModule }
-      }
+      ChiselStage.emitCHIRRTL { new MyModule }
     }
   }
 
   it should "fail when passing directly to StirngContext.cf a string with  literal \\ correctly escaped  " in {
     a[StringContext.InvalidEscapeException] should be thrownBy {
-      extractCause[StringContext.InvalidEscapeException] {
-        val s_seq = Seq("Test with literal \\ correctly escaped")
-        StringContext(s_seq: _*).cf(Seq(): _*)
-      }
+      val s_seq = Seq("Test with literal \\ correctly escaped")
+      StringContext(s_seq: _*).cf(Seq(): _*)
     }
   }
 

--- a/src/test/scala-2/chiselTests/RebindingSpec.scala
+++ b/src/test/scala-2/chiselTests/RebindingSpec.scala
@@ -7,7 +7,7 @@ import circt.stage.ChiselStage
 
 class RebindingSpec extends ChiselFlatSpec with Utils {
   "Rebinding a literal" should "fail" in {
-    a[BindingException] should be thrownBy extractCause[BindingException] {
+    a[BindingException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {
@@ -19,7 +19,7 @@ class RebindingSpec extends ChiselFlatSpec with Utils {
   }
 
   "Rebinding a hardware type" should "fail" in {
-    a[BindingException] should be thrownBy extractCause[BindingException] {
+    a[BindingException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {

--- a/src/test/scala-2/chiselTests/ResetSpec.scala
+++ b/src/test/scala-2/chiselTests/ResetSpec.scala
@@ -147,7 +147,7 @@ class ResetSpec extends ChiselFlatSpec with Utils {
   }
 
   "Chisel" should "error if sync and async modules are nested" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module with RequireAsyncReset {
         val mod = Module(new Module with RequireSyncReset)
       })

--- a/src/test/scala-2/chiselTests/SwitchSpec.scala
+++ b/src/test/scala-2/chiselTests/SwitchSpec.scala
@@ -8,7 +8,7 @@ import circt.stage.ChiselStage
 
 class SwitchSpec extends ChiselFlatSpec with Utils {
   "switch" should "require literal conditions" in {
-    a[java.lang.IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+    a[java.lang.IllegalArgumentException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val state = RegInit(0.U)
@@ -20,7 +20,7 @@ class SwitchSpec extends ChiselFlatSpec with Utils {
     }
   }
   it should "require mutually exclusive conditions" in {
-    a[java.lang.IllegalArgumentException] should be thrownBy extractCause[IllegalArgumentException] {
+    a[java.lang.IllegalArgumentException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {})
         val state = RegInit(0.U)

--- a/src/test/scala-2/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala-2/chiselTests/ToTargetSpec.scala
@@ -204,7 +204,7 @@ class ToTargetSpec extends ChiselFlatSpec with Utils {
       out := in
     }
 
-    val e = the[ChiselException] thrownBy extractCause[ChiselException] {
+    val e = the[ChiselException] thrownBy {
       var e: Example = null
       circt.stage.ChiselStage.emitCHIRRTL { e = new Example; e }
       e.tpe.toTarget

--- a/src/test/scala-2/chiselTests/TypeAliasSpec.scala
+++ b/src/test/scala-2/chiselTests/TypeAliasSpec.scala
@@ -211,7 +211,7 @@ class TypeAliasSpec extends ChiselFlatSpec with Utils {
   }
 
   "Duplicate bundle type aliases with differing structures" should "error" in {
-    val msg = (the[ChiselException] thrownBy extractCause[ChiselException] {
+    val msg = (the[ChiselException] thrownBy {
       class Test extends Module {
         // These bundles are structurally unequivalent and so must be aliased with different names.
         // Error if they share the same name
@@ -319,7 +319,7 @@ class TypeAliasSpec extends ChiselFlatSpec with Utils {
 
     // Prevent statements like type Clock = { ... }
     firrtlKeywords.map { tpe =>
-      (the[ChiselException] thrownBy extractCause[ChiselException] {
+      (the[ChiselException] thrownBy {
         class Test(val firrtlType: String) extends Module {
           class FooBundle extends Bundle with HasTypeAlias {
             override def aliasName = RecordAlias(firrtlType)

--- a/src/test/scala-2/chiselTests/Vec.scala
+++ b/src/test/scala-2/chiselTests/Vec.scala
@@ -85,7 +85,7 @@ class VecSpec extends ChiselPropSpec with Utils {
   }
 
   property("Vec.fill with a pure type should generate an exception") {
-    a[BindingException] should be thrownBy extractCause[BindingException] {
+    a[BindingException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new IOTesterModFill(8))
     }
   }
@@ -352,7 +352,7 @@ class VecSpec extends ChiselPropSpec with Utils {
   }
 
   property("Bulk connecting a Vec and Seq of different sizes should report a ChiselException") {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val io = IO(new Bundle {
           val out = Output(Vec(4, UInt(8.W)))
@@ -373,7 +373,7 @@ class VecSpec extends ChiselPropSpec with Utils {
   }
 
   property("Indexing a Chisel type Vec by a hardware type should give a sane error message") {
-    a[ExpectedHardwareException] should be thrownBy extractCause[ChiselException] {
+    a[ExpectedHardwareException] should be thrownBy {
       ChiselStage.emitCHIRRTL {
         new Module {
           val io = IO(new Bundle {})

--- a/src/test/scala-2/chiselTests/VecToTargetSpec.scala
+++ b/src/test/scala-2/chiselTests/VecToTargetSpec.scala
@@ -46,7 +46,7 @@ trait VecToTargetSpecUtils extends Utils {
   def conversionFails(data: InstanceId) = {
     describe(".toTarget") {
       it("should fail to convert with a useful error message") {
-        (the[ChiselException] thrownBy extractCause[ChiselException] {
+        (the[ChiselException] thrownBy {
           data.toTarget
         }).getMessage should include(expectedError)
       }
@@ -54,7 +54,7 @@ trait VecToTargetSpecUtils extends Utils {
 
     describe(".toNamed") {
       it("should fail to convert with a useful error message") {
-        (the[ChiselException] thrownBy extractCause[ChiselException] {
+        (the[ChiselException] thrownBy {
           data.toNamed
         }).getMessage should include(expectedError)
       }

--- a/src/test/scala-2/chiselTests/WarningSpec.scala
+++ b/src/test/scala-2/chiselTests/WarningSpec.scala
@@ -32,7 +32,7 @@ class WarningSpec extends ChiselFlatSpec with Utils {
   }
 
   "Warnings" should "be treated as errors with warningsAsErrors" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       val args = Array("--warnings-as-errors")
       ChiselStage.emitCHIRRTL(new MyModule, args)
     }

--- a/src/test/scala-2/chiselTests/experimental/OpaqueTypeSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/OpaqueTypeSpec.scala
@@ -185,13 +185,13 @@ class OpaqueTypeSpec extends ChiselFlatSpec with Utils {
   }
 
   they should "throw an error when map contains a named element and OpaqueType is mixed in" in {
-    (the[Exception] thrownBy extractCause[Exception] {
+    (the[Exception] thrownBy {
       ChiselStage.emitCHIRRTL { new NamedSingleElementModule }
     }).getMessage should include("Opaque types must have exactly one element with an empty name")
   }
 
   they should "throw an error when map contains more than one element and OpaqueType is mixed in" in {
-    (the[Exception] thrownBy extractCause[Exception] {
+    (the[Exception] thrownBy {
       ChiselStage.emitCHIRRTL { new ErroneousOverrideModule }
     }).getMessage should include("Opaque types must have exactly one element with an empty name")
   }

--- a/src/test/scala-2/chiselTests/experimental/ProgrammaticPortsSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/ProgrammaticPortsSpec.scala
@@ -48,7 +48,7 @@ class ProgrammaticPortsSpec extends ChiselFlatSpec with Utils {
   }
 
   "Port names" should "not conflict with any component names" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       doTest(new PortNameUniquenessTester)
     }
   }
@@ -64,7 +64,7 @@ class ProgrammaticPortsSpec extends ChiselFlatSpec with Utils {
   }
 
   "SuggestName collisions on ports" should "be illegal" in {
-    a[ChiselException] should be thrownBy extractCause[ChiselException] {
+    a[ChiselException] should be thrownBy {
       ChiselStage.emitCHIRRTL(new Module {
         val foo = IO(UInt(8.W)).suggestName("apple")
         val bar = IO(UInt(8.W)).suggestName("apple")


### PR DESCRIPTION
Remove `ExitException` and `extractCause` utilities. This hits a lot of tests and I want to bounce it off CI.