### PR TITLE
[chiselsim] Change chiselSettings to settings

### DIFF
--- a/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
+++ b/src/main/scala/chisel3/simulator/EphemeralSimulator.scala
@@ -27,7 +27,7 @@ object EphemeralSimulator extends PeekPokeAPI {
     implicit val temporary: HasTestingDirectory = HasTestingDirectory.temporary(deleteOnExit = true)
     chiselSim.simulateRaw(
       module,
-      chiselSettings = Settings.defaultRaw[T].copy(verilogLayers = layerControl)
+      settings = Settings.defaultRaw[T].copy(verilogLayers = layerControl)
     )(body)
   }
 

--- a/src/main/scala/chisel3/simulator/Simulator.scala
+++ b/src/main/scala/chisel3/simulator/Simulator.scala
@@ -92,7 +92,7 @@ trait Simulator[T <: Backend] {
     * @param module a Chisel module to simulate
     * @param chiselOpts command line options to pass to Chisel
     * @param firtoolOpts command line options to pass to firtool
-    * @param chiselSettings Chisel-related settings used for simulation
+    * @param settings ChiselSim-related settings used for simulation
     * @param body stimulus to apply to the module
     * @param commonSettingsModifications modifications to common compilation
     * settings
@@ -103,10 +103,10 @@ trait Simulator[T <: Backend] {
     * by default and if you set incompatible options, the simulation will fail.
     */
   final def simulate[T <: RawModule, U](
-    module:         => T,
-    chiselOpts:     Array[String] = Array.empty,
-    firtoolOpts:    Array[String] = Array.empty,
-    chiselSettings: Settings[T] = Settings.defaultRaw[T]
+    module:      => T,
+    chiselOpts:  Array[String] = Array.empty,
+    firtoolOpts: Array[String] = Array.empty,
+    settings:    Settings[T] = Settings.defaultRaw[T]
   )(body: (SimulatedModule[T]) => U)(
     implicit chiselOptsModifications: ChiselOptionsModifications,
     firtoolOptsModifications:         FirtoolOptionsModifications,
@@ -130,16 +130,16 @@ trait Simulator[T <: Backend] {
         // ensures that `` `include `` directives can be resolved.
         includeDirs = Some(commonCompilationSettings.includeDirs.getOrElse(Seq.empty) :+ workspace.primarySourcesPath),
         verilogPreprocessorDefines =
-          commonCompilationSettings.verilogPreprocessorDefines ++ chiselSettings.preprocessorDefines(elaboratedModule),
+          commonCompilationSettings.verilogPreprocessorDefines ++ settings.preprocessorDefines(elaboratedModule),
         fileFilter =
-          commonCompilationSettings.fileFilter.orElse(chiselSettings.verilogLayers.shouldIncludeFile(elaboratedModule)),
+          commonCompilationSettings.fileFilter.orElse(settings.verilogLayers.shouldIncludeFile(elaboratedModule)),
         directoryFilter = commonCompilationSettings.directoryFilter.orElse(
-          chiselSettings.verilogLayers.shouldIncludeDirectory(elaboratedModule, workspace.primarySourcesPath)
+          settings.verilogLayers.shouldIncludeDirectory(elaboratedModule, workspace.primarySourcesPath)
         ),
         simulationSettings = commonCompilationSettings.simulationSettings.copy(
-          plusArgs = commonCompilationSettings.simulationSettings.plusArgs ++ chiselSettings.plusArgs,
+          plusArgs = commonCompilationSettings.simulationSettings.plusArgs ++ settings.plusArgs,
           enableWavesAtTimeZero =
-            commonCompilationSettings.simulationSettings.enableWavesAtTimeZero || chiselSettings.enableWavesAtTimeZero
+            commonCompilationSettings.simulationSettings.enableWavesAtTimeZero || settings.enableWavesAtTimeZero
         )
       )
     )

--- a/src/main/scala/chisel3/simulator/SimulatorAPI.scala
+++ b/src/main/scala/chisel3/simulator/SimulatorAPI.scala
@@ -20,7 +20,7 @@ trait SimulatorAPI {
     * @param module the Chisel module to generate
     * @param chiselOpts command line options to pass to Chisel
     * @param firtoolOpts command line options to pass to firtool
-    * @param chiselSettings Chisel-related settings used for simulation
+    * @param settings ChiselSim-related settings used for simulation
     * @param stimulus directed stimulus to use
     * @param testingDirectory a type class implementation that can be used to
     * change the behavior of where files will be created
@@ -29,10 +29,10 @@ trait SimulatorAPI {
     * by default and if you set incompatible options, the simulation will fail.
     */
   def simulateRaw[T <: RawModule](
-    module:         => T,
-    chiselOpts:     Array[String] = Array.empty,
-    firtoolOpts:    Array[String] = Array.empty,
-    chiselSettings: Settings[T] = Settings.defaultRaw[T]
+    module:      => T,
+    chiselOpts:  Array[String] = Array.empty,
+    firtoolOpts: Array[String] = Array.empty,
+    settings:    Settings[T] = Settings.defaultRaw[T]
   )(stimulus: (T) => Unit)(
     implicit hasSimulator:        HasSimulator,
     testingDirectory:             HasTestingDirectory,
@@ -43,9 +43,8 @@ trait SimulatorAPI {
   ): Unit = {
 
     hasSimulator.getSimulator
-      .simulate(module = module, chiselOpts = chiselOpts, firtoolOpts = firtoolOpts, chiselSettings = chiselSettings) {
-        module =>
-          stimulus(module.wrapped)
+      .simulate(module = module, chiselOpts = chiselOpts, firtoolOpts = firtoolOpts, settings = settings) { module =>
+        stimulus(module.wrapped)
       }
       .result
   }
@@ -57,7 +56,7 @@ trait SimulatorAPI {
     * @param module the Chisel module to generate
     * @param chiselOpts command line options to pass to Chisel
     * @param firtoolOpts command line options to pass to firtool
-    * @param chiselSettings Chisel-related settings used for simulation
+    * @param settings ChiselSim-related settings used for simulation
     * @param additionalResetCycles a number of _additional_ cycles to assert
     * reset for
     * @param stimulus directed stimulus to use
@@ -71,7 +70,7 @@ trait SimulatorAPI {
     module:                => T,
     chiselOpts:            Array[String] = Array.empty,
     firtoolOpts:           Array[String] = Array.empty,
-    chiselSettings:        Settings[T] = Settings.default[T],
+    settings:              Settings[T] = Settings.default[T],
     additionalResetCycles: Int = 0
   )(stimulus: (T) => Unit)(
     implicit hasSimulator:        HasSimulator,
@@ -84,7 +83,7 @@ trait SimulatorAPI {
     module = module,
     chiselOpts = chiselOpts,
     firtoolOpts = firtoolOpts,
-    chiselSettings = chiselSettings
+    settings = settings
   ) { dut =>
     ResetProcedure.module(additionalResetCycles)(dut)
     stimulus(dut)

--- a/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/SimulatorSpec.scala
@@ -308,15 +308,14 @@ class SimulatorSpec extends AnyFunSpec with Matchers {
         new VerilatorSimulator("test_run_dir/simulator/does_not_compile_disabled_layers-enabledf")
           .simulate(
             new Foo,
-            chiselSettings = Settings.default[Foo].copy(verilogLayers = LayerControl.EnableAll)
+            settings = Settings.default[Foo].copy(verilogLayers = LayerControl.EnableAll)
           ) { _ => }
           .result
       }.getMessage() should include("Unsupported: s_eventually")
 
       info("disabling unsupported constracts causes compilation to succeed")
       new VerilatorSimulator("test_run_dir/simulator/does_not_compile_disabled_layers-disabled")
-        .simulate(new Foo, chiselSettings = Settings.default[Foo].copy(verilogLayers = LayerControl.DisableAll)) { _ =>
-        }
+        .simulate(new Foo, settings = Settings.default[Foo].copy(verilogLayers = LayerControl.DisableAll)) { _ => }
         .result
 
     }

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -117,7 +117,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
         val a, b, c = IO(Input(Bool()))
       }
 
-      val chiselSettings = Settings
+      val settings = Settings
         .defaultRaw[Foo]
         .copy(
           assertVerboseCond = Some(MacroText.Signal(_.a)),
@@ -125,7 +125,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
           stopCond = Some(MacroText.NotSignal(_.c))
         )
 
-      simulateRaw(new Foo, chiselSettings = chiselSettings) { _ => }
+      simulateRaw(new Foo, settings = settings) { _ => }
 
       io.Source
         .fromFile(
@@ -229,7 +229,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
 
       vcdFile.delete
 
-      simulate(new Foo, chiselSettings = Settings.default.copy(enableWavesAtTimeZero = true)) { _ => }
+      simulate(new Foo, settings = Settings.default.copy(enableWavesAtTimeZero = true)) { _ => }
 
       info(s"$vcdFile exists")
       vcdFile should (exist)
@@ -247,7 +247,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
 
       simulateRaw(
         new Foo,
-        chiselSettings = Settings.default.copy(
+        settings = Settings.default.copy(
           plusArgs = Seq(
             new svsim.PlusArg("value", Some("1")),
             new svsim.PlusArg("test", None)


### PR DESCRIPTION
Rename the parameter to some functions from "chiselSettings" to "settings".  The type of the parameter had already been changed, but not the parameter name.

#### Release Notes

Change the `chiselSettings` parameter of some ChiselSim functions to be called `settings`.