### PR TITLE
Add support for modifiers to format specifiers in printing

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -23,7 +23,8 @@ private[chisel3] object Converter {
         (fmts.mkString, args.flatten.toSeq)
       case PString(str) => (str.replaceAll("%", "%%"), List.empty)
       case format: FirrtlFormat =>
-        ("%" + format.specifier, List(format.bits.ref))
+        val (str, bits) = format.unpack
+        (str, List(bits.ref))
       case Name(data)       => (data.ref.name, List.empty)
       case FullName(data)   => (data.ref.fullName(ctx), List.empty)
       case Percent          => ("%%", List.empty)

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -83,7 +83,8 @@ private[chisel3] object Serializer {
         (fmts.mkString, args.flatten.toSeq)
       case PString(str) => (str.replaceAll("%", "%%"), List.empty)
       case format: FirrtlFormat =>
-        ("%" + format.specifier, List(format.bits.ref))
+        val (str, bits) = format.unpack
+        (str, List(bits.ref))
       case Name(data)       => (data.ref.name, List.empty)
       case FullName(data)   => (data.ref.fullName(ctx), List.empty)
       case Percent          => ("%%", List.empty)

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -287,9 +287,13 @@ package object chisel3 {
           val fmtArg: Printable = arg match {
             case d: Data => {
               fmt match {
-                case Some("%n")                          => Name(d)
-                case Some("%N")                          => FullName(d)
-                case Some(fForm) if d.isInstanceOf[Bits] => FirrtlFormat(fForm.substring(1, 2), d)
+                case Some("%n") => Name(d)
+                case Some("%N") => FullName(d)
+                case Some(fForm) if d.isInstanceOf[Bits] =>
+                  FirrtlFormat.parse(fForm, d.asInstanceOf[Bits]) match {
+                    case Left(err) => throw new UnknownFormatConversionException(err)
+                    case Right(p)  => p
+                  }
                 case Some(x) => {
                   val msg = s"Illegal format specifier '$x' for Chisel Data type!\n"
                   throw new UnknownFormatConversionException(msg)

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -72,6 +72,30 @@ printf(cf"100$Percent\n") // 100%
 printf(cf"100%%\n") // equivalent to the above
 ```
 
+#### Format modifiers
+
+Chisel supports standard Verilog-style modifiers for `%d`, `%x`, and `%b` between the `%` and the format specifier.
+
+Verilog simulators will pad values out to the width of the signal.
+With decimal formatting, space is used for padding.
+For all other formats, `0` is used for padding.
+
+* A non-negative field width will override the default Verilog sizing of the value.
+* Specifying a field width of `0` will always display the value with the minimum width (no zero nor space padding).
+
+```scala mdoc:compile-only
+val foo = WireInit(UInt(32.W), 33.U)
+printf(cf"foo = $foo%d!\n")  // foo =         33!
+printf(cf"foo = $foo%0d!\n") // foo = 33!
+printf(cf"foo = $foo%4d!\n") // foo =   33!
+printf(cf"foo = $foo%x!\n")  // foo = 00000021!
+printf(cf"foo = $foo%0x!\n") // foo = 21!
+printf(cf"foo = $foo%4x!\n") // foo = 0021!
+val bar = WireInit(UInt(8.W), 5.U)
+printf(cf"bar = $bar%b!\n")  // foo = 00000101!
+printf(cf"bar = $bar%0b!\n") // foo = 101!
+printf(cf"bar = $bar%4b!\n") // foo = 0101!
+```
 
 #### Aggregate data-types
 
@@ -143,6 +167,8 @@ Chisel provides `printf` in a similar style to its C namesake. It accepts a doub
 | `%c` | 8-bit ASCII character |
 | `%%` | literal percent |
 | `%m` | hierarchical name |
+
+`%d`, `%x`, and `%b` support the modifiers described in the [Format modifiers](#format-modifiers) section above.
 
 It also supports a small set of escape characters:
 

--- a/src/test/scala-2/chiselTests/PrintableSpec.scala
+++ b/src/test/scala-2/chiselTests/PrintableSpec.scala
@@ -3,13 +3,16 @@
 package chiselTests
 
 import chisel3._
+import chisel3.FirrtlFormat.FormatWidth
 import circt.stage.ChiselStage
 import chisel3.testing.scalatest.FileCheck
 import org.scalactic.source.Position
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scala.annotation.nowarn
 
 /* Printable Tests */
+@nowarn("msg=method apply in object FirrtlFormat is deprecated")
 class PrintableSpec extends AnyFlatSpec with Matchers with FileCheck {
   // This regex is brittle, it specifically finds the clock and enable signals followed by commas
   private val PrintfRegex = """\s*printf\(\w+, [^,]+,(.*)\).*""".r
@@ -322,5 +325,52 @@ class PrintableSpec extends AnyFlatSpec with Matchers with FileCheck {
       .fileCheck()(
         """CHECK: printf(clock, UInt<1>(0h1), "%m %d %x %b %c %%\n", in, in, in, in)"""
       )
+  }
+
+  it should "support modifiers to format specifiers" in {
+    class MyModule extends Module {
+      val in = IO(Input(UInt(8.W)))
+      printf(cf"$in%0d $in%0x $in%5d $in%13b $in%c $in%5x\n")
+    }
+    ChiselStage
+      .emitCHIRRTL(new MyModule)
+      .fileCheck()(
+        """CHECK: printf(clock, UInt<1>(0h1), "%0d %0x %5d %13b %c %5x\n", in, in, in, in, in, in)"""
+      )
+  }
+
+  "FirrtlFormat" should "support all legal format specifiers" in {
+    val x = 123.U
+    // Legacy API of just the character
+    FirrtlFormat("d", x) should be(Decimal(x))
+    FirrtlFormat("x", x) should be(Hexadecimal(x))
+    FirrtlFormat("b", x) should be(Binary(x))
+    FirrtlFormat("c", x) should be(Character(x))
+    FirrtlFormat.parse("%d", x) should be(Right(Decimal(x)))
+    FirrtlFormat.parse("%x", x) should be(Right(Hexadecimal(x)))
+    FirrtlFormat.parse("%b", x) should be(Right(Binary(x)))
+    FirrtlFormat.parse("%c", x) should be(Right(Character(x)))
+    FirrtlFormat.parse("%0d", x) should be(Right(Decimal(x, FormatWidth.Minimum)))
+    FirrtlFormat.parse("%0x", x) should be(Right(Hexadecimal(x, FormatWidth.Minimum)))
+    FirrtlFormat.parse("%0b", x) should be(Right(Binary(x, FormatWidth.Minimum)))
+    FirrtlFormat.parse("%23d", x) should be(Right(Decimal(x, FormatWidth.Fixed(23))))
+    FirrtlFormat.parse("%23x", x) should be(Right(Hexadecimal(x, FormatWidth.Fixed(23))))
+    FirrtlFormat.parse("%23b", x) should be(Right(Binary(x, FormatWidth.Fixed(23))))
+  }
+  it should "not support illegal format specifiers" in {
+    val x = 123.U
+    an[Exception] should be thrownBy {
+      FirrtlFormat("a", x)
+    }
+    FirrtlFormat.parse("%a", x) should be(Left("Illegal format specifier 'a'!"))
+    FirrtlFormat.parse("d", x) should be(Left("Format specifier 'd' must start with '%'!"))
+    FirrtlFormat.parse("%0c", x) should be(Left("'%c' does not support width modifiers!"))
+    FirrtlFormat.parse("%-d", x) should be(
+      Left("Chisel does not support non-standard Verilog left-justified format specifiers!")
+    )
+    FirrtlFormat.parse("%02d", x) should be(
+      Left("Chisel does not support non-standard Verilog zero-padded format specifiers!")
+    )
+    FirrtlFormat.parse("%5c", x) should be(Left("'%c' does not support width modifiers!"))
   }
 }

--- a/src/test/scala-2/chiselTests/Printf.scala
+++ b/src/test/scala-2/chiselTests/Printf.scala
@@ -84,4 +84,16 @@ class PrintfSpec extends AnyFlatSpec with Matchers with FileCheck {
         """CHECK: printf(clock, UInt<1>(0h1), "%m %d %x %b %c %%\n", in, in, in, in)"""
       )
   }
+
+  "printf" should "support modifiers to format specifiers" in {
+    class MyModule extends Module {
+      val in = IO(Input(UInt(8.W)))
+      printf("%0d %0x %5d %13b %c %5x\n", in, in, in, in, in, in)
+    }
+    ChiselStage
+      .emitCHIRRTL(new MyModule)
+      .fileCheck()(
+        """CHECK: printf(clock, UInt<1>(0h1), "%0d %0x %5d %13b %c %5x\n", in, in, in, in, in, in)"""
+      )
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This includes modifiers defined in the SystemVerilog spec like minimum width (e.g. `%0d`) and set width (e.g. `%8d`). It does **not** include non-standard extensions like left-justification and zero-padding for decimal.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
