### PR TITLE
[test] Remove unnecessary usages of BasicTester

### DIFF
--- a/integration-tests/src/test/scala-2/chiselTest/LFSRSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/LFSRSpec.scala
@@ -6,7 +6,6 @@ import chisel3._
 import circt.stage.ChiselStage
 import chisel3.util.{Cat, Counter}
 import chisel3.util.random._
-import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
 import org.scalatest.flatspec.AnyFlatSpec
@@ -16,7 +15,7 @@ class FooLFSR(val reduction: LFSRReduce, seed: Option[BigInt]) extends PRNG(4, s
   def delta(s: Seq[Bool]): Seq[Bool] = s
 }
 
-class LFSRMaxPeriod(gen: => UInt) extends BasicTester {
+class LFSRMaxPeriod(gen: => UInt) extends Module {
 
   val rv = gen
   val started = RegNext(true.B, false.B)
@@ -39,7 +38,7 @@ class LFSRMaxPeriod(gen: => UInt) extends BasicTester {
   * Each cycle it adds them together and adds a count to the bin corresponding to that value
   * The asserts check that the bins show the correct distribution.
   */
-class LFSRDistribution(gen: => UInt, cycles: Int = 10000) extends BasicTester {
+class LFSRDistribution(gen: => UInt, cycles: Int = 10000) extends Module {
 
   val rv = gen
   val bins = Reg(Vec(8, UInt(32.W)))
@@ -76,7 +75,7 @@ class LFSRDistribution(gen: => UInt, cycles: Int = 10000) extends BasicTester {
   * @param gen an LFSR to test
   * @param lockUpValue the value that would lock up the LFSR
   */
-class LFSRResetTester(gen: => LFSR, lockUpValue: BigInt) extends BasicTester {
+class LFSRResetTester(gen: => LFSR, lockUpValue: BigInt) extends Module {
 
   val lfsr = Module(gen)
   lfsr.io.seed.valid := false.B

--- a/integration-tests/src/test/scala-2/chiselTest/MixedVecIntegrationSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/MixedVecIntegrationSpec.scala
@@ -8,11 +8,10 @@ import circt.stage.ChiselStage
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import chisel3.util._
 import org.scalatest.propspec.AnyPropSpec
 
-class MixedVecAssignTester(w: Int, values: List[Int]) extends BasicTester {
+class MixedVecAssignTester(w: Int, values: List[Int]) extends Module {
   val v = MixedVecInit(values.map(v => v.U(w.W)))
   for ((a, b) <- v.zip(values)) {
     assert(a === b.asUInt)
@@ -20,7 +19,7 @@ class MixedVecAssignTester(w: Int, values: List[Int]) extends BasicTester {
   stop()
 }
 
-class MixedVecRegTester(w: Int, values: List[Int]) extends BasicTester {
+class MixedVecRegTester(w: Int, values: List[Int]) extends Module {
   val valuesInit = MixedVecInit(values.map(v => v.U(w.W)))
   val reg = Reg(MixedVec(chiselTypeOf(valuesInit)))
 
@@ -47,7 +46,7 @@ class MixedVecIOPassthroughModule[T <: Data](hvec: MixedVec[T]) extends Module {
   io.out := io.in
 }
 
-class MixedVecIOTester(boundVals: Seq[Data]) extends BasicTester {
+class MixedVecIOTester(boundVals: Seq[Data]) extends Module {
   val v = MixedVecInit(boundVals)
   val dut = Module(new MixedVecIOPassthroughModule(MixedVec(chiselTypeOf(v))))
   dut.io.in := v
@@ -57,7 +56,7 @@ class MixedVecIOTester(boundVals: Seq[Data]) extends BasicTester {
   stop()
 }
 
-class MixedVecZeroEntryTester extends BasicTester {
+class MixedVecZeroEntryTester extends Module {
   def zeroEntryMixedVec: MixedVec[Data] = MixedVec(Seq.empty)
 
   require(zeroEntryMixedVec.getWidth == 0)
@@ -78,7 +77,7 @@ class MixedVecZeroEntryTester extends BasicTester {
   stop()
 }
 
-class MixedVecUIntDynamicIndexTester extends BasicTester {
+class MixedVecUIntDynamicIndexTester extends Module {
   val wire: MixedVec[UInt] = Wire(MixedVec(Seq(UInt(8.W), UInt(16.W), UInt(4.W), UInt(7.W))))
   val n = wire.length
 
@@ -104,7 +103,7 @@ class MixedVecSmallTestBundle extends Bundle {
   val y = UInt(3.W)
 }
 
-class MixedVecFromVecTester extends BasicTester {
+class MixedVecFromVecTester extends Module {
   val wire = Wire(MixedVec(Vec(3, UInt(8.W))))
   wire := MixedVecInit(Seq(20.U, 40.U, 80.U))
 
@@ -115,7 +114,7 @@ class MixedVecFromVecTester extends BasicTester {
   stop()
 }
 
-class MixedVecConnectWithVecTester extends BasicTester {
+class MixedVecConnectWithVecTester extends Module {
   val mixedVecType = MixedVec(Vec(3, UInt(8.W)))
 
   val m = Module(new MixedVecIOPassthroughModule(mixedVecType))
@@ -129,7 +128,7 @@ class MixedVecConnectWithVecTester extends BasicTester {
   stop()
 }
 
-class MixedVecConnectWithSeqTester extends BasicTester {
+class MixedVecConnectWithSeqTester extends Module {
   val mixedVecType = MixedVec(Vec(3, UInt(8.W)))
 
   val m = Module(new MixedVecIOPassthroughModule(mixedVecType))
@@ -143,7 +142,7 @@ class MixedVecConnectWithSeqTester extends BasicTester {
   stop()
 }
 
-class MixedVecOneBitTester extends BasicTester {
+class MixedVecOneBitTester extends Module {
   val flag = RegInit(false.B)
 
   val oneBit = Reg(MixedVec(Seq(UInt(1.W))))
@@ -160,7 +159,7 @@ class MixedVecOneBitTester extends BasicTester {
 class MixedVecIntegrationSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
   property("MixedVec varargs API should work") {
     simulate {
-      new BasicTester {
+      new Module {
         val wire = Wire(MixedVec(UInt(1.W), UInt(8.W)))
         wire(0) := 1.U
         wire(1) := 101.U

--- a/integration-tests/src/test/scala-2/chiselTest/QueueFlushSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/QueueFlushSpec.scala
@@ -5,7 +5,6 @@ import org.scalacheck._
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.util._
 import chisel3.util.random.LFSR
 import org.scalatest.propspec.AnyPropSpec
@@ -40,7 +39,7 @@ abstract class FlushQueueTesterBase(
   bitWidth:       Int,
   tap:            Int,
   useSyncReadMem: Boolean
-) extends BasicTester {
+) extends Module {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, hasFlush = true))
   val elems = VecInit(elements.map(_.U))
   val inCnt = Counter(elements.length + 1)

--- a/integration-tests/src/test/scala-2/chiselTest/QueueSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/QueueSpec.scala
@@ -6,7 +6,6 @@ import circt.stage.ChiselStage
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import chisel3.util._
 import chisel3.util.random.LFSR
 import org.scalacheck._
@@ -20,7 +19,7 @@ class ThingsPassThroughTester(
   tap:            Int,
   useSyncReadMem: Boolean,
   hasFlush:       Boolean
-) extends BasicTester {
+) extends Module {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, useSyncReadMem = useSyncReadMem, hasFlush = hasFlush))
   val elems = VecInit(elements.map {
     _.asUInt
@@ -46,7 +45,7 @@ class ThingsPassThroughTester(
 }
 
 class QueueReasonableReadyValid(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: Int, useSyncReadMem: Boolean)
-    extends BasicTester {
+    extends Module {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, useSyncReadMem = useSyncReadMem))
   val elems = VecInit(elements.map {
     _.asUInt
@@ -75,7 +74,7 @@ class QueueReasonableReadyValid(elements: Seq[Int], queueDepth: Int, bitWidth: I
 }
 
 class CountIsCorrectTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: Int, useSyncReadMem: Boolean)
-    extends BasicTester {
+    extends Module {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, useSyncReadMem = useSyncReadMem))
   val elems = VecInit(elements.map {
     _.asUInt(bitWidth.W)
@@ -102,7 +101,7 @@ class CountIsCorrectTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, t
   }
 }
 
-class QueueSinglePipeTester(elements: Seq[Int], bitWidth: Int, tap: Int, useSyncReadMem: Boolean) extends BasicTester {
+class QueueSinglePipeTester(elements: Seq[Int], bitWidth: Int, tap: Int, useSyncReadMem: Boolean) extends Module {
   val q = Module(new Queue(UInt(bitWidth.W), 1, pipe = true, useSyncReadMem = useSyncReadMem))
   val elems = VecInit(elements.map {
     _.asUInt(bitWidth.W)
@@ -129,7 +128,7 @@ class QueueSinglePipeTester(elements: Seq[Int], bitWidth: Int, tap: Int, useSync
 }
 
 class QueuePipeTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: Int, useSyncReadMem: Boolean)
-    extends BasicTester {
+    extends Module {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, pipe = true, useSyncReadMem = useSyncReadMem))
   val elems = VecInit(elements.map {
     _.asUInt(bitWidth.W)
@@ -156,7 +155,7 @@ class QueuePipeTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: I
 }
 
 class QueueFlowTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: Int, useSyncReadMem: Boolean)
-    extends BasicTester {
+    extends Module {
   val q = Module(new Queue(UInt(bitWidth.W), queueDepth, flow = true, useSyncReadMem = useSyncReadMem))
   val elems = VecInit(elements.map {
     _.asUInt
@@ -185,7 +184,7 @@ class QueueFlowTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: I
 }
 
 class QueueFactoryTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap: Int, useSyncReadMem: Boolean)
-    extends BasicTester {
+    extends Module {
   val enq = Wire(Decoupled(UInt(bitWidth.W)))
   val deq = Queue(enq, queueDepth, useSyncReadMem = useSyncReadMem)
 
@@ -217,7 +216,7 @@ class QueueFactoryTester(elements: Seq[Int], queueDepth: Int, bitWidth: Int, tap
   * into the shadow queue.  It then checks that each data read out has the
   * expected identifier.
   */
-class ShadowQueueFactoryTester(queueDepth: Int, tap: Int, useSyncReadMem: Boolean) extends BasicTester {
+class ShadowQueueFactoryTester(queueDepth: Int, tap: Int, useSyncReadMem: Boolean) extends Module {
   val enq, deq = Wire(Decoupled(UInt(32.W)))
 
   private val (dataCounter, _) = Counter(0 to 31 by 2, enable = enq.fire)

--- a/integration-tests/src/test/scala-2/chiselTest/ShiftRegisterMemSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/ShiftRegisterMemSpec.scala
@@ -5,12 +5,11 @@ package chiselTests
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import chisel3.util.{Counter, ShiftRegister}
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.propspec.AnyPropSpec
 
-class ShiftMemTester(n: Int, dp_mem: Boolean) extends BasicTester {
+class ShiftMemTester(n: Int, dp_mem: Boolean) extends Module {
   val (cntVal, done) = Counter(true.B, n)
   val start = 23.U
   val sr = ShiftRegister.mem(cntVal + start, n, true.B, dp_mem, Some("simple_sr"))

--- a/integration-tests/src/test/scala-2/chiselTest/VecIntegrationSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/VecIntegrationSpec.scala
@@ -7,7 +7,6 @@ import chisel3._
 import chisel3.util._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import org.scalacheck._
 import scala.language.reflectiveCalls
 import org.scalatest.propspec.AnyPropSpec
@@ -31,7 +30,7 @@ class VecIntegrationSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
       io.out := vecReg
     }
 
-    class RegTester(w: Int, values: List[Int]) extends BasicTester {
+    class RegTester(w: Int, values: List[Int]) extends Module {
       val v = VecInit(values.map(_.U(w.W)))
       val dut = Module(new RegTesterMod(values.length))
       val doneReg = RegInit(false.B)
@@ -53,7 +52,7 @@ class VecIntegrationSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
   }
 
   property("VecInit should iterate correctly") {
-    class IterateTester(start: Int, len: Int)(f: UInt => UInt) extends BasicTester {
+    class IterateTester(start: Int, len: Int)(f: UInt => UInt) extends Module {
       val controlVec = VecInit(Seq.iterate(start.U, len)(f))
       val testVec = VecInit.iterate(start.U, len)(f)
       chisel3.assert(
@@ -68,7 +67,7 @@ class VecIntegrationSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
   }
 
   property("Regs of vecs should be usable as shift registers") {
-    class ShiftRegisterTester(n: Int) extends BasicTester {
+    class ShiftRegisterTester(n: Int) extends Module {
       val (cnt, wrap) = Counter(true.B, n * 2)
       val shifter = Reg(Vec(n, UInt((log2Ceil(n).max(1)).W)))
       shifter.zip(shifter.drop(1)).foreach { case (l, r) => l := r }
@@ -86,7 +85,7 @@ class VecIntegrationSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
   }
 
   property("Dynamic indexing of a Vec of Module IOs should work") {
-    class ModuleIODynamicIndexTester(n: Int) extends BasicTester {
+    class ModuleIODynamicIndexTester(n: Int) extends Module {
       val duts = VecInit.fill(n)(Module(new PassthroughModule).io)
       val tester = Module(new PassthroughModuleTester)
 

--- a/integration-tests/src/test/scala-2/chiselTest/util/SparseVecSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/util/SparseVecSpec.scala
@@ -3,7 +3,6 @@
 package chiselTests.util
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util.{log2Up, Counter, SparseVec}
@@ -25,7 +24,7 @@ import org.scalatest.matchers.should.Matchers
   * @param mapping a mapping of index to value
   */
 class SparseVecDynamicIndexEquivalenceTest(size: Int, tpe: UInt, mapping: Seq[(Int, UInt)], debug: Boolean = false)
-    extends BasicTester {
+    extends Module {
 
   // The number of indices that needs to be checked.  This is larger than `size`
   // if `size` is not a power of 2.  This is done to check out-of-bounds
@@ -98,7 +97,7 @@ class SparseVecTest(
   mapping:              Seq[(Int, UInt)],
   expected:             Seq[(Int, Data)],
   debug:                Boolean = false
-) extends BasicTester {
+) extends Module {
   // Create a wire SparseVec and initialize it to the values in the mapping.
   private val sparseVec = Wire(new SparseVec(size, tpe, mapping.map(_._1), defaultValueBehavior, outOfBoundsBehavior))
   sparseVec.elements.values.zip(mapping.map(_._2)).foreach { case (a, b) => a :<>= b }

--- a/integration-tests/src/test/scala-2/chiselTest/util/experimental/PlaSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/util/experimental/PlaSpec.scala
@@ -4,13 +4,12 @@ import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.stage.PrintFullStackTraceAnnotation
-import chisel3.testers.BasicTester
 import chisel3.util.{pla, BitPat}
 import org.scalatest.flatspec.AnyFlatSpec
 
 class PlaSpec extends AnyFlatSpec with ChiselSim {
   "A 1-of-8 decoder (eg. 74xx138 without enables)" should "be generated correctly" in {
-    simulate(new BasicTester {
+    simulate(new Module {
       val table = Seq(
         (BitPat("b000"), BitPat("b00000001")),
         (BitPat("b001"), BitPat("b00000010")),
@@ -35,7 +34,7 @@ class PlaSpec extends AnyFlatSpec with ChiselSim {
   }
 
   "An active-low 1-of-8 decoder (eg. inverted 74xx138 without enables)" should "be generated correctly" in {
-    simulate(new BasicTester {
+    simulate(new Module {
       val table = Seq(
         (BitPat("b000"), BitPat("b00000001")),
         (BitPat("b001"), BitPat("b00000010")),
@@ -60,7 +59,7 @@ class PlaSpec extends AnyFlatSpec with ChiselSim {
   }
 
   "#2112" should "be generated correctly" in {
-    simulate(new BasicTester {
+    simulate(new Module {
       val table = Seq(
         (BitPat("b000"), BitPat("b?01")),
         (BitPat("b111"), BitPat("b?01"))
@@ -75,7 +74,7 @@ class PlaSpec extends AnyFlatSpec with ChiselSim {
   }
 
   "A simple PLA" should "be generated correctly" in {
-    simulate(new BasicTester {
+    simulate(new Module {
       val table = Seq(
         (BitPat("b0000"), BitPat("b1")),
         (BitPat("b0001"), BitPat("b1")),

--- a/src/test/scala-2/chisel3/internal/ContainsProbeSpec.scala
+++ b/src/test/scala-2/chisel3/internal/ContainsProbeSpec.scala
@@ -3,7 +3,6 @@ package chisel3.internal
 import chisel3._
 import chisel3.probe._
 import chisel3.util.DecoupledIO
-import chisel3.testers.{BasicTester, TesterDriver}
 import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala-2/chiselTests/AnalogIntegrationSpec.scala
+++ b/src/test/scala-2/chiselTests/AnalogIntegrationSpec.scala
@@ -6,7 +6,6 @@ import chisel3._
 import chisel3.util._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.experimental._
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -109,7 +108,7 @@ class AnalogSmallDUT extends AnalogDUTModule(4) { // 4 BlackBoxes
 }
 
 // This tester is primarily intended to be able to pass the dut to synthesis
-class AnalogIntegrationTester(mod: => AnalogDUTModule) extends BasicTester {
+class AnalogIntegrationTester(mod: => AnalogDUTModule) extends Module {
   val BusValue = 2.U(32.W) // arbitrary
 
   val dut = Module(mod)

--- a/src/test/scala-2/chiselTests/AnalogSpec.scala
+++ b/src/test/scala-2/chiselTests/AnalogSpec.scala
@@ -7,7 +7,6 @@ import circt.stage.ChiselStage
 import chisel3.util._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.experimental.{attach, Analog, BaseModule}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -81,7 +80,7 @@ class VecBundleAnalogReaderWrapper extends RawModule with AnalogReader {
 }
 
 // Parent class for tests connecing up AnalogReaders and AnalogWriters
-abstract class AnalogTester extends BasicTester {
+abstract class AnalogTester extends Module {
   final val BusValue = "hdeadbeef".U
 
   final val (cycle, done) = Counter(true.B, 2)
@@ -169,7 +168,7 @@ class AnalogSpec extends AnyFlatSpec with Matchers with ChiselSim {
   it should "NOT be connectable to UInts" in {
     a[Exception] should be thrownBy {
       ChiselStage.emitSystemVerilog {
-        new BasicTester {
+        new Module {
           val uint = WireDefault(0.U(32.W))
           val sint = Wire(Analog(32.W))
           sint := uint

--- a/src/test/scala-2/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala-2/chiselTests/AnnotatingDiamondSpec.scala
@@ -5,7 +5,6 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.{annotate, AnyTargetable}
 import chisel3.stage.ChiselGeneratorAnnotation
-import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 import firrtl.annotations.{CircuitTarget, SingleTargetAnnotation, Target}
 import org.scalatest._
@@ -102,7 +101,7 @@ class TopOfDiamond extends Module {
   identify(modB.io.in, s"modB.io.in annotated from outside modB")
 }
 
-class DiamondTester extends BasicTester {
+class DiamondTester extends Module {
   val dut = Module(new TopOfDiamond)
 
   stop()

--- a/src/test/scala-2/chiselTests/AsTypeOfTester.scala
+++ b/src/test/scala-2/chiselTests/AsTypeOfTester.scala
@@ -7,12 +7,11 @@ import chisel3._
 import chisel3.reflect.DataMirror
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import chisel3.experimental.Analog
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class AsTypeOfBundleTester extends BasicTester {
+class AsTypeOfBundleTester extends Module {
   class MultiTypeBundle extends Bundle {
     val u = UInt(4.W)
     val s = SInt(4.W)
@@ -28,7 +27,7 @@ class AsTypeOfBundleTester extends BasicTester {
   stop()
 }
 
-class AsTypeOfBundleZeroWidthTester extends BasicTester {
+class AsTypeOfBundleZeroWidthTester extends Module {
   class ZeroWidthBundle extends Bundle {
     val a = UInt(0.W)
     val b = UInt(1.W)
@@ -46,7 +45,7 @@ class AsTypeOfBundleZeroWidthTester extends BasicTester {
   stop()
 }
 
-class AsTypeOfVecTester extends BasicTester {
+class AsTypeOfVecTester extends Module {
   val vec = ((15 << 12) + (0 << 8) + (1 << 4) + (2 << 0)).U.asTypeOf(Vec(4, SInt(4.W)))
 
   assert(vec(0) === 2.S)
@@ -57,7 +56,7 @@ class AsTypeOfVecTester extends BasicTester {
   stop()
 }
 
-class AsTypeOfTruncationTester extends BasicTester {
+class AsTypeOfTruncationTester extends Module {
   val truncate = (64 + 3).U.asTypeOf(UInt(3.W))
   val expand = 1.U.asTypeOf(UInt(3.W))
 
@@ -69,12 +68,12 @@ class AsTypeOfTruncationTester extends BasicTester {
   stop()
 }
 
-class ResetAsTypeOfBoolTester extends BasicTester {
+class ResetAsTypeOfBoolTester extends Module {
   assert(reset.asTypeOf(Bool()) === reset.asBool)
   stop()
 }
 
-class AsTypeOfClockTester extends BasicTester {
+class AsTypeOfClockTester extends Module {
   class MyBundle extends Bundle {
     val x = UInt(4.W)
     val y = Clock()
@@ -85,7 +84,7 @@ class AsTypeOfClockTester extends BasicTester {
   stop()
 }
 
-class AsChiselEnumTester extends BasicTester {
+class AsChiselEnumTester extends Module {
   object MyEnum extends ChiselEnum {
     val foo, bar = Value
     val fizz = Value(2.U)

--- a/src/test/scala-2/chiselTests/AsyncResetSpec.scala
+++ b/src/test/scala-2/chiselTests/AsyncResetSpec.scala
@@ -5,13 +5,12 @@ package chiselTests
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import chisel3.util.{Counter, Queue}
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class AsyncResetTester extends BasicTester {
+class AsyncResetTester extends Module {
   val (_, cDiv) = Counter(true.B, 4)
   // First rising edge when count === 3
   val slowClk = cDiv.asClock
@@ -41,7 +40,7 @@ class AsyncResetTester extends BasicTester {
   }
 }
 
-class AsyncResetAggregateTester extends BasicTester {
+class AsyncResetAggregateTester extends Module {
   class MyBundle extends Bundle {
     val x = UInt(8.W)
     val y = UInt(8.W)
@@ -92,7 +91,7 @@ class AsyncResetAggregateTester extends BasicTester {
   }
 }
 
-class AsyncResetQueueTester extends BasicTester {
+class AsyncResetQueueTester extends Module {
   val (_, cDiv) = Counter(true.B, 4)
   val slowClk = cDiv.asClock
 
@@ -150,14 +149,14 @@ class AsyncResetSpec extends AnyFlatSpec with Matchers with ChiselSim {
   }
 
   it should "be allowed with literal reset values" in {
-    ChiselStage.emitCHIRRTL(new BasicTester {
+    ChiselStage.emitCHIRRTL(new Module {
       withReset(reset.asAsyncReset)(RegInit(123.U))
     })
   }
 
   it should "NOT be allowed with non-literal reset values" in {
     val e = intercept[RuntimeException] {
-      ChiselStage.emitSystemVerilog(new BasicTester {
+      ChiselStage.emitSystemVerilog(new Module {
         val x = WireInit(123.U + 456.U)
         withReset(reset.asAsyncReset)(RegInit(x))
       })
@@ -168,7 +167,7 @@ class AsyncResetSpec extends AnyFlatSpec with Matchers with ChiselSim {
 
   it should "NOT be allowed to connect directly to a Bool" in {
     intercept[ChiselException] {
-      ChiselStage.emitCHIRRTL(new BasicTester {
+      ChiselStage.emitCHIRRTL(new Module {
         val bool = Wire(Bool())
         val areset = reset.asAsyncReset
         bool := areset
@@ -185,7 +184,7 @@ class AsyncResetSpec extends AnyFlatSpec with Matchers with ChiselSim {
   }
 
   it should "allow casting to and from Bool" in {
-    ChiselStage.emitCHIRRTL(new BasicTester {
+    ChiselStage.emitCHIRRTL(new Module {
       val r: Reset = reset
       val a: AsyncReset = WireInit(r.asAsyncReset)
       val b: Bool = a.asBool
@@ -198,7 +197,7 @@ class AsyncResetSpec extends AnyFlatSpec with Matchers with ChiselSim {
   }
 
   it should "support SInt regs" in {
-    simulate(new BasicTester {
+    simulate(new Module {
       // Also check that it traces through wires
       val initValue = Wire(SInt())
       val reg = withReset(reset.asAsyncReset)(RegNext(initValue, 27.S))
@@ -218,7 +217,7 @@ class AsyncResetSpec extends AnyFlatSpec with Matchers with ChiselSim {
       val x = UInt(16.W)
       val y = UInt(16.W)
     }
-    simulate(new BasicTester {
+    simulate(new Module {
       val reg = withReset(reset.asAsyncReset) {
         RegNext(0xbad0cad0L.U.asTypeOf(new MyBundle), 0xdeadbeefL.U.asTypeOf(new MyBundle))
       }
@@ -232,7 +231,7 @@ class AsyncResetSpec extends AnyFlatSpec with Matchers with ChiselSim {
     })(RunUntilFinished(5))
   }
   it should "allow literals cast to Vecs as reset values" in {
-    simulate(new BasicTester {
+    simulate(new Module {
       val reg = withReset(reset.asAsyncReset) {
         RegNext(0xbad0cad0L.U.asTypeOf(Vec(4, UInt(8.W))), 0xdeadbeefL.U.asTypeOf(Vec(4, UInt(8.W))))
       }

--- a/src/test/scala-2/chiselTests/BlackBox.scala
+++ b/src/test/scala-2/chiselTests/BlackBox.scala
@@ -8,7 +8,6 @@ import chisel3.experimental._
 import chisel3.reflect.DataMirror
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.{BasicTester, TesterDriver}
 import chisel3.util._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -63,7 +62,7 @@ class BlackBoxRegister extends BlackBox with HasBlackBoxResource {
   addResource("/chisel3/BlackBoxTest.v")
 }
 
-class BlackBoxTester extends BasicTester {
+class BlackBoxTester extends Module {
   val blackBoxPos = Module(new BlackBoxInverter)
   val blackBoxNeg = Module(new BlackBoxInverter)
 
@@ -75,7 +74,7 @@ class BlackBoxTester extends BasicTester {
   stop()
 }
 
-class BlackBoxTesterSuggestName extends BasicTester {
+class BlackBoxTesterSuggestName extends Module {
   val blackBoxPos = Module(new BlackBoxInverterSuggestName)
   val blackBoxNeg = Module(new BlackBoxInverterSuggestName)
 
@@ -87,7 +86,7 @@ class BlackBoxTesterSuggestName extends BasicTester {
   stop()
 }
 
-class BlackBoxFlipTester extends BasicTester {
+class BlackBoxFlipTester extends Module {
   val blackBox = Module(new BlackBoxPassthrough2)
 
   blackBox.io.in := 1.U
@@ -100,7 +99,7 @@ class BlackBoxFlipTester extends BasicTester {
   * deduplication.
   */
 
-class MultiBlackBoxTester extends BasicTester {
+class MultiBlackBoxTester extends Module {
   val blackBoxInvPos = Module(new BlackBoxInverter)
   val blackBoxInvNeg = Module(new BlackBoxInverter)
   val blackBoxPassPos = Module(new BlackBoxPassthrough)
@@ -118,7 +117,7 @@ class MultiBlackBoxTester extends BasicTester {
   stop()
 }
 
-class BlackBoxWithClockTester extends BasicTester {
+class BlackBoxWithClockTester extends Module {
   val blackBox = Module(new BlackBoxRegister)
   val model = Reg(Bool())
 
@@ -185,7 +184,7 @@ class BlackBoxUIntIO extends BlackBox with HasBlackBoxResource {
   addResource("/chisel3/BlackBoxTest.v")
 }
 
-class SimplerBlackBoxWithParamsTester extends BasicTester {
+class SimplerBlackBoxWithParamsTester extends Module {
   val blackBoxTypeParamBit = Module(new BlackBoxTypeParam(1, "bit"))
   val blackBoxTypeParamWord = Module(new BlackBoxTypeParam(32, "bit [31:0]"))
 
@@ -197,7 +196,7 @@ class SimplerBlackBoxWithParamsTester extends BasicTester {
   when(end) { stop() }
 }
 
-class BlackBoxWithParamsTester extends BasicTester {
+class BlackBoxWithParamsTester extends Module {
   val blackBoxOne = Module(new BlackBoxConstant(1))
   val blackBoxFour = Module(new BlackBoxConstant(4))
   val blackBoxStringParamOne = Module(new BlackBoxStringParam("one"))

--- a/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
@@ -4,7 +4,6 @@ package chiselTests
 
 import chisel3._
 import chisel3.util.Counter
-import chisel3.testers._
 import chisel3.experimental.{BaseModule, OpaqueType}
 import chisel3.probe._
 import chisel3.properties.Property
@@ -16,7 +15,7 @@ import firrtl.transforms.DontTouchAnnotation
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-abstract class ShouldntAssertTester(cyclesToWait: BigInt = 4) extends BasicTester {
+abstract class ShouldntAssertTester(cyclesToWait: BigInt = 4) extends Module {
   val dut: BaseModule
   val (_, done) = Counter(true.B, 2)
   when(done) { stop() }

--- a/src/test/scala-2/chiselTests/BulkConnectSpec.scala
+++ b/src/test/scala-2/chiselTests/BulkConnectSpec.scala
@@ -1,7 +1,6 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.util.Decoupled
 import circt.stage.ChiselStage
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -9,7 +9,6 @@ import circt.stage.ChiselStage
 import chisel3.util._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.freespec.AnyFreeSpec
@@ -188,7 +187,7 @@ class LoadStoreExample extends Module {
   printf(p"${io.opcode}")
 }
 
-class CastToUIntTester extends BasicTester {
+class CastToUIntTester extends Module {
   for ((enumVal, lit) <- EnumExample.all.zip(EnumExample.litValues)) {
     val mod = Module(new CastToUInt)
     mod.io.in := enumVal
@@ -197,7 +196,7 @@ class CastToUIntTester extends BasicTester {
   stop()
 }
 
-class CastFromLitTester extends BasicTester {
+class CastFromLitTester extends Module {
   for ((enumVal, lit) <- EnumExample.all.zip(EnumExample.litValues)) {
     val mod = Module(new CastFromLit(lit))
     assert(mod.io.out === enumVal)
@@ -206,7 +205,7 @@ class CastFromLitTester extends BasicTester {
   stop()
 }
 
-class CastFromNonLitTester extends BasicTester {
+class CastFromNonLitTester extends Module {
   for ((enumVal, lit) <- EnumExample.all.zip(EnumExample.litValues)) {
     val mod = Module(new CastFromNonLit)
     mod.io.in := lit
@@ -227,7 +226,7 @@ class CastFromNonLitTester extends BasicTester {
   stop()
 }
 
-class SafeCastFromNonLitTester extends BasicTester {
+class SafeCastFromNonLitTester extends Module {
   for ((enumVal, lit) <- EnumExample.all.zip(EnumExample.litValues)) {
     val mod = Module(new SafeCastFromNonLit)
     mod.io.in := lit
@@ -248,12 +247,12 @@ class SafeCastFromNonLitTester extends BasicTester {
   stop()
 }
 
-class CastToInvalidEnumTester extends BasicTester {
+class CastToInvalidEnumTester extends Module {
   val invalid_value: UInt = EnumExample.litValues.last + 1.U
   Module(new CastFromLit(invalid_value))
 }
 
-class EnumOpsTester extends BasicTester {
+class EnumOpsTester extends Module {
   for {
     x <- EnumExample.all
     y <- EnumExample.all
@@ -272,13 +271,13 @@ class EnumOpsTester extends BasicTester {
   stop()
 }
 
-class InvalidEnumOpsTester extends BasicTester {
+class InvalidEnumOpsTester extends Module {
   val mod = Module(new EnumOps(EnumExample, OtherEnum))
   mod.io.x := EnumExample.e0
   mod.io.y := OtherEnum.otherEnum
 }
 
-class IsLitTester extends BasicTester {
+class IsLitTester extends Module {
   for (e <- EnumExample.all) {
     val wire = WireDefault(e)
 
@@ -288,7 +287,7 @@ class IsLitTester extends BasicTester {
   stop()
 }
 
-class NextTester extends BasicTester {
+class NextTester extends Module {
   for ((e, n) <- EnumExample.all.zip(EnumExample.litValues.tail :+ EnumExample.litValues.head)) {
     assert(e.next.litValue == n.litValue)
     val w = WireDefault(e)
@@ -297,7 +296,7 @@ class NextTester extends BasicTester {
   stop()
 }
 
-class WidthTester extends BasicTester {
+class WidthTester extends Module {
   assert(EnumExample.getWidth == EnumExample.litValues.last.getWidth)
   assert(EnumExample.all.forall(_.getWidth == EnumExample.litValues.last.getWidth))
   assert(EnumExample.all.forall { e =>
@@ -307,7 +306,7 @@ class WidthTester extends BasicTester {
   stop()
 }
 
-class ChiselEnumFSMTester extends BasicTester {
+class ChiselEnumFSMTester extends Module {
   import ChiselEnumFSM.State._
 
   val dut = Module(new ChiselEnumFSM)
@@ -330,7 +329,7 @@ class ChiselEnumFSMTester extends BasicTester {
   }
 }
 
-class IsOneOfTester extends BasicTester {
+class IsOneOfTester extends Module {
   import EnumExample._
 
   // is one of itself

--- a/src/test/scala-2/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala-2/chiselTests/ConnectableSpec.scala
@@ -7,7 +7,6 @@ import chisel3.experimental.{Analog, OpaqueType}
 import chisel3.experimental.BundleLiterals._
 import chisel3.experimental.VecLiterals._
 import chisel3.reflect.DataMirror
-import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala-2/chiselTests/Counter.scala
+++ b/src/test/scala-2/chiselTests/Counter.scala
@@ -3,7 +3,6 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.util.Counter
@@ -20,12 +19,14 @@ class CountTester(max: Int) extends Module {
   }
 }
 
-class EnableTester(seed: Int) extends BasicTester {
+class EnableTester(seed: Int) extends Module {
   val ens = RegInit(seed.asUInt)
   ens := ens >> 1
 
   val (cntEnVal, _) = Counter(ens(0), 32)
   val (_, done) = Counter(true.B, 33)
+
+  private def popCount(n: Long): Int = n.toBinaryString.count(_ == '1')
 
   when(done) {
     assert(cntEnVal === popCount(seed).asUInt)

--- a/src/test/scala-2/chiselTests/DataEqualitySpec.scala
+++ b/src/test/scala-2/chiselTests/DataEqualitySpec.scala
@@ -8,7 +8,6 @@ import circt.stage.ChiselStage
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.Exceptions.AssertionFailed
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import chisel3.util.Valid
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -22,7 +21,7 @@ class EqualityModule(lhsGen: => Data, rhsGen: => Data) extends Module {
   out := lhs === rhs
 }
 
-class EqualityTester(lhsGen: => Data, rhsGen: => Data) extends BasicTester {
+class EqualityTester(lhsGen: => Data, rhsGen: => Data) extends Module {
   val equalityModule = Module(new EqualityModule(lhsGen, rhsGen))
 
   assert(equalityModule.out)
@@ -45,7 +44,7 @@ class AnalogExceptionModule extends Module {
   val io = IO(new AnalogExceptionModuleIO)
 }
 
-class AnalogExceptionTester extends BasicTester {
+class AnalogExceptionTester extends Module {
   val module = Module(new AnalogExceptionModule)
 
   module.io.bundle1 <> DontCare

--- a/src/test/scala-2/chiselTests/DisableSpec.scala
+++ b/src/test/scala-2/chiselTests/DisableSpec.scala
@@ -3,12 +3,10 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
-import _root_.circt.stage.ChiselStage
-
+import chisel3.experimental.prefix
+import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import chisel3.experimental.prefix
 
 class DisableSpec extends AnyFlatSpec with Matchers {
 

--- a/src/test/scala-2/chiselTests/GCD.scala
+++ b/src/test/scala-2/chiselTests/GCD.scala
@@ -5,7 +5,6 @@ package chiselTests
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.propspec.AnyPropSpec
@@ -26,7 +25,7 @@ class GCD extends Module {
   io.v := y === 0.U
 }
 
-class GCDTester(a: Int, b: Int, z: Int) extends BasicTester {
+class GCDTester(a: Int, b: Int, z: Int) extends Module {
   val dut = Module(new GCD)
   val first = RegInit(true.B)
   dut.io.a := a.U

--- a/src/test/scala-2/chiselTests/IntegerMathSpec.scala
+++ b/src/test/scala-2/chiselTests/IntegerMathSpec.scala
@@ -5,10 +5,9 @@ package chiselTests
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import org.scalatest.propspec.AnyPropSpec
 
-class IntegerMathTester extends BasicTester {
+class IntegerMathTester extends Module {
 
   // TODO: Add more operators
 

--- a/src/test/scala-2/chiselTests/IntrinsicModule.scala
+++ b/src/test/scala-2/chiselTests/IntrinsicModule.scala
@@ -4,7 +4,6 @@ package chiselTests
 
 import chisel3._
 import chisel3.experimental._
-import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
@@ -22,7 +21,7 @@ class IntModuleParam(str: String, dbl: Double)
 
 class IntModuleGenName(GenIntName: String) extends IntrinsicModule(GenIntName) {}
 
-class IntModuleTester extends BasicTester {
+class IntModuleTester extends Module {
   val intM1 = Module(new IntModuleTest)
   val intM2 = Module(new IntModuleParam("one", 1.0))
   val intM4 = Module(new IntModuleGenName("someIntName"))

--- a/src/test/scala-2/chiselTests/LTLSpec.scala
+++ b/src/test/scala-2/chiselTests/LTLSpec.scala
@@ -6,7 +6,6 @@ import chisel3._
 import chisel3.ltl._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import chisel3.experimental.SourceLine
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
@@ -420,7 +419,7 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselSim {
 
   it should "fail correctly in verilator simulation" in {
     intercept[chisel3.simulator.Exceptions.AssertionFailed] {
-      simulate(new BasicTester {
+      simulate(new Module {
         withClockAndReset(clock, reset) {
           AssertProperty(0.U === 1.U)
         }

--- a/src/test/scala-2/chiselTests/MulLookup.scala
+++ b/src/test/scala-2/chiselTests/MulLookup.scala
@@ -5,7 +5,6 @@ package chiselTests
 import chisel3._
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.BasicTester
 import org.scalatest.propspec.AnyPropSpec
 
 class MulLookup(val w: Int) extends Module {
@@ -23,7 +22,7 @@ class MulLookup(val w: Int) extends Module {
   io.z := tbl(((io.x << w) | io.y))
 }
 
-class MulLookupTester(w: Int, x: Int, y: Int) extends BasicTester {
+class MulLookupTester(w: Int, x: Int, y: Int) extends Module {
   val dut = Module(new MulLookup(w))
   dut.io.x := x.asUInt
   dut.io.y := y.asUInt

--- a/src/test/scala-2/chiselTests/PrintableSpec.scala
+++ b/src/test/scala-2/chiselTests/PrintableSpec.scala
@@ -3,7 +3,6 @@
 package chiselTests
 
 import chisel3._
-import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 import org.scalactic.source.Position
 import org.scalatest.flatspec.AnyFlatSpec
@@ -46,21 +45,21 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   behavior.of("Printable & Custom Interpolator")
 
   it should "pass exact strings through" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(p"An exact string")
     }
     generateAndCheck(new MyModule) { case Seq(Printf("An exact string", Seq())) =>
     }
   }
   it should "handle Printable and String concatenation" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(p"First " + PString("Second ") + "Third")
     }
     generateAndCheck(new MyModule) { case Seq(Printf("First Second Third", Seq())) =>
     }
   }
   it should "call toString on non-Printable objects" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val myInt = 1234
       printf(p"myInt = $myInt")
     }
@@ -68,7 +67,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     }
   }
   it should "generate proper printf for simple Decimal printing" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val myWire = WireDefault(1234.U)
       printf(p"myWire = ${Decimal(myWire)}")
     }
@@ -76,7 +75,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     }
   }
   it should "handle printing literals" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(Decimal(10.U(32.W)))
     }
     generateAndCheck(new MyModule) { case Seq(Printf("%d", Seq(lit))) =>
@@ -84,14 +83,14 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     }
   }
   it should "correctly escape percent" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(p"%")
     }
     generateAndCheck(new MyModule) { case Seq(Printf("%%", Seq())) =>
     }
   }
   it should "correctly emit tab" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(p"\t")
     }
     generateAndCheck(new MyModule) { case Seq(Printf("\\t", Seq())) =>
@@ -108,7 +107,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     class MyBundle extends Bundle {
       val foo = UInt(32.W)
     }
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       override def desiredName: String = "MyModule"
       val myWire = Wire(new MyBundle)
       val myInst = Module(new MySubModule)
@@ -126,7 +125,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
         val fizz = UInt(32.W)
       })
     }
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val myInst = Module(new MySubModule)
       printf(p"${myInst.io.fizz}")
     }
@@ -134,7 +133,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     }
   }
   it should "print UInts and SInts as Decimal by default" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val myUInt = WireDefault(0.U)
       val mySInt = WireDefault(-1.S)
       printf(p"$myUInt & $mySInt")
@@ -143,7 +142,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     }
   }
   it should "print Vecs like Scala Seqs by default" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val myVec = Wire(Vec(4, UInt(32.W)))
       myVec.foreach(_ := 0.U)
       printf(p"$myVec")
@@ -153,7 +152,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     }
   }
   it should "print Bundles like Scala Maps by default" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val myBun = Wire(new Bundle {
         val foo = UInt(32.W)
         val bar = UInt(32.W)
@@ -183,7 +182,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   // Unit tests for cf
   it should "print regular scala variables with cf format specifier" in {
 
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val f1 = 20.4517
       val i1 = 10
       val str1 = "String!"
@@ -208,7 +207,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
           cf"Foo : $foo%x Bar : $bar%x"
       }
     }
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val b1 = 10.U
       val w1 = Wire(new MyBundle)
       w1.foo := 5.U
@@ -230,7 +229,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
     class MyBundle extends Bundle {
       val foo = UInt(32.W)
     }
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       override def desiredName: String = "MyModule"
       val myWire = Wire(new MyBundle)
       val myInst = Module(new MySubModule)
@@ -244,7 +243,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "correctly print strings after modifier" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val b1 = 10.U
       printf(cf"This is here $b1%x!!!! And should print everything else")
     }
@@ -254,7 +253,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "correctly print strings with a lot of literal %% and different format specifiers for Wires" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val b1 = 10.U
       val b2 = 20.U
       printf(cf"%%  $b1%x%%$b2%b = ${b1 % b2}%d %%%% Tail String")
@@ -266,7 +265,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "not allow unescaped % in the message" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(cf"This should error out for sure because of % - it should be %%")
     }
     a[java.util.UnknownFormatConversionException] should be thrownBy {
@@ -275,7 +274,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "allow Printables to be expanded and used" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       val w1 = 20.U
       val f1 = 30.2
       val i1 = 14
@@ -289,7 +288,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "fail with a single  % in the message" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(cf"%")
     }
     a[java.util.UnknownFormatConversionException] should be thrownBy {
@@ -305,7 +304,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "pass correctly escaped \\ when using Printable.pack" in {
-    class MyModule extends BasicTester {
+    class MyModule extends Module {
       printf(Printable.pack("\\ \\]"))
     }
     generateAndCheck(new MyModule) { case Seq(Printf("\\\\ \\\\]", Seq())) =>

--- a/src/test/scala-2/chiselTests/ProbeSpec.scala
+++ b/src/test/scala-2/chiselTests/ProbeSpec.scala
@@ -8,7 +8,6 @@ import chisel3.probe._
 import chisel3.util.Counter
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
-import chisel3.testers.{BasicTester, TesterDriver}
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -661,7 +660,7 @@ class ProbeSpec extends AnyFlatSpec with Matchers with FileCheck with ChiselSim 
       define(b.refs.out, RWProbeValue(out))
       define(b.refs.reg, RWProbeValue(r))
     }
-    simulate(new BasicTester {
+    simulate(new Module {
       layer.enable(layers.Verification)
       layer.enable(layers.Verification.Assert)
       val dut = Module(new Top)

--- a/src/test/scala-2/chiselTests/aop/SelectSpec.scala
+++ b/src/test/scala-2/chiselTests/aop/SelectSpec.scala
@@ -7,14 +7,13 @@ import chisel3.aop.Select
 import chisel3.aop.Select.{PredicatedConnect, When, WhenNot}
 import chisel3.experimental.ExtModule
 import chisel3.stage.{ChiselGeneratorAnnotation, DesignAnnotation}
-import chisel3.testers.BasicTester
 import circt.stage.ChiselStage
 import firrtl.AnnotationSeq
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import scala.reflect.runtime.universe.TypeTag
 
-class SelectTester(results: Seq[Int]) extends BasicTester {
+class SelectTester(results: Seq[Int]) extends Module {
   val values = VecInit(results.map(_.U))
   val counter = RegInit(0.U(results.length.W))
   val added = counter + 1.U

--- a/src/test/scala-2/chiselTests/util/circt/ClockGate.scala
+++ b/src/test/scala-2/chiselTests/util/circt/ClockGate.scala
@@ -3,7 +3,6 @@
 package chiselTests.util.circt
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.util.circt.ClockGate
 import circt.stage.ChiselStage
 

--- a/src/test/scala-2/chiselTests/util/circt/IsXSpec.scala
+++ b/src/test/scala-2/chiselTests/util/circt/IsXSpec.scala
@@ -4,7 +4,6 @@ package chiselTests.util.circt
 
 import chisel3._
 import chisel3.stage.ChiselGeneratorAnnotation
-import chisel3.testers.BasicTester
 import chisel3.util.circt.IsX
 import circt.stage.ChiselStage
 

--- a/src/test/scala-2/chiselTests/util/circt/PlusArgsTestSpec.scala
+++ b/src/test/scala-2/chiselTests/util/circt/PlusArgsTestSpec.scala
@@ -3,13 +3,10 @@
 package chiselTests.util.circt
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.util.circt.PlusArgsTest
 import circt.stage.ChiselStage
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
 import scala.io.Source
 
 private class PlusArgsTestTop extends Module {

--- a/src/test/scala-2/chiselTests/util/circt/PlusArgsValueSpec.scala
+++ b/src/test/scala-2/chiselTests/util/circt/PlusArgsValueSpec.scala
@@ -3,13 +3,10 @@
 package chiselTests.util.circt
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.util.circt.PlusArgsValue
 import circt.stage.ChiselStage
-
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-
 import scala.io.Source
 
 private class PlusArgsValueTop extends Module {

--- a/src/test/scala-2/chiselTests/util/circt/SizeOfSpec.scala
+++ b/src/test/scala-2/chiselTests/util/circt/SizeOfSpec.scala
@@ -3,7 +3,6 @@
 package chiselTests.util.circt
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.util.circt.SizeOf
 import circt.stage.ChiselStage
 

--- a/src/test/scala-2/chiselTests/util/circt/Synthesis.scala
+++ b/src/test/scala-2/chiselTests/util/circt/Synthesis.scala
@@ -3,7 +3,6 @@
 package chiselTests.util.circt
 
 import chisel3._
-import chisel3.testers.BasicTester
 import chisel3.util.circt.{Mux2Cell, Mux4Cell}
 import circt.stage.ChiselStage
 

--- a/src/test/scala-2/cookbook/CookbookSpec.scala
+++ b/src/test/scala-2/cookbook/CookbookSpec.scala
@@ -5,7 +5,6 @@ package cookbook
 import chisel3._
 import chisel3.util.Counter
 import chisel3.simulator.scalatest.ChiselSim
-import chisel3.testers.BasicTester
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 


### PR DESCRIPTION
Move all tests off of `BasicTester` except for those actually testing `BasicTester`. All tests could directly use `Module` except for tests of `Counter` which were the only users of `BasicTester`'s `popCount` method. Just inline this.

This is in preparation to deprecate and remove `BasicTester` as it is not doing enough on top of a `Module` to justify its existence.