### PR TITLE
[testing] Cleanup default and Scalatest directory structure

### DIFF
--- a/src/main/scala/chisel3/testing/HasTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/HasTestingDirectory.scala
@@ -27,7 +27,7 @@ object HasTestingDirectory {
     * E.g., this may produce something like:
     *
     * {{{
-    * test_run_dir
+    * build
     * └── chiselsim
     *     ├── 2025-02-05T16-58-02.175175
     *     ├── 2025-02-05T16-58-11.941263
@@ -37,7 +37,7 @@ object HasTestingDirectory {
   val timestamp: HasTestingDirectory = new HasTestingDirectory {
     override def getDirectory: Path = FileSystems
       .getDefault()
-      .getPath("test_run_dir", "chiselsim", LocalDateTime.now().toString.replace(':', '-'))
+      .getPath("build", "chiselsim", LocalDateTime.now().toString.replace(':', '-'))
   }
 
   /** An implementation generator of [[HasTestingDirectory]] which will use an

--- a/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
@@ -32,7 +32,7 @@ trait TestingDirectory { self: TestSuite =>
     *
     * For different behavior, please override this in your test suite.
     */
-  def buildDir: Path = Paths.get("build")
+  def buildDir: Path = Paths.get("build", "chiselsim")
 
   // Assemble all the directories that should be created for this test.  This is
   // done by examining the test (via a fixture) and then setting a dynamic

--- a/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
@@ -3,7 +3,7 @@
 package chisel3.testing.scalatest
 
 import chisel3.testing.HasTestingDirectory
-import java.nio.file.{FileSystems, Path}
+import java.nio.file.{FileSystems, Path, Paths}
 import org.scalatest.TestSuite
 import scala.util.DynamicVariable
 
@@ -32,7 +32,7 @@ trait TestingDirectory { self: TestSuite =>
     *
     * For different behavior, please override this in your test suite.
     */
-  def buildDir: String = "build"
+  def buildDir: Path = Paths.get("build")
 
   // Assemble all the directories that should be created for this test.  This is
   // done by examining the test (via a fixture) and then setting a dynamic
@@ -68,7 +68,7 @@ trait TestingDirectory { self: TestSuite =>
 
     override def getDirectory: Path = FileSystems
       .getDefault()
-      .getPath(buildDir, self.suiteName +: getTestName: _*)
+      .getPath(buildDir.toString, self.suiteName +: getTestName: _*)
 
   }
 

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -80,7 +80,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: ---
            |CHECK-NEXT:      0  [5] %Error:
            |CHECK:      For more information, see the complete log file:
-           |CHECK:        build/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3.assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
+           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3.assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )
@@ -105,7 +105,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: ---
            |CHECK-NEXT:      0  [5] %Error:
            |CHECK:      For more information, see the complete log file:
-           |CHECK:        build/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl.AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
+           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl.AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )

--- a/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
@@ -51,6 +51,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
     it("should generate a directory structure derived from the suite and test name") {
       checkDirectoryStructure(
         "build",
+        "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-generate-a-directory-structure-derived-from-the-suite-and-test-name"
@@ -62,6 +63,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
     it("should generate another directory, too") {
       checkDirectoryStructure(
         "build",
+        "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-generate-another-directory,-too"
@@ -73,6 +75,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
     it("should handle emojis, e.g., 🚀") {
       checkDirectoryStructure(
         "build",
+        "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-handle-emojis,-e.g.,-🚀"
@@ -84,6 +87,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
     it("should handle CJK characters, e.g., 好猫咪") {
       checkDirectoryStructure(
         "build",
+        "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-handle-CJK-characters,-e.g.,-好猫咪"


### PR DESCRIPTION
Change the default directory that `HasTestingDirectory` uses from
`test_run_dir/chiselsim` to `build/chiselsim`.  Generally, `test_run_dir/`
is an older style and `build/` is both newer (for Chisel) and more
standard (generally).

Change the return type of the abstract method `buildDir` to be `Path`
instead of `String`.  This is better as it avoids problems with separators
which could plague Windows users.

Change the directory that Scalatest tests use from being rooted at
`build/` to being rooted at `build/chiselsim/`.  The former can have a lot
of contention with many output files and it would be better to add this
additional level.  Also, this aligns this with the new default behavior of
the non-Scalatest WithTestingDirectory.

This does not need to get release notes as these APIs have never hit a release.

CC: @mmaloney-sf: This fixes that `test_run_dir/` that you observed and switches things to `build/chiselsim/`.