### PR TITLE
[test] Migrate tests to chisel3.testing FileCheck, delete test-only FileCheck

### DIFF
--- a/src/test/scala-2/chisel3/PlaceholderSpec.scala
+++ b/src/test/scala-2/chisel3/PlaceholderSpec.scala
@@ -2,7 +2,7 @@
 
 package chisel3
 
-import chiselTests.FileCheck
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -23,7 +23,7 @@ class PlaceholderSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     }
 
-    generateFirrtlAndFileCheck(new Foo) {
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
       s"""|CHECK:      wire b : UInt<2>
           |CHECK-NEXT: wire a : UInt<1>
           |""".stripMargin
@@ -54,7 +54,7 @@ class PlaceholderSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     }
 
-    generateFirrtlAndFileCheck(new Foo) {
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
       s"""|CHECK:      wire c : UInt<3>
           |CHECK-NEXT: wire b : UInt<2>
           |CHECK-NEXT: wire d : UInt<4>
@@ -70,7 +70,7 @@ class PlaceholderSpec extends AnyFlatSpec with Matchers with FileCheck {
       val a = new Placeholder()
     }
 
-    generateFirrtlAndFileCheck(new Foo) {
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
       """|CHECK: public module Foo :
          |CHECK:   skip
          |""".stripMargin
@@ -97,7 +97,7 @@ class PlaceholderSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     }
 
-    generateFirrtlAndFileCheck(new Foo) {
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
       """|CHECK:      module Bar :
          |CHECK-NOT:    {{wire|connect}}
          |

--- a/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
@@ -9,7 +9,9 @@ import chisel3.probe._
 import chisel3.properties.Property
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.experimental.BoringUtils
+import circt.stage.ChiselStage
 import firrtl.annotations.Annotation
 import firrtl.transforms.DontTouchAnnotation
 import org.scalatest.flatspec.AnyFlatSpec
@@ -149,22 +151,24 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       b := BoringUtils.bore(bar.b_wire)
       c := BoringUtils.bore(c_wire)
     }
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Baz :
-         |CHECK:         output a_bore : UInt<1>
-         |CHECK:         connect a_bore, a_wire
-         |CHECK-LABEL: module Bar :
-         |CHECK:         output b_bore : UInt<2>
-         |CHECK:         connect a_bore, baz.a_bore
-         |CHECK:         connect b_bore, b_wire
-         |CHECK-LABEL: module Foo :
-         |CHECK:         connect a, a_bore
-         |CHECK:         connect b, b_bore
-         |CHECK:         connect c, c_wire
-         |CHECK:         connect a_bore, bar.a_bore
-         |CHECK:         connect b_bore, bar.b_bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Baz :
+           |CHECK:         output a_bore : UInt<1>
+           |CHECK:         connect a_bore, a_wire
+           |CHECK-LABEL: module Bar :
+           |CHECK:         output b_bore : UInt<2>
+           |CHECK:         connect a_bore, baz.a_bore
+           |CHECK:         connect b_bore, b_wire
+           |CHECK-LABEL: module Foo :
+           |CHECK:         connect a, a_bore
+           |CHECK:         connect b, b_bore
+           |CHECK:         connect c, c_wire
+           |CHECK:         connect a_bore, bar.a_bore
+           |CHECK:         connect b_bore, bar.b_bore
+           |""".stripMargin
+      )
   }
 
   it should "bore up and down through the lowest common ancestor" in {
@@ -181,19 +185,21 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       val baz = Module(new Baz(bar.a))
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output b_bore : UInt<1>
-         |CHECK:         connect b_bore, a
-         |CHECK-LABEL: module Baz :
-         |CHECK:         input b_bore : UInt<1>
-         |CHECK:         wire b_bore_1 : UInt<1>
-         |CHECK:         connect b, b_bore_1
-         |CHECK:         connect b_bore_1, b_bore
-         |CHECK-LABEL: module Foo
-         |CHECK:         connect baz.b_bore, bar.b_bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output b_bore : UInt<1>
+           |CHECK:         connect b_bore, a
+           |CHECK-LABEL: module Baz :
+           |CHECK:         input b_bore : UInt<1>
+           |CHECK:         wire b_bore_1 : UInt<1>
+           |CHECK:         connect b, b_bore_1
+           |CHECK:         connect b_bore_1, b_bore
+           |CHECK-LABEL: module Foo
+           |CHECK:         connect baz.b_bore, bar.b_bore
+           |""".stripMargin
+      )
   }
 
   it should "not create input probes" in {
@@ -255,13 +261,15 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       val bar = Instance(Definition((new Bar)))
       val sink = BoringUtils.bore(bar.out)
     }
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output out : UInt<1>
-         |CHECK-LABEL: module Foo :
-         |CHECK:         connect sink, bar.out
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output out : UInt<1>
+           |CHECK-LABEL: module Foo :
+           |CHECK:         connect sink, bar.out
+           |""".stripMargin
+      )
   }
 
   it should "work if driving an Instance's input port" in {
@@ -274,13 +282,15 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       val bar = Instance(Definition((new Bar)))
       val source = BoringUtils.drive(bar.in)
     }
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         input in : UInt<1>
-         |CHECK-LABEL: module Foo :
-         |CHECK:         connect bar.in, source
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         input in : UInt<1>
+           |CHECK-LABEL: module Foo :
+           |CHECK:         connect bar.in, source
+           |""".stripMargin
+      )
   }
 
   it should "work boring upwards" in {
@@ -293,16 +303,18 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       val a = IO(Input(UInt(1.W)))
       val bar = Module(new Bar(a))
     }
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         input q_bore : UInt<1>
-         |CHECK:         connect q, q_bore_1
-         |CHECK:         connect q_bore_1, q_bore
-         |CHECK-LABEL: module Foo :
-         |CHECK:         input a : UInt<1>
-         |CHECK:         connect bar.q_bore, a
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         input q_bore : UInt<1>
+           |CHECK:         connect q, q_bore_1
+           |CHECK:         connect q_bore_1, q_bore
+           |CHECK-LABEL: module Foo :
+           |CHECK:         input a : UInt<1>
+           |CHECK:         connect bar.q_bore, a
+           |""".stripMargin
+      )
   }
 
   it should "be included in DataMirror.modulePorts" in {
@@ -390,18 +402,20 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       val y = BoringUtils.bore(bar.a_wire)
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output port : UInt<8>
-         |CHECK:         output x_bore : UInt<1>
-         |CHECK:         output y_bore : UInt<1>
-         |CHECK:         connect x_bore, a_wire
-         |CHECK:         connect y_bore, a_wire
-         |CHECK-LABEL: module Foo :
-         |CHECK:         connect x, bar.x_bore
-         |CHECK:         connect y, bar.y_bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output port : UInt<8>
+           |CHECK:         output x_bore : UInt<1>
+           |CHECK:         output y_bore : UInt<1>
+           |CHECK:         connect x_bore, a_wire
+           |CHECK:         connect y_bore, a_wire
+           |CHECK-LABEL: module Foo :
+           |CHECK:         connect x, bar.x_bore
+           |CHECK:         connect y, bar.y_bore
+           |""".stripMargin
+      )
   }
 
   it should "not create a new port when source is a port" in {
@@ -462,14 +476,16 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       a := BoringUtils.bore(bar.baz.a)
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output a_bore : Integer
-         |CHECK:         propassign a_bore, baz.a
-         |CHECK-LABEL: public module Foo :
-         |CHECK:         propassign a, bar.a_bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output a_bore : Integer
+           |CHECK:         propassign a_bore, baz.a
+           |CHECK-LABEL: public module Foo :
+           |CHECK:         propassign a, bar.a_bore
+           |""".stripMargin
+      )
   }
 
   it should "bore from an opaque type that wraps a Property" in {
@@ -495,14 +511,16 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       a := BoringUtils.bore(bar.baz.a)
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output a_bore : Integer
-         |CHECK:         propassign a_bore, baz.a
-         |CHECK-LABEL: public module Foo :
-         |CHECK:         propassign a_bore, bar.a_bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output a_bore : Integer
+           |CHECK:         propassign a_bore, baz.a
+           |CHECK-LABEL: public module Foo :
+           |CHECK:         propassign a_bore, bar.a_bore
+           |""".stripMargin
+      )
 
   }
 
@@ -535,14 +553,16 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       a := BoringUtils.bore(bar.baz.a)
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output a_bore : Integer
-         |CHECK:         propassign a_bore, baz.a
-         |CHECK-LABEL: public module Foo :
-         |CHECK:         propassign a_bore, bar.a_bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output a_bore : Integer
+           |CHECK:         propassign a_bore, baz.a
+           |CHECK-LABEL: public module Foo :
+           |CHECK:         propassign a_bore, bar.a_bore
+           |""".stripMargin
+      )
   }
 
   behavior.of("BoringUtils.drive")
@@ -575,16 +595,18 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       BoringUtils.drive(foo.a) := 1.B
     }
 
-    generateFirrtlAndFileCheck(new Bar)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         input bore
-         |CHECK:         connect a, bore
-         |CHECK-LABEL: module Bar :
-         |CHECK:         wire bore
-         |CHECK:         connect bore, UInt<1>(0h1)
-         |CHECK:         connect foo.bore, bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Bar)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         input bore
+           |CHECK:         connect a, bore
+           |CHECK-LABEL: module Bar :
+           |CHECK:         wire bore
+           |CHECK:         connect bore, UInt<1>(0h1)
+           |CHECK:         connect foo.bore, bore
+           |""".stripMargin
+      )
 
   }
 
@@ -599,14 +621,16 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       BoringUtils.drive(foo.a) := Property(1)
     }
 
-    generateFirrtlAndFileCheck(new Bar)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         input bore :
-         |CHECK:         propassign a, bore
-         |CHECK-LABEL: public module Bar :
-         |CHECK:         propassign foo.bore, Integer(1)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Bar)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         input bore :
+           |CHECK:         propassign a, bore
+           |CHECK-LABEL: public module Bar :
+           |CHECK:         propassign foo.bore, Integer(1)
+           |""".stripMargin
+      )
   }
 
   it should "bore to the final instance, but not into it, for inputs" in {
@@ -624,14 +648,16 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       BoringUtils.drive(bar.foo.a) := Property(1)
     }
 
-    generateFirrtlAndFileCheck(new Baz)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         input bore :
-         |CHECK:         propassign foo.a, bore
-         |CHECK-LABEL: public module Baz :
-         |CHECK:         propassign bar.bore, Integer(1)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Baz)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         input bore :
+           |CHECK:         propassign foo.a, bore
+           |CHECK-LABEL: public module Baz :
+           |CHECK:         propassign bar.bore, Integer(1)
+           |""".stripMargin
+      )
   }
 
   it should "bore into the final instance for outputs" in {
@@ -649,16 +675,18 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with Utils with FileChec
       BoringUtils.drive(bar.foo.a) := Property(1)
     }
 
-    generateFirrtlAndFileCheck(new Baz)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         input bore :
-         |CHECK:         propassign a, bore
-         |CHECk-LABEL: module Bar :
-         |CHECK:         input bore :
-         |CHECK:         propassign foo.bore, bore
-         |CHECK-LABEL: public module Baz :
-         |CHECK:         propassign bar.bore, Integer(1)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Baz)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         input bore :
+           |CHECK:         propassign a, bore
+           |CHECk-LABEL: module Bar :
+           |CHECK:         input bore :
+           |CHECK:         propassign foo.bore, bore
+           |CHECK-LABEL: public module Baz :
+           |CHECK:         propassign bar.bore, Integer(1)
+           |""".stripMargin
+      )
   }
 }

--- a/src/test/scala-2/chiselTests/BoringUtilsTapSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsTapSpec.scala
@@ -4,8 +4,10 @@ package chiselTests
 
 import chisel3._
 import chisel3.probe
+import chisel3.testing.scalatest.FileCheck
 import chisel3.testers._
 import chisel3.util.experimental.BoringUtils
+import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -69,17 +71,19 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       probe.define(outProbe, BoringUtils.tap(foo.internalWire))
       out := BoringUtils.tapAndRead(foo.internalWire)
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         output bore : Probe<UInt<1>>
-         |CHECK:         output out_bore : Probe<UInt<1>>
-         |CHECK:         define bore = probe(internalWire)
-         |CHECK:         define out_bore = probe(internalWire)
-         |CHECK-LABEL: module Top :
-         |CHECK:         define outProbe = foo.bore
-         |CHECK:         connect out, read(foo.out_bore)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         output bore : Probe<UInt<1>>
+           |CHECK:         output out_bore : Probe<UInt<1>>
+           |CHECK:         define bore = probe(internalWire)
+           |CHECK:         define out_bore = probe(internalWire)
+           |CHECK-LABEL: module Top :
+           |CHECK:         define outProbe = foo.bore
+           |CHECK:         connect out, read(foo.out_bore)
+           |""".stripMargin
+      )
   }
 
   it should "work downwards from grandparent to grandchild" in {
@@ -94,17 +98,19 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val out = IO(Bool())
       out := BoringUtils.tapAndRead(foo.bar.internalWire)
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output out_bore : Probe<UInt<1>>
-         |CHECK:         define out_bore = probe(internalWire)
-         |CHECK-LABEL: module Foo :
-         |CHECK:         output out_bore : Probe<UInt<1>>
-         |CHECK:         define out_bore = bar.out_bore
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect out, read(foo.out_bore)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output out_bore : Probe<UInt<1>>
+           |CHECK:         define out_bore = probe(internalWire)
+           |CHECK-LABEL: module Foo :
+           |CHECK:         output out_bore : Probe<UInt<1>>
+           |CHECK:         define out_bore = bar.out_bore
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect out, read(foo.out_bore)
+           |""".stripMargin
+      )
   }
 
   // This test requires ability to identify what region to add commands to,
@@ -132,12 +138,14 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
     }
 
     // The define should be at the end of the when block.
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK: when UInt<1>(0h1) :
-         |CHECK:   inst bar of Bar
-         |CHECK:   define w_bore = bar.w_bore
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK: when UInt<1>(0h1) :
+           |CHECK:   inst bar of Bar
+           |CHECK:   define w_bore = bar.w_bore
+           |""".stripMargin
+      )
 
     // Check is valid FIRRTL.
     circt.stage.ChiselStage.emitFIRRTLDialect(new Top)
@@ -155,19 +163,21 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val parentWire = Wire(Bool())
       val foo = Module(new Foo(parentWire))
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         output outProbe : Probe<UInt<1>>
-         |CHECK:         input bore : UInt<1>
-         |CHECK:         input out_bore : UInt<1>
-         |CHECK:         define outProbe = probe(bore)
-         |CHECK:         connect out, out_bore
-         |CHECK:         connect out, read(outProbe)
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect foo.bore, parentWire
-         |CHECK:         connect foo.out_bore, parentWire
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         output outProbe : Probe<UInt<1>>
+           |CHECK:         input bore : UInt<1>
+           |CHECK:         input out_bore : UInt<1>
+           |CHECK:         define outProbe = probe(bore)
+           |CHECK:         connect out, out_bore
+           |CHECK:         connect out, read(outProbe)
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect foo.bore, parentWire
+           |CHECK:         connect foo.out_bore, parentWire
+           |""".stripMargin
+      )
   }
 
   it should "work upwards from grandchild to grandparent" in {
@@ -182,17 +192,19 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val parentWire = Wire(Bool())
       val foo = Module(new Foo(parentWire))
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         input out_bore : UInt<1>
-         |CHECK:         connect out, out_bore
-         |CHECK-LABEL: module Foo :
-         |CHECK:         input out_bore : UInt<1>
-         |CHECK:         connect bar.out_bore, out_bore
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect foo.out_bore, parentWire
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         input out_bore : UInt<1>
+           |CHECK:         connect out, out_bore
+           |CHECK-LABEL: module Foo :
+           |CHECK:         input out_bore : UInt<1>
+           |CHECK:         connect bar.out_bore, out_bore
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect foo.out_bore, parentWire
+           |""".stripMargin
+      )
   }
 
   it should "work upwards from grandchild to grandparent through when" in {
@@ -212,14 +224,16 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
     }
 
     // The connect should be at the end of the when block.
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         when UInt<1>(0h1) :
-         |CHECK:           inst bar of Bar
-         |CHECK:           connect bar.out_bore, out_bore
-         |CHECK-LABEL: public module Top :
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         when UInt<1>(0h1) :
+           |CHECK:           inst bar of Bar
+           |CHECK:           connect bar.out_bore, out_bore
+           |CHECK-LABEL: public module Top :
+           |""".stripMargin
+      )
 
     // Check is valid FIRRTL.
     circt.stage.ChiselStage.emitFIRRTLDialect(new Top)
@@ -243,13 +257,15 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
     }
 
     // The connect should be at the end of the layerblock.
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         layerblock TestLayer :
-         |CHECK:           inst bar of Bar
-         |CHECK:           connect bar.out_bore, out_bore
-         |CHECK-LABEL: public module Top :""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         layerblock TestLayer :
+           |CHECK:           inst bar of Bar
+           |CHECK:           connect bar.out_bore, out_bore
+           |CHECK-LABEL: public module Top :""".stripMargin
+      )
 
     // Check is valid FIRRTL and builds to SV.
     circt.stage.ChiselStage.emitSystemVerilog(new Top)
