### PR TITLE
[scalatest] Add subdirectory control

### DIFF
--- a/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
@@ -25,6 +25,26 @@ import scala.util.DynamicVariable
   * You may change the `buildDir` by overridding a method of the same name in
   * this trait.
   *
+  * If multiple tests are being run with the same directory, you may override
+  * the optional `subDir` to add hierarchy under final test directory.  This is
+  * typically used to add information about a test seed if one is used.
+  *
+  * E.g., the above directory structure can be modified to create a directory
+  * structure like the following:
+  *
+  * {{{
+  * <buildDir>
+  * └── <suite-name>
+  *     └── <scope-1-name>
+  *         └── ...
+  *             └── <scope-n-name>
+  *                 ├── <test-1-name>
+  *                 │   └── <subDir>
+  *                 ├── ...
+  *                 └── <test-n-name>
+  *                     └── <subDir>
+  * }}}
+  *
   */
 trait TestingDirectory { self: TestSuite =>
 
@@ -33,6 +53,12 @@ trait TestingDirectory { self: TestSuite =>
     * For different behavior, please override this in your test suite.
     */
   def buildDir: Path = Paths.get("build", "chiselsim")
+
+  /** An option subdirectory to put the test in _under_ theh final test directory.
+    * This is typically used to differentiate different runs of the same test,
+    * e.g., if the test is given a seed.
+    */
+  def subDir: Option[Path] = None
 
   // Assemble all the directories that should be created for this test.  This is
   // done by examining the test (via a fixture) and then setting a dynamic
@@ -68,7 +94,7 @@ trait TestingDirectory { self: TestSuite =>
 
     override def getDirectory: Path = FileSystems
       .getDefault()
-      .getPath(buildDir.toString, self.suiteName +: getTestName: _*)
+      .getPath(buildDir.toString, self.suiteName +: (getTestName ++ subDir.map(_.toString)): _*)
 
   }
 

--- a/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
@@ -5,10 +5,12 @@ package chiselTests.testing.scalatest
 import chisel3._
 import chisel3.simulator.SimulatorAPI
 import chisel3.testing.scalatest.TestingDirectory
-import java.nio.file.FileSystems
+import java.nio.file.{FileSystems, Paths}
+import org.scalatest.Suite
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 import scala.reflect.io.Directory
+import scala.util.DynamicVariable
 
 class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI with TestingDirectory {
 
@@ -45,6 +47,10 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
     }
 
   }
+
+  private val seed = new DynamicVariable[Option[String]](None)
+
+  override def subDir = seed.value.map(Paths.get(_))
 
   describe("A test suite mixing in WithTestingDirectory") {
 
@@ -86,6 +92,23 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
         "A-test-suite-mixing-in-WithTestingDirectory",
         "should-handle-CJK-characters,-e.g.,-好猫咪"
       )
+    }
+
+  }
+
+  describe("A test that sets a subdirectory") {
+
+    it("should have a subdirectory") {
+      seed.withValue(Some("foo")) {
+        checkDirectoryStructure(
+          "build",
+          "chiselsim",
+          "TestingDirectorySpec",
+          "A-test-that-sets-a-subdirectory",
+          "should-have-a-subdirectory",
+          "foo"
+        )
+      }
     }
 
   }


### PR DESCRIPTION
Add a new overridable member function to `scalatest.TestingDirectory` which allows a user to set a subdirectory for a test.  The primary use case for this is to allow the user to set a directory derived from a seed for a test (or a timestamp).  This is not the standard behavior. Normally, you only have one output directory and you are fine to override it.  However, we have internal uses where these directories need to be split up based on seed.

#### Release Notes

- Add subdirectory customization to `chisel3.testing.scalatest.TestingDirectory` via an overridable member, `subDir`. This can be used to have multiple runs of a test output to different subdirectories, e.g., to differentiate runs of the same test by time or by seed.