### PR TITLE
[testing] Add FileCheck API

### DIFF
--- a/src/main/scala/chisel3/testing/FileCheck.scala
+++ b/src/main/scala/chisel3/testing/FileCheck.scala
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.testing
+
+import firrtl.options.StageUtils.dramaticMessage
+import java.io.{ByteArrayOutputStream, IOException, PrintWriter}
+import java.nio.file.{Files, StandardOpenOption}
+import scala.Console.{withErr, withOut}
+import scala.util.control.NoStackTrace
+import scala.sys.process._
+
+object FileCheck {
+
+  object Exceptions {
+
+    /** Indicates that `FileCheck` was not found. */
+    class NotFound private[FileCheck] (message: String)
+        extends RuntimeException(
+          dramaticMessage(
+            header = Some("FileCheck was not found! Did you forget to install it?"),
+            body = message
+          )
+        )
+        with NoStackTrace
+
+    /** Indicates that `FileCheck` failed. */
+    class NonZeroExitCode private[FileCheck] (binary: String, exitCode: Int, message: String)
+        extends RuntimeException(
+          dramaticMessage(
+            header = Some(s"FileCheck returned a non-zero exit code."),
+            body = s"""|Exit Code: $exitCode
+                       |
+                       |Command:
+                       |  $binary
+                       |
+                       |Command output:
+                       |---
+                       |$message
+                       |---""".stripMargin
+          )
+        )
+        with NoStackTrace
+
+  }
+
+}
+
+trait FileCheck {
+
+  /** Helpers to run `FileCheck` on a string input. */
+  implicit class StringHelpers(input: String) {
+
+    /** Run `FileCheck` on a string with some options.
+      *
+      * {{{
+      * import chisel3.testing.FileCheck
+      * import org.scalatest.flatspec.AnyFlatSpec
+      * import org.scalatest.matchers.should.Matchers
+      *
+      * class Foo extends AnyFlatSpec with Matchers with FileCheck {
+      *
+      *   behavior of ("Bar")
+      *
+      *   it should "work" in {
+      *     "Hello world!".fileCheck()(
+      *       """|CHECK:      Hello
+      *          |CHECK-SAME: world
+      *          |""".stripMargin
+      *     )
+      *   }
+      *
+      * }
+      *
+      * }}}
+      *
+      * @param fileCheckArgs arguments to pass directly to FileCheck
+      * @param check a string of checks to pass to `FileCheck`
+      * @param testingDirectory an implementation of [[HasTestingDirectory]]
+      * that controls where intermediary files are written.
+      *
+      * @note See [FileCheck
+      * Documentation](https://llvm.org/docs/CommandGuide/FileCheck.html) for
+      * more information.
+      */
+    def fileCheck(fileCheckArgs: String*)(
+      check: String
+    )(implicit testingDirectory: HasTestingDirectory): Unit = {
+      // Filecheck needs to have the thing to check in a file.
+      //
+      // TODO: This could be made ephemeral or use a named pipe?
+      // os.makeDir(os.RelPath(testingDirectory.getDirectory))
+      val dir = os.pwd / os.RelPath(testingDirectory.getDirectory)
+      os.makeDir.all(dir)
+      val tempDir = os.temp.dir(dir = os.pwd / os.RelPath(testingDirectory.getDirectory))
+      val checkFile = tempDir / "check"
+      val inputFile = tempDir / "input"
+      os.write.over(target = checkFile, data = check, createFolders = true)
+      os.write.over(target = inputFile, data = input, createFolders = true)
+
+      val extraArgs = os.Shellable(fileCheckArgs)
+      val stdoutStream, stderrStream = new java.io.ByteArrayOutputStream
+      val stdoutWriter = new PrintWriter(stdoutStream)
+      val stderrWriter = new PrintWriter(stderrStream)
+      val result =
+        try {
+          os.proc("FileCheck", checkFile, extraArgs)
+            .call(
+              stdin = inputFile,
+              stdout = os.ProcessOutput.Readlines(stdoutWriter.println),
+              stderr = os.ProcessOutput.Readlines(stderrWriter.println),
+              check = false
+            )
+        } catch {
+          case a: IOException if a.getMessage.startsWith("Cannot run program") =>
+            throw new FileCheck.Exceptions.NotFound(a.getMessage)
+        }
+      stdoutWriter.close()
+      stderrWriter.close()
+
+      result match {
+        case os.CommandResult(_, 0, _) => Seq(checkFile, inputFile).foreach(os.remove)
+        case os.CommandResult(command, exitCode, _) =>
+          throw new FileCheck.Exceptions.NonZeroExitCode(
+            s"cat $inputFile | ${command.mkString(" ")}",
+            exitCode,
+            stderrStream.toString
+          )
+      }
+    }
+
+  }
+
+}