@@ -267,16 +283,18 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val bar = Module(new Bar)
       val baz = Module(new Baz(bar.a))
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output b_bore : Probe<UInt<1>>
-         |CHECK:         define b_bore = probe(a)
-         |CHECK-LABEL: module Baz :
-         |CHECK:         input b_bore : UInt<1>
-         |CHECK:         connect b, b_bore
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect baz.b_bore, read(bar.b_bore)""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output b_bore : Probe<UInt<1>>
+           |CHECK:         define b_bore = probe(a)
+           |CHECK-LABEL: module Baz :
+           |CHECK:         input b_bore : UInt<1>
+           |CHECK:         connect b, b_bore
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect baz.b_bore, read(bar.b_bore)""".stripMargin
+      )
   }
 
   it should "work from child to sibling at different levels" in {
@@ -294,20 +312,22 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val bar = Module(new Bar)
       val foo = Module(new Foo(bar.a))
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output b_bore : Probe<UInt<1>>
-         |CHECK:         define b_bore = probe(a)
-         |CHECK-LABEL: module Baz :
-         |CHECK:         input b_bore : UInt<1>
-         |CHECK:         connect b, b_bore
-         |CHECK-LABEL: module Foo :
-         |CHECK:         input b_bore : UInt<1>
-         |CHECK:         connect baz.b_bore, b_bore
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect foo.b_bore, read(bar.b_bore)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output b_bore : Probe<UInt<1>>
+           |CHECK:         define b_bore = probe(a)
+           |CHECK-LABEL: module Baz :
+           |CHECK:         input b_bore : UInt<1>
+           |CHECK:         connect b, b_bore
+           |CHECK-LABEL: module Foo :
+           |CHECK:         input b_bore : UInt<1>
+           |CHECK:         connect baz.b_bore, b_bore
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect foo.b_bore, read(bar.b_bore)
+           |""".stripMargin
+      )
   }
 
   it should "work for identity views" in {
@@ -323,17 +343,19 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       probe.define(outProbe, BoringUtils.tap(foo.view))
       out := BoringUtils.tapAndRead(foo.view)
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         output bore : Probe<UInt<1>>
-         |CHECK:         output out_bore : Probe<UInt<1>>
-         |CHECK:         define bore = probe(internalWire)
-         |CHECK:         define out_bore = probe(internalWire)
-         |CHECK-LABEL: module Top :
-         |CHECK:         define outProbe = foo.bore
-         |CHECK:         connect out, read(foo.out_bore)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         output bore : Probe<UInt<1>>
+           |CHECK:         output out_bore : Probe<UInt<1>>
+           |CHECK:         define bore = probe(internalWire)
+           |CHECK:         define out_bore = probe(internalWire)
+           |CHECK-LABEL: module Top :
+           |CHECK:         define outProbe = foo.bore
+           |CHECK:         connect out, read(foo.out_bore)
+           |""".stripMargin
+      )
   }
 
   it should "NOT work [yet] for non-identity views" in {
@@ -377,18 +399,20 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       out := probe.read(BoringUtils.rwTap(foo.bar.internalWire))
       probe.forceInitial(BoringUtils.rwTap(foo.bar.internalWire), false.B)
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output out_bore : RWProbe<UInt<1>>
-         |CHECK:         define out_bore = rwprobe(internalWire)
-         |CHECK-LABEL: module Foo :
-         |CHECK:         output out_bore : RWProbe<UInt<1>>
-         |CHECK:         define out_bore = bar.out_bore
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect out, read(foo.out_bore)
-         |CHECK:         force_initial(foo.bore, UInt<1>(0h0))
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output out_bore : RWProbe<UInt<1>>
+           |CHECK:         define out_bore = rwprobe(internalWire)
+           |CHECK-LABEL: module Foo :
+           |CHECK:         output out_bore : RWProbe<UInt<1>>
+           |CHECK:         define out_bore = bar.out_bore
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect out, read(foo.out_bore)
+           |CHECK:         force_initial(foo.bore, UInt<1>(0h0))
+           |""".stripMargin
+      )
   }
 
   it should "not work upwards child to parent" in {
@@ -428,7 +452,7 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
   }
 
   it should "work when tapping an element within a Bundle" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         class MiniBundle extends Bundle {
           val x = Bool()
@@ -449,7 +473,7 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
         probe.define(outRWBundleProbe, BoringUtils.rwTap(child.b))
         probe.define(outElem, outRWBundleProbe.x)
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire b : { x : UInt<1>}
          |CHECK: define bore = rwprobe(b.x)
          |CHECK: define bore_1 = rwprobe(b)
@@ -461,7 +485,7 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
   }
 
   it should "work when tapping an element within a Vec" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         class Child() extends RawModule {
           val b = Wire(Vec(4, Bool()))
@@ -479,7 +503,7 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
         probe.define(outRWVecProbe, BoringUtils.rwTap(child.b))
         probe.define(outElem, outRWVecProbe(1))
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire b : UInt<1>[4]
          |CHECK: define bore = rwprobe(b[2])
          |CHECK: define bore_1 = rwprobe(b)
@@ -515,25 +539,29 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val outV_1_in = IO(probe.RWProbe(Bool()))
       probe.define(outV_1_in, BoringUtils.rwTap(child.v(1).in))
     }
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Child :
-         |CHECK:         output v : { flip in : UInt<1>, out : UInt<1>}[2]
-         |CHECK:         define outV_0_out = rwprobe(child.v[0].out)
-         |CHECK:         define outV_1_in = rwprobe(child.v[1].in)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Child :
+           |CHECK:         output v : { flip in : UInt<1>, out : UInt<1>}[2]
+           |CHECK:         define outV_0_out = rwprobe(child.v[0].out)
+           |CHECK:         define outV_1_in = rwprobe(child.v[1].in)
+           |""".stripMargin
+      )
     // Send through firtool and lightly check output.
     // Bit fragile across firtool versions.
-    generateSystemVerilogAndFileCheck(new Foo, "--implicit-check-not=v_1_in", "--implicit-check-not=v_1_out")(
-      // Child ports.
-      """|CHECK-LABEL: module Child(
-         |CHECK:         input  v_0_in,
-         |CHECK:         output v_0_out
-         |CHECK:         Child child (
-         |CHECK: .v_0_in  (inputs_0),
-         |CHECK: .v_0_out (
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitSystemVerilog(new Foo)
+      .fileCheck("--implicit-check-not=v_1_in", "--implicit-check-not=v_1_out")(
+        // Child ports.
+        """|CHECK-LABEL: module Child(
+           |CHECK:         input  v_0_in,
+           |CHECK:         output v_0_out
+           |CHECK:         Child child (
+           |CHECK: .v_0_in  (inputs_0),
+           |CHECK: .v_0_out (
+           |""".stripMargin
+      )
   }
 
   it should "work to rwTap a RWProbe IO" in {
@@ -565,33 +593,35 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
           }
     }
     // Probe creation should happen outside of this function
-    generateFirrtlAndFileCheck(new Dut)(
-      """|CHECK-LABEL: module Widget :
-         |CHECK:         output prb : RWProbe<UInt<32>>
-         |CHECK:         define prb = rwprobe(intermediate)
-         |CHECK-LABEL: module ArbitrarilyDeeperHierarchy :
-         |CHECK:         output widgetProbes_p_bore : RWProbe<UInt<32>>
-         |CHECK:         output widgetProbes_p_bore_1 : RWProbe<UInt<32>>
-         |CHECK:         inst widgets_0 of Widget
-         |CHECK:         inst widgets_1 of Widget
-         |CHECK:         define widgetProbes_p_bore = widgets_0.prb
-         |CHECK:         define widgetProbes_p_bore_1 = widgets_1.prb
-         |CHECK-LABEL: module ArbitrarilyDeepHierarchy :
-         |CHECK:         output widgetProbes_p_bore : RWProbe<UInt<32>>
-         |CHECK:         output widgetProbes_p_bore_1 : RWProbe<UInt<32>>
-         |CHECK:         inst hier of ArbitrarilyDeeperHierarchy
-         |CHECK:         define widgetProbes_p_bore = hier.widgetProbes_p_bore
-         |CHECK:         define widgetProbes_p_bore_1 = hier.widgetProbes_p_bore_1
-         |CHECK-LABEL: public module Dut :
-         |CHECK:         input clock : Clock
-         |CHECK:         input reset : UInt<1>
-         |CHECK:         output widgetProbes_0 : RWProbe<UInt<32>>
-         |CHECK:         output widgetProbes_1 : RWProbe<UInt<32>>
-         |CHECK:         inst hier of ArbitrarilyDeepHierarchy
-         |CHECK:         define widgetProbes_0 = hier.widgetProbes_p_bore
-         |CHECK:         define widgetProbes_1 = hier.widgetProbes_p_bore_1
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Dut)
+      .fileCheck()(
+        """|CHECK-LABEL: module Widget :
+           |CHECK:         output prb : RWProbe<UInt<32>>
+           |CHECK:         define prb = rwprobe(intermediate)
+           |CHECK-LABEL: module ArbitrarilyDeeperHierarchy :
+           |CHECK:         output widgetProbes_p_bore : RWProbe<UInt<32>>
+           |CHECK:         output widgetProbes_p_bore_1 : RWProbe<UInt<32>>
+           |CHECK:         inst widgets_0 of Widget
+           |CHECK:         inst widgets_1 of Widget
+           |CHECK:         define widgetProbes_p_bore = widgets_0.prb
+           |CHECK:         define widgetProbes_p_bore_1 = widgets_1.prb
+           |CHECK-LABEL: module ArbitrarilyDeepHierarchy :
+           |CHECK:         output widgetProbes_p_bore : RWProbe<UInt<32>>
+           |CHECK:         output widgetProbes_p_bore_1 : RWProbe<UInt<32>>
+           |CHECK:         inst hier of ArbitrarilyDeeperHierarchy
+           |CHECK:         define widgetProbes_p_bore = hier.widgetProbes_p_bore
+           |CHECK:         define widgetProbes_p_bore_1 = hier.widgetProbes_p_bore_1
+           |CHECK-LABEL: public module Dut :
+           |CHECK:         input clock : Clock
+           |CHECK:         input reset : UInt<1>
+           |CHECK:         output widgetProbes_0 : RWProbe<UInt<32>>
+           |CHECK:         output widgetProbes_1 : RWProbe<UInt<32>>
+           |CHECK:         inst hier of ArbitrarilyDeepHierarchy
+           |CHECK:         define widgetProbes_0 = hier.widgetProbes_p_bore
+           |CHECK:         define widgetProbes_1 = hier.widgetProbes_p_bore_1
+           |""".stripMargin
+      )
   }
 
   it should "work when tapping IO, as probe() from outside module" in {
@@ -623,15 +653,17 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val outV_1_out_refsub = IO(probe.Probe(Bool()))
       probe.define(outV_1_out_refsub, outProbeForChildVec(1).out)
     }
-    generateFirrtlAndFileCheck(new Foo, "--implicit-check-not='define bore'")(
-      // Child port.
-      """|CHECK-LABEL: module Child :
-         |CHECK:         output v : { flip in : UInt<1>, out : UInt<1>}[2]
-         |CHECK:         define outProbeForChildVec = probe(child.v)
-         |CHECK:         define outV_1_in = probe(child.v[1].in)
-         |CHECK:         define outV_1_out_refsub = outProbeForChildVec[1].out
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck("--implicit-check-not='define bore'")(
+        // Child port.
+        """|CHECK-LABEL: module Child :
+           |CHECK:         output v : { flip in : UInt<1>, out : UInt<1>}[2]
+           |CHECK:         define outProbeForChildVec = probe(child.v)
+           |CHECK:         define outV_1_in = probe(child.v[1].in)
+           |CHECK:         define outV_1_out_refsub = outProbeForChildVec[1].out
+           |""".stripMargin
+      )
 
     // Send through firtool but don't inspect output.
     // Read-only probes only ensure they'll read same as in input FIRRTL,
@@ -660,15 +692,17 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val outProbe = IO(probe.RWProbe(Bool()))
       probe.define(outProbe, fooInstB.tapTarget)
     }
-    generateFirrtlAndFileCheck(new Top(Definition(new Foo)))(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         output tapTarget : RWProbe<UInt<1>>
-         |CHECK:         define tapTarget = rwprobe(internalWire)
-         |CHECK-LABEL: module Top :
-         |CHECK:         force_initial(fooInstA.tapTarget, UInt<1>(0h1))
-         |CHECK:         define outProbe = fooInstB.tapTarget
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top(Definition(new Foo)))
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         output tapTarget : RWProbe<UInt<1>>
+           |CHECK:         define tapTarget = rwprobe(internalWire)
+           |CHECK-LABEL: module Top :
+           |CHECK:         force_initial(fooInstA.tapTarget, UInt<1>(0h1))
+           |CHECK:         define outProbe = fooInstB.tapTarget
+           |""".stripMargin
+      )
 
     // Check that firtool also passes
     val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Top(Definition(new Foo)))
@@ -702,20 +736,22 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
         widgetProbe
       }
     }
-    generateFirrtlAndFileCheck(new UnitTestHarness)(
-      """|CHECK-LABEL: module Widget :
-         |CHECK:         input clock : Clock
-         |CHECK:         input reset : Reset
-         |CHECK:         input in : UInt<32>
-         |CHECK:         output out : UInt<32>
-         |CHECK:         node _out_T = not(in)
-         |CHECK:         connect out, _out_T
-         |CHECK-LABEL: module Dut :
-         |CHECK:         define widgetProbes_0 = rwprobe(widgets_0.out)
-         |CHECK:         public module UnitTestHarness :
-         |CHECK:         force(clock, _T, dut.widgetProbes_0, UInt<32>(0hffff))
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new UnitTestHarness)
+      .fileCheck()(
+        """|CHECK-LABEL: module Widget :
+           |CHECK:         input clock : Clock
+           |CHECK:         input reset : Reset
+           |CHECK:         input in : UInt<32>
+           |CHECK:         output out : UInt<32>
+           |CHECK:         node _out_T = not(in)
+           |CHECK:         connect out, _out_T
+           |CHECK-LABEL: module Dut :
+           |CHECK:         define widgetProbes_0 = rwprobe(widgets_0.out)
+           |CHECK:         public module UnitTestHarness :
+           |CHECK:         force(clock, _T, dut.widgetProbes_0, UInt<32>(0hffff))
+           |""".stripMargin
+      )
   }
 
   it should "work to tap an Instance[..]'s port" in {
@@ -747,20 +783,22 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
         widgetProbe
       }
     }
-    generateFirrtlAndFileCheck(new UnitTestHarness)(
-      """|CHECK-LABEL: module Widget :
-         |CHECK:         input clock : Clock
-         |CHECK:         input reset : Reset
-         |CHECK:         input in : UInt<32>
-         |CHECK:         output out : UInt<32>
-         |CHECK:         node _out_T = not(in)
-         |CHECK:         connect out, _out_T
-         |CHECK-LABEL: module Dut :
-         |CHECK:         define widgetProbes_0 = probe(widgets_0.out)
-         |CHECK:         public module UnitTestHarness :
-         |CHECK:         printf(clock, UInt<1>(0h1), "%d", read(dut.widgetProbes_0))
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new UnitTestHarness)
+      .fileCheck()(
+        """|CHECK-LABEL: module Widget :
+           |CHECK:         input clock : Clock
+           |CHECK:         input reset : Reset
+           |CHECK:         input in : UInt<32>
+           |CHECK:         output out : UInt<32>
+           |CHECK:         node _out_T = not(in)
+           |CHECK:         connect out, _out_T
+           |CHECK-LABEL: module Dut :
+           |CHECK:         define widgetProbes_0 = probe(widgets_0.out)
+           |CHECK:         public module UnitTestHarness :
+           |CHECK:         printf(clock, UInt<1>(0h1), "%d", read(dut.widgetProbes_0))
+           |""".stripMargin
+      )
   }
 
   it should "work with DecoupledIO in a hierarchy" in {
@@ -781,19 +819,21 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val fakeView = Module(new FakeView(foo))
     }
 
-    generateFirrtlAndFileCheck(new Top())(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output decoupledThing_bore : Probe<{ ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}>
-         |CHECK:         define decoupledThing_bore = probe(decoupledThing)
-         |CHECK-LABEL: module Foo :
-         |CHECK:         output decoupledThing_bore : Probe<{ ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}>
-         |CHECK:         define decoupledThing_bore = bar.decoupledThing_bore
-         |CHECK-LABEL: module FakeView :
-         |CHECK:         input decoupledThing_bore : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect fakeView.decoupledThing_bore, read(foo.decoupledThing_bore)
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top())
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output decoupledThing_bore : Probe<{ ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}>
+           |CHECK:         define decoupledThing_bore = probe(decoupledThing)
+           |CHECK-LABEL: module Foo :
+           |CHECK:         output decoupledThing_bore : Probe<{ ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}>
+           |CHECK:         define decoupledThing_bore = bar.decoupledThing_bore
+           |CHECK-LABEL: module FakeView :
+           |CHECK:         input decoupledThing_bore : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect fakeView.decoupledThing_bore, read(foo.decoupledThing_bore)
+           |""".stripMargin
+      )
 
     // Check that firtool also passes
     val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Top())
@@ -810,14 +850,16 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       val bar = Module(new Bar(a))
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         input bore : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
-         |CHECK-LABEL: module Foo :
-         |CHECK:         wire a : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
-         |CHECK:         connect bar.bore, read(probe(a))
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         input bore : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
+           |CHECK-LABEL: module Foo :
+           |CHECK:         wire a : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
+           |CHECK:         connect bar.bore, read(probe(a))
+           |""".stripMargin
+      )
 
     // Check that firtool also passes
     val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Foo)
@@ -831,15 +873,17 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       assert(chisel3.reflect.DataMirror.isFullyAligned(b), "tapAndRead should always return passive data")
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         wire a : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
-         |CHECK:         wire b : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
-         |CHECK:         connect b.bits, a.bits
-         |CHECK:         connect b.valid, a.valid
-         |CHECK:         connect b.ready, a.ready
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         wire a : { flip ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
+           |CHECK:         wire b : { ready : UInt<1>, valid : UInt<1>, bits : UInt<1>}
+           |CHECK:         connect b.bits, a.bits
+           |CHECK:         connect b.valid, a.valid
+           |CHECK:         connect b.ready, a.ready
+           |""".stripMargin
+      )
 
     // Check that firtool also passes
     val verilog = circt.stage.ChiselStage.emitSystemVerilog(new Foo)
