### PR TITLE
feat: add waveform tracing support for simulateRaw and simulate in SimulatorAPI

### DIFF
--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -24,11 +24,13 @@ trait SimulatorAPI {
     */
   def simulateRaw[T <: RawModule](
     module:         => T,
-    chiselSettings: ChiselSettings[T] = ChiselSettings.defaultRaw[T]
+    chiselSettings: ChiselSettings[T] = ChiselSettings.defaultRaw[T],
+    enableTrace:    Boolean = false
   )(stimulus: (T) => Unit)(implicit hasSimulator: HasSimulator, testingDirectory: HasTestingDirectory): Unit = {
 
     hasSimulator.getSimulator
       .simulate(module, chiselSettings) { module =>
+        module.controller.setTraceEnabled(enableTrace)
         stimulus(module.wrapped)
       }
       .result
@@ -76,7 +78,8 @@ trait SimulatorAPI {
   def simulate[T <: Module](
     module:                => T,
     chiselSettings:        ChiselSettings[T] = ChiselSettings.default[T],
-    additionalResetCycles: Int = 0
+    additionalResetCycles: Int = 0,
+    enableTrace:           Boolean = false
   )(stimulus: (T) => Unit)(implicit hasSimulator: HasSimulator, testingDirectory: HasTestingDirectory): Unit = {
 
     hasSimulator.getSimulator
@@ -85,6 +88,9 @@ trait SimulatorAPI {
         val reset = module.port(dut.reset)
         val clock = module.port(dut.clock)
         val controller = module.controller
+
+        // Set the trace enable flag.
+        controller.setTraceEnabled(enableTrace)
 
         // Run the initialization procedure.
         controller.run(1)


### PR DESCRIPTION
This commit introduces a new `enableTrace` parameter to the `simulate` and `simulateRaw` methods in `SimulatorAPI.scala`, allowing users to enable waveform tracing during simulations. Additionally, corresponding test cases have been added to `ChiselSimSpec.scala` to verify that waveform files are correctly generated for both `Module` and `RawModule` simulations.

By adding this feature, users can enable tracing like this:
```scala
class GCDSpec extends AnyFreeSpec with Matchers {
  class Foo extends Module {
    val a = IO(Input(Bool()))
    val b = IO(Output(Bool()))

    b :<= !a
  }
  implicit val verilator = simulators
    .verilator(verilatorSettings =
      svsim.verilator.Backend.CompilationSettings(
        traceStyle =
          Some(svsim.verilator.Backend.CompilationSettings.TraceStyle.Vcd(traceUnderscore = true, "trace.vcd"))
      )
    )
  simulate(new Foo, enableTrace = true) { foo =>
    foo.a.poke(true.B)
    foo.b.expect(false.B)
    foo.a.poke(false.B)
    foo.b.expect(true.B)
  }(hasSimulator = verilator)
}
```

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
