### PR TITLE
[chiselsim] Add CLI FSDB, VPD support, enable waves (VCD, too)

### DIFF
--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -116,20 +116,22 @@ trait Simulator[T <: Backend] {
     val elaboratedModule = workspace.elaborateGeneratedModule({ () => module }, firtoolArgs = firtoolOpts.toSeq)
     workspace.generateAdditionalSources()
 
-    val commonCompilationSettingsUpdated = commonSettingsModifications(commonCompilationSettings).copy(
-      // Append to the include directorires based on what the
-      // workspace indicates is the path for primary sources.  This
-      // ensures that `` `include `` directives can be resolved.
-      includeDirs = Some(commonCompilationSettings.includeDirs.getOrElse(Seq.empty) :+ workspace.primarySourcesPath),
-      verilogPreprocessorDefines =
-        commonCompilationSettings.verilogPreprocessorDefines ++ chiselSettings.preprocessorDefines(elaboratedModule),
-      fileFilter =
-        commonCompilationSettings.fileFilter.orElse(chiselSettings.verilogLayers.shouldIncludeFile(elaboratedModule)),
-      directoryFilter = commonCompilationSettings.directoryFilter.orElse(
-        chiselSettings.verilogLayers.shouldIncludeDirectory(elaboratedModule, workspace.primarySourcesPath)
-      ),
-      simulationSettings = commonCompilationSettings.simulationSettings.copy(
-        plusArgs = commonCompilationSettings.simulationSettings.plusArgs ++ chiselSettings.plusArgs
+    val commonCompilationSettingsUpdated = commonSettingsModifications(
+      commonCompilationSettings.copy(
+        // Append to the include directorires based on what the
+        // workspace indicates is the path for primary sources.  This
+        // ensures that `` `include `` directives can be resolved.
+        includeDirs = Some(commonCompilationSettings.includeDirs.getOrElse(Seq.empty) :+ workspace.primarySourcesPath),
+        verilogPreprocessorDefines =
+          commonCompilationSettings.verilogPreprocessorDefines ++ chiselSettings.preprocessorDefines(elaboratedModule),
+        fileFilter =
+          commonCompilationSettings.fileFilter.orElse(chiselSettings.verilogLayers.shouldIncludeFile(elaboratedModule)),
+        directoryFilter = commonCompilationSettings.directoryFilter.orElse(
+          chiselSettings.verilogLayers.shouldIncludeDirectory(elaboratedModule, workspace.primarySourcesPath)
+        ),
+        simulationSettings = commonCompilationSettings.simulationSettings.copy(
+          plusArgs = commonCompilationSettings.simulationSettings.plusArgs ++ chiselSettings.plusArgs
+        )
       )
     )
 

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -170,7 +170,10 @@ trait Simulator[T <: Backend] {
     // Note: this would be much better to handle with extensions to the FIRRTL
     // ABI which would abstract away these differences.
     val simulationOutcome = Try {
-      simulation.runElaboratedModule(elaboratedModule = elaboratedModule) { (module: SimulatedModule[T]) =>
+      simulation.runElaboratedModule(
+        elaboratedModule = elaboratedModule,
+        traceEnabled = commonCompilationSettingsUpdated.simulationSettings.enableWavesAtTimeZero
+      ) { (module: SimulatedModule[T]) =>
         val outcome = body(module)
         module.completeSimulation()
         outcome

--- a/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
@@ -127,26 +127,30 @@ object CLI {
 
   import HasCliArguments.CliOption
 
-  trait FsdbCapability { this: HasCliArguments =>
+  trait EmitFsdb { this: HasCliArguments =>
 
     addOption(
       CliOption[Unit](
-        name = "withFsdbCapability",
-        help = "compiles the simulator with FSDB support. (Use `enableWaves` to dump a FSDB.)",
+        name = "emitFsdb",
+        help = "emit a FSDB waveform for the entire simulation",
         convert = value => {
           val trueValue = Set("true", "1")
           trueValue.contains(value) match {
             case true => ()
             case false =>
               throw new IllegalArgumentException(
-                s"""invalid argument '$value' for option 'enableFsdbSupport', must be one of ${trueValue
+                s"""invalid argument '$value' for option 'emitFsdb', must be one of ${trueValue
                     .mkString("[", ", ", "]")}"""
               ) with NoStackTrace
           }
         },
         updateCommonSettings = (_, options) => {
-          options.copy(verilogPreprocessorDefines =
-            options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableFsdbTracingSupport)
+          options.copy(
+            verilogPreprocessorDefines =
+              options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableFsdbTracingSupport),
+            simulationSettings = options.simulationSettings.copy(
+              enableWavesAtTimeZero = true
+            )
           )
         },
         updateBackendSettings = (_, options) =>
@@ -174,26 +178,30 @@ object CLI {
 
   }
 
-  trait VcdCapability { this: HasCliArguments =>
+  trait EmitVcd { this: HasCliArguments =>
 
     addOption(
       CliOption[Unit](
-        name = "withVcdCapability",
-        help = "compiles the simulator with VCD support. (Use `enableWaves` to dump a VCD.)",
+        name = "emitVcd",
+        help = "compile with VCD waveform support and start dumping waves at time zero",
         convert = value => {
           val trueValue = Set("true", "1")
           trueValue.contains(value) match {
             case true => ()
             case false =>
               throw new IllegalArgumentException(
-                s"""invalid argument '$value' for option 'enableVcdSupport', must be one of ${trueValue
+                s"""invalid argument '$value' for option 'emitVcd', must be one of ${trueValue
                     .mkString("[", ", ", "]")}"""
               ) with NoStackTrace
           }
         },
         updateCommonSettings = (_, options) => {
-          options.copy(verilogPreprocessorDefines =
-            options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVcdTracingSupport)
+          options.copy(
+            verilogPreprocessorDefines =
+              options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVcdTracingSupport),
+            simulationSettings = options.simulationSettings.copy(
+              enableWavesAtTimeZero = true
+            )
           )
         },
         updateBackendSettings = (_, options) =>
@@ -215,26 +223,30 @@ object CLI {
 
   }
 
-  trait VpdCapability { this: HasCliArguments =>
+  trait EmitVpd { this: HasCliArguments =>
 
     addOption(
       CliOption[Unit](
-        name = "withVpdCapability",
-        help = "compiles the simulator with VPD support. (Use `enableWaves` to dump a VPD.)",
+        name = "emitVpd",
+        help = "compile with VPD waveform support and start dumping waves at time zero",
         convert = value => {
           val trueValue = Set("true", "1")
           trueValue.contains(value) match {
             case true => ()
             case false =>
               throw new IllegalArgumentException(
-                s"""invalid argument '$value' for option 'enableVpdSupport', must be one of ${trueValue
+                s"""invalid argument '$value' for option 'emitVpd', must be one of ${trueValue
                     .mkString("[", ", ", "]")}"""
               ) with NoStackTrace
           }
         },
         updateCommonSettings = (_, options) => {
-          options.copy(verilogPreprocessorDefines =
-            options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVpdTracingSupport)
+          options.copy(
+            verilogPreprocessorDefines =
+              options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVpdTracingSupport),
+            simulationSettings = options.simulationSettings.copy(
+              enableWavesAtTimeZero = true
+            )
           )
         },
         updateBackendSettings = (_, options) =>

--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -19,16 +19,19 @@ object CommonSettingsModifications {
   * class.
   */
 final class CommonSimulationSettings private[svsim] (
-  val plusArgs: Seq[PlusArg]
+  val plusArgs:              Seq[PlusArg],
+  val enableWavesAtTimeZero: Boolean
 ) {
 
   /** Return a copy of this [[CommonSimulationSettings]] with some fields
     * modified.
     */
   def copy(
-    plusArgs: Seq[PlusArg] = plusArgs
+    plusArgs:              Seq[PlusArg] = plusArgs,
+    enableWavesAtTimeZero: Boolean = enableWavesAtTimeZero
   ) = new CommonSimulationSettings(
-    plusArgs = plusArgs
+    plusArgs = plusArgs,
+    enableWavesAtTimeZero = enableWavesAtTimeZero
   )
 }
 
@@ -40,7 +43,8 @@ object CommonSimulationSettings {
     * runtime
     */
   def default = new CommonSimulationSettings(
-    plusArgs = Seq.empty
+    plusArgs = Seq.empty,
+    enableWavesAtTimeZero = false
   )
 
 }


### PR DESCRIPTION
Change the existing VCD waveform CLI API to _also_ enable waves. There was enough infrastructure there to do this and this is actually a way better API.

Add FSDB and VPD CLI emission. These require VCS and will throw an `IllegalArgumentException` if you try to use them with Verilator.

#### Release Notes

- Add ChiselSim traits which can be used to add Scalatest CLI support for compiling in FSDB and VPD waveform support into a test.
- Modify existing Scalatest CLI traits to both compile _and enable_ waves. These can be accessed with `-DemitVcd=1`, `-DemitVpd=1`, and `-DemitFsdb=1`.