@@ -873,18 +917,20 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       out := probe.read(BoringUtils.rwTap(foo.bar.view))
       probe.forceInitial(BoringUtils.rwTap(foo.bar.view), false.B)
     }
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Bar :
-         |CHECK:         output out_bore : RWProbe<UInt<1>>
-         |CHECK:         define out_bore = rwprobe(internalWire)
-         |CHECK-LABEL: module Foo :
-         |CHECK:         output out_bore : RWProbe<UInt<1>>
-         |CHECK:         define out_bore = bar.out_bore
-         |CHECK-LABEL: module Top :
-         |CHECK:         connect out, read(foo.out_bore)
-         |CHECK:         force_initial(foo.bore, UInt<1>(0h0))
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Bar :
+           |CHECK:         output out_bore : RWProbe<UInt<1>>
+           |CHECK:         define out_bore = rwprobe(internalWire)
+           |CHECK-LABEL: module Foo :
+           |CHECK:         output out_bore : RWProbe<UInt<1>>
+           |CHECK:         define out_bore = bar.out_bore
+           |CHECK-LABEL: module Top :
+           |CHECK:         connect out, read(foo.out_bore)
+           |CHECK:         force_initial(foo.bore, UInt<1>(0h0))
+           |""".stripMargin
+      )
   }
 
   it should "NOT work [yet] for non-identity views" in {
@@ -939,20 +985,22 @@ class BoringUtilsTapSpec extends AnyFlatSpec with Matchers with Utils with FileC
       probe.forceInitial(reProbe, 1.U)
     }
 
-    generateFirrtlAndFileCheck(new Baz)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         output io : UInt<32>
-         |CHECK:         output ioProbe : RWProbe<UInt<32>>
-         |CHECK:         define ioProbe = rwprobe(io)
-         |CHECK-LABEL: module Bar :
-         |CHECK:         output bore : RWProbe<UInt<32>>
-         |CHECK:         inst foo of Foo
-         |CHECK:         define bore = foo.ioProbe
-         |CHECK-LABEL: module Baz :
-         |CHECK:         inst bar of Bar
-         |CHECK:         wire reProbe : RWProbe<UInt<32>>
-         |CHECK:         define reProbe = bar.bore
-         |CHECK:         force_initial(reProbe, UInt<32>(0h1))""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Baz)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         output io : UInt<32>
+           |CHECK:         output ioProbe : RWProbe<UInt<32>>
+           |CHECK:         define ioProbe = rwprobe(io)
+           |CHECK-LABEL: module Bar :
+           |CHECK:         output bore : RWProbe<UInt<32>>
+           |CHECK:         inst foo of Foo
+           |CHECK:         define bore = foo.ioProbe
+           |CHECK-LABEL: module Baz :
+           |CHECK:         inst bar of Bar
+           |CHECK:         wire reProbe : RWProbe<UInt<32>>
+           |CHECK:         define reProbe = bar.bore
+           |CHECK:         force_initial(reProbe, UInt<32>(0h1))""".stripMargin
+      )
   }
 }

--- a/src/test/scala-2/chiselTests/ChiselSpec.scala
+++ b/src/test/scala-2/chiselTests/ChiselSpec.scala
@@ -12,7 +12,6 @@ import svsim._
 import firrtl.annotations.Annotation
 import firrtl.ir.Circuit
 import firrtl.stage.FirrtlCircuitAnnotation
-import firrtl.util.BackendCompilationUtilities
 import firrtl.{AnnotationSeq, EmittedVerilogCircuitAnnotation}
 import org.scalacheck._
 import org.scalatest._
@@ -81,55 +80,6 @@ trait WidthHelpers extends Assertions {
     }
   }
 
-}
-
-trait FileCheck extends BeforeAndAfterEachTestData { this: Suite =>
-  import scala.Console.{withErr, withOut}
-
-  private def sanitize(n: String): String = n.replaceAll(" ", "_").replaceAll("\\W+", "")
-
-  private val testRunDir: os.Path = os.pwd / os.RelPath(BackendCompilationUtilities.TestDirectory)
-  private val suiteDir:   os.Path = testRunDir / sanitize(suiteName)
-  private var checkFile:  Option[os.Path] = None
-
-  override def beforeEach(testData: TestData): Unit = {
-    // TODO check that these are always available
-    val nameDir = suiteDir / sanitize(testData.name)
-    os.makeDir.all(nameDir)
-    checkFile = Some(nameDir / s"${sanitize(testData.text)}.check")
-    super.beforeEach(testData) // To be stackable, must call super.beforeEach
-  }
-
-  override def afterEach(testData: TestData): Unit = {
-    checkFile = None
-    super.afterEach(testData) // To be stackable, must call super.beforeEach
-  }
-
-  /** Run FileCheck on a String against some checks */
-  def fileCheckString(in: String, fileCheckArgs: String*)(check: String): Unit = {
-    // Filecheck needs the thing to check in a file
-    os.write.over(checkFile.get, check)
-    val extraArgs = os.Shellable(fileCheckArgs)
-    os.proc("FileCheck", "--allow-empty", checkFile.get, extraArgs).call(stdin = in)
-  }
-
-  /** Elaborate a Module to FIRRTL and check the FIRRTL with FileCheck */
-  def generateFirrtlAndFileCheck(t: => RawModule, fileCheckArgs: String*)(check: String): Unit = {
-    fileCheckString(ChiselStage.emitCHIRRTL(t), fileCheckArgs: _*)(check)
-  }
-
-  /** Generate SystemVerilog and run it through FileCheck */
-  def generateSystemVerilogAndFileCheck(t: => RawModule, fileCheckArgs: String*)(check: String): Unit = {
-    fileCheckString(ChiselStage.emitSystemVerilog(t), fileCheckArgs: _*)(check)
-  }
-
-  /** Elaborate a Module, capture the stdout and stderr, check stdout and stderr with FileCheck */
-  def elaborateAndFileCheckOutAndErr(t: => RawModule, fileCheckArgs: String*)(check: String): Unit = {
-    val outStream = new ByteArrayOutputStream()
-    withOut(outStream)(withErr(outStream)(ChiselStage.emitCHIRRTL(t)))
-    val result = outStream.toString
-    fileCheckString(outStream.toString, fileCheckArgs: _*)(check)
-  }
 }
 
 /** Utilities for writing property-based checks */

--- a/src/test/scala-2/chiselTests/DedupSpec.scala
+++ b/src/test/scala-2/chiselTests/DedupSpec.scala
@@ -7,6 +7,7 @@ import chisel3.experimental.hierarchy._
 import chisel3.experimental.{annotate, dedupGroup}
 import chisel3.properties.Class
 import chisel3.stage.{ChiselGeneratorAnnotation, CircuitSerializationAnnotation}
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.circt.PlusArgsValue
 import chisel3.util.{Counter, Decoupled, Queue}
 import circt.stage.ChiselStage
@@ -172,7 +173,7 @@ class DedupSpec extends AnyFlatSpec with Matchers with FileCheck {
       .emitLazily(annotations.collect { case a: DedupGroupAnnotation => a })
       .mkString
 
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK:      "class":"firrtl.transforms.DedupGroupAnnotation"
          |CHECK-NEXT: "target":"~ModuleWithIntrinsic|ModuleWithIntrinsic"
          |CHECK-NEXT: "group":"ModuleWithIntrinsic"
@@ -194,7 +195,7 @@ class DedupSpec extends AnyFlatSpec with Matchers with FileCheck {
       .emitLazily(annotations.collect { case a: DedupGroupAnnotation => a })
       .mkString
 
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK:      "class":"firrtl.transforms.DedupGroupAnnotation"
          |CHECK-NEXT: "target":"~ModuleWithClass|ModuleWithClass"
          |CHECK-NEXT: "group":"ModuleWithClass"

--- a/src/test/scala-2/chiselTests/FixedIOModuleSpec.scala
+++ b/src/test/scala-2/chiselTests/FixedIOModuleSpec.scala
@@ -7,6 +7,7 @@ import chisel3.experimental.SourceInfo
 import chisel3.experimental.hierarchy.{instantiable, Definition, Instance, Instantiate}
 import chisel3.probe.Probe
 import chisel3.reflect.DataMirror.internal.chiselTypeClone
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -48,14 +49,16 @@ class FixedIOModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
       val baz = Module(new Baz)
     }
 
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: extmodule Bar :
-         |CHECK:         output io : UInt<1>
-         |CHECK-LABEL: extmodule Baz :
-         |CHECK:         output a : UInt<2>
-         |CHECK-LABEL: public module Foo :
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: extmodule Bar :
+           |CHECK:         output io : UInt<1>
+           |CHECK-LABEL: extmodule Baz :
+           |CHECK:         output a : UInt<2>
+           |CHECK-LABEL: public module Foo :
+           |""".stripMargin
+      )
   }
 
   "User defined RawModules" should "be able to lock down their ios" in {
@@ -94,13 +97,15 @@ class FixedIOModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
     }
     exception.getMessage should include("This module cannot have IOs instantiated after disallowing IOs")
 
-    generateFirrtlAndFileCheck(new Bar(false))(
-      """|CHECK-LABEL: public module Bar :
-         |CHECK:         input in : UInt<1>
-         |CHECK:         output out : UInt<1>
-         |CHECK:         input end : UInt<1>
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Bar(false))
+      .fileCheck()(
+        """|CHECK-LABEL: public module Bar :
+           |CHECK:         input in : UInt<1>
+           |CHECK:         output out : UInt<1>
+           |CHECK:         input end : UInt<1>
+           |""".stripMargin
+      )
   }
 
   class Agg extends Bundle {
@@ -192,44 +197,50 @@ class FixedIOModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   "FixedIORaw/ExtModules" should "be able to have a Record with Probes of Elements in their IOs" in {
-    generateFirrtlAndFileCheck(new Parent(false, false))(
-      """|CHECK-LABEL: module ExampleRaw :
-         |CHECK:         output elem : Probe<UInt<1>>
-         |CHECK-LABEL: extmodule ExampleExt
-         |CHECK:         output elem : Probe<UInt<1>>
-         |CHECK-LABEL: public module Parent :
-         |CHECK:         define probeElemWireRaw = childRaw.elem
-         |CHECK:         define probeElemWireExt = childExt.elem
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Parent(false, false))
+      .fileCheck()(
+        """|CHECK-LABEL: module ExampleRaw :
+           |CHECK:         output elem : Probe<UInt<1>>
+           |CHECK-LABEL: extmodule ExampleExt
+           |CHECK:         output elem : Probe<UInt<1>>
+           |CHECK-LABEL: public module Parent :
+           |CHECK:         define probeElemWireRaw = childRaw.elem
+           |CHECK:         define probeElemWireExt = childExt.elem
+           |""".stripMargin
+      )
   }
 
   "FixedIORaw/ExtModules" should "be able to have a Record with Probes of Aggregates in their IOs" in {
-    generateFirrtlAndFileCheck(new Parent(true, false))(
-      """|CHECK-LABEL: module ExampleRaw :
-         |CHECK:         output agg : Probe<{ foo : UInt<1>, bar : UInt<1>}>
-         |CHECK-LABEL: extmodule ExampleExt
-         |CHECK:         output agg : Probe<{ foo : UInt<1>, bar : UInt<1>}>
-         |CHECK-LABEL: public module Parent :
-         |CHECK:         define probeAggWireRaw = childRaw.agg
-         |CHECK:         define probeAggWireExt = childExt.agg
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Parent(true, false))
+      .fileCheck()(
+        """|CHECK-LABEL: module ExampleRaw :
+           |CHECK:         output agg : Probe<{ foo : UInt<1>, bar : UInt<1>}>
+           |CHECK-LABEL: extmodule ExampleExt
+           |CHECK:         output agg : Probe<{ foo : UInt<1>, bar : UInt<1>}>
+           |CHECK-LABEL: public module Parent :
+           |CHECK:         define probeAggWireRaw = childRaw.agg
+           |CHECK:         define probeAggWireExt = childExt.agg
+           |""".stripMargin
+      )
   }
 
   "FixedIORaw/ExtModules" should "be able to have a Record with Aggregates with Probes in their IOs" in {
-    generateFirrtlAndFileCheck(new Parent(false, true))(
-      """|CHECK-LABEL: module ExampleRaw :
-         |CHECK:         output nested : { foo : Probe<UInt<1>>, bar : Probe<UInt<1>>}
-         |CHECK-LABEL: extmodule ExampleExt
-         |CHECK:         output nested : { foo : Probe<UInt<1>>, bar : Probe<UInt<1>>}
-         |CHECK-LABEL: public module Parent :
-         |CHECK:         define probeNestedWireRaw.bar = childRaw.nested.bar
-         |CHECK:         define probeNestedWireRaw.foo = childRaw.nested.foo
-         |CHECK:         define probeNestedWireExt.bar = childExt.nested.bar
-         |CHECK:         define probeNestedWireExt.foo = childExt.nested.foo
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Parent(false, true))
+      .fileCheck()(
+        """|CHECK-LABEL: module ExampleRaw :
+           |CHECK:         output nested : { foo : Probe<UInt<1>>, bar : Probe<UInt<1>>}
+           |CHECK-LABEL: extmodule ExampleExt
+           |CHECK:         output nested : { foo : Probe<UInt<1>>, bar : Probe<UInt<1>>}
+           |CHECK-LABEL: public module Parent :
+           |CHECK:         define probeNestedWireRaw.bar = childRaw.nested.bar
+           |CHECK:         define probeNestedWireRaw.foo = childRaw.nested.foo
+           |CHECK:         define probeNestedWireExt.bar = childExt.nested.bar
+           |CHECK:         define probeNestedWireExt.foo = childExt.nested.foo
+           |""".stripMargin
+      )
   }
   "FixedIOExtModules" should "be able to have a Probe(Element) as its FixedIO" in {
     class ProbeElemExt extends FixedIOExtModule(Probe(Bool()))
@@ -240,13 +251,15 @@ class FixedIOModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
       wireElem :<>= child.io
       ioElem := probe.read(wireElem)
     }
-    generateFirrtlAndFileCheck(new Parent)(
-      """|CHECK-LABEL: extmodule ProbeElemExt :
-         |CHECK:         output io : Probe<UInt<1>>
-         |CHECK-LABEL: public module Parent :
-         |CHECK:         define wireElem = child.io
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Parent)
+      .fileCheck()(
+        """|CHECK-LABEL: extmodule ProbeElemExt :
+           |CHECK:         output io : Probe<UInt<1>>
+           |CHECK-LABEL: public module Parent :
+           |CHECK:         define wireElem = child.io
+           |""".stripMargin
+      )
   }
   "FixedIOExtModules" should "be able to have a Probe(Aggregate) as its FixedIO" in {
     class ProbeAggExt extends FixedIOExtModule(Probe(new Agg()))
@@ -257,13 +270,15 @@ class FixedIOModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
       wireAgg :<>= child.io
       ioAgg := probe.read(wireAgg)
     }
-    generateFirrtlAndFileCheck(new Parent)(
-      """|CHECK-LABEL: extmodule ProbeAggExt :
-         |CHECK:         output io : Probe<{ foo : UInt<1>, bar : UInt<1>}>
-         |CHECK-LABEL: public module Parent :
-         |CHECK:         define wireAgg = child.io
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Parent)
+      .fileCheck()(
+        """|CHECK-LABEL: extmodule ProbeAggExt :
+           |CHECK:         output io : Probe<{ foo : UInt<1>, bar : UInt<1>}>
+           |CHECK-LABEL: public module Parent :
+           |CHECK:         define wireAgg = child.io
+           |""".stripMargin
+      )
   }
 
   "FixedIOExtModules" should "be able to have an Aggregate with Probes as its FixedIO" in {
@@ -275,15 +290,17 @@ class FixedIOModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
       wireNested :<>= child.io
       ioBar := probe.read(wireNested.bar)
     }
-    generateFirrtlAndFileCheck(new Parent)(
-      """|CHECK-LABEL: extmodule ProbeNestedExt :
-         |CHECK:         output foo : Probe<UInt<1>>
-         |CHECK:         output bar : Probe<UInt<1>>
-         |CHECK-LABEL: public module Parent :
-         |CHECK:         define wireNested.bar = child.bar
-         |CHECK:         define wireNested.foo = child.foo
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Parent)
+      .fileCheck()(
+        """|CHECK-LABEL: extmodule ProbeNestedExt :
+           |CHECK:         output foo : Probe<UInt<1>>
+           |CHECK:         output bar : Probe<UInt<1>>
+           |CHECK-LABEL: public module Parent :
+           |CHECK:         define wireNested.bar = child.bar
+           |CHECK:         define wireNested.foo = child.foo
+           |""".stripMargin
+      )
   }
 
   "FixedIOModule" should "work with D/I API" in {

--- a/src/test/scala-2/chiselTests/InlineSpec.scala
+++ b/src/test/scala-2/chiselTests/InlineSpec.scala
@@ -3,8 +3,8 @@
 package chiselTests
 
 import chisel3._
+import chisel3.testing.FileCheck
 import chisel3.util.experimental.{InlineInstance, InlineInstanceAllowDedup}
-import chiselTests.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -24,11 +24,13 @@ class InlineInstanceSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   "InlineInstanceAllowDedup" should "Inline any module that dedups with a module marked inline" in {
-    generateSystemVerilogAndFileCheck(new TopModule, "--implicit-check-not=ModuleB")(
-      """|CHECK: ModuleA()
-         |CHECK: TopModule()
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitSystemVerilog(new TopModule)
+      .fileCheck("--implicit-check-not=ModuleB")(
+        """|CHECK: ModuleA()
+           |CHECK: TopModule()
+           |""".stripMargin
+      )
   }
 }
 
@@ -47,10 +49,12 @@ class InlineInstanceAllowDedupSpec extends AnyFlatSpec with Matchers with FileCh
   }
 
   "InlineInstanceAllowDedup" should "Inline any module that dedups with a module marked inline" in {
-    generateSystemVerilogAndFileCheck(new TopModule)(
-      """|CHECK-NOT: Module{{A|B}}
-         |CHECK:     TopModule()
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitSystemVerilog(new TopModule)
+      .fileCheck()(
+        """|CHECK-NOT: Module{{A|B}}
+           |CHECK:     TopModule()
+           |""".stripMargin
+      )
   }
 }

--- a/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
+++ b/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
@@ -6,6 +6,7 @@ import chisel3._
 import chisel3.experimental.ExtModule
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance, Instantiate}
 import chisel3.stage.{ChiselGeneratorAnnotation, CircuitSerializationAnnotation}
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.SRAM
 import circt.stage.ChiselStage
 import firrtl.transforms.DedupGroupAnnotation
