### PR TITLE
Deprecate ChiselStage.convert, replace with elaborate

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -69,6 +69,9 @@ final case class Definition[+A] private[chisel3] (private[chisel3] val underlyin
 object Definition extends SourceInfoDoc {
   implicit class DefinitionBaseModuleExtensions[T <: BaseModule](d: Definition[T]) {
 
+    /** The name of the Module definition */
+    def name: String = d.proto.name
+
     /** If this is an instance of a Module, returns the toTarget of this instance
       * @return target of this instance
       */

--- a/docs/src/cookbooks/hierarchy.md
+++ b/docs/src/cookbooks/hierarchy.md
@@ -162,7 +162,7 @@ class Top extends Module {
 ```scala mdoc:passthrough
 println("```")
 // Run elaboration so that the println above shows up
-circt.stage.ChiselStage.convert(new Top)
+circt.stage.ChiselStage.elaborate(new Top)
 println("```")
 ```
 

--- a/docs/src/explanations/chisel-type-vs-scala-type.md
+++ b/docs/src/explanations/chisel-type-vs-scala-type.md
@@ -60,9 +60,7 @@ class MyModule(gen: () => MyBundle) extends Module {
 
 ```scala mdoc:invisible
 // Just here to compile check the above
-def elaborate(module: => chisel3.RawModule) = {
-  circt.stage.ChiselStage.convert(module)
-}
+import circt.stage.ChiselStage.elaborate
 elaborate(new MyModule(() => new MyBundle(3)))
 ```
 

--- a/integration-tests/src/test/scala-2/chiselTest/util/SparseVecSpec.scala
+++ b/integration-tests/src/test/scala-2/chiselTest/util/SparseVecSpec.scala
@@ -337,7 +337,7 @@ class SparseVecSpec extends AnyFlatSpec with Matchers with ChiselSim {
 
   "SparseVec error behavior" should "disallow indices large than the size" in {
     val exception = intercept[IllegalArgumentException] {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         new SparseVec(1, UInt(1.W), Seq(0, 1))
       })
     }
@@ -346,7 +346,7 @@ class SparseVecSpec extends AnyFlatSpec with Matchers with ChiselSim {
 
   it should "disallow non-unique indices" in {
     val exception = intercept[ChiselException] {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         new SparseVec(2, UInt(1.W), Seq(0, 0))
       })
     }
@@ -355,7 +355,7 @@ class SparseVecSpec extends AnyFlatSpec with Matchers with ChiselSim {
 
   it should "disallow a SparseVec write" in {
     val exception = intercept[ChiselException] {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val vec = Wire(new SparseVec(2, UInt(1.W), Seq(0, 1)))
         vec(0.U(1.W)) := 1.U
       })

--- a/src/main/scala/circt/stage/ChiselStage.scala
+++ b/src/main/scala/circt/stage/ChiselStage.scala
@@ -64,6 +64,27 @@ object ChiselStage {
     )
   )
 
+  /** Run elaboration and return the [[ElaboratedCircuit]]
+    *
+    * @param gen  a call-by-name Chisel module
+    * @param args additional command line arguments to pass to Chisel
+    * @return     the [[ElaboratedCircuit]]
+    */
+  def elaborate(
+    gen:  => RawModule,
+    args: Array[String] = Array.empty
+  ): ElaboratedCircuit = {
+    val annos = Seq(
+      ChiselGeneratorAnnotation(() => gen),
+      CIRCTTargetAnnotation(CIRCTTarget.CHIRRTL)
+    ) ++ (new Shell("circt")).parse(args)
+
+    phase
+      .transform(annos)
+      .collectFirst { case a: ChiselCircuitAnnotation => a.elaboratedCircuit }
+      .get
+  }
+
   /** Elaborate a Chisel circuit into a CHIRRTL string */
   def emitCHIRRTL(
     gen:  => RawModule,
@@ -107,6 +128,7 @@ object ChiselStage {
     *
     * @param gen a call-by-name Chisel module
     */
+  @deprecated("Use elaborate or one of the emit* methods instead", "Chisel 6.8.0")
   def convert(
     gen:  => RawModule,
     args: Array[String] = Array.empty

--- a/src/test/scala-2/chisel3/experimental/dataview/ReifySpec.scala
+++ b/src/test/scala-2/chisel3/experimental/dataview/ReifySpec.scala
@@ -79,7 +79,7 @@ class ReifySpec extends AnyFunSpec {
   describe("dataview.reify") {
 
     it("should reify single targets and identity for all non-view Elements") {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val wires = (new AllElementsBundle).getElements.map(Wire(_))
 
         // .getElements returns Data so we have to match that these are Elements.
@@ -92,7 +92,7 @@ class ReifySpec extends AnyFunSpec {
     }
 
     it("should reify single targets and identity for all non-view Elements even as children of an Aggregate") {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val bundle = IO(new AllElementsBundle)
 
         // .getElements returns Data so we have to match that these are Elements.
@@ -105,7 +105,7 @@ class ReifySpec extends AnyFunSpec {
     }
 
     it("should reify single targets and identity for all Elements in an Aggregate identity-view") {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val bundle = IO(new AllElementsBundle)
         val view = bundle.viewAs[AllElementsBundle]
 
@@ -122,7 +122,7 @@ class ReifySpec extends AnyFunSpec {
     }
 
     it("should reify single targets and identity for all Elements in an Aggregate non-identity and non-1-1 view") {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val wires = (new AllElementsBundle).getElements.map(Wire(_))
         val view = wires.viewAs[AllElementsBundle]
 
@@ -139,7 +139,7 @@ class ReifySpec extends AnyFunSpec {
     }
 
     it("should distinguish identity views from single-target views (even if the single target is the same type!") {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val vec = IO(Vec(2, UInt(8.W)))
         val view = vec.viewAs[ReversedVec[UInt]]
 
@@ -159,7 +159,7 @@ class ReifySpec extends AnyFunSpec {
     }
 
     it("should correctly reify single-target views despite complex hierarchy") {
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val in0 = IO(Input(UInt(8.W)))
         val in1 = IO(Input(new TargetBundle))
         val view = (in0, in1).viewAs[ViewBundle]
@@ -186,7 +186,7 @@ class ReifySpec extends AnyFunSpec {
       class MyModule extends RawModule {
         @public val ios = (new AllElementsBundle).getElements.map(IO(_))
       }
-      ChiselStage.convert(new RawModule {
+      ChiselStage.elaborate(new RawModule {
 
         val child = Instantiate(new MyModule)
 
@@ -204,7 +204,7 @@ class ReifySpec extends AnyFunSpec {
       class MyModule extends RawModule {
         @public val bundle = IO(new AllElementsBundle)
       }
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val child = Instantiate(new MyModule)
 
         // .getElements returns Data so we have to match that these are Elements.
@@ -222,7 +222,7 @@ class ReifySpec extends AnyFunSpec {
         @public val bundle = IO(new AllElementsBundle)
         @public val view = bundle.viewAs[AllElementsBundle]
       }
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val child = Instantiate(new MyModule)
 
         _reifyIdentityView(child.view) should be(Some(child.bundle))
@@ -243,7 +243,7 @@ class ReifySpec extends AnyFunSpec {
         @public val wires = (new AllElementsBundle).getElements.map(Wire(_))
         @public val view = wires.viewAs[AllElementsBundle]
       }
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val child = Instantiate(new MyModule)
 
         _reifyIdentityView(child.view) should be(None)
@@ -264,7 +264,7 @@ class ReifySpec extends AnyFunSpec {
         @public val vec = IO(Vec(2, UInt(8.W)))
         @public val view = vec.viewAs[ReversedVec[UInt]]
       }
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val child = Instantiate(new MyModule)
         val vec = child.vec
         val view = child.view
@@ -291,7 +291,7 @@ class ReifySpec extends AnyFunSpec {
         @public val in1 = IO(Input(new TargetBundle))
         @public val view = (in0, in1).viewAs[ViewBundle]
       }
-      ChiselStage.convert(new Module {
+      ChiselStage.elaborate(new Module {
         val child = Instantiate(new MyModule)
         val in0 = child.in0
         val in1 = child.in1

--- a/src/test/scala-2/chiselTests/CloneModuleSpec.scala
+++ b/src/test/scala-2/chiselTests/CloneModuleSpec.scala
@@ -4,6 +4,7 @@ package chiselTests
 
 import chisel3._
 import circt.stage.ChiselStage
+import chisel3.aop.Select
 import chisel3.util.{log2Ceil, Decoupled, DeqIO, EnqIO, Queue, QueueIO}
 import chisel3.experimental.CloneModuleAsRecord
 import chisel3.simulator.scalatest.ChiselSim
@@ -96,8 +97,9 @@ class CloneModuleSpec extends AnyPropSpec with PropertyUtils with Matchers with 
   }
 
   property("QueueClone's cloned queues should share the same module") {
-    val c = ChiselStage.convert(new QueueClone)
-    assert(c.modules.length == 2)
+    val c = ChiselStage.elaborate(new QueueClone)
+    val modules = Select.allDefinitionsOf[RawModule](c.topDefinition)
+    assert(modules.length == 2)
   }
 
   property("Clone of Module should simulate correctly") {
@@ -107,14 +109,15 @@ class CloneModuleSpec extends AnyPropSpec with PropertyUtils with Matchers with 
   }
 
   property("Clones of Modules should share the same module") {
-    val c = ChiselStage.convert(new QueueClone(multiIO = true))
-    assert(c.modules.length == 3)
+    val c = ChiselStage.elaborate(new QueueClone(multiIO = true))
+    val modules = Select.allDefinitionsOf[RawModule](c.topDefinition)
+    assert(modules.length == 3)
   }
 
   property("Cloned Modules should annotate correctly") {
     // Hackily get the actually Module object out
     var mod: CloneModuleAsRecordAnnotate = null
-    val res = ChiselStage.convert {
+    val res = ChiselStage.elaborate {
       mod = new CloneModuleAsRecordAnnotate
       mod
     }

--- a/src/test/scala-2/chiselTests/DataEqualitySpec.scala
+++ b/src/test/scala-2/chiselTests/DataEqualitySpec.scala
@@ -176,7 +176,7 @@ class DataEqualitySpec extends AnyFlatSpec with Matchers with ChiselSim {
   }
   it should "throw a ChiselException with differing sizes" in {
     intercept[ChiselException] {
-      ChiselStage.convert(
+      ChiselStage.elaborate(
         new EqualityTester(
           Vec(3, UInt(8.W)).Lit(0 -> 1.U, 1 -> 2.U, 2 -> 3.U),
           Vec(4, UInt(8.W)).Lit(0 -> 1.U, 1 -> 2.U, 2 -> 3.U, 3 -> 4.U)
@@ -214,7 +214,7 @@ class DataEqualitySpec extends AnyFlatSpec with Matchers with ChiselSim {
   }
   it should "throw a ChiselException with differing runtime types" in {
     intercept[ChiselException] {
-      ChiselStage.convert(
+      ChiselStage.elaborate(
         new EqualityTester(
           (new RuntimeSensitiveBundle(new MyBundle)).Lit(
             _.a -> 1.U,
@@ -262,7 +262,7 @@ class DataEqualitySpec extends AnyFlatSpec with Matchers with ChiselSim {
 
   behavior.of("Analog === Analog")
   it should "throw a ChiselException" in {
-    intercept[ChiselException] { ChiselStage.convert(new AnalogExceptionTester) }.getMessage should include(
+    intercept[ChiselException] { ChiselStage.elaborate(new AnalogExceptionTester) }.getMessage should include(
       "Equality isn't defined for Analog values"
     )
   }

--- a/src/test/scala-2/chiselTests/LayerSpec.scala
+++ b/src/test/scala-2/chiselTests/LayerSpec.scala
@@ -179,7 +179,7 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck {
       define(y, ProbeValue(b))
     }
 
-    ChiselStage.convert(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   they should "allow for defines to layer-colored probes regardless of enabled layers" in {
@@ -193,7 +193,7 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck {
       define(y, ProbeValue(b))
     }
 
-    ChiselStage.convert(new Foo)
+    ChiselStage.elaborate(new Foo)
   }
 
   they should "be enabled with a trait" in {
@@ -432,7 +432,7 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     }
 
-    intercept[ChiselException] { ChiselStage.convert(new Foo, Array("--throw-on-first-error")) }
+    intercept[ChiselException] { ChiselStage.elaborate(new Foo, Array("--throw-on-first-error")) }
       .getMessage() should include("cannot return probe of color 'C' from a layer block associated with layer 'A'")
   }
 
@@ -505,7 +505,7 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck {
       }
     }
 
-    intercept[ChiselException] { ChiselStage.convert(new Foo, Array("--throw-on-first-error")) }
+    intercept[ChiselException] { ChiselStage.elaborate(new Foo, Array("--throw-on-first-error")) }
       .getMessage() should include(
       "Cannot define 'Foo.a: IO[Probe[A]<Bool>]' from colors {'C'} since at least one of these is NOT enabled when 'Foo.a: IO[Probe[A]<Bool>]' is enabled"
     )

--- a/src/test/scala-2/chiselTests/ReadOnlySpec.scala
+++ b/src/test/scala-2/chiselTests/ReadOnlySpec.scala
@@ -84,7 +84,7 @@ class ReadOnlySpec extends AnyFlatSpec with Matchers {
 
   def check(m: => RawModule)(implicit pos: Position): Unit = {
     val e = the[ChiselException] thrownBy {
-      ChiselStage.convert(m, Array("--throw-on-first-error"))
+      ChiselStage.elaborate(m, Array("--throw-on-first-error"))
     }
     e.getMessage should include("Cannot connect to read-only value")
   }
@@ -264,7 +264,7 @@ class ReadOnlySpec extends AnyFlatSpec with Matchers {
         op(out, z)
       })
       // But note that it's fine if x (not flipped) is readOnly.
-      ChiselStage.convert(new RawModule {
+      ChiselStage.elaborate(new RawModule {
         val x, y = Wire(UInt(8.W))
         val z = (x.readOnly, y).viewAs[BidirectionalBundle]
         val out = IO(new BidirectionalBundle)

--- a/src/test/scala-2/chiselTests/experimental/ExtensionMethods.scala
+++ b/src/test/scala-2/chiselTests/experimental/ExtensionMethods.scala
@@ -16,7 +16,7 @@ private[experimental] object ExtensionMethods {
       */
     def getModule[A <: RawModule](gen: => A): A = {
       var res: Any = null
-      obj.convert {
+      obj.elaborate {
         res = gen
         res.asInstanceOf[A]
       }

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -594,7 +594,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         i.mem(0) := 100.U // should be illegal!
       }
       intercept[ChiselException] {
-        ChiselStage.convert(new Top)
+        ChiselStage.elaborate(new Top)
       }.getMessage should include(
         "Cannot create a memory port in a different module (Top) than where the memory is (HasMems)."
       )

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/InstantiateSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/InstantiateSpec.scala
@@ -4,11 +4,13 @@ package chiselTests
 package experimental.hierarchy
 
 import chisel3._
+import chisel3.aop.Select
 import chisel3.util.Valid
 import chisel3.properties._
 import chisel3.experimental.hierarchy._
-import circt.stage.ChiselStage.convert
-import chisel3.experimental.{ExtModule, IntrinsicModule, SourceLine}
+import circt.stage.ChiselStage.{elaborate, emitCHIRRTL}
+import chisel3.experimental.{BaseModule, ExtModule, IntrinsicModule, SourceLine}
+import chisel3.testing.scalatest.FileCheck
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -186,104 +188,134 @@ class ParameterizedReset(hasAsyncNotSyncReset: Boolean) extends Module {
   override def resetType = if (hasAsyncNotSyncReset) Module.ResetType.Asynchronous else Module.ResetType.Synchronous
 }
 
-class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
+class InstantiateSpec extends AnyFunSpec with Matchers with FileCheck {
 
   import InstantiateSpec._
 
   describe("Module classes that take no arguments") {
     it("should be Instantiate-able") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new NoArgs)
         val inst1 = Instantiate(new NoArgs)
-      }).modules.map(_.name)
-      assert(modules == Seq("NoArgs", "Top"))
+      }).fileCheck()(
+        """|CHECK: module NoArgs :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
   }
 
   describe("Module classes that take only implicit arguments") {
     it("should be Instantiate-able if there are only a single implicit argument") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         implicit val n = 3
         val inst0 = Instantiate(new OneImplicitArg)
         val inst1 = Instantiate(new OneImplicitArg)
-      }).modules.map(_.name)
-      assert(modules == Seq("OneImplicitArg", "Top"))
+      }).fileCheck()(
+        """|CHECK: module OneImplicitArg :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should be Instantiate-able if there are multiple implicit arguments") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         implicit val n = 3
         implicit val str = "4"
         val inst0 = Instantiate(new TwoImplicitArgs)
         val inst1 = Instantiate(new TwoImplicitArgs)
-      }).modules.map(_.name)
-      assert(modules == Seq("TwoImplicitArgs", "Top"))
+      }).fileCheck()(
+        """|CHECK: module TwoImplicitArgs :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should be Instantiate-able when arguments are passed manually") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         implicit val n = 5
         implicit val str = "6"
         val inst0 = Instantiate(new TwoImplicitArgs)
         val inst1 = Instantiate(new TwoImplicitArgs()(n, str))
-      }).modules.map(_.name)
-      assert(modules == Seq("TwoImplicitArgs", "Top"))
+      }).fileCheck()(
+        """|CHECK: module TwoImplicitArgs :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
   }
 
   describe("Module classes that take a single argument list") {
     it("should be Instantiate-able when there is only a single argument") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val n = 3
         val inst0 = Instantiate(new OneArg(3))
         val inst1 = Instantiate(new OneArg(n))
-      }).modules.map(_.name)
-      assert(modules == Seq("OneArg", "Top"))
+      }).fileCheck()(
+        """|CHECK: module OneArg :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should be Instantiate-able when there are 3 arguments") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new ThreeArgs(3, 4, "5"))
         val inst1 = Instantiate(new ThreeArgs(3, 4, "5"))
-      }).modules.map(_.name)
-      assert(modules == Seq("ThreeArgs", "Top"))
+      }).fileCheck()(
+        """|CHECK: module ThreeArgs :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
   }
 
   describe("Module classes that take default argument lists") {
     it("should be Instantiable-able with all arguments as defaults") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new DefaultArguments)
         val inst1 = Instantiate(new DefaultArguments)
-      }).modules.map(_.name)
-      assert(modules == Seq("DefaultArguments", "Top"))
+      }).fileCheck()(
+        """|CHECK: module DefaultArguments :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should be Instantiable-able with arguments passed explicitly") {
       val m = 13
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new DefaultArguments(10, 13))
         val inst1 = Instantiate(new DefaultArguments(10, m))
-      }).modules.map(_.name)
-      assert(modules == Seq("DefaultArguments", "Top"))
+      }).fileCheck()(
+        """|CHECK: module DefaultArguments :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should be Instantiable-able with only some default arguments passed explicitly") {
       val n = 11
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new DefaultArguments(n))
         val inst1 = Instantiate(new DefaultArguments(11))
-      }).modules.map(_.name)
-      assert(modules == Seq("DefaultArguments", "Top"))
+      }).fileCheck()(
+        """|CHECK: module DefaultArguments :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should be Instantiable-able with mixed regular and default arguments") {
       val n = 7
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new MixedDefaultArguments(7))
         val inst1 = Instantiate(new MixedDefaultArguments(n, 2))
-      }).modules.map(_.name)
-      assert(modules == Seq("MixedDefaultArguments", "Top"))
+      }).fileCheck()(
+        """|CHECK: module MixedDefaultArguments :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should NOT compile with named arguments") {
@@ -303,54 +335,72 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
       val n = 7
       val m = 18
       val s = "3"
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new HogWild()(7)(18, "3"))
         val inst1 = Instantiate(new HogWild()(n)(m, s))
-      }).modules.map(_.name)
-      assert(modules == Seq("HogWild", "Top"))
+      }).fileCheck()(
+        """|CHECK: module HogWild :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
   }
 
   describe("Module classes with type parameters") {
     it("should work for non-Data type parameters") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val n = "17"
         val inst0 = Instantiate(new TypeParameterized("17"))
         val inst1 = Instantiate(new TypeParameterized(n))
-      }).modules.map(_.name)
-      assert(modules == Seq("TypeParameterized", "Top"))
+      }).fileCheck()(
+        """|CHECK: module TypeParameterized :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should work for UInt type parameters") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new DataTypeParameterized(UInt(8.W)))
         val inst1 = Instantiate(new DataTypeParameterized(UInt(8.W)))
-      }).modules.map(_.name)
-      assert(modules == Seq("DataTypeParameterized_UInt8", "Top"))
+      }).fileCheck()(
+        """|CHECK: module DataTypeParameterized_UInt8 :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should work for Vec type parameters") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new DataTypeParameterized(Vec(2, UInt(8.W))))
         val inst1 = Instantiate(new DataTypeParameterized(Vec(2, UInt(8.W))))
-      }).modules.map(_.name)
-      assert(modules == Seq("DataTypeParameterized_Vec_2_UInt8", "Top"))
+      }).fileCheck()(
+        """|CHECK: module DataTypeParameterized_Vec_2_UInt8 :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should work for Bundle type parameters") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new DataTypeParameterized(Valid(UInt(8.W))))
         val inst1 = Instantiate(new DataTypeParameterized(Valid(UInt(8.W))))
-      }).modules.map(_.name)
-      assert(modules == Seq("DataTypeParameterized_Valid", "Top"))
+      }).fileCheck()(
+        """|CHECK: module DataTypeParameterized_Valid :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should work for by name Data gen parameters") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new DataTypeParameterizedByName(UInt(8.W)))
         val inst1 = Instantiate(new DataTypeParameterizedByName(UInt(8.W)))
-      }).modules.map(_.name)
-      assert(modules == Seq("DataTypeParameterizedByName_UInt8", "Top"))
+      }).fileCheck()(
+        """|CHECK: module DataTypeParameterizedByName_UInt8 :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
   }
 
@@ -359,11 +409,17 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
       class MyTop extends Top {
         val inst = Instantiate(new OneArg(3))
       }
-      val modules = convert(new MyTop).modules.map(_.name)
-      assert(modules == Seq("OneArg", "Top"))
+      emitCHIRRTL(new MyTop).fileCheck()(
+        """|CHECK: module OneArg :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
       // Building the same thing a second time should work
-      val modules2 = convert(new MyTop).modules.map(_.name)
-      assert(modules2 == Seq("OneArg", "Top"))
+      emitCHIRRTL(new MyTop).fileCheck()(
+        """|CHECK: module OneArg :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should properly handle case objects as parameters") {
@@ -371,9 +427,11 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
         val inst0 = Instantiate(new ModuleParameterizedByProductTypes(FooEnum))
         val inst1 = Instantiate(new ModuleParameterizedByProductTypes(BarEnum))
       }
-      val modules = convert(new MyTop).modules.map(_.name)
-      assert(
-        modules == Seq("ModuleParameterizedByProductTypes_FooEnum", "ModuleParameterizedByProductTypes_BarEnum", "Top")
+      emitCHIRRTL(new MyTop).fileCheck()(
+        """|CHECK: module ModuleParameterizedByProductTypes_FooEnum :
+           |CHECK: module ModuleParameterizedByProductTypes_BarEnum :
+           |CHECK: module Top :
+           |""".stripMargin
       )
     }
 
@@ -382,13 +440,11 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
         val inst0 = Instantiate(new ModuleParameterizedByProductTypes(FizzEnum(3)))
         val inst1 = Instantiate(new ModuleParameterizedByProductTypes(BuzzEnum(3)))
       }
-      val modules = convert(new MyTop).modules.map(_.name)
-      assert(
-        modules == Seq(
-          "ModuleParameterizedByProductTypes_FizzEnum3",
-          "ModuleParameterizedByProductTypes_BuzzEnum3",
-          "Top"
-        )
+      emitCHIRRTL(new MyTop).fileCheck()(
+        """|CHECK: module ModuleParameterizedByProductTypes_FizzEnum3 :
+           |CHECK: module ModuleParameterizedByProductTypes_BuzzEnum3 :
+           |CHECK: module Top :
+           |""".stripMargin
       )
     }
 
@@ -397,12 +453,10 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
         val inst0 = Instantiate(new ModuleParameterizedBySeq(List(1, 2, 3)))
         val inst1 = Instantiate(new ModuleParameterizedBySeq(Vector(1, 2, 3)))
       }
-      val modules = convert(new MyTop).modules.map(_.name)
-      assert(
-        modules == Seq(
-          "ModuleParameterizedBySeq_1_2_3",
-          "Top"
-        )
+      emitCHIRRTL(new MyTop).fileCheck()(
+        """|CHECK: module ModuleParameterizedBySeq_1_2_3 :
+           |CHECK: module Top :
+           |""".stripMargin
       )
     }
   }
@@ -411,57 +465,65 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
     it("should provide source locators for module instances") {
       // Materialize the source info so we can use it in the check
       implicit val info = implicitly[chisel3.experimental.SourceInfo]
-      val chirrtl = convert(new Top {
+      val chirrtl = emitCHIRRTL(new Top {
         val inst = Instantiate(new OneArg(3))
-      }).serialize
+      })
+      // Exact check simpler without FileCheck
       chirrtl should include(s"inst inst of OneArg @[${info.asInstanceOf[SourceLine].serialize}]")
     }
 
     it("should support BlackBoxes") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new InstantiableBlackBox)
         val inst1 = Instantiate(new InstantiableBlackBox)
-      }).modules.map(_.name)
-      assert(modules == Seq("InstantiableBlackBox", "Top"))
+      }).fileCheck()(
+        """|CHECK: extmodule InstantiableBlackBox :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should support ExtModules") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new InstantiableExtModule)
         val inst1 = Instantiate(new InstantiableExtModule)
-      }).modules.map(_.name)
-      assert(modules == Seq("InstantiableExtModule", "Top"))
+      }).fileCheck()(
+        """|CHECK: extmodule InstantiableExtModule :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
 
     it("should support Intrinsics") {
-      val modules = convert(new Top {
+      emitCHIRRTL(new Top {
         val inst0 = Instantiate(new InstantiableIntrinsic)
         val inst1 = Instantiate(new InstantiableIntrinsic)
-      }).modules.map(_.name)
-      assert(modules == Seq("InstantiableIntrinsic", "Top"))
+      }).fileCheck()(
+        """|CHECK: intmodule InstantiableIntrinsic :
+           |CHECK: module Top :
+           |""".stripMargin
+      )
     }
   }
 
   describe("Arguments not of the proper form `new ModuleSubclass(...)(...)`") {
     it("should NOT compile if the `new Module` call is outside `Instantiate(...)`") {
-      """val modules = convert(new Top {
+      """emitCHIRRTL(new Top {
         val gen0 = new NoArgs
         val gen1 = new NoArgs
         val inst0 = Instantiate(gen0)
         val inst1 = Instantiate(gen1)
-      }).modules.map(_.name)
-      assert(modules == Seq("Should", "Not", "Get", "Here"))
+      })
       """ shouldNot compile
     }
     it("should NOT compile if what we are Instantiating is not a Module") {
-      """val modules = convert(new Top {
+      """emitCHIRRTL(new Top {
         class NotAModule(n: Int){
           val foo = n
         }
         val inst0 = Instantiate(new NotAModule(3))
         val inst1 = Instantiate(new NotAModule(3))
-      }).modules.map(_.name)
-      assert(modules == Seq("Should", "Not", "Get", "Here"))
+      })
       """ shouldNot compile
     }
   }
@@ -484,13 +546,11 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
         }
       }
     }
-    val modules = convert(new MyTop).modules.map(_.name)
-    assert(
-      modules == Seq(
-        "ParameterizedReset",
-        "ParameterizedReset_1",
-        "Top"
-      )
+    emitCHIRRTL(new MyTop).fileCheck()(
+      """|CHECK: module ParameterizedReset :
+         |CHECK: module ParameterizedReset_1 :
+         |CHECK: module Top :
+         |""".stripMargin
     )
   }
 
@@ -499,7 +559,15 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
       val inst0 = Instantiate(new Foo(0))
       val inst1 = Instantiate(new Foo(1))
     }
-    assert(convert(new MyTop).modules.map(_.name).sorted == Seq("Bar", "Bar_1", "Baz", "Foo", "Foo_1", "Top").sorted)
+    emitCHIRRTL(new MyTop).fileCheck()(
+      """|CHECK: module Baz :
+         |CHECK: module Bar :
+         |CHECK: module Bar_1 :
+         |CHECK: module Foo :
+         |CHECK: module Foo_1 :
+         |CHECK: module Top :
+         |""".stripMargin
+    )
   }
 
   it("Instantiate.definition should work") {
@@ -508,6 +576,13 @@ class InstantiateSpec extends AnyFunSpec with Matchers with Utils {
       val inst0 = def0.toInstance
       val inst1 = Instantiate(new Foo(1))
     }
-    assert(convert(new MyTop).modules.map(_.name).sorted == Seq("Bar", "Bar_1", "Baz", "Foo", "Top").sorted)
+    emitCHIRRTL(new MyTop).fileCheck()(
+      """|CHECK: module Baz :
+         |CHECK: module Bar :
+         |CHECK: module Bar_1 :
+         |CHECK: module Foo :
+         |CHECK: module Top :
+         |""".stripMargin
+    )
   }
 }

--- a/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
@@ -1079,7 +1079,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.LogUtils
 
     it("should convert a module to FIRRTL IR") {
 
-      ChiselStage.convert(new ChiselStageSpec.Foo).main should be("Foo")
+      ChiselStage.elaborate(new ChiselStageSpec.Foo).name should be("Foo")
 
     }
 


### PR DESCRIPTION
I would like for the Convert phase to stop converting the IR (it will then only convert annotations) so that standard ChiselStage APIs will stop converting the IR. To do this though, I first need to be able to remove `ChiselStage.convert` which I will deprecate in 6.8.0 and remove on main.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Also add `name` to `Definition[BaseModule]`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
