### PR TITLE
[svsim][chiselsim] Add plusarg support

### DIFF
--- a/src/main/scala/chisel3/simulator/ChiselSettings.scala
+++ b/src/main/scala/chisel3/simulator/ChiselSettings.scala
@@ -76,22 +76,26 @@ object MacroText {
   * @param stopCond a condition that guards terminating the simulation (via
   * `$fatal`) for asserts created from `circt_chisel_ifelsefatal` intrinsics
   * enabled _during Verilog elaboration_.
+  * @param plusArgs Verilog `$value$plusargs` or `$test$plusargs` to set at
+  * simulation runtime.
   */
 final class ChiselSettings[A <: RawModule] private[simulator] (
   /** Layers to turn on/off during Verilog elaboration */
   val verilogLayers:     LayerControl.Type,
   val assertVerboseCond: Option[MacroText.Type[A]],
   val printfCond:        Option[MacroText.Type[A]],
-  val stopCond:          Option[MacroText.Type[A]]
+  val stopCond:          Option[MacroText.Type[A]],
+  val plusArgs:          Seq[svsim.PlusArg]
 ) {
 
   def copy(
     verilogLayers:     LayerControl.Type = verilogLayers,
     assertVerboseCond: Option[MacroText.Type[A]] = assertVerboseCond,
     printfCond:        Option[MacroText.Type[A]] = printfCond,
-    stopCond:          Option[MacroText.Type[A]] = stopCond
+    stopCond:          Option[MacroText.Type[A]] = stopCond,
+    plusArgs:          Seq[svsim.PlusArg] = plusArgs
   ) =
-    new ChiselSettings(verilogLayers, assertVerboseCond, printfCond, stopCond)
+    new ChiselSettings(verilogLayers, assertVerboseCond, printfCond, stopCond, plusArgs)
 
   private[simulator] def preprocessorDefines(
     elaboratedModule: ElaboratedModule[A]
@@ -136,7 +140,8 @@ object ChiselSettings {
     verilogLayers = LayerControl.EnableAll,
     assertVerboseCond = Some(MacroText.NotSignal(get = _.reset)),
     printfCond = Some(MacroText.NotSignal(get = _.reset)),
-    stopCond = Some(MacroText.NotSignal(get = _.reset))
+    stopCond = Some(MacroText.NotSignal(get = _.reset)),
+    plusArgs = Seq.empty
   )
 
   /** Retun a default [[ChiselSettings]] for a [[RawModule]].
@@ -162,7 +167,8 @@ object ChiselSettings {
     verilogLayers = LayerControl.EnableAll,
     assertVerboseCond = None,
     printfCond = None,
-    stopCond = None
+    stopCond = None,
+    plusArgs = Seq.empty
   )
 
   /** Simple factory for construcing a [[ChiselSettings]] from arguments.
@@ -182,12 +188,14 @@ object ChiselSettings {
     verilogLayers:     LayerControl.Type,
     assertVerboseCond: Option[MacroText.Type[A]],
     printfCond:        Option[MacroText.Type[A]],
-    stopCond:          Option[MacroText.Type[A]]
+    stopCond:          Option[MacroText.Type[A]],
+    plusArgs:          Seq[svsim.PlusArg]
   ): ChiselSettings[A] = new ChiselSettings(
     verilogLayers = verilogLayers,
     assertVerboseCond = assertVerboseCond,
     printfCond = printfCond,
-    stopCond = stopCond
+    stopCond = stopCond,
+    plusArgs = plusArgs
   )
 
 }

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -127,6 +127,9 @@ trait Simulator[T <: Backend] {
         commonCompilationSettings.fileFilter.orElse(chiselSettings.verilogLayers.shouldIncludeFile(elaboratedModule)),
       directoryFilter = commonCompilationSettings.directoryFilter.orElse(
         chiselSettings.verilogLayers.shouldIncludeDirectory(elaboratedModule, workspace.primarySourcesPath)
+      ),
+      simulationSettings = commonCompilationSettings.simulationSettings.copy(
+        plusArgs = commonCompilationSettings.simulationSettings.plusArgs ++ chiselSettings.plusArgs
       )
     )
 

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -13,6 +13,38 @@ object CommonSettingsModifications {
 
 // -- Compilation Settings
 
+/** Backend-independent simulation runtime settings
+  *
+  * @note Use [[CommonSimulationSettings$]] methods to create objects of this
+  * class.
+  */
+final class CommonSimulationSettings private[svsim] (
+  val plusArgs: Seq[PlusArg]
+) {
+
+  /** Return a copy of this [[CommonSimulationSettings]] with some fields
+    * modified.
+    */
+  def copy(
+    plusArgs: Seq[PlusArg] = plusArgs
+  ) = new CommonSimulationSettings(
+    plusArgs = plusArgs
+  )
+}
+
+object CommonSimulationSettings {
+
+  /** Return a [[CommonSimulationSettings]] with default values.
+    *
+    * @param plusArgs Verilog value or test plusargs to set at simulation
+    * runtime
+    */
+  def default = new CommonSimulationSettings(
+    plusArgs = Seq.empty
+  )
+
+}
+
 /** Settings supported by all svsim backends.
   */
 case class CommonCompilationSettings(
@@ -20,12 +52,13 @@ case class CommonCompilationSettings(
   optimizationStyle: CommonCompilationSettings.OptimizationStyle = CommonCompilationSettings.OptimizationStyle.Default,
   availableParallelism: CommonCompilationSettings.AvailableParallelism =
     CommonCompilationSettings.AvailableParallelism.Default,
-  defaultTimescale:  Option[CommonCompilationSettings.Timescale] = None,
-  libraryExtensions: Option[Seq[String]] = None,
-  libraryPaths:      Option[Seq[String]] = None,
-  includeDirs:       Option[Seq[String]] = None,
-  fileFilter:        PartialFunction[File, Boolean] = PartialFunction.empty,
-  directoryFilter:   PartialFunction[File, Boolean] = PartialFunction.empty
+  defaultTimescale:   Option[CommonCompilationSettings.Timescale] = None,
+  libraryExtensions:  Option[Seq[String]] = None,
+  libraryPaths:       Option[Seq[String]] = None,
+  includeDirs:        Option[Seq[String]] = None,
+  fileFilter:         PartialFunction[File, Boolean] = PartialFunction.empty,
+  directoryFilter:    PartialFunction[File, Boolean] = PartialFunction.empty,
+  simulationSettings: CommonSimulationSettings = CommonSimulationSettings.default
 )
 object CommonCompilationSettings {
   object VerilogPreprocessorDefine {
@@ -75,6 +108,27 @@ object CommonCompilationSettings {
   object Timescale {
     case class FromString(value: String) extends Timescale
   }
+}
+
+/** A key/value pair representing a Verilog plusarg
+  *
+  * When `value` is a `Some`, this acts like a `$value$plusargs`.  When `value`
+  * is `None`, this acts like a `$test$plusargs`.  I.e., when `None`, the
+  * plusarg is simply set.  When `Some`, the plusarg has a value.
+  *
+  * @param name the name of the plusarg
+  * @param value an optional value for the plusarg
+  */
+final class PlusArg(
+  val name:  String,
+  val value: Option[String] = None
+) {
+
+  /** Return Verilator-compliant or VCS-compliant simulator options to set this
+    * plusarg.
+    */
+  def simulatorFlags: String = (name +: value.toSeq).mkString("+", "=", "")
+
 }
 
 trait Backend {

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -241,7 +241,7 @@ final class Backend(
 ) extends svsim.Backend {
   type CompilationSettings = Backend.CompilationSettings
 
-  def generateParameters(
+  override def generateParameters(
     outputBinaryName:        String,
     topModuleName:           String,
     additionalHeaderPaths:   Seq[String],
@@ -359,6 +359,7 @@ final class Backend(
             case None                                          => Seq()
             case Some(Backend.AssertGlobalMaxFailCount(count)) => Seq("-assert", s"global_finish_maxfail=$count")
           },
+          commonSettings.simulationSettings.plusArgs.map(_.simulatorFlags),
         ).flatten,
         environment = environment
       )

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -163,7 +163,7 @@ final class Backend(executablePath: String) extends svsim.Backend {
         ).flatten,
         environment = Seq()
       ),
-      simulationInvocation = svsim.Backend.Parameters.Invocation(Seq(), Seq())
+      simulationInvocation = svsim.Backend.Parameters.Invocation(commonSettings.simulationSettings.plusArgs.map(_.simulatorFlags), Seq())
     )
     //format: on
   }

--- a/svsim/src/test/resources/PlusArg.sv
+++ b/svsim/src/test/resources/PlusArg.sv
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+module PlusArg(output reg value, output reg test);
+
+  initial begin
+    value = 0;
+    test = 0;
+    $value$plusargs("value=%d", value);
+    if ($test$plusargs("test"))
+      test = 1;
+  end
+
+
+endmodule

--- a/svsim/src/test/scala/BackendSpec.scala
+++ b/svsim/src/test/scala/BackendSpec.scala
@@ -127,7 +127,7 @@ class VCSSpec extends BackendSpec {
   */
 case class CustomVerilatorBackend(actualBackend: verilator.Backend) extends Backend {
   type CompilationSettings = verilator.Backend.CompilationSettings
-  def generateParameters(
+  override def generateParameters(
     outputBinaryName:        String,
     topModuleName:           String,
     additionalHeaderPaths:   Seq[String],
@@ -468,6 +468,43 @@ trait BackendSpec extends AnyFunSpec with Matchers {
           .filter(finishRe.matches(_))
           .toArray
           .size must be(1)
+      }
+
+      it("should support both $value$plusargs and $test$plusargs") {
+        workspace.reset()
+        workspace.elaboratePlusArgTest()
+        workspace.generateAdditionalSources()
+        simulation = workspace.compile(
+          backend
+        )(
+          workingDirectoryTag = name,
+          commonSettings = CommonCompilationSettings(
+            simulationSettings = CommonSimulationSettings.default.copy(
+              plusArgs = Seq(
+                new PlusArg(name = "value", value = Some("1")),
+                new PlusArg(name = "test", value = None)
+              )
+            )
+          ),
+          backendSpecificSettings = compilationSettings,
+          customSimulationWorkingDirectory = None,
+          verbose = false
+        )
+        simulation.run(
+          verbose = false,
+          executionScriptLimit = None
+        ) { controller =>
+          val value = controller.port("value")
+          val test = controller.port("test")
+          value.check() { a =>
+            info("$value$plusargs work")
+            a.asBigInt must be(1)
+          }
+          test.check() { a =>
+            info("$test$plusargs work")
+            a.asBigInt must be(1)
+          }
+        }
       }
     }
   }

--- a/svsim/src/test/scala/Resources.scala
+++ b/svsim/src/test/scala/Resources.scala
@@ -146,5 +146,25 @@ object Resources {
         )
       )
     }
+    def elaboratePlusArgTest(): Unit = {
+      workspace.addPrimarySourceFromResource(getClass, "/PlusArg.sv")
+      workspace.elaborate(
+        ModuleInfo(
+          name = "PlusArg",
+          ports = Seq(
+            new ModuleInfo.Port(
+              name = "value",
+              isSettable = false,
+              isGettable = true
+            ),
+            new ModuleInfo.Port(
+              name = "test",
+              isSettable = false,
+              isGettable = true
+            )
+          )
+        )
+      )
+    }
   }
 }


### PR DESCRIPTION
Add the ability to set `$value$plusarg` and `$test$plusargs` directly from
ChiselSim simulate APIs.  These can be specified using the lower level
options to the simulator or via the implicit common/backend-specific
options.  However, this new API is the intended way that these should be
set by the user going forward.

Add the ability to pass plusargs to svsim simulations.

Note: there is some ugliness here in that simulation options are passed to functions that are doing "compilation".  This is a software architecture problem in svsim as evidenced by backend compilation options including runtime options (for VCS).  This all needs to be cleaned up separately.

#### Release Notes

Add support for Verilog `$value$plusargs` and `$test$plusargs` to svsim and ChiselSim.