@@ -37,16 +38,18 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val pref_foo = withModulePrefix("Pref") { Module(new Foo) }
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo :
-         |CHECK:         wire a : UInt<1>
-         |CHECK-LABEL: module Pref_Foo :
-         |CHECK:         wire a : UInt<1>
-         |CHECK-LABEL: module Top :
-         |CHECK:         inst foo of Foo
-         |CHECK-NEXT:    inst pref_foo of Pref_Foo
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         wire a : UInt<1>
+           |CHECK-LABEL: module Pref_Foo :
+           |CHECK:         wire a : UInt<1>
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Foo
+           |CHECK-NEXT:    inst pref_foo of Pref_Foo
+           |""".stripMargin
+      )
   }
 
   it should "Allow nested module prefixes" in {
@@ -66,15 +69,17 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       }
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Outer_Inner_Bar :
-         |CHECK:         wire a : UInt<1>
-         |CHECK-LABEL: module Outer_Foo
-         |CHECK:         inst bar of Outer_Inner_Bar
-         |CHECK-LABEL: module Top :
-         |CHECK:         inst foo of Outer_Foo
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Outer_Inner_Bar :
+           |CHECK:         wire a : UInt<1>
+           |CHECK-LABEL: module Outer_Foo
+           |CHECK:         inst bar of Outer_Inner_Bar
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Outer_Foo
+           |""".stripMargin
+      )
   }
 
   it should "Instantiate should create distinct module definitions when instantiated with distinct prefixes" in {
@@ -100,16 +105,18 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       np_inst.in := in
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo_AddOne :
-         |CHECK-LABEL: module Bar_AddOne :
-         |CHECK-LABEL: module AddOne :
-         |CHECK-LABEL: public module Top :
-         |CHECK:         inst foo_inst of Foo_AddOne
-         |CHECK:         inst bar_inst of Bar_AddOne
-         |CHECK:         inst np_inst of AddOne
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo_AddOne :
+           |CHECK-LABEL: module Bar_AddOne :
+           |CHECK-LABEL: module AddOne :
+           |CHECK-LABEL: public module Top :
+           |CHECK:         inst foo_inst of Foo_AddOne
+           |CHECK:         inst bar_inst of Bar_AddOne
+           |CHECK:         inst np_inst of AddOne
+           |""".stripMargin
+      )
   }
 
   it should "Instantiate should reference the same module definitions when instantiated with the same prefix" in {
@@ -130,13 +137,15 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       out := foo_inst1.out
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Foo_AddOne :
-         |CHECK-LABEL: public module Top :
-         |CHECK:         inst foo_inst1 of Foo_AddOne
-         |CHECK:         inst foo_inst2 of Foo_AddOne
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Foo_AddOne :
+           |CHECK-LABEL: public module Top :
+           |CHECK:         inst foo_inst1 of Foo_AddOne
+           |CHECK:         inst foo_inst2 of Foo_AddOne
+           |""".stripMargin
+      )
   }
 
   it should "Memories work" in {
@@ -165,24 +174,26 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       io.dataOut := smem.read(io.addr, io.enable)
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK:      {
-         |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
-         |CHECK-NEXT:   "target":"~Top|Top>smem",
-         |CHECK-NEXT:   "prefix":"Foo_"
-         |CHECK-NEXT: },
-         |CHECK-NEXT: {
-         |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
-         |CHECK-NEXT:   "target":"~Top|Top>cmem",
-         |CHECK-NEXT:   "prefix":"Bar_"
-         |CHECK-NEXT: },
-         |CHECK-NEXT: {
-         |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
-         |CHECK-NEXT:   "target":"~Top|Top>sram_sram",
-         |CHECK-NEXT:   "prefix":"Baz_"
-         |CHECK-NEXT: }
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK:      {
+           |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
+           |CHECK-NEXT:   "target":"~Top|Top>smem",
+           |CHECK-NEXT:   "prefix":"Foo_"
+           |CHECK-NEXT: },
+           |CHECK-NEXT: {
+           |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
+           |CHECK-NEXT:   "target":"~Top|Top>cmem",
+           |CHECK-NEXT:   "prefix":"Bar_"
+           |CHECK-NEXT: },
+           |CHECK-NEXT: {
+           |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
+           |CHECK-NEXT:   "target":"~Top|Top>sram_sram",
+           |CHECK-NEXT:   "prefix":"Baz_"
+           |CHECK-NEXT: }
+           |""".stripMargin
+      )
   }
 
   it should "Definitions that appear within withModulePrefix get prefixed" in {
@@ -194,11 +205,13 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val addone = Instance(dfn)
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK: module Foo_AddOne
-         |CHECK: module Top
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK: module Foo_AddOne
+           |CHECK: module Top
+           |""".stripMargin
+      )
   }
 
   it should "allow definitions to be instantiated within a withModulePrefix block without prefixing it" in {
@@ -214,12 +227,14 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       }
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK: module AddOne
-         |CHECK: module Foo_Child
-         |CHECK: public module Top
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK: module AddOne
+           |CHECK: module Foo_Child
+           |CHECK: public module Top
+           |""".stripMargin
+      )
   }
 
   it should "withModulePrefix does not automatically affect ExtModules" in {
@@ -229,12 +244,14 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val sub_foo = withModulePrefix("Foo") { Module(new Sub) }
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: extmodule Sub
-         |CHECK:         defname = Sub
-         |CHECK-LABEL: module Top
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: extmodule Sub
+           |CHECK:         defname = Sub
+           |CHECK-LABEL: module Top
+           |""".stripMargin
+      )
   }
 
   it should "Using modulePrefix to force the name of an extmodule" in {
@@ -246,12 +263,14 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val sub_foo = withModulePrefix("Foo") { Module(new Sub) }
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: extmodule Foo_Sub
-         |CHECK:  defname = Foo_Sub
-         |CHECK:module Top
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: extmodule Foo_Sub
+           |CHECK:  defname = Foo_Sub
+           |CHECK:module Top
+           |""".stripMargin
+      )
   }
 
   it should "support omitting the separator" in {
@@ -262,12 +281,14 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       }
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module PrefixFoo :
-         |CHECK-LABEL: module Top :
-         |CHECK:         inst foo of PrefixFoo
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module PrefixFoo :
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of PrefixFoo
+           |""".stripMargin
+      )
   }
 
   behavior.of("BaseModule.localModulePrefix")
@@ -283,14 +304,16 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val bar = Module(new Bar)
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Prefix_Foo :
-         |CHECK-LABEL: module Prefix_Bar :
-         |CHECK-LABEL: module Prefix_Top :
-         |CHECK:         inst foo of Prefix_Foo
-         |CHECK:         inst bar of Prefix_Bar
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Prefix_Foo :
+           |CHECK-LABEL: module Prefix_Bar :
+           |CHECK-LABEL: module Prefix_Top :
+           |CHECK:         inst foo of Prefix_Foo
+           |CHECK:         inst bar of Prefix_Bar
       """.stripMargin
-    )
+      )
   }
 
   it should "set the prefix for a Module's children but not the Module itself if localModulePrefixAppliesToSelf is false" in {
@@ -305,14 +328,16 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val bar = Module(new Bar)
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Prefix_Foo :
-         |CHECK-LABEL: module Prefix_Bar :
-         |CHECK-LABEL: module Top :
-         |CHECK:         inst foo of Prefix_Foo
-         |CHECK:         inst bar of Prefix_Bar
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Prefix_Foo :
+           |CHECK-LABEL: module Prefix_Bar :
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of Prefix_Foo
+           |CHECK:         inst bar of Prefix_Bar
+           |""".stripMargin
+      )
   }
 
   it should "compose with withModulePrefix" in {
@@ -331,16 +356,18 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       }
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module Outer_Inner_Foo :
-         |CHECK-LABEL: module Outer_Prefix_Inner_Foo :
-         |CHECK-LABEL: module Outer_Prefix_Bar :
-         |CHECK-LABEL: module Outer_Top :
-         |CHECK:         inst f1 of Outer_Inner_Foo
-         |CHECK:         inst f2 of Outer_Prefix_Inner_Foo
-         |CHECK:         inst bar of Outer_Prefix_Bar
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module Outer_Inner_Foo :
+           |CHECK-LABEL: module Outer_Prefix_Inner_Foo :
+           |CHECK-LABEL: module Outer_Prefix_Bar :
+           |CHECK-LABEL: module Outer_Top :
+           |CHECK:         inst f1 of Outer_Inner_Foo
+           |CHECK:         inst f2 of Outer_Prefix_Inner_Foo
+           |CHECK:         inst bar of Outer_Prefix_Bar
+           |""".stripMargin
+      )
   }
 
   it should "omit the prefix if localModulePrefixUseSeparator is false" in {
@@ -355,12 +382,14 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val foo = Module(new Foo)
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module OuterInnerFoo :
-         |CHECK-LABEL: module Top :
-         |CHECK:         inst foo of OuterInnerFoo
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module OuterInnerFoo :
+           |CHECK-LABEL: module Top :
+           |CHECK:         inst foo of OuterInnerFoo
+           |""".stripMargin
+      )
   }
 
   it should "support mixing and matching of separator omission" in {
@@ -377,14 +406,16 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       val bar = Module(new Bar)
     }
 
-    generateFirrtlAndFileCheck(new Top)(
-      """|CHECK-LABEL: module OuterMiddle_Inner_Foo :
-         |CHECK-LABEL: module OuterMiddle_Bar :
-         |CHECK:         inst foo of OuterMiddle_Inner_Foo
-         |CHECK-LABEL: module OuterTop :
-         |CHECK:         inst bar of OuterMiddle_Bar
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Top)
+      .fileCheck()(
+        """|CHECK-LABEL: module OuterMiddle_Inner_Foo :
+           |CHECK-LABEL: module OuterMiddle_Bar :
+           |CHECK:         inst foo of OuterMiddle_Inner_Foo
+           |CHECK-LABEL: module OuterTop :
+           |CHECK:         inst bar of OuterMiddle_Bar
+           |""".stripMargin
+      )
   }
 
   behavior.of("Module prefixes")
@@ -412,7 +443,7 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
     val firrtl = annotations.collectFirst { case a: CircuitSerializationAnnotation => a }.get
       .emitLazily(annotations.collect { case a: DedupGroupAnnotation => a })
       .mkString
-    fileCheckString(firrtl)(
+    firrtl.fileCheck()(
       """|CHECK:      "target":"~Top|Outer_Inner_Foo"
          |CHECK-NEXT: "group":"Outer_Inner_Foo"
          |CHECK:      "target":"~Top|Outer_Bar"

--- a/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
+++ b/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
@@ -7,6 +7,7 @@ import circt.stage.ChiselStage
 import chisel3._
 import chisel3.experimental.{annotate, AnyTargetable}
 import chisel3.stage.ChiselGeneratorAnnotation
+import chisel3.testing.scalatest.FileCheck
 import chiselTests.experimental.hierarchy.Utils
 
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
@@ -75,32 +76,34 @@ class NewAnnotationsSpec extends AnyFreeSpec with Matchers with Utils with FileC
     }
 
     "It should be possible to annotate heterogeneous Targetable things" in {
-      generateFirrtlAndFileCheck(new RawModule {
-        override def desiredName: String = "Top"
-        val in = IO(Input(UInt(8.W)))
-        val out = IO(Output(UInt(8.W)))
-        out := in
-        // Given a Seq[UInt]
-        val xs: Seq[UInt] = Seq(in, out)
-        // We can manually use AnyTargetable to also include a Module
-        // Using either type ascriptions to invoke the implicit conversion, or manually
-        val ys = Seq[AnyTargetable](this) ++ xs.map(AnyTargetable(_))
-        annotate(ys)(
-          Seq(
-            DontTouchAnnotation(in.toTarget),
-            DontTouchAnnotation(out.toTarget),
-            NoDedupAnnotation(this.toNamed)
+      ChiselStage
+        .emitCHIRRTL(new RawModule {
+          override def desiredName: String = "Top"
+          val in = IO(Input(UInt(8.W)))
+          val out = IO(Output(UInt(8.W)))
+          out := in
+          // Given a Seq[UInt]
+          val xs: Seq[UInt] = Seq(in, out)
+          // We can manually use AnyTargetable to also include a Module
+          // Using either type ascriptions to invoke the implicit conversion, or manually
+          val ys = Seq[AnyTargetable](this) ++ xs.map(AnyTargetable(_))
+          annotate(ys)(
+            Seq(
+              DontTouchAnnotation(in.toTarget),
+              DontTouchAnnotation(out.toTarget),
+              NoDedupAnnotation(this.toNamed)
+            )
           )
+        })
+        .fileCheck()(
+          """|CHECK:      "class":"firrtl.transforms.DontTouchAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top>in"
+             |CHECK:      "class":"firrtl.transforms.DontTouchAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top>out"
+             |CHECK:      "class":"firrtl.transforms.NoDedupAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top"
+             |""".stripMargin
         )
-      })(
-        """|CHECK:      "class":"firrtl.transforms.DontTouchAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top>in"
-           |CHECK:      "class":"firrtl.transforms.DontTouchAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top>out"
-           |CHECK:      "class":"firrtl.transforms.NoDedupAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top"
-           |""".stripMargin
-      )
     }
   }
 }

