### PR TITLE
[svsim] Add coverage collection to VCS backend

### DIFF
--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -154,12 +154,36 @@ object Backend {
 
   }
 
+  /** Settings for controlling VCS toggle coverage.
+    *
+    * These options map to the `-cm_tgl` option.  Consult the Synopsys VCS user
+    * guide for documentation.
+    */
+  final case class ToggleCoverageSettings(
+    assign:              Boolean = false,
+    portsonly:           Boolean = false,
+    fullintf:            Boolean = false,
+    mda:                 Boolean = false,
+    count:               Boolean = false,
+    structarr:           Boolean = false,
+    modportarr:          Boolean = false,
+    union_excl:          Boolean = false,
+    union_adv:           Boolean = false,
+    unencrypted_signals: Boolean = false,
+    old:                 Boolean = false
+  ) extends PlusSeparated {
+
+    override def name = "cm_tgl"
+
+  }
+
   case class CompilationSettings(
     xProp:                       Option[CompilationSettings.XProp] = None,
     randomlyInitializeRegisters: Boolean = false,
     traceSettings:               CompilationSettings.TraceSettings = CompilationSettings.TraceSettings(),
     simulationSettings:          SimulationSettings = SimulationSettings(),
     coverageSettings:            CoverageSettings = CoverageSettings(),
+    toggleCoverageSettings:      ToggleCoverageSettings = ToggleCoverageSettings(),
     licenceExpireWarningTimeout: Option[Int] = None,
     archOverride:                Option[String] = None,
     waitForLicenseIfUnavailable: Boolean = false

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -177,6 +177,20 @@ object Backend {
 
   }
 
+  /** Settings for controlling VCS branch coverage.
+    *
+    * These options map to the `-cm_branch` option.  Consult the Synopsys VCS
+    * user guide for documentation of this option.
+    */
+  final case class BranchCoverageSettings(
+    values:               Boolean = false,
+    ignoreMissingDefault: Boolean = false
+  ) extends PlusSeparated {
+
+    override def name = "cm_branch"
+
+  }
+
   case class CompilationSettings(
     xProp:                       Option[CompilationSettings.XProp] = None,
     randomlyInitializeRegisters: Boolean = false,
@@ -184,6 +198,7 @@ object Backend {
     simulationSettings:          SimulationSettings = SimulationSettings(),
     coverageSettings:            CoverageSettings = CoverageSettings(),
     toggleCoverageSettings:      ToggleCoverageSettings = ToggleCoverageSettings(),
+    branchCoverageSettings:      BranchCoverageSettings = BranchCoverageSettings(),
     licenceExpireWarningTimeout: Option[Int] = None,
     archOverride:                Option[String] = None,
     waitForLicenseIfUnavailable: Boolean = false

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -75,6 +75,44 @@ class VCSSpec extends BackendSpec {
           info("a VCS coverage database was created")
           Paths.get(workspace.absolutePath, "workdir-vcs", "simulation.vdb").toFile must (exist)
         }
+
+        // TODO: Find a way to test this.
+        they("extra toggle coverage options should not error") {
+          val workspace =
+            new svsim.Workspace(path = s"test_run_dir/${getClass().getSimpleName()}/ToggleCoverageSettings")
+
+          import Resources._
+          workspace.reset()
+          workspace.elaborateGCD()
+          workspace.generateAdditionalSources()
+          val simulation = workspace.compile(
+            backend
+          )(
+            workingDirectoryTag = "vcs",
+            commonSettings = CommonCompilationSettings(),
+            backendSpecificSettings = compilationSettings.copy(
+              coverageSettings = vcs.Backend.CoverageSettings(
+                tgl = true
+              ),
+              toggleCoverageSettings = vcs.Backend.ToggleCoverageSettings(
+                assign = true,
+                portsonly = true,
+                fullintf = true,
+                mda = true,
+                count = true,
+                structarr = true,
+                modportarr = true,
+                union_excl = true,
+                union_adv = true,
+                unencrypted_signals = true,
+                old = true
+              )
+            ),
+            customSimulationWorkingDirectory = None,
+            verbose = false
+          )
+        }
+
       }
   }
 }

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -77,7 +77,7 @@ class VCSSpec extends BackendSpec {
         }
 
         // TODO: Find a way to test this.
