### PR TITLE
Enable inlining in Scalac options

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -91,7 +91,10 @@ object v extends Module {
     // Deprecated for external users, will eventually be removed.
     "cat=deprecation&msg=Looking up Modules is deprecated:s",
     // Only for testing of deprecated APIs
-    "cat=deprecation&msg=Use of @instantiable on user-defined types is deprecated:s"
+    "cat=deprecation&msg=Use of @instantiable on user-defined types is deprecated:s",
+    // FirtoolResolver uses package shading which causes issues with metadata for inlining.
+    // We don't want to inline from it anyway so just suppress the warning.
+    "msg=reading InlineInfoAttribute from firtoolresolver:s"
   )
 
   // ScalacOptions
@@ -107,6 +110,12 @@ object v extends Module {
     "-Xlint:infer-any",
     "-Xlint:missing-interpolator",
     "-language:reflectiveCalls",
+    // It is crucial to only ever inline from within the same artifact.
+    // Despite having several comilation units, we publish them together as a
+    // single artifact so it is safe to inline anything in the chisel3 package.
+    // See documentation: https://docs.scala-lang.org/overviews/compiler-options/optimizer.html
+    "-opt:l:inline",
+    "-opt-inline-from:chisel3.**",
     s"-Wconf:${(scala2WarnConf ++ extraWarnConf).mkString(",")}"
   )
 }


### PR DESCRIPTION
This probably improves performance, but the main reason I want to do it is to make user-code stacktraces a lot less miserable.

Consider the following:
```scala
class Child extends Module {
  val foo, bar = IO(Input(UInt(8.W)))
  val out = IO(Output(UInt(8.W)))

  out := foo + bar
  ???
}

class Foo extends Module {
  val foo, bar = IO(Input(UInt(8.W)))
  val out = IO(Output(UInt(8.W)))

  val c = Module(new Child)
  c.foo := foo
  c.bar := bar
  out := c.out
}
```
If I build this with head of main, the stack trace I get is:
```
Exception in thread "main" scala.NotImplementedError: an implementation is missing
        at ... ()
        at Child.$anonfun$out$2(chisel-example.scala:16)
        at chisel3.experimental.prefix$.apply(prefix.scala:50)
        at Child.$anonfun$out$1(chisel-example.scala:13)
        at chisel3.package$.withName(package.scala:471)
        at Child.<init>(chisel-example.scala:13)
        at Foo.$anonfun$c$2(chisel-example.scala:24)
        at chisel3.Module$.$anonfun$evaluate$2(Module.scala:72)
        at chisel3.internal.Builder$State$.guard(Builder.scala:1243)
        at chisel3.Module$.evaluate(Module.scala:71)
        at chisel3.Module$._applyImpl(Module.scala:35)
        at chisel3.Module$Intf.do_apply(ModuleIntf.scala:22)
        at chisel3.Module$Intf.do_apply$(ModuleIntf.scala:22)
        at chisel3.Module$.do_apply(Module.scala:31)
        at Foo.$anonfun$c$1(chisel-example.scala:24)
        at chisel3.package$.withName(package.scala:471)
        at Foo.<init>(chisel-example.scala:24)
        at Main$.$anonfun$new$4(chisel-example.scala:33)
        at chisel3.Module$.$anonfun$evaluate$2(Module.scala:72)
        at chisel3.internal.Builder$State$.guard(Builder.scala:1243)
        at chisel3.Module$.evaluate(Module.scala:71)
        at chisel3.Module$._applyImpl(Module.scala:35)
        at chisel3.Module$Intf.do_apply(ModuleIntf.scala:22)
        at chisel3.Module$Intf.do_apply$(ModuleIntf.scala:22)
        at chisel3.Module$.do_apply(Module.scala:31)
        at chisel3.stage.phases.Elaborate.$anonfun$transform$2(Elaborate.scala:59)
        at chisel3.internal.Builder$.$anonfun$buildImpl$1(Builder.scala:1062)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at chisel3.internal.Builder$.buildImpl(Builder.scala:1052)
        at chisel3.internal.Builder$.$anonfun$build$1(Builder.scala:1044)
        at logger.Logger$.$anonfun$makeScope$4(Logger.scala:148)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:59)
        at logger.Logger$.makeScope(Logger.scala:146)
        at logger.Logger$.makeScope(Logger.scala:133)
        at ... ()
```

With this PR, I get
```
Exception in thread "main" scala.NotImplementedError: an implementation is missing
        at ... ()
        at Child.$anonfun$out$2(chisel-example.scala:16)
        at chisel3.experimental.prefix$.apply(prefix.scala:50)
        at Child.$anonfun$out$1(chisel-example.scala:13)
        at chisel3.package$.withName(package.scala:471)
        at Child.<init>(chisel-example.scala:13)
        at Foo.$anonfun$c$2(chisel-example.scala:24)
        at chisel3.Module$Intf.do_apply(ModuleIntf.scala:22)
        at chisel3.Module$Intf.do_apply$(ModuleIntf.scala:22)
        at chisel3.Module$.do_apply(Module.scala:31)
        at Foo.$anonfun$c$1(chisel-example.scala:24)
        at chisel3.package$.withName(package.scala:471)
        at Foo.<init>(chisel-example.scala:24)
        at Main$.$anonfun$new$4(chisel-example.scala:33)
        at ... ()
```

That's MUCH better and mainly just shows the user code.

Screenshot from meld really does it justice:

![Screenshot 2025-03-18 at 4 44 04 PM](https://github.com/user-attachments/assets/d25fbc9d-bb62-4c16-adaa-591c49bdcaf4)



### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Performance improvement


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
