### PR TITLE
[test] Delete ChiselRunners

### DIFF
--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -32,17 +32,7 @@ import java.util.Calendar
 import chisel3.reflect.DataMirror
 
 /** Common utility functions for Chisel unit tests. */
-sealed trait ChiselRunners extends Assertions {
-
-  def elaborateAndGetModule[A <: RawModule](t: => A): A = {
-    var res: Any = null
-    ChiselStage.emitCHIRRTL {
-      res = t
-      res.asInstanceOf[A]
-    }
-    res.asInstanceOf[A]
-  }
-}
+sealed trait ChiselRunners extends Assertions
 
 trait WidthHelpers extends Assertions {
 

--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -31,9 +31,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import chisel3.reflect.DataMirror
 
-/** Common utility functions for Chisel unit tests. */
-sealed trait ChiselRunners extends Assertions
-
 trait WidthHelpers extends Assertions {
 
   def assertKnownWidth(expected: Int, args: Iterable[String] = Nil)(gen: => Data)(implicit pos: Position): Unit = {
@@ -136,13 +133,13 @@ trait FileCheck extends BeforeAndAfterEachTestData { this: Suite =>
 }
 
 /** Spec base class for BDD-style testers. */
-abstract class ChiselFlatSpec extends AnyFlatSpec with ChiselRunners with Matchers
+abstract class ChiselFlatSpec extends AnyFlatSpec with Matchers
 
 /** Spec base class for BDD-style testers. */
-abstract class ChiselFreeSpec extends AnyFreeSpec with ChiselRunners with Matchers
+abstract class ChiselFreeSpec extends AnyFreeSpec with Matchers
 
 /** Spec base class for BDD-style testers. */
-abstract class ChiselFunSpec extends AnyFunSpec with ChiselRunners with Matchers
+abstract class ChiselFunSpec extends AnyFunSpec with Matchers
 
 /** Utilities for writing property-based checks */
 trait PropertyUtils extends ScalaCheckPropertyChecks {
@@ -212,7 +209,7 @@ trait PropertyUtils extends ScalaCheckPropertyChecks {
 }
 
 /** Spec base class for property-based testers. */
-abstract class ChiselPropSpec extends AnyPropSpec with ChiselRunners with PropertyUtils with Matchers
+abstract class ChiselPropSpec extends AnyPropSpec with PropertyUtils with Matchers
 
 trait Utils {
 

--- a/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
@@ -8,6 +8,8 @@ import chisel3.experimental.dataview._
 import chisel3.experimental.conversions._
 import chisel3.experimental.annotate
 import chiselTests.{ChiselFlatSpec, FileCheck}
+import chiselTests.experimental.ExtensionMethods.ChiselStageHelpers
+import circt.stage.ChiselStage
 
 object DataViewTargetSpec {
   import firrtl.annotations._
@@ -56,7 +58,7 @@ class DataViewTargetSpec extends ChiselFlatSpec with FileCheck {
       val inst = Module(new MyChild)
       out := inst.out
     }
-    val m = elaborateAndGetModule(new MyParent)
+    val m = ChiselStage.getModule(new MyParent)
     val outsideView = m.inst.out.viewAs[UInt]
     checkSameAs(m.inst.out, m.inst.insideView, outsideView)
   }
@@ -81,7 +83,7 @@ class DataViewTargetSpec extends ChiselFlatSpec with FileCheck {
       val inst = Module(new MyChild)
       out := inst.out
     }
-    val m = elaborateAndGetModule(new MyParent)
+    val m = ChiselStage.getModule(new MyParent)
     val outView = m.inst.out.viewAs[Vec[UInt]] // Note different type
     val outFooView = m.inst.out.foo.viewAs[UInt]
     val outBarsView = m.inst.out.bars.viewAs[Vec[UInt]]

--- a/src/test/scala-2/chiselTests/experimental/ExtensionMethods.scala
+++ b/src/test/scala-2/chiselTests/experimental/ExtensionMethods.scala
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.experimental
+
+import chisel3.RawModule
+import circt.stage.ChiselStage
+
+/** Object that contains various extension methods for all the [[experimental]] package. */
+private[experimental] object ExtensionMethods {
+
+  /** Extension methods for [[ChiselStage]]. */
+  implicit class ChiselStageHelpers(obj: ChiselStage.type) {
+
+    /** Construct a module and return it.  This has a _very_ narrow use case and
+      * should not be generally used for writing tests of Chisel.
+      */
+    def getModule[A <: RawModule](gen: => A): A = {
+      var res: Any = null
+      obj.convert {
+        res = gen
+        res.asInstanceOf[A]
+      }
+      res.asInstanceOf[A]
+    }
+
+  }
+
+}

--- a/src/test/scala-2/chiselTests/experimental/ModuleDataProductSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/ModuleDataProductSpec.scala
@@ -6,6 +6,8 @@ import chisel3._
 import chisel3.experimental.{BaseModule, ExtModule}
 import chisel3.experimental.dataview.DataProduct
 import chiselTests.ChiselFlatSpec
+import chiselTests.experimental.ExtensionMethods.ChiselStageHelpers
+import circt.stage.ChiselStage
 
 object ModuleDataProductSpec {
   class MyBundle extends Bundle {
@@ -42,7 +44,7 @@ class ModuleDataProductSpec extends ChiselFlatSpec {
   behavior.of("DataProduct")
 
   it should "work for UserModules (recursively)" in {
-    val m = elaborateAndGetModule(new MyUserModule)
+    val m = ChiselStage.getModule(new MyUserModule)
     val expected = Seq(
       m.clock -> "m.clock",
       m.reset -> "m.reset",
@@ -72,7 +74,7 @@ class ModuleDataProductSpec extends ChiselFlatSpec {
   }
 
   it should "work for (wrapped) ExtModules" in {
-    val m = elaborateAndGetModule(new MyExtModuleWrapper).inst
+    val m = ChiselStage.getModule(new MyExtModuleWrapper).inst
     val expected = Seq(
       m.in -> "m.in",
       m.in.bar -> "m.in.bar",

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -6,6 +6,7 @@ package experimental.hierarchy
 import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
+import chiselTests.experimental.ExtensionMethods.ChiselStageHelpers
 import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -303,14 +304,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
   }
   describe("(2): Annotations on designs not in the same chisel compilation") {
     // Extract the built `AddTwo` module for use in other tests.
-    val first = {
-      var result: AddTwo = null
-      ChiselStage.emitCHIRRTL {
-        result = new AddTwo
-        result
-      }
-      result
-    }
+    val first = ChiselStage.getModule(new AddTwo)
     it("(2.a): should work on an innerWire, marked in a different compilation") {
       class Top(x: AddTwo) extends Module {
         val parent = Definition(new ViewerParent(x, false, true))

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Utils.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Utils.scala
@@ -3,7 +3,6 @@
 package chiselTests.experimental.hierarchy
 
 import _root_.firrtl.annotations._
-import chiselTests.ChiselRunners
 import org.scalatest.matchers.should.Matchers
 
 trait Utils extends chiselTests.Utils with Matchers {


### PR DESCRIPTION
Move the last method provided by `ChiselRunners` into an extension method scoped to the testing package that needs it. Delete `ChiselRunners` after that.