### PR TITLE
[testing] Testing package w/ HasTestingDirectory

### DIFF
--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -2,6 +2,7 @@ package chisel3.simulator
 
 import svsim._
 import chisel3.RawModule
+import chisel3.testing.HasTestingDirectory
 import java.nio.file.Files
 import java.io.File
 

--- a/src/main/scala/chisel3/simulator/HasSimulator.scala
+++ b/src/main/scala/chisel3/simulator/HasSimulator.scala
@@ -2,6 +2,7 @@
 
 package chisel3.simulator
 
+import chisel3.testing.HasTestingDirectory
 import java.nio.file.Files
 
 /** Type class for providing a simulator. */

--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -3,6 +3,7 @@
 package chisel3.simulator
 
 import chisel3.{Module, RawModule}
+import chisel3.testing.HasTestingDirectory
 import chisel3.util.simpleClassName
 import java.nio.file.Files
 

--- a/src/main/scala/chisel3/simulator/scalatest/package.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/package.scala
@@ -2,6 +2,7 @@
 
 package chisel3.simulator
 
+import chisel3.testing.scalatest.TestingDirectory
 import org.scalatest.TestSuite
 
 package object scalatest {
@@ -21,6 +22,6 @@ package object scalatest {
     *
     * @see [[chisel3.simulator.ChiselSim]]
     */
-  trait ChiselSim extends PeekPokeAPI with SimulatorAPI with WithTestingDirectory { self: TestSuite => }
+  trait ChiselSim extends PeekPokeAPI with SimulatorAPI with TestingDirectory { self: TestSuite => }
 
 }

--- a/src/main/scala/chisel3/testing/HasTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/HasTestingDirectory.scala
@@ -1,4 +1,4 @@
-package chisel3.simulator
+package chisel3.testing
 
 import java.io.IOException
 import java.nio.file._

--- a/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chisel3.simulator.scalatest
+package chisel3.testing.scalatest
 
-import chisel3.simulator.HasTestingDirectory
+import chisel3.testing.HasTestingDirectory
 import java.nio.file.{FileSystems, Path}
 import org.scalatest.TestSuite
 import scala.util.DynamicVariable
@@ -26,7 +26,7 @@ import scala.util.DynamicVariable
   * this trait.
   *
   */
-trait WithTestingDirectory { self: TestSuite =>
+trait TestingDirectory { self: TestSuite =>
 
   /** Return the name of the root test directory.
     *

--- a/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests.simulator
 
 import chisel3._
-import chisel3.simulator.HasTestingDirectory
+import chisel3.testing.HasTestingDirectory
 import chisel3.simulator.DefaultSimulator._
 import chiselTests.FileCheck
 import java.nio.file.FileSystems

--- a/src/test/scala-2/chiselTests/simulator/HasSimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/HasSimulatorSpec.scala
@@ -2,7 +2,8 @@
 
 package chiselTests.simulator
 
-import chisel3.simulator.{HasSimulator, HasTestingDirectory, Simulator}
+import chisel3.simulator.{HasSimulator, Simulator}
+import chisel3.testing.HasTestingDirectory
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -4,14 +4,15 @@ package chiselTests.simulator.scalatest
 
 import chisel3._
 import chisel3.simulator.PeekPokeAPI.FailedExpectationException
-import chisel3.simulator.{ChiselSettings, ChiselSim, HasTestingDirectory, MacroText}
-import chisel3.simulator.scalatest.WithTestingDirectory
+import chisel3.simulator.{ChiselSettings, ChiselSim, MacroText}
+import chisel3.testing.HasTestingDirectory
+import chisel3.testing.scalatest.TestingDirectory
 import chiselTests.FileCheck
 import java.nio.file.FileSystems
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileCheck with WithTestingDirectory {
+class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileCheck with TestingDirectory {
 
   describe("scalatest.ChiselSim") {
 

--- a/src/test/scala-2/chiselTests/simulator/scalatest/TestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/TestingDirectorySpec.scala
@@ -3,14 +3,14 @@
 package chiselTests.simulator.scalatest
 
 import chisel3._
-import chisel3.simulator.scalatest.WithTestingDirectory
+import chisel3.testing.scalatest.TestingDirectory
 import chisel3.simulator.DefaultSimulator._
 import java.nio.file.FileSystems
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import scala.reflect.io.Directory
 
-class WithTestingDirectorySpec extends AnyFunSpec with Matchers with WithTestingDirectory {
+class TestingDirectorySpec extends AnyFunSpec with Matchers with TestingDirectory {
 
   /** Check that the directory structure and the files contained within make sense
     * for a Chiselsim/svsim build.

--- a/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package chiselTests.simulator.scalatest
+package chiselTests.testing.scalatest
 
 import chisel3._
 import chisel3.testing.scalatest.TestingDirectory
@@ -51,7 +51,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with TestingDirector
     it("should generate a directory structure derived from the suite and test name") {
       checkDirectoryStructure(
         "build",
-        "WithTestingDirectorySpec",
+        "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-generate-a-directory-structure-derived-from-the-suite-and-test-name"
       ) {
@@ -62,7 +62,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with TestingDirector
     it("should generate another directory, too") {
       checkDirectoryStructure(
         "build",
-        "WithTestingDirectorySpec",
+        "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-generate-another-directory,-too"
       ) {
@@ -73,7 +73,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with TestingDirector
     it("should handle emojis, e.g., 🚀") {
       checkDirectoryStructure(
         "build",
-        "WithTestingDirectorySpec",
+        "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-handle-emojis,-e.g.,-🚀"
       ) {
@@ -84,7 +84,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with TestingDirector
     it("should handle CJK characters, e.g., 好猫咪") {
       checkDirectoryStructure(
         "build",
-        "WithTestingDirectorySpec",
+        "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-handle-CJK-characters,-e.g.,-好猫咪"
       ) {


### PR DESCRIPTION
Create a new package, `chisel3.testing`, and move
`simulator.HasTestingDirectory` and the scalatest implementation of it to the new package.  This is done because the ability to get a testing directory is really a general property of "testing" and not "simulation".

This also builds towards moving the FileCheck utility out of `ChiselSpec` (i.e., only being available for tests) and into a proper home in `testing`.  It also makes sense for FileCheck to use the `HasTestingDirectory` type class as it has the same problem of needing to be given a "testing directory".