### PR TITLE
Provide custom error for Mem masked write wrong data type

### DIFF
--- a/core/src/main/scala-2/chisel3/MemIntf.scala
+++ b/core/src/main/scala-2/chisel3/MemIntf.scala
@@ -6,6 +6,7 @@ import scala.language.experimental.macros
 
 import chisel3.internal.sourceinfo.{MemTransform, SourceInfoTransform}
 import chisel3.experimental.SourceInfo
+import chisel3.Mem.HasVecDataType
 
 private[chisel3] trait Mem$Intf extends SourceInfoDoc { self: Mem.type =>
 
@@ -120,7 +121,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
     writeData: T,
     mask:      Seq[Bool]
   )(
-    implicit evidence: T <:< Vec[_]
+    implicit evidence: HasVecDataType[T]
   ): Unit = macro SourceInfoTransform.idxDataMaskArg
 
   def do_write(
@@ -128,7 +129,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
     data: T,
     mask: Seq[Bool]
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ): Unit = _writeImpl(idx, data, mask)
 
@@ -149,7 +150,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
     mask:      Seq[Bool],
     clock:     Clock
   )(
-    implicit evidence: T <:< Vec[_]
+    implicit evidence: HasVecDataType[T]
   ): Unit = macro SourceInfoTransform.idxDataMaskClockArg
 
   def do_write(
@@ -158,7 +159,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
     mask:  Seq[Bool],
     clock: Clock
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ): Unit = _writeImpl(idx, data, mask, clock)
 }
@@ -334,7 +335,7 @@ private[chisel3] trait SyncReadMemIntf[T <: Data] extends SourceInfoDoc { self: 
     en:        Bool,
     isWrite:   Bool
   )(
-    implicit evidence: T <:< Vec[_]
+    implicit evidence: HasVecDataType[T]
   ): T = macro SourceInfoTransform.idxDataMaskEnIswArg
 
   def do_readWrite(
@@ -344,7 +345,7 @@ private[chisel3] trait SyncReadMemIntf[T <: Data] extends SourceInfoDoc { self: 
     en:        Bool,
     isWrite:   Bool
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ): T = _readWriteImpl(idx, writeData, mask, en, isWrite)
 
@@ -374,7 +375,7 @@ private[chisel3] trait SyncReadMemIntf[T <: Data] extends SourceInfoDoc { self: 
     isWrite:   Bool,
     clock:     Clock
   )(
-    implicit evidence: T <:< Vec[_]
+    implicit evidence: HasVecDataType[T]
   ): T = macro SourceInfoTransform.idxDataMaskEnIswClockArg
 
   def do_readWrite(
@@ -385,7 +386,7 @@ private[chisel3] trait SyncReadMemIntf[T <: Data] extends SourceInfoDoc { self: 
     isWrite:   Bool,
     clock:     Clock
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ) = _readWriteImpl(idx, writeData, mask, en, isWrite, clock)
 }

--- a/core/src/main/scala-3/chisel3/MemIntf.scala
+++ b/core/src/main/scala-3/chisel3/MemIntf.scala
@@ -3,6 +3,7 @@
 package chisel3
 
 import chisel3.experimental.SourceInfo
+import chisel3.Mem.HasVecDataType
 
 private[chisel3] trait Mem$Intf { self: Mem.type =>
 
@@ -89,7 +90,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
     data: T,
     mask: Seq[Bool]
   )(
-    using T <:< Vec[_],
+    using HasVecDataType[T],
     SourceInfo
   ): Unit = _writeImpl(idx, data, mask)
 
@@ -110,7 +111,7 @@ private[chisel3] trait MemBaseIntf[T <: Data] extends SourceInfoDoc { self: MemB
     mask:  Seq[Bool],
     clock: Clock
   )(
-    using T <:< Vec[_],
+    using HasVecDataType[T],
     SourceInfo
   ): Unit = _writeImpl(idx, data, mask, clock)
 }
@@ -246,7 +247,7 @@ private[chisel3] trait SyncReadMemIntf[T <: Data] { self: SyncReadMem[T] =>
     en:        Bool,
     isWrite:   Bool
   )(
-    using T <:< Vec[_],
+    using HasVecDataType[T],
     SourceInfo
   ): T = _readWriteImpl(idx, writeData, mask, en, isWrite)
 
@@ -276,7 +277,7 @@ private[chisel3] trait SyncReadMemIntf[T <: Data] { self: SyncReadMem[T] =>
     isWrite:   Bool,
     clock:     Clock
   )(
-    using T <:< Vec[_],
+    using HasVecDataType[T],
     SourceInfo
   ): T = _readWriteImpl(idx, writeData, mask, en, isWrite, clock)
 }

--- a/src/main/scala-2/chisel3/util/SRAM.scala
+++ b/src/main/scala-2/chisel3/util/SRAM.scala
@@ -7,6 +7,7 @@ import chisel3.experimental.{OpaqueType, SourceInfo}
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance, Instantiate}
 import chisel3.internal.sourceinfo.MemTransform
 import chisel3.internal.firrtl.ir.{Arg, FirrtlMemory, LitIndex, Node, Ref, Slot}
+import chisel3.Mem.HasVecDataType
 import chisel3.util.experimental.loadMemoryFromFileInline
 import chisel3.reflect.DataMirror
 import firrtl.annotations.{IsMember, MemoryLoadFileType}
@@ -486,7 +487,7 @@ object SRAM {
     numWritePorts:     Int,
     numReadwritePorts: Int
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ): SRAMInterface[T] = {
     val clock = Builder.forcedClock
@@ -526,7 +527,7 @@ object SRAM {
     numReadwritePorts: Int,
     memoryFile:        MemoryFile
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ): SRAMInterface[T] = {
     val clock = Builder.forcedClock
@@ -564,7 +565,7 @@ object SRAM {
     writePortClocks:     Seq[Clock],
     readwritePortClocks: Seq[Clock]
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ): SRAMInterface[T] =
     memInterface_impl(
@@ -602,7 +603,7 @@ object SRAM {
     readwritePortClocks: Seq[Clock],
     memoryFile:          MemoryFile
   )(
-    implicit evidence: T <:< Vec[_],
+    implicit evidence: HasVecDataType[T],
     sourceInfo:        SourceInfo
   ): SRAMInterface[T] =
     memInterface_impl(
@@ -623,7 +624,7 @@ object SRAM {
     writePortClocks:     Seq[Clock],
     readwritePortClocks: Seq[Clock],
     memoryFile:          Option[MemoryFile],
-    evidenceOpt:         Option[T <:< Vec[_]],
+    evidenceOpt:         Option[HasVecDataType[T]],
     sourceInfo:          SourceInfo
   ): SRAMInterface[T] = {
     val numReadPorts = readPortClocks.size
@@ -728,7 +729,7 @@ object SRAM {
     writePortClocks:     Seq[Clock],
     readwritePortClocks: Seq[Clock],
     memoryFile:          Option[MemoryFile],
-    evidenceOpt:         Option[T <:< Vec[_]],
+    evidenceOpt:         Option[HasVecDataType[T]],
     sourceInfo:          SourceInfo
   ): SRAMInterface[T] = {
     if (Builder.useSRAMBlackbox)


### PR DESCRIPTION
Hard to test for this but easy to validate which I did.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

The old error was `Cannot prove that chisel3.UInt <:< chisel3.Vec[_]`, the new error is `Masked write requires that the data type is a Vec, got chisel3.UInt`.

### Reviewer Checklist (only modified by reviewer)
- [x] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [x] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
