### PR TITLE
Fix extmodule emission when instantiating an imported Definition multiple times

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -124,7 +124,7 @@ object Instance extends SourceInfoDoc {
     }
   }
 
-  class ImportedDefinitionExtModule(
+  private class ImportedDefinitionExtModule(
     override val desiredName: String,
     val importedDefinition:   Definition[BaseModule with IsInstantiable]
   ) extends ExtModule {

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -124,6 +124,23 @@ object Instance extends SourceInfoDoc {
     }
   }
 
+  class ImportedDefinitionExtModule(
+    override val desiredName: String,
+    val importedDefinition:   Definition[BaseModule with IsInstantiable]
+  ) extends ExtModule {
+    override private[chisel3] def _isImportedDefinition = true
+    override def generateComponent(): Option[Component] = {
+      require(!_closed, s"Can't generate $desiredName module more than once")
+      _closed = true
+      val firrtlPorts = importedDefinition.proto.getModulePortsAndLocators.map { case (port, sourceInfo) =>
+        Port(port, port.specifiedDirection, sourceInfo): @nowarn // Deprecated code allowed for internal use
+      }
+      val component =
+        DefBlackBox(this, importedDefinition.proto.name, firrtlPorts, SpecifiedDirection.Unspecified, params)
+      Some(component)
+    }
+  }
+
   /** A constructs an [[Instance]] from a [[Definition]]
     *
     * @param definition the Module being created
@@ -136,10 +153,11 @@ object Instance extends SourceInfoDoc {
   ): Instance[T] = {
     // Check to see if the module is already defined internally or externally
     val existingMod = Builder.definitions.view.map(_.proto).exists {
-      case c: Class               => c == definition.proto
-      case c: RawModule           => c == definition.proto
-      case c: BaseBlackBox        => c.name == definition.proto.name
-      case c: BaseIntrinsicModule => c.name == definition.proto.name
+      case c: Class                       => c == definition.proto
+      case c: RawModule                   => c == definition.proto
+      case c: ImportedDefinitionExtModule => c.importedDefinition == definition
+      case c: BaseBlackBox                => c.name == definition.proto.name
+      case c: BaseIntrinsicModule         => c.name == definition.proto.name
       case _ => false
     }
 
@@ -152,20 +170,7 @@ object Instance extends SourceInfoDoc {
           s"Imported Definition information not found for ${definition.proto.name} - possibly forgot to add ImportDefinition annotation?"
         )
       )
-      class EmptyExtModule extends ExtModule {
-        override def desiredName: String = extModName
-        override private[chisel3] def _isImportedDefinition = true
-        override def generateComponent(): Option[Component] = {
-          require(!_closed, s"Can't generate $desiredName module more than once")
-          _closed = true
-          val firrtlPorts = definition.proto.getModulePortsAndLocators.map { case (port, sourceInfo) =>
-            Port(port, port.specifiedDirection, sourceInfo): @nowarn // Deprecated code allowed for internal use
-          }
-          val component = DefBlackBox(this, definition.proto.name, firrtlPorts, SpecifiedDirection.Unspecified, params)
-          Some(component)
-        }
-      }
-      Definition(new EmptyExtModule() {})
+      Definition(new ImportedDefinitionExtModule(extModName, definition))
     }
 
     val ports = experimental.CloneModuleAsRecord(definition.proto)

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -142,6 +142,10 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils with T
         args = Array("-td", testDir, "--full-stacktrace", "--target", "chirrtl"),
         annotations = Seq(ChiselGeneratorAnnotation(() => new Testbench(dutDef)), ImportDefinitionAnnotation(dutDef))
       )
+
+      val tbFir = Source.fromFile(s"${testDir}/Testbench.fir").getLines().mkString
+      assert("extmodule AddOne".r.findAllMatchIn(tbFir).length == 1)
+      assert("""inst \S+ of AddOne""".r.findAllMatchIn(tbFir).length == 2)
     }
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Bugfix



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Fix multiple instantiation of imported Definitions.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
