### PR TITLE
[test] Remove usages of BackendCompilationUtilities

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -16,7 +16,6 @@ import _root_.firrtl.annotations.{Annotation, CircuitName, ComponentName, IsMemb
 import _root_.firrtl.annotations.AnnotationUtils.validComponentName
 import _root_.firrtl.{annoSeqToSeq, AnnotationSeq}
 import _root_.firrtl.renamemap.MutableRenameMap
-import _root_.firrtl.util.BackendCompilationUtilities._
 import _root_.firrtl.{ir => fir}
 import chisel3.experimental.dataview.{reify, reifyIdentityView, reifySingleTarget}
 import chisel3.internal.Builder.Prefix

--- a/firrtl/src/test/scala/firrtl/testutils/FirrtlSpec.scala
+++ b/firrtl/src/test/scala/firrtl/testutils/FirrtlSpec.scala
@@ -19,7 +19,6 @@ import firrtl.stage.InfoModeAnnotation
 import firrtl.annotations._
 import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
 import firrtl.renamemap.MutableRenameMap
-import firrtl.util.BackendCompilationUtilities
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec

--- a/firrtl/src/test/scala/firrtlTests/StringSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/StringSpec.scala
@@ -4,7 +4,6 @@ package firrtlTests
 
 import firrtl.ir.StringLit
 import firrtl.testutils._
-import firrtl.util.BackendCompilationUtilities._
 
 import java.io._
 import scala.sys.process._

--- a/firrtl/src/test/scala/firrtlTests/options/phases/GetIncludesSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/options/phases/GetIncludesSpec.scala
@@ -8,7 +8,6 @@ import firrtl.{annoSeqToSeq, seqToAnnoSeq, AnnotationSeq}
 import firrtl.annotations.{AnnotationFileNotFoundException, JsonProtocol, NoTargetAnnotation}
 import firrtl.options.phases.GetIncludes
 import firrtl.options.{InputAnnotationFileAnnotation, Phase}
-import firrtl.util.BackendCompilationUtilities
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala-2/chiselTests/InvalidateAPISpec.scala
+++ b/src/test/scala-2/chiselTests/InvalidateAPISpec.scala
@@ -6,21 +6,11 @@ import chisel3._
 import chisel3.stage.ChiselGeneratorAnnotation
 import chisel3.util.Counter
 import circt.stage.ChiselStage
-import firrtl.util.BackendCompilationUtilities._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 
 class InvalidateAPISpec extends AnyPropSpec with Matchers {
 
-  def myGenerateFirrtl(t: => Module): String = ChiselStage.emitCHIRRTL(t)
-  def compileFirrtl(t: => Module): Unit = {
-    val testDir = createTestDirectory(this.getClass.getSimpleName)
-
-    (new ChiselStage).execute(
-      Array[String]("-td", testDir.getAbsolutePath, "--target", "verilog"),
-      Seq(ChiselGeneratorAnnotation(() => t))
-    )
-  }
   class TrivialInterface extends Bundle {
     val in = Input(Bool())
     val out = Output(Bool())
@@ -32,7 +22,7 @@ class InvalidateAPISpec extends AnyPropSpec with Matchers {
       io.out := DontCare
       io.out := io.in
     }
-    val firrtlOutput = myGenerateFirrtl(new ModuleWithDontCare)
+    val firrtlOutput = ChiselStage.emitCHIRRTL(new ModuleWithDontCare)
     firrtlOutput should include("invalidate io.out")
   }
 
@@ -41,7 +31,7 @@ class InvalidateAPISpec extends AnyPropSpec with Matchers {
       val io = IO(new TrivialInterface)
       io.out := io.in
     }
-    val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
+    val firrtlOutput = ChiselStage.emitCHIRRTL(new ModuleWithoutDontCare)
     (firrtlOutput should not).include("invalidate")
   }
 
@@ -50,7 +40,7 @@ class InvalidateAPISpec extends AnyPropSpec with Matchers {
       val io = IO(new TrivialInterface)
       io <> DontCare
     }
-    val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
+    val firrtlOutput = ChiselStage.emitCHIRRTL(new ModuleWithoutDontCare)
     firrtlOutput should include("invalidate io.out")
     firrtlOutput should include("invalidate io.in")
   }
@@ -63,7 +53,7 @@ class InvalidateAPISpec extends AnyPropSpec with Matchers {
       })
       io.outs <> DontCare
     }
-    val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
+    val firrtlOutput = ChiselStage.emitCHIRRTL(new ModuleWithoutDontCare)
     for (i <- 0 until nElements)
       firrtlOutput should include(s"invalidate io.outs[$i]")
   }
@@ -76,7 +66,7 @@ class InvalidateAPISpec extends AnyPropSpec with Matchers {
       })
       io.ins := DontCare
     }
-    val firrtlOutput = myGenerateFirrtl(new ModuleWithoutDontCare)
+    val firrtlOutput = ChiselStage.emitCHIRRTL(new ModuleWithoutDontCare)
     for (i <- 0 until nElements)
       firrtlOutput should include(s"invalidate io.ins[$i]")
   }
@@ -158,6 +148,6 @@ class InvalidateAPISpec extends AnyPropSpec with Matchers {
       val foo = IO(Output(Clock()))
       foo := DontCare
     }
-    myGenerateFirrtl(new ClockConnectedToDontCare) should include("invalidate foo")
+    ChiselStage.emitCHIRRTL(new ClockConnectedToDontCare) should include("invalidate foo")
   }
 }

--- a/src/test/scala-2/chiselTests/experimental/TraceSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/TraceSpec.scala
@@ -5,16 +5,17 @@ package chiselTests
 import chisel3._
 import chisel3.experimental.Trace._
 import chisel3.stage.{ChiselGeneratorAnnotation, DesignAnnotation}
