### PR TITLE
[chiselsim] Chisel/firtool Options on SimulatorAPI

### DIFF
--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -27,7 +27,7 @@ object EphemeralSimulator extends PeekPokeAPI {
     implicit val temporary: HasTestingDirectory = HasTestingDirectory.temporary(deleteOnExit = true)
     chiselSim.simulateRaw(
       module,
-      ChiselSettings.defaultRaw[T].copy(verilogLayers = layerControl)
+      chiselSettings = ChiselSettings.defaultRaw[T].copy(verilogLayers = layerControl)
     )(body)
   }
 

--- a/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
@@ -153,10 +153,8 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
       // Check now the debug info is stripped
       val expectedSV = ChiselStage.emitSystemVerilog(new Bar, firtoolOpts = Array("--strip-debug-info", "-g"))
 
-      new VerilatorSimulator("test_run_dir/simulator/bar_debug_mode") {
-        override val firtoolArgs = Seq("--strip-debug-info", "-g")
-      }
-        .simulate(new Bar) { module =>
+      new VerilatorSimulator("test_run_dir/simulator/bar_debug_mode")
+        .simulate(new Bar, firtoolOpts = Array("-strip-debug-info", "-g")) { module =>
           import PeekPokeAPI._
           val bar = module.wrapped
 
@@ -188,10 +186,8 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
     it("simulate a circuit with zero-width ports") {
       val width = 0
       // Run a simulation with zero width foo
-      new VerilatorSimulator("test_run_dir/simulator/foo_zero_width") {
-        override val firtoolArgs = Seq("--strip-debug-info", "-g")
-      }
-        .simulate(new OptionalIOModule(n = width)) { module =>
+      new VerilatorSimulator("test_run_dir/simulator/foo_zero_width")
+        .simulate(new OptionalIOModule(n = width), firtoolOpts = Array("--strip-debug-info", "-g")) { module =>
           import PeekPokeAPI._
           val dut = module.wrapped
           dut.clock.step(2)
@@ -224,10 +220,8 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
     it("simulate a circuit with non zero-width ports") {
       val width = 8
       // Run a simulation with zero width foo
-      new VerilatorSimulator("test_run_dir/simulator/foo_non_zero_width") {
-        override val firtoolArgs = Seq("--strip-debug-info", "-g")
-      }
-        .simulate(new OptionalIOModule(n = width)) { module =>
+      new VerilatorSimulator("test_run_dir/simulator/foo_non_zero_width")
+        .simulate(new OptionalIOModule(n = width), Array("--strip-debug-info", "-g")) { module =>
           import PeekPokeAPI._
           val dut = module.wrapped
           dut.clock.step(2)
@@ -312,13 +306,18 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
       info("illegal constructs cause compilation failure")
       intercept[Exception] {
         new VerilatorSimulator("test_run_dir/simulator/does_not_compile_disabled_layers-enabledf")
-          .simulate(new Foo, ChiselSettings.default[Foo].copy(verilogLayers = LayerControl.EnableAll)) { _ => }
+          .simulate(
+            new Foo,
+            chiselSettings = ChiselSettings.default[Foo].copy(verilogLayers = LayerControl.EnableAll)
+          ) { _ => }
           .result
       }.getMessage() should include("Unsupported: s_eventually")
 
       info("disabling unsupported constracts causes compilation to succeed")
       new VerilatorSimulator("test_run_dir/simulator/does_not_compile_disabled_layers-disabled")
-        .simulate(new Foo, ChiselSettings.default[Foo].copy(verilogLayers = LayerControl.DisableAll)) { _ => }
+        .simulate(new Foo, chiselSettings = ChiselSettings.default[Foo].copy(verilogLayers = LayerControl.DisableAll)) {
+          _ =>
+        }
         .result
 
     }


### PR DESCRIPTION
Modify ChiselSim simulate methods to allow for Chsiel and firtool options to be passed to the `simulate` methods.  This is done to allow for things like `--throw-on-first-error` to be passed.

For more context, we have a number of CLI options internally for working around the fact that ChiselSim doesn't support passing the Chisel/firtool compilation options to ChiselStage.  This seems wrong to me as I want to have the SimulatorAPI methods be richer externsions of what you can do with ChiselStage.  Ergo, because ChiselStage can control Chisel and firtool options, so should the SimulatorAPI.

The only slightly sharp edge here is that certain Chisel options may be illegal.  The Simulator APIs are already going to compile your module to SystemVerilog.  If you were to try to use `--target chirrtl`, then that is an illegal option combination.  This seems fine with the understanding that this can happen and users need to know what they are doing.

This is technically an API modification.

@jackkoenig: The original APIs here used `Seq[String]`. This isn't the same type as ChiselStage which is all `Array[String]`. I originally used `Array[String]` for this because it is the same type as what Scala 2 main functions use. Do you think it is worth hard-breaking all the public, but really internal ChiselSim APIs here?

#### Release Notes

Allow users to pass Chisel and `firtool` options directly to ChiselSim simulation functions.