--- a/src/test/scala-2/chiselTests/PortSpec.scala
+++ b/src/test/scala-2/chiselTests/PortSpec.scala
@@ -1,6 +1,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -23,13 +24,15 @@ class PortSpec extends AnyFlatSpec with Matchers with FileCheck {
   they should "have source locators" in {
     info("Module-provided ports (clock and reset) point at the line with `Module`")
     info("User-defined ports point at the correct lines")
-    generateFirrtlAndFileCheck(new Dummy)(
-      """|CHECK:      public module Dummy :
-         |CHECK-NEXT:   input clock : Clock @[src/test/scala-2/chiselTests/PortSpec.scala 15:9
-         |CHECK-NEXT:   input reset : UInt<1> @[src/test/scala-2/chiselTests/PortSpec.scala 15:9
-         |CHECK-NEXT:   output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[src/test/scala-2/chiselTests/PortSpec.scala 16:16
-         |CHECK-NEXT:   output out : UInt<1> @[src/test/scala-2/chiselTests/PortSpec.scala 17:17
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Dummy)
+      .fileCheck()(
+        """|CHECK:      public module Dummy :
+           |CHECK-NEXT:   input clock : Clock @[src/test/scala-2/chiselTests/PortSpec.scala 16:9
+           |CHECK-NEXT:   input reset : UInt<1> @[src/test/scala-2/chiselTests/PortSpec.scala 16:9
+           |CHECK-NEXT:   output in : { flip foo : UInt<1>, flip bar : UInt<8>} @[src/test/scala-2/chiselTests/PortSpec.scala 17:16
+           |CHECK-NEXT:   output out : UInt<1> @[src/test/scala-2/chiselTests/PortSpec.scala 18:17
+           |""".stripMargin
+      )
   }
 }

--- a/src/test/scala-2/chiselTests/ProbeSpec.scala
+++ b/src/test/scala-2/chiselTests/ProbeSpec.scala
@@ -8,6 +8,7 @@ import chisel3.probe._
 import chisel3.util.Counter
 import chisel3.simulator.scalatest.ChiselSim
 import chisel3.simulator.stimulus.RunUntilFinished
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -729,14 +730,16 @@ class ProbeSpec extends AnyFlatSpec with Matchers with FileCheck with ChiselSim 
       val a = IO(Output(Probe.apply(UInt(1.W), LayerA)))
       val b = IO(Output(Probe.apply(UInt(2.W), LayerA.LayerB)))
     }
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK-LABEL: layer LayerA,
-         |CHECK-NEXT:    layer LayerB,
-         |CHECK-LABEL: public module Foo :
-         |CHECK:         output a : Probe<UInt<1>, LayerA>
-         |CHECK:         output b : Probe<UInt<2>, LayerA.LayerB>
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK-LABEL: layer LayerA,
+           |CHECK-NEXT:    layer LayerB,
+           |CHECK-LABEL: public module Foo :
+           |CHECK:         output a : Probe<UInt<1>, LayerA>
+           |CHECK:         output b : Probe<UInt<2>, LayerA.LayerB>
+           |""".stripMargin
+      )
   }
 
   "Probes" should "have valid names" in {

--- a/src/test/scala-2/chiselTests/PublicModuleSpec.scala
+++ b/src/test/scala-2/chiselTests/PublicModuleSpec.scala
@@ -3,6 +3,7 @@
 package chiselTests
 
 import chisel3._
+import chisel3.testing.scalatest.FileCheck
 import chisel3.experimental.hierarchy.{instantiable, Definition, Instance}
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
@@ -46,7 +47,7 @@ class PublicModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   "non-main modules" should "be implicitly private" in {
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK-NOT: public module Qux
          |CHECK:     module Qux
          |"""".stripMargin
@@ -54,7 +55,7 @@ class PublicModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   "definitions" should "be implicitly private" in {
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK-NOT: public module Quz
          |CHECK:     module Quz
          |"""".stripMargin
@@ -64,7 +65,7 @@ class PublicModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
   behavior.of("the Public trait")
 
   it should "cause a module that mixes it in to be public" in {
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK-NOT: public module Bar
          |CHECK:     module Bar
          |"""".stripMargin
@@ -72,7 +73,7 @@ class PublicModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "allow making a module that mixes it in private via an override" in {
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK-NOT: public module Baz
          |CHECK:     module Baz
          |"""".stripMargin
@@ -84,7 +85,7 @@ class PublicModuleSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "allow making a Definition that mixes it in private via an override" in {
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK-NOT: public module Grault
          |CHECK:     module Grault
          |"""".stripMargin

--- a/src/test/scala-2/chiselTests/UnitTestMainSpec.scala
+++ b/src/test/scala-2/chiselTests/UnitTestMainSpec.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import chisel3.test._
+import chisel3.testing.scalatest.FileCheck
 import java.io.{ByteArrayOutputStream, PrintStream}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -17,8 +18,8 @@ class UnitTestMainSpec extends AnyFlatSpec with Matchers with FileCheck {
         UnitTests.main(args.toArray)
       }
     }
-    if (!checkOut.isEmpty) fileCheckString(outStream.toString)(checkOut)
-    if (!checkErr.isEmpty) fileCheckString(errStream.toString)(checkErr)
+    if (!checkOut.isEmpty) outStream.toString.fileCheck("--allow-empty")(checkOut)
+    if (!checkErr.isEmpty) errStream.toString.fileCheck("--allow-empty")(checkErr)
   }
 
   def checkOutAndErr(args: String*)(checkOut: String, checkErr: String): Unit = check(args)(checkOut, checkErr)

--- a/src/test/scala-2/chiselTests/experimental/DataViewIntegrationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/DataViewIntegrationSpec.scala
@@ -4,8 +4,9 @@ package chiselTests.experimental
 
 import chisel3._
 import chisel3.experimental.dataview._
-import chisel3.util._
-import chiselTests.FileCheck
+import chisel3.testing.scalatest.FileCheck
+import chisel3.util.{log2Ceil, Decoupled, DecoupledIO, Queue, QueueIO}
+import circt.stage.ChiselStage
 import firrtl.transforms.DontTouchAnnotation
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -51,8 +52,10 @@ class DataViewIntegrationSpec extends AnyFlatSpec with Matchers with FileCheck {
   import DataViewIntegrationSpec.MyModule
 
   "Users" should "be able to view and annotate Modules" in {
-    generateFirrtlAndFileCheck(new MyModule)(
-      """CHECK: "target":"~MyModule|Queue4_UInt8>enq_ptr_value""""
-    )
+    ChiselStage
+      .emitCHIRRTL(new MyModule)
+      .fileCheck()(
+        """CHECK: "target":"~MyModule|Queue4_UInt8>enq_ptr_value""""
+      )
   }
 }

--- a/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
@@ -7,7 +7,7 @@ import chisel3.experimental.BaseModule
 import chisel3.experimental.dataview._
 import chisel3.experimental.conversions._
 import chisel3.experimental.annotate
-import chiselTests.FileCheck
+import chisel3.testing.scalatest.FileCheck
 import chiselTests.experimental.ExtensionMethods.ChiselStageHelpers
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
@@ -124,17 +124,19 @@ class DataViewTargetSpec extends AnyFlatSpec with Matchers with FileCheck {
       val inst = Module(new MyChild)
       out := inst.out
     }
-    generateFirrtlAndFileCheck(new MyParent)(
-      """|CHECK:      "target":"~MyParent|MyChild>out.foo"
-         |CHECK-NEXT: "id":0
-         |CHECK:      "target":"~MyParent|MyChild>out.foo"
-         |CHECK-NEXT: "id":1
-         |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out.foo"
-         |CHECK-NEXT: "id":2
-         |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
-         |CHECK-NEXT: "id":3
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new MyParent)
+      .fileCheck()(
+        """|CHECK:      "target":"~MyParent|MyChild>out.foo"
+           |CHECK-NEXT: "id":0
+           |CHECK:      "target":"~MyParent|MyChild>out.foo"
+           |CHECK-NEXT: "id":1
+           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out.foo"
+           |CHECK-NEXT: "id":2
+           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
+           |CHECK-NEXT: "id":3
+           |""".stripMargin
+      )
   }
 
   it should "support annotating views that cannot be mapped to a single ReferenceTarget" in {
@@ -160,29 +162,31 @@ class DataViewTargetSpec extends AnyFlatSpec with Matchers with FileCheck {
       val inst = Module(new MyChild)
       io <> inst.io
     }
-    generateFirrtlAndFileCheck(new MyParent)(
-      """|CHECK:      "target":"~MyParent|MyChild>io.b"
-         |CHECK-NEXT: "id":0
-         |CHECK:      "target":"~MyParent|MyChild>io.a"
-         |CHECK-NEXT: "id":0
-         |CHECK:      "target":"~MyParent|MyChild>io.d"
-         |CHECK-NEXT: "id":1
-         |CHECK:      "target":"~MyParent|MyChild>io.c"
-         |CHECK-NEXT: "id":1
-         |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.b"
-         |CHECK-NEXT: "id":2
-         |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.a"
-         |CHECK-NEXT: "id":2
-         |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.d"
-         |CHECK-NEXT: "id":3
-         |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.c"
-         |CHECK-NEXT: "id":3
-         |CHECK:      "target":"~MyParent|MyChild>io.d"
-         |CHECK-NEXT: "id":4
-         |CHECK:      "target":"~MyParent|MyChild>io.b"
-         |CHECK-NEXT: "id":4
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new MyParent)
+      .fileCheck()(
+        """|CHECK:      "target":"~MyParent|MyChild>io.b"
+           |CHECK-NEXT: "id":0
+           |CHECK:      "target":"~MyParent|MyChild>io.a"
+           |CHECK-NEXT: "id":0
+           |CHECK:      "target":"~MyParent|MyChild>io.d"
+           |CHECK-NEXT: "id":1
+           |CHECK:      "target":"~MyParent|MyChild>io.c"
+           |CHECK-NEXT: "id":1
+           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.b"
+           |CHECK-NEXT: "id":2
+           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.a"
+           |CHECK-NEXT: "id":2
+           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.d"
+           |CHECK-NEXT: "id":3
+           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.c"
+           |CHECK-NEXT: "id":3
+           |CHECK:      "target":"~MyParent|MyChild>io.d"
+           |CHECK-NEXT: "id":4
+           |CHECK:      "target":"~MyParent|MyChild>io.b"
+           |CHECK-NEXT: "id":4
+           |""".stripMargin
+      )
   }
 
   it should "support views with toRelativeTarget" in {
@@ -205,15 +209,17 @@ class DataViewTargetSpec extends AnyFlatSpec with Matchers with FileCheck {
         markRel(inst.outView, None, 2)
       }
     }
-    generateFirrtlAndFileCheck(new MyParent)(
-      """|CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
-         |CHECK-NEXT: "id":0
-         |CHECK:      "target":"~MyParent|MyChild>out"
-         |CHECK-NEXT: "id":1
-         |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
-         |CHECK-NEXT: "id":2
-         |""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new MyParent)
+      .fileCheck()(
+        """|CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
+           |CHECK-NEXT: "id":0
+           |CHECK:      "target":"~MyParent|MyChild>out"
+           |CHECK-NEXT: "id":1
+           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
+           |CHECK-NEXT: "id":2
+           |""".stripMargin
+      )
   }
 
   // TODO check these properties when using @instance API (especially preservation of totality)

--- a/src/test/scala-2/chiselTests/experimental/FlatIOSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/FlatIOSpec.scala
@@ -3,10 +3,10 @@
 package chiselTests.experimental
 
 import chisel3._
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.Valid
 import circt.stage.ChiselStage.emitCHIRRTL
 import chisel3.experimental.Analog
-import chiselTests.FileCheck
 import chisel3.reflect.DataMirror
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
@@ -24,12 +24,14 @@ class FlatIOSpec extends AnyFlatSpec with Matchers with FileCheck {
       })
       io.out := io.in
     }
-    generateFirrtlAndFileCheck(new MyModule)(
-      """|CHECK:      input in : UInt<8>
-         |CHECK-NEXT: output out : UInt<8>
-         |CHECK:      connect out, in
-         |"""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new MyModule)
+      .fileCheck()(
+        """|CHECK:      input in : UInt<8>
+           |CHECK-NEXT: output out : UInt<8>
+           |CHECK:      connect out, in
+           |"""".stripMargin
+      )
   }
 
   it should "support bulk connections between FlatIOs and regular IOs" in {
@@ -38,11 +40,13 @@ class FlatIOSpec extends AnyFlatSpec with Matchers with FileCheck {
       val out = IO(Output(Valid(UInt(8.W))))
       out := in
     }
-    generateFirrtlAndFileCheck(new MyModule)(
-      """|CHECK:      connect out.bits, bits
-         |CHECK-NEXT: connect out.valid, valid
-         |"""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new MyModule)
+      .fileCheck()(
+        """|CHECK:      connect out.bits, bits
+           |CHECK-NEXT: connect out.valid, valid
+           |"""".stripMargin
+      )
   }
 
   it should "support dynamically indexing Vecs inside of FlatIOs" in {
@@ -70,11 +74,13 @@ class FlatIOSpec extends AnyFlatSpec with Matchers with FileCheck {
       })
       io.out <> io.in
     }
-    generateFirrtlAndFileCheck(new MyModule)(
-      """|CHECK:      attach (out.bar, in.bar)
-         |CHECK-NEXT: connect out.foo, in.foo
-         |"""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new MyModule)
+      .fileCheck()(
+        """|CHECK:      attach (out.bar, in.bar)
+           |CHECK-NEXT: connect out.foo, in.foo
+           |"""".stripMargin
+      )
   }
 
   it should "be an `IO` for elements and vectors" in {
@@ -83,11 +89,13 @@ class FlatIOSpec extends AnyFlatSpec with Matchers with FileCheck {
       val a = FlatIO(UInt(1.W))
       val b = FlatIO(Vec(2, UInt(2.W)))
     }
-    generateFirrtlAndFileCheck(new Foo)(
-      """|CHECK:      output a : UInt<1>
-         |CHECK-NEXT: output b : UInt<2>[2]
-         |"""".stripMargin
-    )
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK:      output a : UInt<1>
+           |CHECK-NEXT: output b : UInt<2>[2]
+           |"""".stripMargin
+      )
   }
 
   it should "maintain port order for Bundles" in {
@@ -102,16 +110,20 @@ class FlatIOSpec extends AnyFlatSpec with Matchers with FileCheck {
       val io = FlatIO(Input(new MyBundle))
     }
 
-    generateSystemVerilogAndFileCheck(new MyModule)(
-      """|CHECK:      io_foo
-         |CHECK-NEXT: io_bar
-         |"""".stripMargin
-    )
-    generateSystemVerilogAndFileCheck(new MyFlatIOModule)(
-      """|CHECK:      foo
-         |CHECK-NEXT: bar
-         |"""".stripMargin
-    )
+    ChiselStage
+      .emitSystemVerilog(new MyModule)
+      .fileCheck()(
+        """|CHECK:      io_foo
+           |CHECK-NEXT: io_bar
+           |"""".stripMargin
+      )
+    ChiselStage
+      .emitSystemVerilog(new MyFlatIOModule)
+      .fileCheck()(
+        """|CHECK:      foo
+           |CHECK-NEXT: bar
+           |"""".stripMargin
+      )
   }
 
   it should "maintain port order for Records" in {
@@ -124,16 +136,20 @@ class FlatIOSpec extends AnyFlatSpec with Matchers with FileCheck {
     class MyFlatIOModule extends Module {
       val io = FlatIO(Input(new MyRecord))
     }
-    generateSystemVerilogAndFileCheck(new MyModule)(
-      """|CHECK:      io_bar
-         |CHECK-NEXT: io_foo
-         |"""".stripMargin
-    )
-    generateSystemVerilogAndFileCheck(new MyFlatIOModule)(
-      """|CHECK:      bar
-         |CHECK-NEXT: foo
-         |"""".stripMargin
-    )
+    ChiselStage
+      .emitSystemVerilog(new MyModule)
+      .fileCheck()(
+        """|CHECK:      io_bar
+           |CHECK-NEXT: io_foo
+           |"""".stripMargin
+      )
+    ChiselStage
+      .emitSystemVerilog(new MyFlatIOModule)
+      .fileCheck()(
+        """|CHECK:      bar
+           |CHECK-NEXT: foo
+           |"""".stripMargin
+      )
   }
 
 }

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -6,6 +6,7 @@ package experimental.hierarchy
 import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
+import chisel3.testing.scalatest.FileCheck
 import chiselTests.experimental.ExtensionMethods.ChiselStageHelpers
 import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
@@ -126,48 +127,56 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         val definition: Definition[AddOne] = Definition(new AddOne)
         mark(definition, "mark")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOne"
-           |CHECK-NEXT: "tag":"mark"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOne"
+             |CHECK-NEXT: "tag":"mark"
+             |""".stripMargin
+        )
     }
     it("(1.b): should work on a single definition, annotating an inner wire") {
       class Top extends Module {
         val definition: Definition[AddOne] = Definition(new AddOne)
         mark(definition.innerWire, "i0.innerWire")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
-           |CHECK-NEXT: "tag":"i0.innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
+             |CHECK-NEXT: "tag":"i0.innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.c): should work on a two nested definitions, annotating the definition") {
       class Top extends Module {
         val definition: Definition[AddTwo] = Definition(new AddTwo)
         mark(definition.definition, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.d): should work on an instance in a definition, annotating the instance") {
       class Top extends Module {
         val definition: Definition[AddTwo] = Definition(new AddTwo)
         mark(definition.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.e): should work on a definition in an instance, annotating the definition") {
       class Top extends Module {
@@ -175,36 +184,42 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         val i0 = Instance(definition)
         mark(i0.definition, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.f): should work on a wire in an instance in a definition") {
       class Top extends Module {
         val definition: Definition[AddTwo] = Definition(new AddTwo)
         mark(definition.i0.innerWire, "i0.i0.innerWire")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"i0.i0.innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"i0.i0.innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.g): should work on a nested module in a definition, annotating the module") {
       class Top extends Module {
         val definition: Definition[AddTwoMixedModules] = Definition(new AddTwoMixedModules)
         mark(definition.i1, "i0.i1")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwoMixedModules/i1:AddOne_1"
-           |CHECK-NEXT: "tag":"i0.i1"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwoMixedModules/i1:AddOne_1"
+             |CHECK-NEXT: "tag":"i0.i1"
+             |""".stripMargin
+        )
     }
     // Can you define an instantiable container? I think not.
     // Instead, we can test the instantiable container in a definition
@@ -213,71 +228,83 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         val definition: Definition[AddOneWithInstantiableWire] = Definition(new AddOneWithInstantiableWire)
         mark(definition.wireContainer.innerWire, "i0.innerWire")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableWire>innerWire"
-           |CHECK-NEXT: "tag":"i0.innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableWire>innerWire"
+             |CHECK-NEXT: "tag":"i0.innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.i): should work on an instantiable container, annotating a module") {
       class Top extends Module {
         val definition = Definition(new AddOneWithInstantiableModule)
         mark(definition.moduleContainer.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableModule/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableModule/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.j): should work on an instantiable container, annotating an instance") {
       class Top extends Module {
         val definition = Definition(new AddOneWithInstantiableInstance)
         mark(definition.instanceContainer.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstance/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstance/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.k): should work on an instantiable container, annotating an instantiable container's module") {
       class Top extends Module {
         val definition = Definition(new AddOneWithInstantiableInstantiable)
         mark(definition.containerContainer.container.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstantiable/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.l): should work on public member which references public member of another instance") {
       class Top extends Module {
         val definition = Definition(new AddOneWithInstantiableInstantiable)
         mark(definition.containerContainer.container.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstantiable/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.m): should work for targets on definition to have correct circuit name") {
       class Top extends Module {
         val definition = Definition(new AddOneWithAnnotation)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithAnnotation>innerWire"
-           |CHECK-NEXT: "tag":"innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithAnnotation>innerWire"
+             |CHECK-NEXT: "tag":"innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.n): should work on user-defined types that provide Lookupable") {
       class Top extends Module {
@@ -288,18 +315,20 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(defn.simple.inst, "inst")
         mark(defn.parameterized.inst, "inst2")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasUserDefinedType>wire"
-           |CHECK-NEXT: "tag":"data"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasUserDefinedType/inst0:AddOne"
-           |CHECK-NEXT: "tag":"inst"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasUserDefinedType/inst1:AddOne"
-           |CHECK-NEXT: "tag":"inst2"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasUserDefinedType>wire"
+             |CHECK-NEXT: "tag":"data"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasUserDefinedType/inst0:AddOne"
+             |CHECK-NEXT: "tag":"inst"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasUserDefinedType/inst1:AddOne"
+             |CHECK-NEXT: "tag":"inst2"
+             |""".stripMargin
+        )
     }
   }
   describe("(2): Annotations on designs not in the same chisel compilation") {
@@ -309,35 +338,41 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
       class Top(x: AddTwo) extends Module {
         val parent = Definition(new ViewerParent(x, false, true))
       }
-      generateFirrtlAndFileCheck(new Top(first))(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"first"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top(first))
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"first"
+             |""".stripMargin
+        )
     }
     it("(2.b): should work on an innerWire, marked in a different compilation, in instanced instantiable") {
       class Top(x: AddTwo) extends Module {
         val parent = Definition(new ViewerParent(x, true, false))
       }
-      generateFirrtlAndFileCheck(new Top(first))(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"second"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top(first))
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"second"
+             |""".stripMargin
+        )
     }
     it("(2.c): should work on an innerWire, marked in a different compilation, in instanced module") {
       class Top(x: AddTwo) extends Module {
         val parent = Definition(new ViewerParent(x, false, false))
         mark(parent.viewer.x.i0.innerWire, "third")
       }
-      generateFirrtlAndFileCheck(new Top(first))(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"third"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top(first))
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"third"
+             |""".stripMargin
+        )
     }
   }
   describe("(3): @public") {
@@ -346,24 +381,28 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         val mv = Definition(new MultiVal())
         mark(mv.x, "mv.x")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|MultiVal>x"
-           |CHECK-NEXT: "tag":"mv.x"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|MultiVal>x"
+             |CHECK-NEXT: "tag":"mv.x"
+             |""".stripMargin
+        )
     }
     it("(3.b): should work on lazy vals") {
       class Top() extends Module {
         val lv = Definition(new LazyVal())
         mark(lv.x, lv.y)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|LazyVal>x"
-           |CHECK-NEXT: "tag":"Hi"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|LazyVal>x"
+             |CHECK-NEXT: "tag":"Hi"
+             |""".stripMargin
+        )
     }
     it("(3.c): should work on islookupables") {
       class Top() extends Module {
@@ -371,96 +410,112 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         val up = Definition(new UsesParameters(p))
         mark(up.x, up.y.string + up.y.int)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|UsesParameters>x"
-           |CHECK-NEXT: "tag":"hi0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|UsesParameters>x"
+             |CHECK-NEXT: "tag":"hi0"
+             |""".stripMargin
+        )
     }
     it("(3.d): should work on lists") {
       class Top() extends Module {
         val i = Definition(new HasList())
         mark(i.x(1), i.y(1).toString)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasList>x_1"
-           |CHECK-NEXT: "tag":"2"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasList>x_1"
+             |CHECK-NEXT: "tag":"2"
+             |""".stripMargin
+        )
     }
     it("(3.e): should work on seqs") {
       class Top() extends Module {
         val i = Definition(new HasSeq())
         mark(i.x(1), i.y(1).toString)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasSeq>x_1"
-           |CHECK-NEXT: "tag":"2"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasSeq>x_1"
+             |CHECK-NEXT: "tag":"2"
+             |""".stripMargin
+        )
     }
     it("(3.f): should work on options") {
       class Top() extends Module {
         val i = Definition(new HasOption())
         i.x.map(x => mark(x, "x"))
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasOption>x"
-           |CHECK-NEXT: "tag":"x"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasOption>x"
+             |CHECK-NEXT: "tag":"x"
+             |""".stripMargin
+        )
     }
     it("(3.g): should work on vecs") {
       class Top() extends Module {
         val i = Definition(new HasVec())
         mark(i.x, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasVec>x"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasVec>x"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(3.h): should work on statically indexed vectors external to module") {
       class Top() extends Module {
         val i = Definition(new HasVec())
         mark(i.x(1), "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasVec>x[1]"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasVec>x[1]"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(3.i): should work on statically indexed vectors internal to module") {
       class Top() extends Module {
         val i = Definition(new HasIndexedVec())
         mark(i.y, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasIndexedVec>x[1]"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasIndexedVec>x[1]"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     ignore("(3.j): should work on vals in constructor arguments") {
       class Top() extends Module {
         val i = Definition(new HasPublicConstructorArgs(10))
         // mark(i.x, i.int.toString)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasPublicConstructorArgs>x"
-           |CHECK-NEXT: "tag":"10"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasPublicConstructorArgs>x"
+             |CHECK-NEXT: "tag":"10"
+             |""".stripMargin
+        )
     }
     it("(3.k): should work on unimplemented vals in abstract classes/traits") {
       class Top() extends Module {
@@ -470,12 +525,14 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         }
         f(i)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ConcreteHasBlah"
-           |CHECK-NEXT: "tag":"10"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ConcreteHasBlah"
+             |CHECK-NEXT: "tag":"10"
+             |""".stripMargin
+        )
     }
     it("(3.l): should work on eithers") {
       class Top() extends Module {
@@ -483,15 +540,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         i.x.map(x => mark(x, "xright")).left.map(x => mark(x, "xleft"))
         i.y.map(x => mark(x, "yright")).left.map(x => mark(x, "yleft"))
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasEither>x"
-           |CHECK-NEXT: "tag":"xright"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasEither>y"
-           |CHECK-NEXT: "tag":"yleft"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasEither>x"
+             |CHECK-NEXT: "tag":"xright"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasEither>y"
+             |CHECK-NEXT: "tag":"yleft"
+             |""".stripMargin
+        )
     }
     it("(3.m): should work on tuple2") {
       class Top() extends Module {
@@ -499,15 +558,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(i.xy._1, "x")
         mark(i.xy._2, "y")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasTuple2>x"
-           |CHECK-NEXT: "tag":"x"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasTuple2>y"
-           |CHECK-NEXT: "tag":"y"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasTuple2>x"
+             |CHECK-NEXT: "tag":"x"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasTuple2>y"
+             |CHECK-NEXT: "tag":"y"
+             |""".stripMargin
+        )
     }
     it("(3.n): should work on Mems/SyncReadMems") {
       class Top() extends Module {
@@ -515,15 +576,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(i.mem, "Mem")
         mark(i.syncReadMem, "SyncReadMem")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasMems>mem"
-           |CHECK-NEXT: "tag":"Mem"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasMems>syncReadMem"
-           |CHECK-NEXT: "tag":"SyncReadMem"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasMems>mem"
+             |CHECK-NEXT: "tag":"Mem"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasMems>syncReadMem"
+             |CHECK-NEXT: "tag":"SyncReadMem"
+             |""".stripMargin
+        )
     }
     it("(3.o): should not create memory ports") {
       class Top() extends Module {
@@ -541,12 +604,14 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         val i = Definition(new HasHasTarget)
         mark(i.x, "x")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasHasTarget>sram_sram"
-           |CHECK-NEXT: "tag":"x"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasHasTarget>sram_sram"
+             |CHECK-NEXT: "tag":"x"
+             |""".stripMargin
+        )
     }
     it("(3.q): should work on Tuple5 with a Module in it") {
       class Top() extends Module {
@@ -556,15 +621,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(w, "wire")
         mark(inst, "inst")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasTuple5>wire"
-           |CHECK-NEXT: "tag":"wire"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasTuple5/inst:AddOne"
-           |CHECK-NEXT: "tag":"inst"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasTuple5>wire"
+             |CHECK-NEXT: "tag":"wire"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasTuple5/inst:AddOne"
+             |CHECK-NEXT: "tag":"inst"
+             |""".stripMargin
+        )
     }
   }
   describe("(4): toDefinition") {
@@ -574,12 +641,14 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         f(i.toDefinition)
       }
       def f(i: Definition[AddOne]): Unit = mark(i.innerWire, "blah")
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(4.b): should work on seqs of modules") {
       class Top() extends Module {
@@ -587,12 +656,14 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(f(is), "blah")
       }
       def f(i: Seq[Definition[AddTwo]]): Data = i.head.i0.innerWire
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(4.c): should work on options of modules") {
       class Top() extends Module {
@@ -600,12 +671,14 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(f(is), "blah")
       }
       def f(i: Option[Definition[AddTwo]]): Data = i.get.i0.innerWire
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
   }
   describe("(5): Absolute Targets should work as expected") {
@@ -614,48 +687,56 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         val i = Definition(new AddTwo())
         amark(i.in, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo>in"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo>in"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.b): toAbsoluteTarget on a subinstance's data within a definition") {
       class Top() extends Module {
         val i = Definition(new AddTwo())
         amark(i.i0.innerWire, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.c): toAbsoluteTarget on a submodule's data within a definition") {
       class Top() extends Module {
         val i = Definition(new AddTwoMixedModules())
         amark(i.i1.in, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwoMixedModules/i1:AddOne_1>in"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwoMixedModules/i1:AddOne_1>in"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.d): toAbsoluteTarget on a submodule's data, in an aggregate, within a definition") {
       class Top() extends Module {
         val i = Definition(new InstantiatesHasVec())
         amark(i.i1.x.head, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|InstantiatesHasVec/i1:HasVec_1>x[0]"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|InstantiatesHasVec/i1:HasVec_1>x[0]"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
   }
   describe("(6): @instantiable traits should work as expected") {
@@ -682,15 +763,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(i.io.in, "gotcha")
         mark(i, "inst")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>io.in"
-           |CHECK-NEXT: "tag":"gotcha"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf"
-           |CHECK-NEXT: "tag":"inst"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "tag":"gotcha"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf"
+             |CHECK-NEXT: "tag":"inst"
+             |""".stripMargin
+        )
     }
     it(
       "(6.b): An @instantiable Module implementing an @instantiable trait should be able to use extension methods from both"
@@ -701,18 +784,20 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(i.sum, "also this")
         mark(i, "inst")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>io.in"
-           |CHECK-NEXT: "tag":"gotcha"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>sum"
-           |CHECK-NEXT: "tag":"also this"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf"
-           |CHECK-NEXT: "tag":"inst"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "tag":"gotcha"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>sum"
+             |CHECK-NEXT: "tag":"also this"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf"
+             |CHECK-NEXT: "tag":"inst"
+             |""".stripMargin
+        )
     }
     it("(6.c): A BlackBox that implements an @instantiable trait should be instantiable as that trait") {
       class Top extends Module {
@@ -721,15 +806,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(d.io.in, "gotcha")
         mark(d, "module")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
-           |CHECK-NEXT: "tag":"gotcha"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf"
-           |CHECK-NEXT: "tag":"module"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "tag":"gotcha"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf"
+             |CHECK-NEXT: "tag":"module"
+             |""".stripMargin
+        )
     }
     it("(6.d): It should be possible to have Vectors of @instantiable traits mixing concrete subclasses") {
       class Top extends Module {
@@ -743,18 +830,20 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(insts(1).io.in, "bar")
         mark(insts(2).io.in, "fizz")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfY>io.in"
-           |CHECK-NEXT: "tag":"foo"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
-           |CHECK-NEXT: "tag":"bar"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfX>io.in"
-           |CHECK-NEXT: "tag":"fizz"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfY>io.in"
+             |CHECK-NEXT: "tag":"foo"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "tag":"bar"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfX>io.in"
+             |CHECK-NEXT: "tag":"fizz"
+             |""".stripMargin
+        )
     }
   }
   describe("(7): @instantiable and @public should compose with DataView") {
@@ -780,22 +869,24 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(d.foo, "foo")
         mark(d.bar, "bar")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|MyModule>out"
-           |CHECK-NEXT: "tag":"out"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|MyModule>in"
-           |CHECK-NEXT: "tag":"foo"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|MyModule>sum"
-           |CHECK-NEXT: "tag":"bar"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.in, foo
-           |CHECK:        connect bar, i.out
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|MyModule>out"
+             |CHECK-NEXT: "tag":"out"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|MyModule>in"
+             |CHECK-NEXT: "tag":"foo"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|MyModule>sum"
+             |CHECK-NEXT: "tag":"bar"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.in, foo
+             |CHECK:        connect bar, i.out
+             |""".stripMargin
+        )
     }
     ignore("(7.b): should work on Aggregate Views that are mapped 1:1") {
       import chiselTests.experimental.SimpleBundleDataView._
@@ -817,19 +908,21 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         mark(d.in, "in")
         mark(d.in.bar, "in_bar")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|MyModule>a"
-           |CHECK-NEXT: "tag":"in"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|MyModule>a.foo"
-           |CHECK-NEXT: "tag":"in_bar"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.a, foo
-           |CHECK:        connct bar, i.b.foo
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|MyModule>a"
+             |CHECK-NEXT: "tag":"in"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|MyModule>a.foo"
+             |CHECK-NEXT: "tag":"in_bar"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.a, foo
+             |CHECK:        connct bar, i.b.foo
+             |""".stripMargin
+        )
     }
   }
 }

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -6,6 +6,7 @@ package experimental.hierarchy
 import chisel3._
 import chisel3.experimental.BaseModule
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.{DecoupledIO, Valid}
 import chisel3.experimental.{attach, Analog}
 import chisel3.stage.{ChiselGeneratorAnnotation, DesignAnnotation}
