### PR TITLE
[chiselsim] HasCliOptions, EmitVcd for ChiselSim

### DIFF
--- a/src/main/scala/chisel3/simulator/scalatest/package.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/package.scala
@@ -22,7 +22,12 @@ package object scalatest {
     *
     * @see [[chisel3.simulator.ChiselSim]]
     */
-  trait ChiselSim extends chisel3.simulator.ChiselSim with HasConfigMap with TestingDirectory {
+  trait ChiselSim
+      extends HasCliOptions
+      with HasConfigMap
+      with Cli.EmitVcd
+      with TestingDirectory
+      with chisel3.simulator.ChiselSim {
     self: TestSuite =>
   }
 


### PR DESCRIPTION
Add the `HasCliOptions` and `Cli.EmitVcd` traits to the Scalatest ChiselSim trait. This provides a saner default for end users:

1. Command line options are not allowed to sneak in through Scalatest's ConfigMap and must go through normal option parsing paths.
2. The default ChiselSim environment will always have `-DemitVcd=true` as an available option.

#### Release Notes

- Change the `scalatest.ChiselSim` trait to require that any command line options are passed using the `addOption` method. Users will no longer be able to use Scalatest's ConfigMap directly. This is done for safety reasons. If users would like different behavior, they can construct their own `ChiselSim` trait from the traits they would prefer.
- Add `-DemitVcd=true` option to `scalatest.ChiselSim`. Users can now run any simulation and turn on waveforms by passing this option to Scalatest.