### PR TITLE
Replace autoNameRecursively with chisel3.withName

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -24,7 +24,6 @@ import _root_.firrtl.annotations.{
   Target
 }
 import _root_.firrtl.AnnotationSeq
-import chisel3.internal.plugin.autoNameRecursively
 import chisel3.util.simpleClassName
 import chisel3.experimental.annotate
 import chisel3.experimental.hierarchy.Hierarchy
@@ -128,7 +127,7 @@ object Module extends Module$Intf {
   def disableOption(implicit sourceInfo: SourceInfo): Option[Disable] = {
     Builder.currentDisable match {
       case Disable.Never       => None
-      case Disable.BeforeReset => hasBeenReset.map(x => autoNameRecursively("disable")(!x))
+      case Disable.BeforeReset => hasBeenReset.map(x => withName("disable")(!x))
     }
   }
 

--- a/core/src/main/scala/chisel3/SeqUtils.scala
+++ b/core/src/main/scala/chisel3/SeqUtils.scala
@@ -5,8 +5,6 @@ package chisel3
 import chisel3.experimental.{prefix, SourceInfo}
 import chisel3.internal.throwException
 
-import chisel3.internal.plugin.autoNameRecursively
-
 private[chisel3] object SeqUtils {
 
   /** Concatenates the data elements of the input sequence, in sequence order, together.
@@ -22,10 +20,10 @@ private[chisel3] object SeqUtils {
     } else if (in.tail.isEmpty) {
       in.head.asUInt
     } else {
-      val lo = autoNameRecursively("lo")(prefix("lo") {
+      val lo = withName("lo")(prefix("lo") {
         asUInt(in.slice(0, in.length / 2))
       })
-      val hi = autoNameRecursively("hi")(prefix("hi") {
+      val hi = withName("hi")(prefix("hi") {
         asUInt(in.slice(in.length / 2, in.length))
       })
       hi ## lo

--- a/core/src/main/scala/chisel3/internal/plugin/package.scala
+++ b/core/src/main/scala/chisel3/internal/plugin/package.scala
@@ -4,21 +4,6 @@ package chisel3.internal
 
 package object plugin {
 
-  // The actual implementation
-  private def _autoNameRecursively[T <: Any](prevId: Long, name: String, nameMe: T): T = {
-    chisel3.internal.Builder.nameRecursively(
-      name,
-      nameMe,
-      (id: chisel3.internal.HasId, n: String) => {
-        // Name override only if result was created in this scope
-        if (id._id > prevId) {
-          id.forceAutoSeed(n)
-        }
-      }
-    )
-    nameMe
-  }
-
   /** Used by Chisel's compiler plugin to automatically name signals
     * DO NOT USE in your normal Chisel code!!!
     *
@@ -27,12 +12,8 @@ package object plugin {
     * @tparam T The type of the thing to be named
     * @return The thing, but now named
     */
-  def autoNameRecursively[T <: Any](name: String)(nameMe: => T): T = {
-    // The _id of the most recently constructed HasId
-    val prevId = Builder.idGen.value
-    val result = nameMe
-    _autoNameRecursively(prevId, name, result)
-  }
+  @deprecated("Use chisel3.withName instead", "Chisel 7.0.0")
+  def autoNameRecursively[T <: Any](name: String)(nameMe: => T): T = chisel3.withName[T](name)(nameMe)
 
   /** Used by Chisel's compiler plugin to automatically name signals
     * DO NOT USE in your normal Chisel code!!!
@@ -42,13 +23,7 @@ package object plugin {
     * @tparam T The type of the thing to be named
     * @return The thing, but with each member named
     */
-  def autoNameRecursivelyProduct[T <: Product](names: List[Option[String]])(nameMe: => T): T = {
-    // The _id of the most recently constructed HasId
-    val prevId = Builder.idGen.value
-    val result = nameMe
-    for ((name, t) <- names.iterator.zip(result.productIterator) if name.nonEmpty) {
-      _autoNameRecursively(prevId, name.get, t)
-    }
-    result
-  }
+  @deprecated("Use chisel3.withName instead", "Chisel 7.0.0")
+  def autoNameRecursivelyProduct[T <: Product](names: List[Option[String]])(nameMe: => T): T =
+    chisel3.withNames(names.map(_.getOrElse("")): _*)(nameMe)
 }

--- a/plugin/src/main/scala-2/chisel3/internal/plugin/ChiselComponent.scala
+++ b/plugin/src/main/scala-2/chisel3/internal/plugin/ChiselComponent.scala
@@ -192,8 +192,8 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
         // If a Data and in a Bundle, just get the name but not a prefix
         if (isData && inBundle(dd)) {
           val str = stringFromTermName(name)
-          val newRHS = transform(rhs) // chisel3.internal.plugin.autoNameRecursively
-          val named = q"chisel3.internal.plugin.autoNameRecursively($str)($newRHS)"
+          val newRHS = transform(rhs) // chisel3.withName
+          val named = q"chisel3.withName($str)($newRHS)"
           treeCopy.ValDef(dd, mods, name, tpt, localTyper.typed(named))
         }
         // If a Data or a Memory, get the name and a prefix
@@ -208,7 +208,7 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
           val named =
             if (isNamedComp) {
               // Only name named components (not things that are merely prefixed)
-              q"chisel3.internal.plugin.autoNameRecursively($str)($prefixed)"
+              q"chisel3.withName($str)($prefixed)"
             } else {
               prefixed
             }
@@ -219,7 +219,7 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
         else if (shouldMatchModule(tpe) || shouldMatchInstance(tpe)) {
           val str = stringFromTermName(name)
           val newRHS = transform(rhs)
-          val named = q"chisel3.internal.plugin.autoNameRecursively($str)($newRHS)"
+          val named = q"chisel3.withName($str)($newRHS)"
           treeCopy.ValDef(dd, mods, name, tpt, localTyper.typed(named))
         } else {
           // Otherwise, continue
@@ -232,10 +232,10 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
         if (fieldsOfInterest.reduce(_ || _)) {
           findUnapplyNames(rhs) match {
             case Some(names) =>
-              val onames: List[Option[String]] =
-                fieldsOfInterest.zip(names).map { case (ok, name) => if (ok) Some(name) else None }
+              val onames: List[String] =
+                fieldsOfInterest.zip(names).map { case (ok, name) => if (ok) name else "" }
               val newRHS = transform(rhs)
-              val named = q"chisel3.internal.plugin.autoNameRecursivelyProduct($onames)($newRHS)"
+              val named = q"chisel3.withNames(..$onames)($newRHS)"
               treeCopy.ValDef(dd, mods, name, tpt, localTyper.typed(named))
             case None => // It's not clear how this could happen but we don't want to crash
               super.transform(tree)

--- a/src/main/scala-2/chisel3/util/SRAM.scala
+++ b/src/main/scala-2/chisel3/util/SRAM.scala
@@ -3,7 +3,6 @@ package chisel3.util
 import chisel3._
 import chisel3.internal.{Builder, NamedComponent}
 import chisel3.internal.binding.{FirrtlMemTypeBinding, SramPortBinding}
-import chisel3.internal.plugin.autoNameRecursively
 import chisel3.experimental.{OpaqueType, SourceInfo}
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance, Instantiate}
 import chisel3.internal.sourceinfo.MemTransform
@@ -762,7 +761,7 @@ object SRAM {
     }
 
     // underlying target
-    val mem = autoNameRecursively("sram")(new SramTarget)
+    val mem = withName("sram")(new SramTarget)
 
     val includeMetadata = Builder.includeUtilMetadata
 

--- a/src/test/scala-2/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala-2/chiselTests/naming/NamePluginSpec.scala
@@ -502,4 +502,11 @@ class NamePluginSpec extends AnyFlatSpec with Matchers with FileCheck {
     }
     ChiselStage.emitCHIRRTL(new Test) should include("wire x :")
   }
+
+  "withNames" should "require the same number of names as fields" in {
+    case class Foo(x: Int, y: Int, z: Int)
+    an[IllegalArgumentException] should be thrownBy {
+      chisel3.withNames("a", "b")(Foo(1, 2, 3))
+    }
+  }
 }


### PR DESCRIPTION
`chisel3.internal.plugin.autoNameRecursively` has always felt like a bit of a mouthful to me, especially in stack traces as it is _everywhere_ since it is inserted by the naming plugin. So in celebration of Chisel 7.0, I think it's time to simply the name to just `chisel3.withName`. This API also is pretty reasonable for users to go ahead and use, and I suspect in the near future we should start encouraging (or requiring?) it over `.suggestName`--but that is potentially more controversial so I'll leave that to a future PR (that will also need docs).

I've left `chisel3.internal.plugin.autoNameRecursively` around but deprecated so that people won't get weird linkage errors if they use an older version of the plugin--but they will get lots of deprecation warnings which should encourage them to bump the version of the plugin to match their version of Chisel.

I micro-optimized the arguments to the `Product` version of `withName` (note that it's not called `withNameProduct` since we can overload here). Rather than `List[Option[String]]` which requires creating lots of little objects to call the function, I made if `varargs` of `String` where empty String is the equivalent of `None` so that it's implemented with an Array of String. This probably doesn't matter much in practice but will save some object allocations.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API modification



#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Also use varargs of String instead of List[Option[String]] for the
Product version of withName.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