@@ -112,12 +113,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0:         Instance[AddOne] = Instance(definition)
         mark(i0, "i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0"
+             |""".stripMargin
+        )
     }
     it("(1.b): should work on a single instance, annotating an inner wire") {
       class Top extends Module {
@@ -125,12 +128,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0:         Instance[AddOne] = Instance(definition)
         mark(i0.innerWire, "i0.innerWire")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"i0.innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"i0.innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.c): should work on a two nested instances, annotating the instance") {
       class Top extends Module {
@@ -138,12 +143,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0:         Instance[AddTwo] = Instance(definition)
         mark(i0.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddTwo/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddTwo/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.d): should work on a two nested instances, annotating the inner wire") {
       class Top extends Module {
@@ -151,12 +158,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0:         Instance[AddTwo] = Instance(definition)
         mark(i0.i0.innerWire, "i0.i0.innerWire")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"i0.i0.innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"i0.i0.innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.e): should work on a nested module in an instance, annotating the module") {
       class Top extends Module {
@@ -164,12 +173,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0:         Instance[AddTwoMixedModules] = Instance(definition)
         mark(i0.i1, "i0.i1")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddTwoMixedModules/i1:AddOne_1"
-           |CHECK-NEXT: "tag":"i0.i1"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddTwoMixedModules/i1:AddOne_1"
+             |CHECK-NEXT: "tag":"i0.i1"
+             |""".stripMargin
+        )
     }
     it("(1.f): should work on an instantiable container, annotating a wire") {
       class Top extends Module {
@@ -177,12 +188,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0:         Instance[AddOneWithInstantiableWire] = Instance(definition)
         mark(i0.wireContainer.innerWire, "i0.innerWire")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableWire>innerWire"
-           |CHECK-NEXT: "tag":"i0.innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableWire>innerWire"
+             |CHECK-NEXT: "tag":"i0.innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.g): should work on an instantiable container, annotating a module") {
       class Top extends Module {
@@ -190,12 +203,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0 = Instance(definition)
         mark(i0.moduleContainer.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableModule/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableModule/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.h): should work on an instantiable container, annotating an instance") {
       class Top extends Module {
@@ -203,12 +218,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0 = Instance(definition)
         mark(i0.instanceContainer.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstance/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstance/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.i): should work on an instantiable container, annotating an instantiable container's module") {
       class Top extends Module {
@@ -216,12 +233,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0 = Instance(definition)
         mark(i0.containerContainer.container.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.j): should work on public member which references public member of another instance") {
       class Top extends Module {
@@ -229,12 +248,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0 = Instance(definition)
         mark(i0.containerContainer.container.i0, "i0.i0")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
-           |CHECK-NEXT: "tag":"i0.i0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "tag":"i0.i0"
+             |""".stripMargin
+        )
     }
     it("(1.k): should work for targets on definition to have correct circuit name") {
       class Top extends Module {
@@ -242,12 +263,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val definition = Definition(new AddOneWithAnnotation)
         val i0 = Instance(definition)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithAnnotation>innerWire"
-           |CHECK-NEXT: "tag":"innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithAnnotation>innerWire"
+             |CHECK-NEXT: "tag":"innerWire"
+             |""".stripMargin
+        )
     }
     it("(1.l): should work on things with type parameters") {
       class Top extends Module {
@@ -255,12 +278,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i0 = Instance(definition)
         mark(i0.blah, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:HasTypeParams>blah"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:HasTypeParams>blah"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(1.m): should work on Analog wires") {
       class Top extends Module {
@@ -270,15 +295,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         attach(port, i0.port)
         mark(i0.wire, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:HasAnalogWire>wire"
-           |CHECK-NEXT: "tag":"blah"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        attach (port, i0.port)
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:HasAnalogWire>wire"
+             |CHECK-NEXT: "tag":"blah"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        attach (port, i0.port)
+             |""".stripMargin
+        )
     }
     it("(1.n): should work on user-defined types that provide Lookupable") {
       class Top extends Module {
@@ -290,18 +317,20 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i0.simple.inst, "inst")
         mark(i0.parameterized.inst, "inst2")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType>wire"
-           |CHECK-NEXT: "tag":"data"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType/inst0:AddOne"
-           |CHECK-NEXT: "tag":"inst"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType/inst1:AddOne"
-           |CHECK-NEXT: "tag":"inst2"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType>wire"
+             |CHECK-NEXT: "tag":"data"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType/inst0:AddOne"
+             |CHECK-NEXT: "tag":"inst"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType/inst1:AddOne"
+             |CHECK-NEXT: "tag":"inst2"
+             |""".stripMargin
+        )
     }
   }
   describe("(2) Annotations on designs not in the same chisel compilation") {
@@ -318,23 +347,27 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       class Top(x: AddTwo) extends Module {
         val parent = Instance(Definition(new ViewerParent(x, false, true)))
       }
-      generateFirrtlAndFileCheck(new Top(first))(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"first"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top(first))
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"first"
+             |""".stripMargin
+        )
     }
     it("(2.b): should work on an innerWire, marked in a different compilation, in instanced instantiable") {
       class Top(x: AddTwo) extends Module {
         val parent = Instance(Definition(new ViewerParent(x, true, false)))
       }
-      generateFirrtlAndFileCheck(new Top(first))(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"second"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top(first))
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"second"
+             |""".stripMargin
+        )
     }
     it("(2.c): should work on an innerWire, marked in a different compilation, in instanced module") {
       class Top(x: AddTwo) extends Module {
@@ -342,12 +375,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val parent = Instance(d)
         mark(parent.viewer.x.i0.innerWire, "third")
       }
-      generateFirrtlAndFileCheck(new Top(first))(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"third"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top(first))
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"third"
+             |""".stripMargin
+        )
     }
   }
   describe("(3) @public") {
@@ -356,24 +391,28 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val mv = Instance(Definition(new MultiVal()))
         mark(mv.x, "mv.x")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/mv:MultiVal>x"
-           |CHECK-NEXT: "tag":"mv.x"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/mv:MultiVal>x"
+             |CHECK-NEXT: "tag":"mv.x"
+             |""".stripMargin
+        )
     }
     it("(3.b): should work on lazy vals") {
       class Top() extends Module {
         val lv = Instance(Definition(new LazyVal()))
         mark(lv.x, lv.y)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/lv:LazyVal>x"
-           |CHECK-NEXT: "tag":"Hi"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/lv:LazyVal>x"
+             |CHECK-NEXT: "tag":"Hi"
+             |""".stripMargin
+        )
     }
     it("(3.c): should work on islookupables") {
       class Top() extends Module {
@@ -381,84 +420,98 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val up = Instance(Definition(new UsesParameters(p)))
         mark(up.x, up.y.string + up.y.int)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/up:UsesParameters>x"
-           |CHECK-NEXT: "tag":"hi0"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/up:UsesParameters>x"
+             |CHECK-NEXT: "tag":"hi0"
+             |""".stripMargin
+        )
     }
     it("(3.d): should work on lists") {
       class Top() extends Module {
         val i = Instance(Definition(new HasList()))
         mark(i.x(1), i.y(1).toString)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasList>x_1"
-           |CHECK-NEXT: "tag":"2"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasList>x_1"
+             |CHECK-NEXT: "tag":"2"
+             |""".stripMargin
+        )
     }
     it("(3.e): should work on seqs") {
       class Top() extends Module {
         val i = Instance(Definition(new HasSeq()))
         mark(i.x(1), i.y(1).toString)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasSeq>x_1"
-           |CHECK-NEXT: "tag":"2"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasSeq>x_1"
+             |CHECK-NEXT: "tag":"2"
+             |""".stripMargin
+        )
     }
     it("(3.f): should work on options") {
       class Top() extends Module {
         val i = Instance(Definition(new HasOption()))
         i.x.map(x => mark(x, "x"))
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasOption>x"
-           |CHECK-NEXT: "tag":"x"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasOption>x"
+             |CHECK-NEXT: "tag":"x"
+             |""".stripMargin
+        )
     }
     it("(3.g): should work on vecs") {
       class Top() extends Module {
         val i = Instance(Definition(new HasVec()))
         mark(i.x, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasVec>x"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasVec>x"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(3.h): should work on statically indexed vectors external to module") {
       class Top() extends Module {
         val i = Instance(Definition(new HasVec()))
         mark(i.x(1), "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasVec>x[1]"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasVec>x[1]"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(3.i): should work on statically indexed vectors internal to module") {
       class Top() extends Module {
         val i = Instance(Definition(new HasIndexedVec()))
         mark(i.y, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasIndexedVec>x[1]"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasIndexedVec>x[1]"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(3.j): should work on accessed subfields of aggregate ports") {
       class Top extends Module {
@@ -469,31 +522,35 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.valid, "valid")
         mark(i.bits, "bits")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasSubFieldAccess>in.valid"
-           |CHECK-NEXT: "tag":"valid"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasSubFieldAccess>in.bits"
-           |CHECK-NEXT: "tag":"bits"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.in.valid, input.valid
-           |CHECK:        connect i.in.bits, input.bits
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasSubFieldAccess>in.valid"
+             |CHECK-NEXT: "tag":"valid"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasSubFieldAccess>in.bits"
+             |CHECK-NEXT: "tag":"bits"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.in.valid, input.valid
+             |CHECK:        connect i.in.bits, input.bits
+             |""".stripMargin
+        )
     }
     ignore("(3.k): should work on vals in constructor arguments") {
       class Top() extends Module {
         val i = Instance(Definition(new HasPublicConstructorArgs(10)))
         // mark(i.x, i.int.toString)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasPublicConstructorArgs>x"
-           |CHECK-NEXT: "tag":"10"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasPublicConstructorArgs>x"
+             |CHECK-NEXT: "tag":"10"
+             |""".stripMargin
+        )
     }
     it("(3.l): should work on eithers") {
       class Top() extends Module {
@@ -501,15 +558,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         i.x.map(x => mark(x, "xright")).left.map(x => mark(x, "xleft"))
         i.y.map(x => mark(x, "yright")).left.map(x => mark(x, "yleft"))
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasEither>x"
-           |CHECK-NEXT: "tag":"xright"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasEither>y"
-           |CHECK-NEXT: "tag":"yleft"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasEither>x"
+             |CHECK-NEXT: "tag":"xright"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasEither>y"
+             |CHECK-NEXT: "tag":"yleft"
+             |""".stripMargin
+        )
     }
     it("(3.m): should work on tuple2") {
       class Top() extends Module {
@@ -517,15 +576,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.xy._1, "x")
         mark(i.xy._2, "y")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasTuple2>x"
-           |CHECK-NEXT: "tag":"x"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasTuple2>y"
-           |CHECK-NEXT: "tag":"y"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple2>x"
+             |CHECK-NEXT: "tag":"x"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple2>y"
+             |CHECK-NEXT: "tag":"y"
+             |""".stripMargin
+        )
     }
 
     it("(3.n): should properly support val modifiers") {
@@ -556,41 +617,49 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.mem, "Mem")
         mark(i.syncReadMem, "SyncReadMem")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasMems>mem"
-           |CHECK-NEXT: "tag":"Mem"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasMems>syncReadMem"
-           |CHECK-NEXT: "tag":"SyncReadMem"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasMems>mem"
+             |CHECK-NEXT: "tag":"Mem"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasMems>syncReadMem"
+             |CHECK-NEXT: "tag":"SyncReadMem"
+             |""".stripMargin
+        )
     }
     it("(3.p): should make connectable IOs on nested IsInstantiables that have IO Datas in them") {
-      generateFirrtlAndFileCheck(new AddTwoNestedInstantiableData(4))(
-        """|CHECK-COUNT-3: connect i1.in, i0.out
-           |CHECK-NOT:     connect i1.in, i0.out
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new AddTwoNestedInstantiableData(4))
+        .fileCheck()(
+          """|CHECK-COUNT-3: connect i1.in, i0.out
+             |CHECK-NOT:     connect i1.in, i0.out
+             |""".stripMargin
+        )
     }
     it(
       "(3.q): should make connectable IOs on nested IsInstantiables's Data when the Instance and Definition do not have the same parent"
     ) {
-      generateFirrtlAndFileCheck(new AddTwoNestedInstantiableDataWrapper(4))("""|CHECK-COUNT-3: connect i1.in, i0.out
-                                                                                |CHECK-NOT:     connect i1.in, i0.out
-                                                                                |""".stripMargin)
+      ChiselStage
+        .emitCHIRRTL(new AddTwoNestedInstantiableDataWrapper(4))
+        .fileCheck()("""|CHECK-COUNT-3: connect i1.in, i0.out
+                        |CHECK-NOT:     connect i1.in, i0.out
+                        |""".stripMargin)
     }
     it("(3.r): should work on HasTarget") {
       class Top() extends Module {
         val i = Instance(Definition(new HasHasTarget))
         mark(i.x, "x")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasHasTarget>sram_sram"
-           |CHECK-NEXT: "tag":"x"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasHasTarget>sram_sram"
+             |CHECK-NEXT: "tag":"x"
+             |""".stripMargin
+        )
     }
     it("(3.s): should work on Unit") {
       class Top extends Module {
@@ -599,12 +668,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.y._1, "y_1")
         i.y._2 should be(())
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasPublicUnit>y_1"
-           |CHECK-NEXT: "tag":"y_1"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasPublicUnit>y_1"
+             |CHECK-NEXT: "tag":"y_1"
+             |""".stripMargin
+        )
     }
     it("(3.t): should work on Tuple5 with a Module in it") {
       class Top() extends Module {
@@ -614,15 +685,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(w, "wire")
         mark(inst, "inst")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasTuple5>wire"
-           |CHECK-NEXT: "tag":"wire"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasTuple5/inst:AddOne"
-           |CHECK-NEXT: "tag":"inst"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple5>wire"
+             |CHECK-NEXT: "tag":"wire"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple5/inst:AddOne"
+             |CHECK-NEXT: "tag":"inst"
+             |""".stripMargin
+        )
     }
   }
   describe("(4) toInstance") {
@@ -633,12 +706,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       }
       def f(i: Instance[AddOne]): Unit = mark(i.innerWire, "blah")
       // TODO: Should this be ~Top|Top/i:AddOne>innerWire ???
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(4.b): should work on IsInstantiable") {
       class Top() extends Module {
@@ -647,12 +722,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(f(v.toInstance), "blah")
       }
       def f(i: Instance[Viewer]): Data = i.x.i0.innerWire
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(4.c): should work on seqs of modules") {
       class Top() extends Module {
@@ -661,12 +738,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       }
       def f(i: Seq[Instance[AddTwo]]): Data = i.head.i0.innerWire
       // TODO: Should this be ~Top|Top... ??
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(4.d): should work on seqs of IsInstantiable") {
       class Top() extends Module {
@@ -675,12 +754,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(f(vs), "blah")
       }
       def f(i: Seq[Instance[Viewer]]): Data = i.head.x.i0.innerWire
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(4.e): should work on options of modules") {
       class Top() extends Module {
@@ -688,12 +769,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(f(is), "blah")
       }
       def f(i: Option[Instance[AddTwo]]): Data = i.get.i0.innerWire
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
   }
   describe("(5) Absolute Targets should work as expected") {
@@ -702,48 +785,56 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i = Instance(Definition(new AddTwo()))
         amark(i.in, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:AddTwo>in"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:AddTwo>in"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.b): toAbsoluteTarget on a subinstance's data within an instance") {
       class Top() extends Module {
         val i = Instance(Definition(new AddTwo()))
         amark(i.i0.innerWire, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:AddTwo/i0:AddOne>innerWire"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.c): toAbsoluteTarget on a submodule's data within an instance") {
       class Top() extends Module {
         val i = Instance(Definition(new AddTwoMixedModules()))
         amark(i.i1.in, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:AddTwoMixedModules/i1:AddOne_1>in"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:AddTwoMixedModules/i1:AddOne_1>in"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.d): toAbsoluteTarget on a submodule's data, in an aggregate, within an instance") {
       class Top() extends Module {
         val i = Instance(Definition(new InstantiatesHasVec()))
         amark(i.i1.x.head, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0]"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0]"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.e): toAbsoluteTarget on a submodule's data, in an aggregate, within an instance, ILit") {
       class MyBundle extends Bundle { val x = UInt(3.W) }
@@ -760,36 +851,42 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val i = Instance(Definition(new InstantiatesHasVec()))
         amark(i.i1.x.head.x, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0].x"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0].x"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.f): toAbsoluteTarget on a subinstance") {
       class Top() extends Module {
         val i = Instance(Definition(new AddTwo()))
         amark(i.i1, "blah")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:AddTwo/i1:AddOne"
-           |CHECK-NEXT: "tag":"blah"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:AddTwo/i1:AddOne"
+             |CHECK-NEXT: "tag":"blah"
+             |""".stripMargin
+        )
     }
     it("(5.g): should work for absolute targets on definition to have correct circuit name") {
       class Top extends Module {
         val definition = Definition(new AddOneWithAbsoluteAnnotation)
         val i0 = Instance(definition)
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|AddOneWithAbsoluteAnnotation>innerWire"
-           |CHECK-NEXT: "tag":"innerWire"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|AddOneWithAbsoluteAnnotation>innerWire"
+             |CHECK-NEXT: "tag":"innerWire"
+             |""".stripMargin
+        )
     }
   }
   describe("(6) @instantiable traits should work as expected") {
@@ -816,15 +913,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.io.in, "gotcha")
         mark(i, "inst")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>io.in"
-           |CHECK-NEXT: "tag":"gotcha"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf"
-           |CHECK-NEXT: "tag":"inst"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "tag":"gotcha"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf"
+             |CHECK-NEXT: "tag":"inst"
+             |""".stripMargin
+        )
     }
     it(
       "(6.b): An @instantiable Module that implements an @instantiable trait should be able to use extension methods from both"
@@ -835,18 +934,20 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.sum, "also this")
         mark(i, "inst")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>io.in"
-           |CHECK-NEXT: "tag":"gotcha"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>sum"
-           |CHECK-NEXT: "tag":"also this"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf"
-           |CHECK-NEXT: "tag":"inst"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "tag":"gotcha"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>sum"
+             |CHECK-NEXT: "tag":"also this"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf"
+             |CHECK-NEXT: "tag":"inst"
+             |""".stripMargin
+        )
     }
     it("(6.c): A BlackBox that implements an @instantiable trait should be instantiable as that trait") {
       class Top extends Module {
@@ -854,15 +955,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.io.in, "gotcha")
         mark(i, "module")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
-           |CHECK-NEXT: "tag":"gotcha"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf"
-           |CHECK-NEXT: "tag":"module"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "tag":"gotcha"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf"
+             |CHECK-NEXT: "tag":"module"
+             |""".stripMargin
+        )
     }
     it("(6.d): It should be possible to have Vectors of @instantiable traits mixing concrete subclasses") {
       class Top extends Module {
@@ -876,18 +979,20 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(insts(1).io.in, "bar")
         mark(insts(2).io.in, "fizz")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfY>io.in"
-           |CHECK-NEXT: "tag":"foo"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
-           |CHECK-NEXT: "tag":"bar"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/insts_2:ModuleWithCommonIntfX>io.in"
-           |CHECK-NEXT: "tag":"fizz"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfY>io.in"
+             |CHECK-NEXT: "tag":"foo"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "tag":"bar"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/insts_2:ModuleWithCommonIntfX>io.in"
+             |CHECK-NEXT: "tag":"fizz"
+             |""".stripMargin
+        )
     }
   }
   // TODO don't forget to test this with heterogeneous Views (eg. viewing a tuple of a port and non-port as a single Bundle)
