### PR TITLE
[testers] Deprecate everything the testers package

### DIFF
--- a/src/main/scala/chisel3/testers/BasicTester.scala
+++ b/src/main/scala/chisel3/testers/BasicTester.scala
@@ -7,6 +7,7 @@ import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl._
 import chisel3.experimental.SourceInfo
 
+@deprecated("Use a `Module` instead of `BasicTester`", "Chisel 6.7.0")
 class BasicTester extends Module() {
   // The testbench has no IOs, rather it should communicate using printf, assert, and stop.
   val io = IO(new Bundle() {})

--- a/src/main/scala/chisel3/testers/TesterDriver.scala
+++ b/src/main/scala/chisel3/testers/TesterDriver.scala
@@ -16,6 +16,7 @@ import scala.annotation.nowarn
 import scala.sys.process.ProcessLogger
 
 @nowarn("msg=trait BackendCompilationUtilities in package chisel3 is deprecated")
+@deprecated("Please migrate to ChiselSim APIs", "Chisel 6.7.0")
 object TesterDriver extends BackendCompilationUtilities {
   // TODO: need to remove BackendCompilationUtilities here but it will break external API
   //      unless all methods of it are implemented

--- a/src/test/scala-2/chiselTests/TesterDriverSpec.scala
+++ b/src/test/scala-2/chiselTests/TesterDriverSpec.scala
@@ -9,11 +9,13 @@ import chisel3.testers.BasicTester
 import chisel3.util.Counter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scala.annotation.nowarn
 
 /** Extend BasicTester with a simple circuit and finish method.  TesterDriver will call the
   * finish method after the FinishTester's constructor has completed, which will alter the
   * circuit after the constructor has finished.
   */
+@nowarn("msg=class BasicTester in package testers is deprecated")
 class FinishTester extends BasicTester {
   val test_wire_width = 2
   val test_wire_override_value = 3


### PR DESCRIPTION
Deprecate `BasicTester` and `TesterDriver`.  These have been fully replaced with ChiselSim.

#### Release Notes

Deprecate `chisel3.testers.{BasicTester, TesterDriver}`. The former can be replaced with a `Module`. If you are relying on the latter, please switch to ChiselSim.