### PR TITLE
Fix SInt literals to reject too small of widths

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -171,7 +171,9 @@ private[chisel3] object ir {
       val unsigned = if (n < 0) (BigInt(1) << width.get) + n else n
       s"asSInt(${ULit(unsigned, width).name})"
     }
-    def minWidth: Int = (if (w.known) 0 else 1) + n.bitLength
+
+    // Special case for 0 which can be specified to zero-width (but defaults to 1 bit).
+    def minWidth: Int = if (n == 0) (if (w.known) 0 else 1) else 1 + n.bitLength
 
     def cloneWithWidth(newWidth: Width): this.type = {
       SLit(n, newWidth).asInstanceOf[this.type]

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -173,7 +173,7 @@ private[chisel3] object ir {
     }
 
     // Special case for 0 which can be specified to zero-width (but defaults to 1 bit).
-    def minWidth: Int = if (n == 0) (if (w.known) 0 else 1) else 1 + n.bitLength
+    def minWidth: Int = if (n == 0 && w.known) 0 else 1 + n.bitLength
 
     def cloneWithWidth(newWidth: Width): this.type = {
       SLit(n, newWidth).asInstanceOf[this.type]

--- a/src/test/scala-2/chiselTests/SIntOps.scala
+++ b/src/test/scala-2/chiselTests/SIntOps.scala
@@ -284,4 +284,18 @@ class SIntOpsSpec extends AnyPropSpec with Matchers with ShiftRightWidthBehavior
     blit.x.litOption should be(Some(2))
     blit.y.litOption should be(Some(9))
   }
+
+  property("SInt literals with too small of a width should be rejected") {
+    // Sanity checks.
+    0.S.getWidth should be(1)
+    0.S(0.W).getWidth should be(0)
+    -1.S.getWidth should be(1)
+    1.S.getWidth should be(2)
+    // The real check.
+    -2.S.getWidth should be(2)
+    an[IllegalArgumentException] shouldBe thrownBy(-2.S(1.W))
+    0xde.S.getWidth should be(9)
+    an[IllegalArgumentException] shouldBe thrownBy(0xde.S(8.W))
+    an[IllegalArgumentException] shouldBe thrownBy(0xde.S(4.W))
+  }
 }


### PR DESCRIPTION
Found by @tymcauley https://github.com/ucb-bar/fixedpoint/pull/11#issuecomment-2715634001

This bug was introduced 2 years ago when we added support for zero-width literals: https://github.com/chipsalliance/chisel/pull/2932

The problem is that `BigInt.bitlength` excludes the sign bit, so we need to add 1 to it for SInts (which is what we originally did), BUT we need special case support for zero-width SInts (only when specified).

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

For users attempting to reinterpret raw 2s complement values as SInts, use `.U.asSInt`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
