### PR TITLE
[svsim] Cleanup simulation-driver.cpp

### DIFF
--- a/svsim/src/main/resources/simulation-driver.cpp
+++ b/svsim/src/main/resources/simulation-driver.cpp
@@ -405,8 +405,8 @@ static int scanInt(const char **lineCursor, const char *description) {
   return (int)value;
 }
 
-int scanHexCharacterReverse(const char **reverseScanCursor,
-                            const char *description) {
+static int scanHexCharacterReverse(const char **reverseScanCursor,
+                                   const char *description) {
   char value = **reverseScanCursor;
   if (value >= '0' && value <= '9') {
     (*reverseScanCursor)--;
@@ -423,9 +423,9 @@ int scanHexCharacterReverse(const char **reverseScanCursor,
   }
 }
 
-int scanHexByteReverse(const char **reverseScanCursor,
-                       const char *firstCharacterOfValue,
-                       const char *description) {
+static int scanHexByteReverse(const char **reverseScanCursor,
+                              const char *firstCharacterOfValue,
+                              const char *description) {
   char low = scanHexCharacterReverse(reverseScanCursor, description);
   if (*reverseScanCursor < firstCharacterOfValue) {
     return low;


### PR DESCRIPTION
Minor cleanup of simulation-driver.cpp:

1. Move all global mutable state into a single static struct.
2. Mark everything that is only used internally to the module as `static`.

I'm not crazy about the solution of (1). However, the order of calls necessitates something like this. What is going on:

1. `main` runs and sets up global mutable state.
2. `main` calls `simulation_main`.
3. `simulation_main` runs, dropping into Verilog.
4. Verilog calls `simulation_body` via DPI.
5. `simulation_body` needs access to things created by (1).

I'd much rather have a way to _not_ have global mutable state.

This is stacked on #4765.