### PR TITLE
[scalatest] Add HasCliSimulator

### DIFF
--- a/src/main/scala/chisel3/testing/scalatest/HasClilSimulator.scala
+++ b/src/main/scala/chisel3/testing/scalatest/HasClilSimulator.scala
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.testing.scalatest
+
+import chisel3.simulator.HasSimulator
+import chisel3.testing.scalatest.HasConfigMap
+
+/** Mix-in that brings a `HasSimulator` type class implementation into scope
+  * based on a command line argument.
+  *
+  * This provides default implementations of simulators.  Users can change the
+  * simulators provided by overriding the default protected members
+  * `cliSimulatorMap` and `defaultCliSimulator`.
+  *
+  */
+trait HasCliSimulator { this: HasConfigMap =>
+
+  /** A mapping of simulator names to simulators. */
+  protected def cliSimulatorMap: Map[String, HasSimulator] = Map(
+    "verilator" -> HasSimulator.simulators.verilator(),
+    "vcs" -> HasSimulator.simulators.vcs()
+  )
+
+  /** An optional default simulator to use if the user does _not_ provide a simulator.
+    *
+    * If `Some` then the provided default will be used.  If `None`, then a
+    * simulator must be provided.
+    */
+  protected def defaultCliSimulator: Option[HasSimulator] = Some(HasSimulator.default)
+
+  implicit def cliSimulator: HasSimulator = configMap.getOptional[String]("simulator") match {
+    case None =>
+      defaultCliSimulator.getOrElse(
+        throw new IllegalArgumentException(
+          s"""a simulator must be provided to this test using '-Dsimulator=<simulator-name>' where <simulator-name> must be one of ${cliSimulatorMap.keys
+              .mkString("[", ", ", "]")}"""
+        )
+      )
+    case Some(simulator) =>
+      cliSimulatorMap.getOrElse(
+        simulator,
+        throw new IllegalArgumentException(
+          s"""illegal simulator '$simulator', must be one of ${cliSimulatorMap.keys.mkString("[", ", ", "]")}"""
+        )
+      )
+  }
+
+}


### PR DESCRIPTION
Add a new trait, `HasCliSimulator`, that builds on `HasConfigMap` to provide a standardized way to get a simulator that the user can choose at scalatest test time via a `-Dsimulator=<simulator-name>` argument.

Note: this is difficult to test, however, I've tested it manually.

CC: @andrew-gouldey-sifive: I'm planning to get this into the open source and then use it internally. We will customize the simulator used internally slightly for the different Verilator or VCS default options that we use.

#### Release Notes

Add `HasCliSimulator` which can be used, along with `HasConfigMap`, to allow for tests to choose their simulator at test time via a `-D` command line option. This is added to avoid fragmentation of command line options around choosing which simulator to run.