### PR TITLE
[test] Don't dump FIRRTL in WidthSpec method

### DIFF
--- a/src/test/scala-2/chiselTests/WidthSpec.scala
+++ b/src/test/scala-2/chiselTests/WidthSpec.scala
@@ -90,7 +90,7 @@ trait WidthHelpers extends Assertions {
       widthcheck := testPoint
     }
     val verilog =
-      ChiselStage.emitSystemVerilog(new TestModule, args.toArray :+ "--dump-fir", Array("-disable-all-randomization"))
+      ChiselStage.emitSystemVerilog(new TestModule, args.toArray, Array("-disable-all-randomization"))
     expected match {
       case 0 => assert(!verilog.contains("widthcheck"))
       case 1 =>


### PR DESCRIPTION
Avoid dumping FIRRTL to see if this will help with #4761.