### PR TITLE
[testing] Fix testing dir date/time stability

### DIFF
--- a/src/main/scala/chisel3/testing/HasTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/HasTestingDirectory.scala
@@ -56,10 +56,11 @@ object HasTestingDirectory {
     *     └── 2025-02-05T16-58-17.721776
     * }}}
     */
-  val timestamp: HasTestingDirectory = new HasTestingDirectory {
+  def timestamp: HasTestingDirectory = new HasTestingDirectory {
+    val time = LocalDateTime.now()
     override def getDirectory: Path = FileSystems
       .getDefault()
-      .getPath("build", "chiselsim", LocalDateTime.now().toString.replace(':', '-'))
+      .getPath("build", "chiselsim", time.toString.replace(':', '-'))
   }
 
   /** An implementation generator of [[HasTestingDirectory]] which will use an
@@ -69,9 +70,10 @@ object HasTestingDirectory {
     * @param deleteOnExit if true, delete the temporary directory when the JVM exits
     */
   def temporary(deleteOnExit: Boolean = true): HasTestingDirectory = new HasTestingDirectory {
+    val time = LocalDateTime.now()
     override def getDirectory: Path = {
       val dir = Files.createTempDirectory(
-        s"chiselsim-${LocalDateTime.now().toString.replace(':', '-')}"
+        s"chiselsim-${time.toString.replace(':', '-')}"
       )
 
       if (deleteOnExit) {
@@ -87,7 +89,7 @@ object HasTestingDirectory {
     * alternative type class implementation of [[HasTestingDirectory]], then
     * this will be what is used.
     */
-  implicit val default: HasTestingDirectory = timestamp
+  implicit def default: HasTestingDirectory = timestamp
 
   /** Walk directory and delete contents */
   private def deleteDir(directory: Path): Unit = {

--- a/src/test/scala-2/chiselTests/testing/HasTestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/testing/HasTestingDirectorySpec.scala
@@ -31,4 +31,47 @@ class HasTestingDirectorySpec extends AnyFlatSpec with Matchers {
 
   }
 
+  behavior of ("HasTestingDirectory.timestamp")
+
+  it should ("return the same directory for a given instance of the type class") in {
+
+    val foo = HasTestingDirectory.timestamp
+
+    foo.getDirectory should be(foo.getDirectory)
+
+  }
+
+  it should ("return different directories for separate instances of the type class") in {
+
+    val foo = HasTestingDirectory.timestamp
+    val bar = HasTestingDirectory.timestamp
+
+    foo.getDirectory should not be (bar.getDirectory)
+
+  }
+
+  behavior of ("HasTestingDirectory.default")
+
+  it should ("return different directories for different functions that require a type class implementation") in {
+
+    def foo(implicit testingDirectory: HasTestingDirectory) = {
+      testingDirectory.getDirectory
+    }
+
+    foo should not be (foo)
+
+  }
+
+  it should ("allow the user to force the same directory by creating an implicit val") in {
+
+    def foo(implicit testingDirectory: HasTestingDirectory) = {
+      testingDirectory.getDirectory
+    }
+
+    implicit val bar = implicitly[HasTestingDirectory]
+
+    foo should be(foo)
+
+  }
+
 }


### PR DESCRIPTION
Fix a bug in the timestamp and temporary implementations of the `HasTestingDirectory` type class.  These need to, for a given type class implementation, always return the same date/time used when constructing a temporary directory.

This fixes a bug if a user is trying to get the current directory, e.g., via an `implicitly[HasTestingDirectory]` call.

#### Release Notes

Fix a bug in timestamp and default `HasTestingDirectory` type class implementations where this could return a different directory every time.