### PR TITLE
[chiselsim] Add ControlAPI w/ Waveform Enable/Disable Support

### DIFF
--- a/src/main/scala/chisel3/simulator/ControlAPI.scala
+++ b/src/main/scala/chisel3/simulator/ControlAPI.scala
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.simulator
+
+trait ControlAPI {
+
+  /** Enable waveform dumping
+    *
+    * This control function will enable waveforms from the moment it is applied.
+    * A simulator must be compiled with waveform dumping support for this to
+    * have an effect.
+    *
+    * Example usage:
+    * {{{
+    * enableWaves()
+    * }}}
+    */
+  def enableWaves(): Unit = {
+    AnySimulatedModule.current.controller.setTraceEnabled(true)
+  }
+
+  /** Enable waveform dumping
+    *
+    * This control function will disable waveforms from the moment it is
+    * applied.  A simulator must be compiled with waveform dumping support for
+    * this to have an effect.
+    *
+    * Example usage:
+    * {{{
+    * disableWaves()
+    * }}}
+    */
+  def disableWaves(): Unit = {
+    AnySimulatedModule.current.controller.setTraceEnabled(false)
+  }
+
+}

--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -23,7 +23,7 @@ package object simulator {
     *
     * @see [[chisel3.simulator.scalatest.ChiselSim]]
     */
-  trait ChiselSim extends PeekPokeAPI with SimulatorAPI
+  trait ChiselSim extends ControlAPI with PeekPokeAPI with SimulatorAPI
 
   /**
     * An opaque class that can be passed to `Simulation.run` to get access to a `SimulatedModule` in the simulation body.

--- a/src/main/scala/chisel3/simulator/scalatest/package.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/package.scala
@@ -22,6 +22,8 @@ package object scalatest {
     *
     * @see [[chisel3.simulator.ChiselSim]]
     */
-  trait ChiselSim extends HasConfigMap with PeekPokeAPI with SimulatorAPI with TestingDirectory { self: TestSuite => }
+  trait ChiselSim extends HasConfigMap with PeekPokeAPI with SimulatorAPI with ControlAPI with TestingDirectory {
+    self: TestSuite =>
+  }
 
 }

--- a/src/main/scala/chisel3/simulator/scalatest/package.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/package.scala
@@ -22,7 +22,7 @@ package object scalatest {
     *
     * @see [[chisel3.simulator.ChiselSim]]
     */
-  trait ChiselSim extends HasConfigMap with PeekPokeAPI with SimulatorAPI with ControlAPI with TestingDirectory {
+  trait ChiselSim extends chisel3.simulator.ChiselSim with HasConfigMap with TestingDirectory {
     self: TestSuite =>
   }
 

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -173,6 +173,35 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
         allFiles should contain(file)
       }
     }
+
+    it("should dump a waveform when enableWaves is used") {
+
+      implicit val verilator = HasSimulator.simulators
+        .verilator(verilatorSettings =
+          svsim.verilator.Backend.CompilationSettings(
+            traceStyle =
+              Some(svsim.verilator.Backend.CompilationSettings.TraceStyle.Vcd(traceUnderscore = true, "trace.vcd"))
+          )
+        )
+
+      class Foo extends Module {
+        stop()
+      }
+
+      val vcdFile = FileSystems
+        .getDefault()
+        .getPath(implicitly[HasTestingDirectory].getDirectory.toString, "workdir-verilator", "trace.vcd")
+        .toFile
+
+      vcdFile.delete
+
+      simulateRaw(new Foo) { _ =>
+        enableWaves()
+      }
+
+      info(s"$vcdFile exists")
+      vcdFile should (exist)
+    }
   }
 
 }


### PR DESCRIPTION
Add a missing ChiselSim ControlAPI.  This currently only includes APIs to
enable and disalbe waveforms.  This API was previously inaccessible
because you would need to get at an svsim Controller to use it.

Note: the enable/disable waveform APIs will have no effect unless the
simulator is compiled with waveform support.

#### Release Notes

Add `ControlAPI` to ChiselSim. This adds `enableWaves` and `disableWaves` functions. These functions _require_ compiling a simulator with waveform support.