+import chisel3.testing.HasTestingDirectory
+import chisel3.testing.scalatest.TestingDirectory
 import chisel3.util.experimental.InlineInstance
 import circt.stage.ChiselStage
 import firrtl.AnnotationSeq
 import firrtl.annotations.TargetToken.{Instance, OfModule, Ref}
 import firrtl.annotations.{CompleteTarget, InstanceTarget, ReferenceTarget}
-import firrtl.util.BackendCompilationUtilities.createTestDirectory
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class TraceSpec extends AnyFlatSpec with Matchers {
+class TraceSpec extends AnyFlatSpec with Matchers with TestingDirectory {
 
   def refTarget(topName: String, ref: String, path: Seq[(Instance, OfModule)] = Seq()) =
     ReferenceTarget(topName, topName, path, ref, Seq())
@@ -22,8 +23,10 @@ class TraceSpec extends AnyFlatSpec with Matchers {
   def instTarget(topName: String, instance: String, ofModule: String, path: Seq[(Instance, OfModule)] = Seq()) =
     InstanceTarget(topName, topName, path, instance, ofModule)
 
-  def compile(testName: String, gen: () => Module): (os.Path, AnnotationSeq) = {
-    val testDir = os.Path(createTestDirectory(testName).getAbsolutePath)
+  def compile(testName: String, gen: () => Module)(
+    implicit testingDirectory: HasTestingDirectory
+  ): (os.Path, AnnotationSeq) = {
+    val testDir = os.pwd / os.RelPath(testingDirectory.getDirectory)
     val annos = (new ChiselStage).execute(
       Array("--target-dir", s"$testDir", "--target", "systemverilog", "--split-verilog"),
       Seq(

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -8,16 +8,17 @@ import chisel3.experimental.BaseModule
 import chisel3.experimental.hierarchy.core.ImportDefinitionAnnotation
 import chisel3.experimental.hierarchy.{Definition, Instance}
 import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, DesignAnnotation}
+import chisel3.testing.HasTestingDirectory
+import chisel3.testing.scalatest.TestingDirectory
 import circt.stage.{CIRCTTarget, CIRCTTargetAnnotation, ChiselStage}
 import firrtl.AnnotationSeq
-import firrtl.util.BackendCompilationUtilities.createTestDirectory
 import java.nio.file.Paths
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import scala.annotation.nowarn
 import scala.io.Source
 
-class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
+class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils with TestingDirectory {
   import Examples._
 
   /** Return a [[DesignAnnotation]] from a list of annotations. */
@@ -60,7 +61,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
 
   describe("(0): Name conflicts") {
     it("(0.a): should not occur between a Module and an Instance of a previously elaborated Definition.") {
-      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+      val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
       val dutDef = getAddOneDefinition(testDir)
 
@@ -92,7 +93,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
     it(
       "(0.b): should not occur between an Instance of a Definition and an Instance of a previously elaborated Definition."
     ) {
-      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+      val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
       val dutDef = getAddOneDefinition(testDir)
 
@@ -124,7 +125,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
 
   describe("(1): Repeat Module definitions") {
     it("(1.a): should not occur when elaborating multiple Instances separately from its Definition.") {
-      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+      val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
       val dutDef = getAddOneDefinition(testDir)
 
@@ -148,7 +149,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
     it(
       "(2.a): should work if a list of imported Definitions is passed between Stages."
     ) {
-      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+      val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
       val dutAnnos0 = (new ChiselStage).execute(
         Array("--target-dir", s"$testDir/dutDef0", "--target", "systemverilog"),
@@ -201,7 +202,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
     it(
       "(2.b): should throw an exception if information is not passed between Stages."
     ) {
-      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+      val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
       val dutAnnos0 = (new ChiselStage).execute(
         Array("--target-dir", s"$testDir/dutDef0", "--target", "systemverilog"),
@@ -255,7 +256,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
     it(
       "(3.a): should work if a list of imported Definitions for all modules is passed between Stages."
     ) {
-      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+      val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
       val dutAnnos0 = (new ChiselStage).execute(
         Array("--target-dir", s"$testDir/dutDef0", "--target", "systemverilog"),
@@ -309,7 +310,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
   it(
     "(3.b): should throw an exception if submodules are not passed between Definition elaborations."
   ) {
-    val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+    val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
     val dutAnnos0 = (new ChiselStage).execute(
       Array("--target-dir", s"$testDir/dutDef0", "--target", "systemverilog"),
@@ -361,7 +362,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
 
   describe("(4): With ExtMod Names") {
     it("(4.a): should pick correct ExtMod names when passed") {
-      val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+      val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
       val dutDef = getAddOneDefinition(testDir)
 
@@ -395,7 +396,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
   it(
     "(4.b): should work if a list of imported Definitions is passed between Stages with ExtModName."
   ) {
-    val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+    val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
     val dutAnnos0 = (new ChiselStage).execute(
       Array("--target-dir", s"$testDir/dutDef0", "--target", "systemverilog"),
@@ -448,7 +449,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils {
   it(
     "(4.c): should throw an exception  if a list of imported Definitions is passed between Stages with same ExtModName."
   ) {
-    val testDir = createTestDirectory(this.getClass.getSimpleName).toString
+    val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
     val dutAnnos0 = (new ChiselStage).execute(
       Array("--target-dir", s"$testDir/dutDef0", "--target", "systemverilog"),


### PR DESCRIPTION
This is prerequisite work for deprecating and removing `BackendCompilationUtilities`. The only real usages of this are related to getting a test directory. This is fully replaced with the `HasTestingDirectory` type class and its Scalatest-integrated implementation `chisel3.testing.scalatest.TestingDirectory`.