@@ -913,22 +1018,24 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.foo, "foo")
         mark(i.bar, "bar")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>out"
-           |CHECK-NEXT: "tag":"out"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>in"
-           |CHECK-NEXT: "tag":"foo"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>sum"
-           |CHECK-NEXT: "tag":"bar"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.in, foo
-           |CHECK:        connect bar, i.out
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>out"
+             |CHECK-NEXT: "tag":"out"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>in"
+             |CHECK-NEXT: "tag":"foo"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>sum"
+             |CHECK-NEXT: "tag":"bar"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.in, foo
+             |CHECK:        connect bar, i.out
+             |""".stripMargin
+        )
     }
 
     ignore("(7.b): should work on Aggregate Views") {
@@ -957,34 +1064,36 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.deq.bits.fizz, "deq.bits.fizz")
         mark(i.enq_valid, "enq_valid")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
-           |CHECK-NEXT: "tag":"enq"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.fizz"
-           |CHECK-NEXT: "tag":"enq.bits"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.buzz"
-           |CHECK-NEXT: "tag":"enq.bits"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b.fizz"
-           |CHECK-NEXT: "tag":"deq.bits.fizz"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.valid"
-           |CHECK-NEXT: "tag":"enq_valid"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.a.valid, foo.valid
-           |CHECK:        connect foo.ready, i.a.ready
-           |CHECK:        connect i.a.fizz, foo.bits.fizz
-           |CHECK:        connect i.a.buzz, foo.bits.buzz
-           |CHECK:        connect bar.valid, i.b.valid
-           |CHECK:        connect i.b.ready, bar.ready
-           |CHECK:        connect bar.bits.fizz, i.b.fizz
-           |CHECK:        connect bar.bits.buzz, i.b.buzz
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
+             |CHECK-NEXT: "tag":"enq"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.fizz"
+             |CHECK-NEXT: "tag":"enq.bits"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.buzz"
+             |CHECK-NEXT: "tag":"enq.bits"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b.fizz"
+             |CHECK-NEXT: "tag":"deq.bits.fizz"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.valid"
+             |CHECK-NEXT: "tag":"enq_valid"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.a.valid, foo.valid
+             |CHECK:        connect foo.ready, i.a.ready
+             |CHECK:        connect i.a.fizz, foo.bits.fizz
+             |CHECK:        connect i.a.buzz, foo.bits.buzz
+             |CHECK:        connect bar.valid, i.b.valid
+             |CHECK:        connect i.b.ready, bar.ready
+             |CHECK:        connect bar.bits.fizz, i.b.fizz
+             |CHECK:        connect bar.bits.buzz, i.b.buzz
+             |""".stripMargin
+        )
     }
 
     it("(7.c): should work on views of views") {
@@ -1007,19 +1116,21 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.in, "in")
         mark(i.out.bar, "out_bar")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
-           |CHECK-NEXT: "tag":"in"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b.foo"
-           |CHECK-NEXT: "tag":"out_bar"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.a, foo
-           |CHECK:        connect bar.bar, i.b.foo
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
+             |CHECK-NEXT: "tag":"in"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b.foo"
+             |CHECK-NEXT: "tag":"out_bar"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.a, foo
+             |CHECK:        connect bar.bar, i.b.foo
+             |""".stripMargin
+        )
     }
 
     it("(7.d): should work with DataView + implicit conversion") {
@@ -1038,19 +1149,21 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         i.ports <> Seq(foo, bar)
         mark(i.ports, "i.ports")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
-           |CHECK-NEXT: "tag":"i.ports"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b"
-           |CHECK-NEXT: "tag":"i.ports"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.a, foo
-           |CHECK:        connect bar, i.b
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
+             |CHECK-NEXT: "tag":"i.ports"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b"
+             |CHECK-NEXT: "tag":"i.ports"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.a, foo
+             |CHECK:        connect bar, i.b
+             |""".stripMargin
+        )
     }
 
     it("(7.e): should work on Views of BlackBoxes") {
@@ -1076,25 +1189,27 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(i.innerView.in, "i.innerView.in")
         mark(outerView.out, "outerView.out")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>in"
-           |CHECK-NEXT: "tag":"i.foo"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>out"
-           |CHECK-NEXT: "tag":"i.bar"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>in"
-           |CHECK-NEXT: "tag":"i.innerView.in"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>out"
-           |CHECK-NEXT: "tag":"outerView.out"
-           |
-           |CHECK:      public module Top :
-           |CHECK:        connect i.in, foo
-           |CHECK:        connect bar, i.out
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>in"
+             |CHECK-NEXT: "tag":"i.foo"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>out"
+             |CHECK-NEXT: "tag":"i.bar"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>in"
+             |CHECK-NEXT: "tag":"i.innerView.in"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>out"
+             |CHECK-NEXT: "tag":"outerView.out"
+             |
+             |CHECK:      public module Top :
+             |CHECK:        connect i.in, foo
+             |CHECK:        connect bar, i.out
+             |""".stripMargin
+        )
     }
   }
 
@@ -1113,15 +1228,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val bun = d.c("io").asInstanceOf[Record]
         mark(bun.elements("out"), "c.io.out")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasCMAR/c:AggregatePortModule>io"
-           |CHECK-NEXT: "tag":"c.io"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|HasCMAR/c:AggregatePortModule>io.out"
-           |CHECK-NEXT: "tag":"c.io.out"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasCMAR/c:AggregatePortModule>io"
+             |CHECK-NEXT: "tag":"c.io"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|HasCMAR/c:AggregatePortModule>io.out"
+             |CHECK-NEXT: "tag":"c.io.out"
+             |""".stripMargin
+        )
     }
     it("(8.b): it should support @public on a CMAR Record in Instances") {
       @instantiable
@@ -1137,15 +1254,17 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         val bun = i.c("io").asInstanceOf[Record]
         mark(bun.elements("out"), "i.c.io.out")
       }
-      generateFirrtlAndFileCheck(new Top)(
-        """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasCMAR/c:AggregatePortModule>io"
-           |CHECK-NEXT: "tag":"i.c.io"
-           |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-           |CHECK-NEXT: "target":"~Top|Top/i:HasCMAR/c:AggregatePortModule>io.out"
-           |CHECK-NEXT: "tag":"i.c.io.out"
-           |""".stripMargin
-      )
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasCMAR/c:AggregatePortModule>io"
+             |CHECK-NEXT: "tag":"i.c.io"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~Top|Top/i:HasCMAR/c:AggregatePortModule>io.out"
+             |CHECK-NEXT: "tag":"i.c.io.out"
+             |""".stripMargin
+        )
     }
   }
   describe("(9) isA[..]") {

--- a/src/test/scala-2/chiselTests/properties/ClassSpec.scala
+++ b/src/test/scala-2/chiselTests/properties/ClassSpec.scala
@@ -5,7 +5,7 @@ package chiselTests.properties
 import chisel3._
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
 import chisel3.properties.{Class, DynamicObject, Property}
-import chiselTests.FileCheck
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,13 +14,13 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
   behavior.of("Class")
 
   it should "serialize to FIRRTL with anonymous names" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         Definition(new Class)
         Definition(new Class)
         Definition(new Class)
       }
-    }(
+    }.fileCheck()(
       """|CHECK: class Class
          |CHECK: class Class_1
          |CHECK: class Class_2
@@ -45,14 +45,14 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support Property type ports" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         Definition(new Class {
           val in = IO(Input(Property[Int]()))
           val out = IO(Output(Property[Int]()))
         })
       }
