### PR TITLE
Add support for printing hierarchical names in Verilog (%m)

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -24,9 +24,10 @@ private[chisel3] object Converter {
       case PString(str) => (str.replaceAll("%", "%%"), List.empty)
       case format: FirrtlFormat =>
         ("%" + format.specifier, List(format.bits.ref))
-      case Name(data)     => (data.ref.name, List.empty)
-      case FullName(data) => (data.ref.fullName(ctx), List.empty)
-      case Percent        => ("%%", List.empty)
+      case Name(data)       => (data.ref.name, List.empty)
+      case FullName(data)   => (data.ref.fullName(ctx), List.empty)
+      case Percent          => ("%%", List.empty)
+      case HierarchicalName => ("%m", List.empty)
     }
   }
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -84,9 +84,10 @@ private[chisel3] object Serializer {
       case PString(str) => (str.replaceAll("%", "%%"), List.empty)
       case format: FirrtlFormat =>
         ("%" + format.specifier, List(format.bits.ref))
-      case Name(data)     => (data.ref.name, List.empty)
-      case FullName(data) => (data.ref.fullName(ctx), List.empty)
-      case Percent        => ("%%", List.empty)
+      case Name(data)       => (data.ref.name, List.empty)
+      case FullName(data)   => (data.ref.fullName(ctx), List.empty)
+      case Percent          => ("%%", List.empty)
+      case HierarchicalName => ("%m", List.empty)
     }
   }
 

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -66,7 +66,10 @@ There are special values you can include in your `cf` interpolated string:
 
 ```scala mdoc:compile-only
 printf(cf"hierarchical path = $HierarchicalName\n") // hierarchical path = <verilog.module.path>
-printf(cf"100%%\n") // 100%
+printf(cf"hierarchical path = %m\n") // equivalent to the above
+
+printf(cf"100$Percent\n") // 100%
+printf(cf"100%%\n") // equivalent to the above
 ```
 
 

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -57,6 +57,19 @@ printf(cf"myUInt = $myUInt%b") // myUInt = 100001
 printf(cf"myUInt = $myUInt%c") // myUInt = !
 ```
 
+#### Special values
+
+There are special values you can include in your `cf` interpolated string:
+
+* `HierarchicalName` (`%m`): The hierarchical name of the signal
+* `Percent` (`%%`): A literal `%`
+
+```scala mdoc:compile-only
+printf(cf"hierarchical path = $HierarchicalName\n") // hierarchical path = <verilog.module.path>
+printf(cf"100%%\n") // 100%
+```
+
+
 #### Aggregate data-types
 
 Chisel provides default custom "pretty-printing" for Vecs and Bundles. The default printing of a Vec is similar to printing a Seq or List in Scala while printing a Bundle is similar to printing a Scala Map.
@@ -126,6 +139,7 @@ Chisel provides `printf` in a similar style to its C namesake. It accepts a doub
 | `%b` | binary number |
 | `%c` | 8-bit ASCII character |
 | `%%` | literal percent |
+| `%m` | hierarchical name |
 
 It also supports a small set of escape characters:
 


### PR DESCRIPTION
Despite the firrtl spec not mentioning `%m`, it is passed through to Verilog by firtool so #yolo.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