--- a/src/main/scala/chisel3/testing/FileCheck.scala
+++ b/src/main/scala/chisel3/testing/FileCheck.scala
@@ -54,10 +54,11 @@ trait FileCheck {
       *
       * {{{
       * import chisel3.testing.FileCheck
+      * import chisel3.testing.scalatest.TestingDirectory
       * import org.scalatest.flatspec.AnyFlatSpec
       * import org.scalatest.matchers.should.Matchers
       *
-      * class Foo extends AnyFlatSpec with Matchers with FileCheck {
+      * class Foo extends AnyFlatSpec with Matchers with FileCheck with TestingDirectory {
       *
       *   behavior of ("Bar")
       *
@@ -91,7 +92,7 @@ trait FileCheck {
       // os.makeDir(os.RelPath(testingDirectory.getDirectory))
       val dir = os.pwd / os.RelPath(testingDirectory.getDirectory)
       os.makeDir.all(dir)
-      val tempDir = os.temp.dir(dir = os.pwd / os.RelPath(testingDirectory.getDirectory))
+      val tempDir = os.temp.dir(dir = dir, deleteOnExit = false)
       val checkFile = tempDir / "check"
       val inputFile = tempDir / "input"
       os.write.over(target = checkFile, data = check, createFolders = true)
@@ -118,7 +119,7 @@ trait FileCheck {
       stderrWriter.close()
 
       result match {
-        case os.CommandResult(_, 0, _) => Seq(checkFile, inputFile).foreach(os.remove)
+        case os.CommandResult(_, 0, _) => os.remove.all(tempDir)
         case os.CommandResult(command, exitCode, _) =>
           throw new FileCheck.Exceptions.NonZeroExitCode(
             s"cat $inputFile | ${command.mkString(" ")}",

--- a/src/main/scala/chisel3/testing/scalatest/package.scala
+++ b/src/main/scala/chisel3/testing/scalatest/package.scala
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.testing
+
+import chisel3.testing.scalatest.TestingDirectory
+import org.scalatest.TestSuite
+
+package object scalatest {
+
+  /** A trait that provides FileCheck APIs and integration with Scalatest.
+    *
+    * Example usage:
+    * {{{
+    * import chisel3.testing.scalatest.FileCheck.scalatest
+    * import org.scalatest.flatspec.AnyFlatSpec
+    * import org.scalatest.matches.should.Matchers
+    *
+    * class Foo extends AnyFlatSpec with Matchers with FileCheck {
+    *   /** This has access to all FileCheck APIs like `fileCheck`. */
+    * }
+    * }}}
+    *
+    * @see [[chisel3.testing.FileCheck]]
+    */
+  trait FileCheck extends chisel3.testing.FileCheck with TestingDirectory { self: TestSuite => }
+
+}

--- a/src/test/scala-2/chiselTests/testing/FileCheckSpec.scala
+++ b/src/test/scala-2/chiselTests/testing/FileCheckSpec.scala
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.testing
+
+import chisel3.testing.FileCheck
+import chisel3.testing.scalatest.TestingDirectory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FileCheckSpec extends AnyFlatSpec with Matchers with TestingDirectory with FileCheck {
+
+  behavior of ("FileCheck")
+
+  it should "check a string showing success" in {
+    "Hello world!".fileCheck()(
+      """|CHECK:      Hello
+         |CHECK-SAME: world
+         |""".stripMargin
+    )
+    "Hello world!".fileCheck()("CHECK: Hello world!")
+  }
+
+  it should "check a string showing failure" in {
+    intercept[FileCheck.Exceptions.NonZeroExitCode] {
+      "Hello world!".fileCheck()("CHECK: no match")
+    }
+  }
+
+  it should "allow for a user to pass additional options" in {
+    "Hello world!".fileCheck("--check-prefix=FOO")("FOO:Hello world!")
+  }
+
+}

--- a/src/test/scala-2/chiselTests/testing/FileCheckSpec.scala
+++ b/src/test/scala-2/chiselTests/testing/FileCheckSpec.scala
@@ -4,7 +4,6 @@ package chiselTests.testing.scalatest
 
 import chisel3.testing.FileCheck.Exceptions
 import chisel3.testing.scalatest.FileCheck
-import chisel3.testing.scalatest.TestingDirectory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -12,7 +11,7 @@ class FileCheckSpec extends AnyFlatSpec with Matchers with FileCheck {
 
   behavior of ("FileCheck")
 
-  it should "check a string showing success" in {
+  it should "check an input string and suceed" in {
     "Hello world!".fileCheck()(
       """|CHECK:      Hello
          |CHECK-SAME: world
@@ -21,7 +20,7 @@ class FileCheckSpec extends AnyFlatSpec with Matchers with FileCheck {
     "Hello world!".fileCheck()("CHECK: Hello world!")
   }
 
-  it should "check a string showing failure" in {
+  it should "throw a NonZeroExitCode exception on failure" in {
     intercept[Exceptions.NonZeroExitCode] {
       "Hello world!".fileCheck()("CHECK: no match")
     }

--- a/src/test/scala-2/chiselTests/testing/FileCheckSpec.scala
+++ b/src/test/scala-2/chiselTests/testing/FileCheckSpec.scala
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.testing
+package chiselTests.testing.scalatest
 
-import chisel3.testing.FileCheck
+import chisel3.testing.FileCheck.Exceptions
+import chisel3.testing.scalatest.FileCheck
 import chisel3.testing.scalatest.TestingDirectory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class FileCheckSpec extends AnyFlatSpec with Matchers with TestingDirectory with FileCheck {
+class FileCheckSpec extends AnyFlatSpec with Matchers with FileCheck {
 
   behavior of ("FileCheck")
 
@@ -21,7 +22,7 @@ class FileCheckSpec extends AnyFlatSpec with Matchers with TestingDirectory with
   }
 
   it should "check a string showing failure" in {
-    intercept[FileCheck.Exceptions.NonZeroExitCode] {
+    intercept[Exceptions.NonZeroExitCode] {
       "Hello world!".fileCheck()("CHECK: no match")
     }
   }


### PR DESCRIPTION
Add an extension-method based FileCheck API.  This builds off of @jackkoenig's original FileCheck trait inside ChiselSpec and repackages it for publishing.

This makes a number of deviations from the original version:

  1. This opts for extension methods.
  2. This does not add helpers for running Chisel.
  3. This throws dedicated assertions on failures.

Taking (1) and (2) together, this is intended to _not_ duplicate methods which are already availble via ChiselStage.  Specifically, I am intending the API to be used like:

    ChiselStage.emitSystemVerilgo(new Foo).fileCheck()("CHECK: module Foo")

Things are done this way to try to make the APIs as orthogonal as possible without too many redundant ways to accomplish the same thing.

(3): is added for convenience of testing.  On failure, this provides an output that approximates what you get from lit (LLVM's Integrated Tester). This additionally provides a rerun script that you can just copy-paste into a terminal to reproduce the failure.

For ease of reproduction, both the input and the check are written to files with predictable names in a temporary directory underneath what is provided by an implementation of the `HasTestingDirectory` type class. Having both the input and check file are necessary to do easy reruns.

This is stacked on #4750.

#### Release Notes

Add `chisel3.testing.FileCheck` and `chisel3.testing.scalatest.FileCheck` trait for writing [FileCheck](https://llvm.org/docs/CommandGuide/FileCheck.html)-based tests. This is useful for testing generators where you want to examine the output (FIRRTL or Verilog) as opposed to run a simulation. This is intended to complement ChiselSim.