-        they("extra toggle coverage options should not error") {
+        they("extra toggle and branch coverage options should not error") {
           val workspace =
             new svsim.Workspace(path = s"test_run_dir/${getClass().getSimpleName()}/ToggleCoverageSettings")
 
@@ -92,7 +92,8 @@ class VCSSpec extends BackendSpec {
             commonSettings = CommonCompilationSettings(),
             backendSpecificSettings = compilationSettings.copy(
               coverageSettings = vcs.Backend.CoverageSettings(
-                tgl = true
+                tgl = true,
+                branch = true
               ),
               toggleCoverageSettings = vcs.Backend.ToggleCoverageSettings(
                 assign = true,
@@ -106,6 +107,10 @@ class VCSSpec extends BackendSpec {
                 union_adv = true,
                 unencrypted_signals = true,
                 old = true
+              ),
+              branchCoverageSettings = vcs.Backend.BranchCoverageSettings(
+                values = true,
+                ignoreMissingDefault = true
               )
             ),
             customSimulationWorkingDirectory = None,

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import svsim._
 import java.io.{BufferedReader, FileReader}
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 import scala.util.Either
 import scala.util.matching.Regex
 import svsimTests.Resources.TestWorkspace
@@ -31,8 +31,51 @@ class VCSSpec extends BackendSpec {
     waitForLicenseIfUnavailable = true
   )
   backend match {
-    case Right(backend) => test("vcs", backend)(compilationSettings)
-    case Left(_)        => ignore("Svsim backend 'vcs'") {}
+    case Left(_) => ignore("Svsim backend 'vcs'") {}
+    case Right(backend) =>
+      test("vcs", backend)(compilationSettings)
+
+      describe("VCS coverage options") {
+
+        they("coverage options should produce a coverage database") {
+          val workspace = new svsim.Workspace(path = s"test_run_dir/${getClass().getSimpleName()}/CoverageSettings")
+
+          import Resources._
+          workspace.reset()
+          workspace.elaborateGCD()
+          workspace.generateAdditionalSources()
+          val simulation = workspace.compile(
+            backend
+          )(
+            workingDirectoryTag = "vcs",
+            commonSettings = CommonCompilationSettings(),
+            backendSpecificSettings = compilationSettings.copy(coverageSettings =
+              vcs.Backend.CoverageSettings(
+                line = true,
+                cond = true,
+                fsm = true,
+                tgl = true,
+                assert = true,
+                branch = true,
+                // Don't set these options because they require other options.
+                path = false,
+                obc = false,
+                sdc = false
+              )
+            ),
+            customSimulationWorkingDirectory = None,
+            verbose = false
+          )
+
+          simulation.run(
+            verbose = false,
+            executionScriptLimit = None
+          ) { _ => }
+
+          info("a VCS coverage database was created")
+          Paths.get(workspace.absolutePath, "workdir-vcs", "simulation.vdb").toFile must (exist)
+        }
+      }
   }
 }
 


### PR DESCRIPTION
Add VCS backend options to enable coverage collection.  The options for this are taken directly from our internal flow.  I don't think that all these options need to be turned on (e.g., @girishpai indicated that `USE_UNR_ONLY_CONSTRAINTS` isn't load bearing).  However, I'd rather migrate things wholesale and then refactor later.

This includes a very simple test that a coverage database directory is created.  This database is not created if coverage is turned off.

CC: @andrew-gouldey-sifive

#### Release Notes

Add options to svsim VCS backend to allow for coverage collection.