### PR TITLE
[chiselsim] Chisel/firtool update type classes

### DIFF
--- a/src/main/scala/chisel3/simulator/OptionsModifications.scala
+++ b/src/main/scala/chisel3/simulator/OptionsModifications.scala
@@ -1,0 +1,27 @@
+package chisel3.simulator
+
+/** Changes that ChiselSim should make to Chisel command line options
+  *
+  * This follows a type class pattern with a low-priority default of identity.
+  */
+trait ChiselOptionsModifications extends (Array[String] => Array[String])
+
+object ChiselOptionsModifications {
+
+  /** Low-priority default of identity (no opotions modifications) */
+  implicit def unmodified: ChiselOptionsModifications = identity(_)
+
+}
+
+/** Changes that ChiselSim should make to `firtool` command line options
+  *
+  * This follows a type class pattern with a low-priority default of identity.
+  */
+trait FirtoolOptionsModifications extends (Array[String] => Array[String])
+
+object FirtoolOptionsModifications {
+
+  /** Low-priority default of identity (no opotions modifications) */
+  implicit def unmodified: FirtoolOptionsModifications = identity(_)
+
+}

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -108,13 +108,19 @@ trait Simulator[T <: Backend] {
     firtoolOpts:    Array[String] = Array.empty,
     chiselSettings: Settings[T] = Settings.defaultRaw[T]
   )(body: (SimulatedModule[T]) => U)(
-    implicit commonSettingsModifications: svsim.CommonSettingsModifications,
-    backendSettingsModifications:         svsim.BackendSettingsModifications
+    implicit chiselOptsModifications: ChiselOptionsModifications,
+    firtoolOptsModifications:         FirtoolOptionsModifications,
+    commonSettingsModifications:      svsim.CommonSettingsModifications,
+    backendSettingsModifications:     svsim.BackendSettingsModifications
   ): Simulator.BackendInvocationDigest[U] = {
     val workspace = new Workspace(path = workspacePath, workingDirectoryPrefix = workingDirectoryPrefix)
     workspace.reset()
     val elaboratedModule =
-      workspace.elaborateGeneratedModule(() => module, args = chiselOpts.toSeq, firtoolArgs = firtoolOpts.toSeq)
+      workspace.elaborateGeneratedModule(
+        () => module,
+        args = chiselOptsModifications(chiselOpts).toSeq,
+        firtoolArgs = firtoolOptsModifications(firtoolOpts).toSeq
+      )
     workspace.generateAdditionalSources()
 
     val commonCompilationSettingsUpdated = commonSettingsModifications(

--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -36,6 +36,8 @@ trait SimulatorAPI {
   )(stimulus: (T) => Unit)(
     implicit hasSimulator:        HasSimulator,
     testingDirectory:             HasTestingDirectory,
+    chiselOptsModifications:      ChiselOptionsModifications,
+    firtoolOptsModifications:     FirtoolOptionsModifications,
     commonSettingsModifications:  svsim.CommonSettingsModifications,
     backendSettingsModifications: svsim.BackendSettingsModifications
   ): Unit = {
@@ -74,6 +76,8 @@ trait SimulatorAPI {
   )(stimulus: (T) => Unit)(
     implicit hasSimulator:        HasSimulator,
     testingDirectory:             HasTestingDirectory,
+    chiselOptsModifications:      ChiselOptionsModifications,
+    firtoolOptsModifications:     FirtoolOptionsModifications,
     commonSettingsModifications:  svsim.CommonSettingsModifications,
     backendSettingsModifications: svsim.BackendSettingsModifications
   ): Unit = simulateRaw(

--- a/src/main/scala/chisel3/simulator/scalatest/Cli.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/Cli.scala
@@ -43,6 +43,8 @@ object Cli {
               ) with NoStackTrace
           }
         },
+        updateChiselOptions = (_, a) => a,
+        updateFirtoolOptions = (_, a) => a,
         updateCommonSettings = (_, options) => {
           options.copy(
             verilogPreprocessorDefines =
@@ -101,6 +103,8 @@ object Cli {
               ) with NoStackTrace
           }
         },
+        updateChiselOptions = (_, a) => a,
+        updateFirtoolOptions = (_, a) => a,
         updateCommonSettings = (_, options) => {
           options.copy(
             verilogPreprocessorDefines =
@@ -156,6 +160,8 @@ object Cli {
               ) with NoStackTrace
           }
         },
+        updateChiselOptions = (_, a) => a,
+        updateFirtoolOptions = (_, a) => a,
         updateCommonSettings = (_, options) => {
           options.copy(
             verilogPreprocessorDefines =

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -161,6 +161,8 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
         hasSimulator = implicitly[HasSimulator],
         testingDirectory = fooDirectory,
         implicitly,
+        implicitly,
+        implicitly,
         implicitly
       )
 


### PR DESCRIPTION
Add more type classes that can be used to modify the Chisel and `firtool` options of ChiselSim's `SimulatorAPI` methods.

While the number of type classes here is getting comical, these are being added to fill two remaining gaps.  We need the ability to control, via command line arguments, certain options.  With Scalatest, the only way to do this is via `-D` options.  However, the way to use `-D` options is via the `HasCliOptions` API which is implemented via this type class pattern.

#### Release Notes

Provide infrastructure for allowing modifications to Chisel and `firtool` command line arguments when running ChiselSim tests, e.g., via the Scalatest command line.