-    }(
+    }.fileCheck()(
       """|CHECK: input in : Integer
          |CHECK: output out : Integer
          |""".stripMargin
@@ -84,7 +84,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support instantiation through its own API" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = Definition(new Class {
           override def desiredName = "Test"
@@ -96,7 +96,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
         val obj1 = Class.unsafeGetDynamicObject("Test")
         val obj2 = Class.unsafeGetDynamicObject("Test")
       }
-    }(
+    }.fileCheck()(
       """|CHECK: class Test
          |CHECK: object obj1 of Test
          |CHECK: object obj2 of Test
@@ -105,7 +105,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support instantiation within a Class" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = Definition(new Class {
           override def desiredName = "Test"
@@ -119,7 +119,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
           val obj1 = Class.unsafeGetDynamicObject("Test")
         })
       }
-    }(
+    }.fileCheck()(
       """|CHECK: class Test
          |CHECK: class Parent
          |CHECK: object obj1 of Test
@@ -128,7 +128,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support instantiation with Instance" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = Definition(new Class {
           override def desiredName = "Test"
@@ -140,7 +140,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
         val obj1 = Instance(cls)
         val obj2 = Instance(cls)
       }
-    }(
+    }.fileCheck()(
       """|CHECK:         class Test
          |CHECK:         object obj1 of Test
          |CHECK:         object obj2 of Test
@@ -149,7 +149,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support @instantiable and @public" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       @instantiable
       class Test extends Class {
         @public val in = IO(Input(Property[Int]()))
@@ -165,7 +165,7 @@ class ClassSpec extends AnyFlatSpec with Matchers with FileCheck {
 
         obj2.in := obj1.out
       }
-    }(
+    }.fileCheck()(
       """|CHECK-LABEL: class Test
          |CHECK-LABEL: public module
          |CHECK:         object obj1 of Test

--- a/src/test/scala-2/chiselTests/properties/ObjectSpec.scala
+++ b/src/test/scala-2/chiselTests/properties/ObjectSpec.scala
@@ -5,8 +5,8 @@ package chiselTests.properties
 import chisel3._
 import chisel3.experimental.hierarchy.{Definition, Instance}
 import chisel3.properties.{Class, DynamicObject, Property}
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.experimental.BoringUtils
-import chiselTests.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -15,7 +15,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   behavior.of("DynamicObject")
 
   it should "support Objects in Class ports" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = Definition(new Class {
           override def desiredName = "Test"
@@ -31,7 +31,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
           out := obj1.getReference
         })
       }
-    }(
+    }.fileCheck()(
       """|CHECK: class Parent
          |CHECK: output out : Inst<Test>
          |CHECK: propassign out, obj1
@@ -40,7 +40,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support Objects in Module ports" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = Definition(new Class {
           override def desiredName = "Test"
@@ -56,7 +56,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
           out := obj1.getReference
         })
       }
-    }(
+    }.fileCheck()(
       """|CHECK: module Parent
          |CHECK: output out : Inst<Test>
          |CHECK: propassign out, obj1
@@ -65,7 +65,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support output Object fields as sources" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = Definition(new Class {
           override def desiredName = "Test"
@@ -76,7 +76,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
         val obj1 = Class.unsafeGetDynamicObject("Test")
         out := obj1.getField[Int]("out")
       }
-    }(
+    }.fileCheck()(
       """|CHECK: object obj1 of Test
          |CHECK: propassign out, obj1.out
          |""".stripMargin
@@ -84,7 +84,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support input Object fields as sinks" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = Definition(new Class {
           override def desiredName = "Test"
@@ -95,7 +95,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
         val obj1 = Class.unsafeGetDynamicObject("Test")
         obj1.getField[Int]("in") := in
       }
-    }(
+    }.fileCheck()(
       """|CHECK: object obj1 of Test
          |CHECK: propassign obj1.in, in
          |""".stripMargin
@@ -103,7 +103,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support creating DynamicObject from a Class with DynamicObject.apply" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val out = IO(Output(Property[Int]()))
 
@@ -117,7 +117,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
 
         out := obj.getField[Int]("out")
       }
-    }(
+    }.fileCheck()(
       """|CHECK: object obj of Test
          |CHECK: propassign obj.in, Integer(1)
          |CHECK: propassign out, obj.out
@@ -126,7 +126,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support boring ports through a Class created with DynamicObject.apply" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val in = IO(Input(Property[Int]()))
 
@@ -136,7 +136,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
           out := BoringUtils.bore(in)
         })
       }
-    }(
+    }.fileCheck()(
       """|CHECK: input out_bore : Integer
          |CHECK: propassign out, out_bore
          |CHECK: propassign obj.out_bore, in
@@ -147,7 +147,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   behavior.of("StaticObject")
 
   it should "support Instances of Objects in Class ports" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         Definition({
           val cls1 = Definition(new Class {
@@ -177,7 +177,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
           }
         })
       }
-    }(
+    }.fileCheck()(
       """|CHECK: class Parent
          |CHECK: output out1 : Inst<Test>
          |CHECK: output out2 : Inst<Test_1>
@@ -190,7 +190,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support Instances of Objects in Module ports" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls1 = Definition(new Class {
           override def desiredName = "Test"
@@ -217,7 +217,7 @@ class ObjectSpec extends AnyFlatSpec with Matchers with FileCheck {
           out2 := obj2.getPropertyReference
         })
       }
-    }(
+    }.fileCheck()(
       """|CHECK: module Parent
          |CHECK: output out1 : Inst<Test>
          |CHECK: output out2 : Inst<Test_1>

--- a/src/test/scala-2/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertySpec.scala
@@ -4,8 +4,8 @@ package chiselTests.properties
 
 import chisel3._
 import chisel3.properties.{AnyClassType, Class, ClassType, DynamicObject, Path, Property, PropertyType}
+import chisel3.testing.scalatest.FileCheck
 import chisel3.util.experimental.BoringUtils
-import chiselTests.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -159,7 +159,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support path as a Property literal" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new Module {
         val propOutA = IO(Output(Property[Path]()))
         val propOutB = IO(Output(Property[Path]()))
@@ -185,7 +185,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         propOutF := Property(Path(inst.sram.underlying.get))
         propOutG := Property(Path(inst.sram.underlying.get, true))
       }
-    }(
+    }.fileCheck()(
       """|CHECK-LABEL: module Foo :
          |CHECK:         propassign localPropOut, path("OMReferenceTarget:~Top|Foo>data")
          |CHECK-LABEL: public module Top :
@@ -201,7 +201,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support member path target types when requested" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val propOutA = IO(Output(Property[Path]()))
         val propOutB = IO(Output(Property[Path]()))
@@ -220,7 +220,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         propOutC := Property(Path(inst.mem, true))
         propOutD := inst.localPropOut
       }
-    }(
+    }.fileCheck()(
       """|CHECK-LABEL: module Foo :
          |CHECK:         propassign localPropOut, path("OMMemberReferenceTarget:~Top|Foo>data")
          |CHECK-LABEL: public module Top :
@@ -297,13 +297,13 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support Seq[Int], Vector[Int], and List[Int] as a Property type" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val seqProp1 = IO(Input(Property[Seq[Int]]()))
         val seqProp2 = IO(Input(Property[Vector[Int]]()))
         val seqProp3 = IO(Input(Property[List[Int]]()))
       }
-    }(
+    }.fileCheck()(
       """|CHECK: input seqProp1 : List<Integer>
          |CHECK: input seqProp2 : List<Integer>
          |CHECK: input seqProp3 : List<Integer>
@@ -351,7 +351,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
       "Property[Property[Property[Int]]]()"
     }
 
-    fileCheckString(chirrtl)(
+    chirrtl.fileCheck()(
       """|CHECK: output a : List<List<Integer>>
          |CHECK: output b : List<List<Integer>>
          |CHECK: propassign a, List<List<Integer>>(List<Integer>(Integer(123)))
@@ -367,7 +367,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "be supported as a field of a Bundle" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       class MyBundle extends Bundle {
         val foo = UInt(8.W)
         val bar = Property[BigInt]()
@@ -377,7 +377,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         propOut.foo := 123.U
         propOut.bar := Property(3)
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output propOut : { foo : UInt<8>, bar : Integer}
          |CHECK: connect propOut.foo, UInt<7>(0h7b)
          |CHECK: propassign propOut.bar, Integer(3)
@@ -386,7 +386,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "being a flipped field of a Bundle" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       class MyBundle extends Bundle {
         val foo = UInt(8.W)
         val bar = Flipped(Property[BigInt]())
@@ -397,7 +397,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         aligned.foo := flipped.foo
         flipped.bar := aligned.bar
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output aligned : { foo : UInt<8>, flip bar : Integer}
          |CHECK: input flipped : { foo : UInt<8>, flip bar : Integer}
          |CHECK: connect aligned.foo, flipped.foo
@@ -416,11 +416,11 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
       val flipped = IO(Flipped(new MyBundle))
     }
 
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new MyBaseModule {
         aligned :<>= flipped
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output aligned : { foo : String, flip bar : Integer}
          |CHECK: input flipped : { foo : String, flip bar : Integer}
          |CHECK: propassign flipped.bar, aligned.bar
@@ -428,11 +428,11 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
          |""".stripMargin
     )
 
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new MyBaseModule {
         aligned :<= flipped
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output aligned : { foo : String, flip bar : Integer}
          |CHECK: input flipped : { foo : String, flip bar : Integer}
          |CHECK-NOT: propassign
@@ -441,11 +441,11 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
          |""".stripMargin
     )
 
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new MyBaseModule {
         aligned :>= flipped
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output aligned         : { foo : String, flip bar : Integer}
          |CHECK: input flipped  : { foo : String, flip bar : Integer}
          |CHECK-NOT: propassign
@@ -454,13 +454,13 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
          |""".stripMargin
     )
 
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val out = IO(Output(new MyBundle))
         val in = IO(Input(new MyBundle))
         out :#= in
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output out : { foo : String, bar : Integer}
          |CHECK: input in : { foo : String, bar : Integer}
          |CHECK: propassign out.bar, in.bar
@@ -470,7 +470,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support being nested in a Bundle in a wire" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       class MyBundle extends Bundle {
         val foo = Property[String]()
         val bar = Flipped(Property[BigInt]())
@@ -482,7 +482,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         wire :<>= incoming
         outgoing :<>= wire
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output outgoing : { foo : String, flip bar : Integer}
          |CHECK: input incoming : { foo : String, flip bar : Integer}
          |CHECK: wire wire : { foo : String, flip bar : Integer}
@@ -554,7 +554,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "emit correct types for all the ways of creating class references and properties" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val cls = ClassType.unsafeGetClassTypeByName("MyClass")
         val a = IO(Input(Property[cls.Type]()))
@@ -601,7 +601,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         connectAB(ClassType.unsafeGetClassTypeByName("foo"))
         connectAB(ClassType.unsafeGetClassTypeByName("bar"))
       }
-    }(
+    }.fileCheck()(
       """|CHECK:      input a : Inst<MyClass>
          |CHECK-NEXT: output b : List<Inst<MyClass>>
          |CHECK-NEXT: output c : Inst<MyClass>
@@ -636,7 +636,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support FlatIO" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val flatModule = Module(new RawModule {
           val io = FlatIO(new Bundle {
@@ -648,7 +648,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         flatModule.io.bool := true.B
         flatModule.io.prop := Property(1)
       }
-    }(
+    }.fileCheck()(
       """|CHECK: connect flatModule.bool, UInt<1>(0h1)
          |CHECK: propassign flatModule.prop, Integer(1)
          |""".stripMargin
@@ -686,7 +686,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   behavior.of("PropertyArithmeticOps")
 
   it should "support expressions in temporaries, wires, and ports" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = IO(Input(Property[Int]()))
         val b = IO(Input(Property[Int]()))
@@ -702,7 +702,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         d := t + a
         e := w + (a + b)
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire t : Integer
          |CHECK: propassign t, integer_add(a, b)
          |CHECK: wire w : Integer
@@ -721,7 +721,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support boring from expressions" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val child = Module(new RawModule {
           val a = IO(Input(Property[Int]()))
@@ -737,7 +737,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
         child.b := a
         c := BoringUtils.bore(child.c)
       }
-    }(
+    }.fileCheck()(
       """|CHECK: output c_bore : Integer
          |CHECK: wire c : Integer
          |CHECK: propassign c, integer_add(a, b)
@@ -748,7 +748,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support targeting the result of expressions" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         override def desiredName = "Top"
 
@@ -761,7 +761,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
 
         mod.c.toTarget.toString should equal("~Top|Foo>c")
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire c : Integer
          |CHECK: propassign c, integer_add(a, b)
          |""".stripMargin
@@ -792,14 +792,14 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support addition" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = IO(Input(Property[BigInt]()))
         val b = IO(Input(Property[BigInt]()))
         val c = IO(Output(Property[BigInt]()))
         c := a + b
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire _c_propExpr : Integer
          |CHECK: propassign _c_propExpr, integer_add(a, b)
          |CHECK: propassign c, _c_propExpr
@@ -808,14 +808,14 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support multiplication" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = IO(Input(Property[BigInt]()))
         val b = IO(Input(Property[BigInt]()))
         val c = IO(Output(Property[BigInt]()))
         c := a * b
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire _c_propExpr : Integer
          |CHECK: propassign _c_propExpr, integer_mul(a, b)
          |CHECK: propassign c, _c_propExpr
@@ -824,14 +824,14 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support shift right" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = IO(Input(Property[BigInt]()))
         val b = IO(Input(Property[BigInt]()))
         val c = IO(Output(Property[BigInt]()))
         c := a >> b
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire _c_propExpr : Integer
          |CHECK: propassign _c_propExpr, integer_shr(a, b)
          |CHECK: propassign c, _c_propExpr
@@ -840,14 +840,14 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support shift left" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = IO(Input(Property[BigInt]()))
         val b = IO(Input(Property[BigInt]()))
         val c = IO(Output(Property[BigInt]()))
         c := a << b
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire _c_propExpr : Integer
          |CHECK: propassign _c_propExpr, integer_shl(a, b)
          |CHECK: propassign c, _c_propExpr
@@ -881,14 +881,14 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support concatenation for Property[Seq[Int]]" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = IO(Input(Property[Seq[Int]]()))
         val b = IO(Input(Property[Seq[Int]]()))
         val c = IO(Output(Property[Seq[Int]]()))
         c := a ++ b
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire _c_propExpr : List<Integer>
          |CHECK: propassign _c_propExpr, list_concat(a, b)
          |CHECK: propassign c, _c_propExpr
@@ -897,14 +897,14 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
   }
 
   it should "support concatenation for Property[Seq[ClassType]]" in {
-    generateFirrtlAndFileCheck {
+    ChiselStage.emitCHIRRTL {
       new RawModule {
         val a = IO(Input(Property[Seq[AnyClassType]]()))
         val b = IO(Input(Property[Seq[AnyClassType]]()))
         val c = IO(Output(Property[Seq[AnyClassType]]()))
         c := a ++ b
       }
-    }(
+    }.fileCheck()(
       """|CHECK: wire _c_propExpr : List<AnyRef>
          |CHECK: propassign _c_propExpr, list_concat(a, b)
          |CHECK: propassign c, _c_propExpr

--- a/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/DefaultSimulatorSpec.scala
@@ -5,7 +5,7 @@ package chiselTests.simulator
 import chisel3._
 import chisel3.testing.HasTestingDirectory
 import chisel3.simulator.DefaultSimulator._
-import chiselTests.FileCheck
+import chisel3.testing.FileCheck
 import java.nio.file.FileSystems
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -55,7 +55,7 @@ class DefaultSimulatorSpec extends AnyFunSpec with Matchers with FileCheck {
           }
         } { _.a.expect(true.B) }
       }.getMessage
-      fileCheckString(message) {
+      message.fileCheck() {
         """|CHECK:      Failed Expectation
            |CHECK-NEXT: ---
            |CHECK-NEXT: Observed value: '0'

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -6,8 +6,7 @@ import chisel3._
 import chisel3.simulator.PeekPokeAPI.FailedExpectationException
 import chisel3.simulator.{ChiselSettings, ChiselSim, MacroText}
 import chisel3.testing.HasTestingDirectory
-import chisel3.testing.scalatest.TestingDirectory
-import chiselTests.FileCheck
+import chisel3.testing.scalatest.{FileCheck, TestingDirectory}
 import java.nio.file.FileSystems
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -53,7 +52,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
         }
       }.getMessage
 
-      fileCheckString(message)(
+      message.fileCheck()(
         """|CHECK:      One or more assertions failed during Chiselsim simulation
            |CHECK-NEXT: ---
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
@@ -78,7 +77,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
         }
       }.getMessage
 
-      fileCheckString(message)(
+      message.fileCheck()(
         """|CHECK:      One or more assertions failed during Chiselsim simulation
            |CHECK-NEXT: ---
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
@@ -107,21 +106,20 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
 
       simulateRaw(new Foo, chiselSettings = chiselSettings) { _ => }
 
-      fileCheckString(
-        io.Source
-          .fromFile(
-            FileSystems
-              .getDefault()
-              .getPath(implicitly[HasTestingDirectory].getDirectory.toString, "workdir-verilator", "Makefile")
-              .toFile
-          )
-          .mkString
-      )(
-        """|CHECK:      '+define+ASSERT_VERBOSE_COND=svsimTestbench.a'
-           |CHECK-NEXT: '+define+PRINTF_COND=svsimTestbench.b'
-           |CHECK-NEXT: '+define+STOP_COND=!svsimTestbench.c'
-           |""".stripMargin
-      )
+      io.Source
+        .fromFile(
+          FileSystems
+            .getDefault()
+            .getPath(implicitly[HasTestingDirectory].getDirectory.toString, "workdir-verilator", "Makefile")
+            .toFile
+        )
+        .mkString
+        .fileCheck()(
+          """|CHECK:      '+define+ASSERT_VERBOSE_COND=svsimTestbench.a'
+             |CHECK-NEXT: '+define+PRINTF_COND=svsimTestbench.b'
+             |CHECK-NEXT: '+define+STOP_COND=!svsimTestbench.c'
+             |""".stripMargin
+        )
     }
   }
 


### PR DESCRIPTION
Migrate all tests to use one of the FileChecks available in the `chisel3.testing` package. Delete the internal one.

This is stacked on #4749. This patch provides an example of what use of #4749 looks like in practice.