### PR TITLE
[svsim] Use SNPS-specific license in VCS

### DIFF
--- a/src/main/scala/chisel3/simulator/HasSimulator.scala
+++ b/src/main/scala/chisel3/simulator/HasSimulator.scala
@@ -61,11 +61,7 @@ object HasSimulator {
     ): HasSimulator = new HasSimulator {
       override def getSimulator(implicit testingDirectory: HasTestingDirectory): Simulator[svsim.vcs.Backend] =
         new Simulator[svsim.vcs.Backend] {
-          override val backend = svsim.vcs.Backend.initializeFromProcessEnvironment().getOrElse {
-            throw new Exception(
-              "Unable to load VCS from the environment. (Did you forget to set VCS_HOME and LM_LICENSE_FILE?)"
-            )
-          }
+          override val backend = svsim.vcs.Backend.initializeFromProcessEnvironment()
           override val tag = "vcs"
           override val commonCompilationSettings = compilationSettings
           override val backendSpecificCompilationSettings = vcsSettings

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -160,4 +160,11 @@ final object Backend {
       */
     val backendEngagesInASLRShenanigans = "SVSIM_BACKEND_ENGAGES_IN_ASLR_SHENANIGANS"
   }
+
+  object Exceptions {
+
+    /** Indicates that a backend failed to initialize. */
+    final class FailedInitialization private[svsim] (message: String) extends RuntimeException(message)
+
+  }
 }

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -107,22 +107,24 @@ object Backend {
   ) extends svsim.Backend.Settings
 
   def initializeFromProcessEnvironment() = {
-    val vcsUserGuideNote = "Please consult the VCS User Guide for information on how to setup your environment to run VCS."
+    val vcsUserGuideNote =
+      "Please consult the VCS User Guide for information on how to setup your environment to run VCS."
 
     // Extract VCS-specific environment variables.  VCS_HOME must be set.  Then
     // either SNPSLMD_LICENSE_FILE or LM_LICENSE_FILE must be set.
-    val (vcsHome, lic) = (sys.env.get("VCS_HOME"), sys.env.get(LicenseFile.Synopsys.name), sys.env.get(LicenseFile.Generic.name)) match {
-      case (None, _, _) =>
-        throw new svsim.Backend.Exceptions.FailedInitialization(
-          s"Unable to initialize VCS as the environment variable 'VCS_HOME' was not set.  $vcsUserGuideNote"
-        )
-      case (Some(vcsHome), None, None) =>
-        throw new svsim.Backend.Exceptions.FailedInitialization(
-          s"Unable to initialize VCS as neither the environment variable '${LicenseFile.Synopsys.name}' or '${LicenseFile.Generic.name}' was set.  $vcsUserGuideNote"
-        )
-      case (Some(vcsHome), Some(snpsLic), _)  => (vcsHome, LicenseFile.Synopsys(snpsLic))
-      case (Some(vcsHome), None, Some(lmLic)) => (vcsHome, LicenseFile.Generic(lmLic))
-    }
+    val (vcsHome, lic) =
+      (sys.env.get("VCS_HOME"), sys.env.get(LicenseFile.Synopsys.name), sys.env.get(LicenseFile.Generic.name)) match {
+        case (None, _, _) =>
+          throw new svsim.Backend.Exceptions.FailedInitialization(
+            s"Unable to initialize VCS as the environment variable 'VCS_HOME' was not set.  $vcsUserGuideNote"
+          )
+        case (Some(vcsHome), None, None) =>
+          throw new svsim.Backend.Exceptions.FailedInitialization(
+            s"Unable to initialize VCS as neither the environment variable '${LicenseFile.Synopsys.name}' or '${LicenseFile.Generic.name}' was set.  $vcsUserGuideNote"
+          )
+        case (Some(vcsHome), Some(snpsLic), _)  => (vcsHome, LicenseFile.Synopsys(snpsLic))
+        case (Some(vcsHome), None, Some(lmLic)) => (vcsHome, LicenseFile.Generic(lmLic))
+      }
 
     new Backend(
       vcsHome,

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -107,19 +107,21 @@ object Backend {
   ) extends svsim.Backend.Settings
 
   def initializeFromProcessEnvironment() = {
-    val (vcsHome, lic) = List("VCS_HOME", LicenseFile.Synopsys.name, LicenseFile.Generic.name).map(sys.env.get) match {
-      case None :: _ :: _ :: Nil =>
+    val vcsUserGuideNote = "Please consult the VCS User Guide for information on how to setup your environment to run VCS."
+
+    // Extract VCS-specific environment variables.  VCS_HOME must be set.  Then
+    // either SNPSLMD_LICENSE_FILE or LM_LICENSE_FILE must be set.
+    val (vcsHome, lic) = (sys.env.get("VCS_HOME"), sys.env.get(LicenseFile.Synopsys.name), sys.env.get(LicenseFile.Generic.name)) match {
+      case (None, _, _) =>
         throw new svsim.Backend.Exceptions.FailedInitialization(
-          "Unable to initialize VCS as the environment variable 'VCS_HOME' was not set.  Please consult the VCS User Guide for information on how to setup your environment to run VCS."
+          s"Unable to initialize VCS as the environment variable 'VCS_HOME' was not set.  $vcsUserGuideNote"
         )
-      case Some(vcsHome) :: None :: None :: Nil =>
+      case (Some(vcsHome), None, None) =>
         throw new svsim.Backend.Exceptions.FailedInitialization(
-          s"Unable to initialize VCS as neither the environment variable '${LicenseFile.Synopsys.name}' or '${LicenseFile.Generic.name}' was set.  Please consult the VCS User Guide for information on how to setup your environment to run VCS."
+          s"Unable to initialize VCS as neither the environment variable '${LicenseFile.Synopsys.name}' or '${LicenseFile.Generic.name}' was set.  $vcsUserGuideNote"
         )
-      case Some(vcsHome) :: Some(snpsLic) :: _ :: Nil  => (vcsHome, LicenseFile.Synopsys(snpsLic))
-      case Some(vcsHome) :: None :: Some(lmLic) :: Nil => (vcsHome, LicenseFile.Generic(lmLic))
-      // This is truly unreachable.
-      case _ => ???
+      case (Some(vcsHome), Some(snpsLic), _)  => (vcsHome, LicenseFile.Synopsys(snpsLic))
+      case (Some(vcsHome), None, Some(lmLic)) => (vcsHome, LicenseFile.Generic(lmLic))
     }
 
     new Backend(


### PR DESCRIPTION
Fix the logic for grabbing environment variables for the replay Makefile when running VCS tests.  The VCS manual says that you grab the Synopsys-specific license file (SNPSLMD_LICENSE_FILE) first and only use the generic license file (LM_LICENSE_FILE) if that fails.  The existing code was wrong in that it only grabbed the latter.  There is no requirement that the latter is available and that is only a fallback if the former doesn't exist.

Also, add some lightweight infrastructure to cleanup the representation of VCS license files.

I tested this internally and all the tests passed.  (I had to change the test to queue for licenses, though...)

Fixes #4785.

CC: @tymcauley 

#### Release Notes

In svsim, use Synopsys-specific license if available. Otherwise, fallback to the default, generic license file. This is used for generating the rerun Makefile. Previously, this would always use the generic license file which is not _required_ that it must be set. (This aligns svsim with the VCS manual on what the expected environment should look like.)