### PR TITLE
[chiselsim] Allow command line options to be passed to ChiselSim tests

### DIFF
--- a/src/main/scala/chisel3/simulator/scalatest/package.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/package.scala
@@ -2,7 +2,7 @@
 
 package chisel3.simulator
 
-import chisel3.testing.scalatest.TestingDirectory
+import chisel3.testing.scalatest.{HasConfigMap, TestingDirectory}
 import org.scalatest.TestSuite
 
 package object scalatest {

--- a/src/main/scala/chisel3/simulator/scalatest/package.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/package.scala
@@ -22,6 +22,6 @@ package object scalatest {
     *
     * @see [[chisel3.simulator.ChiselSim]]
     */
-  trait ChiselSim extends PeekPokeAPI with SimulatorAPI with TestingDirectory { self: TestSuite => }
+  trait ChiselSim extends HasConfigMap with PeekPokeAPI with SimulatorAPI with TestingDirectory { self: TestSuite => }
 
 }

--- a/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
+++ b/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
@@ -31,14 +31,18 @@ trait HasConfigMap extends TestSuiteMixin { self: TestSuite =>
   // Implement this via a `DynamicVariable` pattern that will be set via the
   // `withFixture` method.  The `super.withFixture` function must be called to
   // make this mix-in "stackable" with other mix-ins.
-  private val _configMap: DynamicVariable[ConfigMap] = new DynamicVariable[ConfigMap](ConfigMap.empty)
+  private val _configMap: DynamicVariable[Option[ConfigMap]] = new DynamicVariable[Option[ConfigMap]](None)
   abstract override def withFixture(test: NoArgTest) = {
-    _configMap.withValue(test.configMap) {
+    _configMap.withValue(Some(test.configMap)) {
       super.withFixture(test)
     }
   }
 
-  /** Return command line options passed to the test as a `Map`. */
-  def configMap: Map[String, Any] = _configMap.value
+  /** Return the config map which contains all command line options passed to Scalatest.
+    *
+    * This is only valid during a test.  It will be `None` if used outside a
+    * test.
+    */
+  def configMap: Option[ConfigMap] = _configMap.value
 
 }

--- a/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
+++ b/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
@@ -42,7 +42,11 @@ trait HasConfigMap extends TestSuiteMixin { self: TestSuite =>
     *
     * This is only valid during a test.  It will be `None` if used outside a
     * test.
+    *
+    * @throws RuntimeException if called outside a Scalatest test
     */
-  def configMap: Option[ConfigMap] = _configMap.value
+  def configMap: ConfigMap = _configMap.value.getOrElse {
+    throw new RuntimeException("configMap may only be accessed inside a Scalatest test")
+  }
 
 }

--- a/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
+++ b/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.testing.scalatest
+
+import org.scalatest.{ConfigMap, TestSuite, TestSuiteMixin}
+import scala.util.DynamicVariable
+
+/** A Scalatest test suite mix-in that provides access to command line options.
+  *
+  * This expose any keys/values passed using the `-D<key>=<value` command line
+  * option to the test via a `Map`.
+  *
+  * For example, you can invoke Scalatest passing the `foo=bar` option like so:
+  * {{{
+  * ./mill 'chisel[2.13.16].test.testOnly' 'fooTest' -Dfoo=bar
+  * }}}
+  *
+  * Inside your test, if the `configMap` member function is accessed this will
+  * return:
+  * {{{
+  * Map(foo -> bar)
+  * }}}
+  *
+  * This is intended to be a building block of more complicated tests that want
+  * to customize their execution via the command line.  It is advisable to use
+  * this sparingly as tests are generally not intended to change when you run
+  * them.
+  */
+trait HasConfigMap extends TestSuiteMixin { self: TestSuite =>
+
+  // Implement this via a `DynamicVariable` pattern that will be set via the
+  // `withFixture` method.  The `super.withFixture` function must be called to
+  // make this mix-in "stackable" with other mix-ins.
+  private val _configMap: DynamicVariable[ConfigMap] = new DynamicVariable[ConfigMap](ConfigMap.empty)
+  abstract override def withFixture(test: NoArgTest) = {
+    _configMap.withValue(test.configMap) {
+      super.withFixture(test)
+    }
+  }
+
+  /** Return command line options passed to the test as a `Map`. */
+  def configMap: Map[String, Any] = _configMap.value
+
+}

--- a/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
+++ b/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
@@ -12,7 +12,7 @@ import scala.util.DynamicVariable
   *
   * For example, you can invoke Scalatest passing the `foo=bar` option like so:
   * {{{
-  * ./mill 'chisel[2.13.16].test.testOnly' 'fooTest' -Dfoo=bar
+  * ./mill 'chisel[2.13.16].test.testOnly' fooTest -Dfoo=bar
   * }}}
   *
   * Inside your test, if the `configMap` member function is accessed this will

--- a/src/test/scala-2/chiselTests/testing/scalatest/HasConfigMapSpec.scala
+++ b/src/test/scala-2/chiselTests/testing/scalatest/HasConfigMapSpec.scala
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.testing.scalatest
+
+import chisel3.testing.scalatest.HasConfigMap
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HasConfigMapSpec extends AnyFlatSpec with Matchers with HasConfigMap {
+
+  behavior of "HasConfigMap"
+
+  it should "be accessible inside a test" in {
+    configMap
+  }
+
+  val outsideTestException = intercept[Exception] {
+    configMap
+  }
+
+  it should "throw a RuntimeException if used outside a test" in {
+    outsideTestException shouldBe a[RuntimeException]
+    outsideTestException.getMessage should include("configMap may only be accessed inside a Scalatest test")
+  }
+
+}


### PR DESCRIPTION
This is three commits that should be reviewed independently.  This builds towards and then adds a `HasConfigMap` trait which allows for `-D<key>=<value>` options to be exposed to `chisel3.simulator.scalatest.ChiselTest`. In order to do this, and without starting to add functionality directly to `ChiselSim`, the existing `TestingDirectory` trait is refactored to be made stackable.

#### Release Notes

Add the ability for users to pass command-line options, via `-D<key>=<value>`, to any `chisel3.simulator.scalatest.ChiselTest` test for them to customize the execution of the test.