### PR TITLE
Use commit hashes for actions not owned by Github

### DIFF
--- a/.github/workflows/build-scala-cli-example.yml
+++ b/.github/workflows/build-scala-cli-example.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install CIRCT
         id: install-circt
         if: ${{ inputs.circt }}
-        uses: circt/install-circt@v1.1.1
+        uses: circt/install-circt@3f8dda6e1c1965537b5801a43c81c287bac4eae4 # v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -32,9 +32,9 @@ jobs:
           dir=$(dirname $(which firtool))
           echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
       - name: Cache Scala-CLI
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@142d2738bd29f0eb9d44610828acb3a19809feab # v6.4.6
       - name: Setup Scala-CLI
-        uses: VirtusLab/scala-cli-setup@v1
+        uses: VirtusLab/scala-cli-setup@28971dc5a5d4e155d2e410220ab21948383baaf9 # v1.7.0
         with:
           jvm: adoptium:17
       - name: Generate Chisel Scala CLI Example

--- a/.github/workflows/cd-circt.yml
+++ b/.github/workflows/cd-circt.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 'circt/update-circt'
-        uses: circt/update-circt@v1
+        uses: circt/update-circt@eacb8963f4f0872649ef5bb3245894929ddebe58 # v1.1.1
         with:
           user: chiselbot
           email: chiselbot@users.noreply.github.com

--- a/.github/workflows/ci-circt-nightly.yml
+++ b/.github/workflows/ci-circt-nightly.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Update Staging Branch
-        uses: circt/update-staging-branch@v1.2.0
+        uses: circt/update-staging-branch@c05f7e8f8357e1f05f351694593c8c13f835fe76 # v1.2.0
         with:
           user: chiselbot
           email: chiselbot@users.noreply.github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cache Scala
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@142d2738bd29f0eb9d44610828acb3a19809feab # v6.4.6
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@v1
+        uses: VirtusLab/scala-cli-setup@28971dc5a5d4e155d2e410220ab21948383baaf9 # v1.7.0
         with:
           jvm: temurin:11
       - name: Publish
@@ -112,7 +112,7 @@ jobs:
       - name: Untar built website
         run: tar zxf website.tar.gz
       - name: Deploy Website to GitHub Pages (From Main Branch)
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build

--- a/.github/workflows/enable-bincompat-checking.yml
+++ b/.github/workflows/enable-bincompat-checking.yml
@@ -77,7 +77,7 @@ jobs:
           VERSION_NO_V=${VERSION#v}
           echo $VERSION_NO_V >> project/previous-versions.txt
       - name: Open PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           base: ${{ matrix.branch }}
           branch: bincompat/${{ matrix.branch }}/${{ needs.determine_version.outputs.version }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build Release Notes
         id: release-notes
-        uses: mikepenz/release-changelog-builder-action@v4.1.1
+        uses: mikepenz/release-changelog-builder-action@5f3409748e2230350e149a7f7b5b8e9bcd785d44 # v4.1.1
         with:
           configuration: .github/workflows/config/release-notes.json
           failOnError: true
@@ -43,7 +43,7 @@ jobs:
         run: echo "$CHANGELOG" >> $GITHUB_STEP_SUMMARY
       - name: Upload Release Notes (on release)
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2.1.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           body: ${{ steps.release-notes.outputs.changelog }}
       - name: Error on uncategorized PRs

--- a/.github/workflows/scala-cli-example.yml
+++ b/.github/workflows/scala-cli-example.yml
@@ -29,6 +29,6 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload To Release Page
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2.1.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           files: chisel-example.scala

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install CIRCT
         id: install-circt
         if: ${{ inputs.circt }}
-        uses: circt/install-circt@v1.1.1
+        uses: circt/install-circt@3f8dda6e1c1965537b5801a43c81c287bac4eae4 # v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -107,7 +107,7 @@ jobs:
       - name: Install CIRCT
         id: install-circt
         if: ${{ inputs.circt }}
-        uses: circt/install-circt@v1.1.1
+        uses: circt/install-circt@3f8dda6e1c1965537b5801a43c81c287bac4eae4 # v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -167,7 +167,7 @@ jobs:
       - name: Install CIRCT
         id: install-circt
         if: ${{ inputs.circt }}
-        uses: circt/install-circt@v1.1.1
+        uses: circt/install-circt@3f8dda6e1c1965537b5801a43c81c287bac4eae4 # v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}
@@ -232,9 +232,9 @@ jobs:
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Cache Scala
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@142d2738bd29f0eb9d44610828acb3a19809feab # v6.4.6
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@v1
+        uses: VirtusLab/scala-cli-setup@28971dc5a5d4e155d2e410220ab21948383baaf9 # v1.7.0
         with:
           jvm: adoptium:17
       - name: Setup Node
@@ -244,7 +244,7 @@ jobs:
       - name: Install CIRCT
         id: install-circt
         if: ${{ inputs.circt }}
-        uses: circt/install-circt@v1.1.1
+        uses: circt/install-circt@3f8dda6e1c1965537b5801a43c81c287bac4eae4 # v1.1.1
         with:
           version: ${{ inputs.circt }}
           github-token: ${{ github.token }}


### PR DESCRIPTION
Try not to be too paranoid, but in light of the recent compromise of a popular action `tj-actions/changed-files` [[1]](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) (that we weren't using, but still). It's probably best to pin to specific commits of Actions. I think leaving the core Github Actions alone is _okay_ because if Github is compromised then we are toast anyway, and I expect them to have better security as an organization--but I am open to imposing the same policy on those actions as well.


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
