### PR TITLE
Warn on <literal>.asUInt|.asSInt(_: Int)

### DIFF
--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -30,10 +30,6 @@ package object chisel3 {
     * after this call using apply, ie. 0.asUInt(1)(0) due to potential for
     * confusion (the 1 is a bit length and the 0 is a bit extraction position).
     * Prefer storing the result and then extracting from it.
-    *
-    * Implementation note: the empty parameter list (like `U()`) is necessary to prevent
-    * interpreting calls that have a non-Width parameter as a chained apply, otherwise things like
-    * `0.asUInt(16)` (instead of `16.W`) compile without error and produce undesired results.
     */
   implicit class fromBigIntToLiteral(bigint: BigInt) {
 

--- a/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
+++ b/macros/src/main/scala/chisel3/internal/sourceinfo/SourceInfoTransform.scala
@@ -361,13 +361,13 @@ class IntLiteralApplyTransform(val c: Context) extends AutoSourceTransform {
     c.macroApplication match {
       case q"$_.$clazz($lit).$func.apply($arg)" =>
         if (
-          Set("U", "S").contains(func.toString) &&
+          Set("U", "S", "asUInt", "asSInt").contains(func.toString) &&
           Set("fromStringToLiteral", "fromIntToLiteral", "fromLongToIteral", "fromBigIntToLiteral").contains(
             clazz.toString
           )
         ) {
           val msg =
-            s"""Passing an Int to .$func is usually a mistake: It does *not* set the width but does a bit extract.
+            s"""Passing an Int to .$func is usually a mistake: It does *not* set the width; it does a bit extraction.
                |Did you mean .$func($arg.W)?
                |If you do want bit extraction, use .$func.extract($arg) instead.
                |""".stripMargin


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/chisel/issues/4733

Unfortunately, this is really hard to write a unit test for, but I did manually check it works (and it's using the same approach as we have been using for `.U` and `.S`). I'm also not sure that this is the _best_ fix for 4733, but it works.

FYI @tymcauley 

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

The user probably forgot .W. Apply the same technique as used for .U|.S.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
