### PR TITLE
Mass deprecations, to be removed in Chisel 7

### DIFF
--- a/firrtl/src/main/scala/firrtl/FileUtils.scala
+++ b/firrtl/src/main/scala/firrtl/FileUtils.scala
@@ -2,6 +2,7 @@
 
 package firrtl
 
+@deprecated("Use os-lib directly or scala.io", "Chisel 6.7.0")
 object FileUtils {
 
   /** Read a text file and return it as a Seq of strings

--- a/firrtl/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
+++ b/firrtl/src/main/scala/firrtl/transforms/BlackBoxSourceHelper.scala
@@ -27,6 +27,7 @@ case class BlackBoxPathAnno(target: ModuleName, path: String)
   override def serialize: String = s"path\n$path"
 }
 
+@deprecated("Use Chisel's HasBlockBoxResource/HasExtModuleResource APIs", "Chisel 6.7.0")
 case class BlackBoxResourceFileNameAnno(resourceFileName: String) extends BlackBoxHelperAnno with NoTargetAnnotation {
   override def serialize: String = s"resourceFileName\n$resourceFileName"
 }
@@ -40,6 +41,7 @@ class BlackBoxNotFoundException(fileName: String, message: String)
       s"BlackBox '$fileName' not found. Did you misspell it? Is it in src/{main,test}/resources?\n$message"
     )
 
+@deprecated("Use Chisel's HasBlockBoxResource/HasExtModuleResource APIs", "Chisel 6.7.0")
 object BlackBoxSourceHelper {
 
   /** Safely access a file converting [[FileNotFoundException]]s and [[NullPointerException]]s into
@@ -59,6 +61,7 @@ object BlackBoxSourceHelper {
     * @param dir the directory in which to write the file
     * @return the closed File object
     */
+  @deprecated("Use Chisel's HasBlockBoxResource/HasExtModuleResource APIs", "Chisel 6.7.0")
   def writeResourceToDirectory(name: String, dir: File): File = {
     val fileName = name.split("/").last
     val outFile = new File(dir, fileName)
@@ -72,6 +75,7 @@ object BlackBoxSourceHelper {
     * @param file the file to write it into
     * @throws BlackBoxNotFoundException if the requested resource does not exist
     */
+  @deprecated("Use Chisel's HasBlockBoxResource/HasExtModuleResource APIs", "Chisel 6.7.0")
   def copyResourceToFile(name: String, file: File): Unit = {
     val in = getClass.getResourceAsStream(name)
     val out = new FileOutputStream(file)
@@ -79,6 +83,7 @@ object BlackBoxSourceHelper {
     out.close()
   }
 
+  @deprecated("Use Chisel's HasBlockBoxResource/HasExtModuleResource APIs", "Chisel 6.7.0")
   val defaultFileListName = "firrtl_black_box_resource_files.f"
 
 }

--- a/firrtl/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/firrtl/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -13,7 +13,10 @@ import firrtl.FileUtils
 
 import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
 
-@deprecated("This object hasn't been practical to use since Chisel 5.0.0. If you are doing compilation to Verilog use `circt.stage.ChiselStage`.  For simulation use ChiselSim.", "Chisel 6.7.0")
+@deprecated(
+  "This object hasn't been practical to use since Chisel 5.0.0. If you are doing compilation to Verilog use `circt.stage.ChiselStage`.  For simulation use ChiselSim.",
+  "Chisel 6.7.0"
+)
 object BackendCompilationUtilities extends LazyLogging {
 
   /** Parent directory for tests */

--- a/firrtl/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
+++ b/firrtl/src/main/scala/firrtl/util/BackendCompilationUtilities.scala
@@ -13,17 +13,21 @@ import firrtl.FileUtils
 
 import scala.sys.process.{ProcessBuilder, ProcessLogger, _}
 
+@deprecated("This object hasn't been practical to use since Chisel 5.0.0. If you are doing compilation to Verilog use `circt.stage.ChiselStage`.  For simulation use ChiselSim.", "Chisel 6.7.0")
 object BackendCompilationUtilities extends LazyLogging {
 
   /** Parent directory for tests */
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   lazy val TestDirectory = new File("test_run_dir")
 
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def timeStamp: String = {
     val format = new SimpleDateFormat("yyyyMMddHHmmss")
     val now = Calendar.getInstance.getTime
     format.format(now)
   }
 
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def loggingProcessLogger: ProcessLogger =
     ProcessLogger(logger.info(_), logger.warn(_))
 
@@ -32,6 +36,7 @@ object BackendCompilationUtilities extends LazyLogging {
     * @param name the name of the resource
     * @param file the file to write it into
     */
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def copyResourceToFile(name: String, file: File): Unit = {
     val in = getClass.getResourceAsStream(name)
     if (in == null) {
@@ -47,12 +52,14 @@ object BackendCompilationUtilities extends LazyLogging {
     * Will create outer directory called testName then inner directory based on
     * the current time
     */
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def createTestDirectory(testName: String): File = {
     val outer = new File(TestDirectory, testName)
     outer.mkdirs()
     Files.createTempDirectory(outer.toPath, timeStamp).toFile
   }
 
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def makeHarness(template: String => String, post: String)(f: File): File = {
     val prefix = f.toString.split("/").last
     val vf = new File(f.toString + post)
@@ -69,6 +76,7 @@ object BackendCompilationUtilities extends LazyLogging {
     * @param dir    directory where file lives
     * @return       true if compiler completed successfully
     */
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def firrtlToVerilog(prefix: String, dir: File): ProcessBuilder = {
     Process(Seq("firrtl", "-i", s"$prefix.fir", "-o", s"$prefix.v", "-X", "verilog"), dir)
   }
@@ -98,6 +106,7 @@ object BackendCompilationUtilities extends LazyLogging {
     * @param resourceFileName specifies what filename to look for to find a .f file
     * @param extraCmdLineArgs list of additional command line arguments
     */
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def verilogToCpp(
     dutFile:          String,
     dir:              File,
@@ -160,9 +169,11 @@ object BackendCompilationUtilities extends LazyLogging {
     command
   }
 
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def cppToExe(prefix: String, dir: File): ProcessBuilder =
     Seq("make", "-C", dir.toString, "-j", "-f", s"V$prefix.mk", s"V$prefix")
 
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def executeExpectingFailure(
     prefix:       String,
     dir:          File,
@@ -183,6 +194,7 @@ object BackendCompilationUtilities extends LazyLogging {
     triggered || (e != 0 && (e != 134 || !assertionMessageSupplied))
   }
 
+  @deprecated("BackendCompilationUtilities will be removed in Chisel 7.0.0", "Chisel 6.7.0")
   def executeExpectingSuccess(prefix: String, dir: File): Boolean = {
     !executeExpectingFailure(prefix, dir)
   }

--- a/firrtl/src/test/scala/firrtlTests/FileUtilsSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/FileUtilsSpec.scala
@@ -5,10 +5,12 @@ package firrtlTests
 import firrtl.FileUtils
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scala.annotation.nowarn
 
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
+@nowarn("msg=object FileUtils in package firrtl is deprecated")
 class FileUtilsSpec extends AnyFlatSpec with Matchers {
 
   private val sampleAnnotations: String = "/annotations/SampleAnnotations.anno.json"

--- a/src/test/scala-2/chiselTests/Harness.scala
+++ b/src/test/scala-2/chiselTests/Harness.scala
@@ -6,7 +6,15 @@ import firrtl.util.BackendCompilationUtilities._
 import java.io.File
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
+import scala.annotation.nowarn
 
+@nowarn("msg=object BackendCompilationUtilities in package util is deprecated")
+@nowarn("msg=method makeHarness in object BackendCompilationUtilities is deprecated")
+@nowarn("msg=method cppToExe in object BackendCompilationUtilities is deprecated")
+@nowarn("msg=method executeExpectingSuccess in object BackendCompilationUtilities is deprecated")
+@nowarn("msg=method executeExpectingFailure in object BackendCompilationUtilities is deprecated")
+@nowarn("msg=method createTestDirectory in object BackendCompilationUtilities is deprecated")
+@nowarn("msg=method verilogToCpp in object BackendCompilationUtilities is deprecated")
 class HarnessSpec extends AnyPropSpec with Matchers {
 
   def makeTrivialVerilog: (File => File) = makeHarness(


### PR DESCRIPTION
Mass deprecation of APIs that we would like to delete in Chisel 7.

#### Release Notes

- Deprecate `FileUtils`
- Deprecate `BlackBoxResourceFileNameAnno`
- Deprecate `BlackBoxSourceHelper`
- Deprecate `BackendCompilationUtilities`