### PR TITLE
[test] Delete ChiselFreeSpec

### DIFF
--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -133,9 +133,6 @@ trait FileCheck extends BeforeAndAfterEachTestData { this: Suite =>
 }
 
 /** Spec base class for BDD-style testers. */
-abstract class ChiselFreeSpec extends AnyFreeSpec with Matchers
-
-/** Spec base class for BDD-style testers. */
 abstract class ChiselFunSpec extends AnyFunSpec with Matchers
 
 /** Utilities for writing property-based checks */

--- a/src/test/scala-2/chiselTests/PortSpec.scala
+++ b/src/test/scala-2/chiselTests/PortSpec.scala
@@ -2,8 +2,10 @@ package chiselTests
 
 import chisel3._
 import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PortSpec extends ChiselFreeSpec {
+class PortSpec extends AnyFlatSpec with Matchers with FileCheck {
 
   class DummyIO extends Bundle {
     val foo = Input(Bool())
@@ -16,15 +18,18 @@ class PortSpec extends ChiselFreeSpec {
     out := in.foo.asUInt + in.bar
   }
 
-  "Ports now have source locators" in {
-    val chirrtl = ChiselStage.emitCHIRRTL(new Dummy)
-    // Automatic clock and reset coming from Module do not get source locators
-    chirrtl should include("input clock : Clock")
-    chirrtl should include("input reset : UInt<1>")
-    // other ports get source locators
-    chirrtl should include(
-      "output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[src/test/scala-2/chiselTests/PortSpec.scala"
+  behavior of "Ports"
+
+  they should "have source locators" in {
+    info("Module-provided ports (clock and reset) point at the line with `Module`")
+    info("User-defined ports point at the correct lines")
+    generateFirrtlAndFileCheck(new Dummy)(
+      """|CHECK:      public module Dummy :
+         |CHECK-NEXT:   input clock : Clock @[src/test/scala-2/chiselTests/PortSpec.scala 15:9
+         |CHECK-NEXT:   input reset : UInt<1> @[src/test/scala-2/chiselTests/PortSpec.scala 15:9
+         |CHECK-NEXT:   output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[src/test/scala-2/chiselTests/PortSpec.scala 16:16
+         |CHECK-NEXT:   output out : UInt<1> @[src/test/scala-2/chiselTests/PortSpec.scala 17:17
+         |""".stripMargin
     )
-    chirrtl should include("output out : UInt<1> @[src/test/scala-2/chiselTests/PortSpec.scala")
   }
 }


### PR DESCRIPTION
Delete ChiselFreeSpec. Refactor PortsSpec to use AnyFlatSpec and FileCheck. This exposed a problem with what the test was checking, so I am opting to lock in the existing behavior.