### PR TITLE
[svsim] Add Coverage Directory and Name to VCS Backend

### DIFF
--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -110,8 +110,8 @@ object Backend {
     /** The name of the option. */
     def name: String
 
-    /** Convert the option into  */
-    final def compileFlags: Seq[String] = {
+    /** Convert the option into command line flags */
+    final def toFlags: Seq[String] = {
       val setFlags: Seq[String] = productElementNames
         .zip(productIterator)
         .flatMap {
@@ -206,7 +206,7 @@ object Backend {
       * drop that when generating the flag.
       */
     sealed trait Type { this: Singleton =>
-      def compileFlag: String = s"-${this.getClass.getSimpleName.dropRight(1)}"
+      def toFlag: String = s"-${this.getClass.getSimpleName.dropRight(1)}"
     }
 
     case object cm_seqnoconst extends Type
@@ -361,13 +361,13 @@ final class Backend(
 
           backendSpecificSettings.traceSettings.compileFlags,
 
-          backendSpecificSettings.coverageSettings.compileFlags,
+          backendSpecificSettings.coverageSettings.toFlags,
 
-          backendSpecificSettings.toggleCoverageSettings.compileFlags,
+          backendSpecificSettings.toggleCoverageSettings.toFlags,
 
-          backendSpecificSettings.branchCoverageSettings.compileFlags,
+          backendSpecificSettings.branchCoverageSettings.toFlags,
 
-          backendSpecificSettings.flags.map(_.compileFlag),
+          backendSpecificSettings.flags.map(_.toFlag),
 
           Seq(
             commonSettings.verilogPreprocessorDefines,

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -93,7 +93,8 @@ object Backend {
 
   final case class SimulationSettings(
     customWorkingDirectory: Option[String] = None,
-    assertionSettings:      Option[AssertionSettings] = None
+    assertionSettings:      Option[AssertionSettings] = None,
+    coverageSettings:       CoverageSettings = CoverageSettings()
   )
 
   /** Trait that encodes a VCS "plus" option.
@@ -388,6 +389,7 @@ final class Backend(
             case None                                          => Seq()
             case Some(Backend.AssertGlobalMaxFailCount(count)) => Seq("-assert", s"global_finish_maxfail=$count")
           },
+          backendSpecificSettings.simulationSettings.coverageSettings.toFlags,
           commonSettings.simulationSettings.plusArgs.map(_.simulatorFlags),
         ).flatten,
         environment = environment

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -94,7 +94,9 @@ object Backend {
   final case class SimulationSettings(
     customWorkingDirectory: Option[String] = None,
     assertionSettings:      Option[AssertionSettings] = None,
-    coverageSettings:       CoverageSettings = CoverageSettings()
+    coverageSettings:       CoverageSettings = CoverageSettings(),
+    coverageDirectory:      Option[CoverageDirectory] = None,
+    coverageName:           Option[CoverageName] = None
   )
 
   /** Trait that encodes a VCS "plus" option.
@@ -155,6 +157,30 @@ object Backend {
   ) extends PlusSeparated {
 
     override def name = "cm"
+
+  }
+
+  /** Settings for controlling the coverage directory
+    *
+    * This maps to the `-cm_dir` option.
+    */
+  final case class CoverageDirectory(
+    directory: String
+  ) {
+
+    def toFlags: Seq[String] = Seq("-cm_dir", directory)
+
+  }
+
+  /** Sets a unique name used for this coverage run
+    *
+    * This maps to the `-cm_name` option.
+    */
+  final case class CoverageName(
+    name: String
+  ) {
+
+    def toFlags: Seq[String] = Seq("-cm_name", name)
 
   }
 
@@ -220,6 +246,7 @@ object Backend {
     traceSettings:               CompilationSettings.TraceSettings = CompilationSettings.TraceSettings(),
     simulationSettings:          SimulationSettings = SimulationSettings(),
     coverageSettings:            CoverageSettings = CoverageSettings(),
+    coverageDirectory:           Option[CoverageDirectory] = None,
     toggleCoverageSettings:      ToggleCoverageSettings = ToggleCoverageSettings(),
     branchCoverageSettings:      BranchCoverageSettings = BranchCoverageSettings(),
     flags:                       Seq[Flag.Type] = Seq.empty,
@@ -364,6 +391,8 @@ final class Backend(
 
           backendSpecificSettings.coverageSettings.toFlags,
 
+          backendSpecificSettings.coverageDirectory.map(_.toFlags).getOrElse(Seq.empty),
+
           backendSpecificSettings.toggleCoverageSettings.toFlags,
 
           backendSpecificSettings.branchCoverageSettings.toFlags,
@@ -390,6 +419,8 @@ final class Backend(
             case Some(Backend.AssertGlobalMaxFailCount(count)) => Seq("-assert", s"global_finish_maxfail=$count")
           },
           backendSpecificSettings.simulationSettings.coverageSettings.toFlags,
+          backendSpecificSettings.simulationSettings.coverageDirectory.map(_.toFlags).getOrElse(Seq.empty),
+          backendSpecificSettings.simulationSettings.coverageName.map(_.toFlags).getOrElse(Seq.empty),
           commonSettings.simulationSettings.plusArgs.map(_.simulatorFlags),
         ).flatten,
         environment = environment


### PR DESCRIPTION
Add some missing compile and simulation time options for the VCS backend.

#### Release Notes

Add support for `-cm_dir` and `-cm_name` to svsim VCS backend.