### PR TITLE
Fix UInt unary negation ScalaDoc

### DIFF
--- a/core/src/main/scala-2/chisel3/BitsIntf.scala
+++ b/core/src/main/scala-2/chisel3/BitsIntf.scala
@@ -277,7 +277,7 @@ private[chisel3] trait BitsIntf extends ToBoolable { self: Bits =>
 private[chisel3] trait UIntIntf { self: UInt =>
 
   // TODO: refactor to share documentation with Num or add independent scaladoc
-  /** Unary negation (expanding width)
+  /** Unary negation (constant width)
     *
     * @return a $coll equal to zero minus this $coll
     * $constantWidth
@@ -287,16 +287,18 @@ private[chisel3] trait UIntIntf { self: UInt =>
 
   /** Unary negation (constant width)
     *
-    * @return a $coll equal to zero minus this $coll shifted right by one.
+    * @return a $coll equal to zero minus this $coll
     * $constantWidth
     * @group Arithmetic
     */
+  @deprecated("Use unary_- which has the same behavior", "Chisel 6.8.0")
   final def unary_-% : UInt = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_unary_-(implicit sourceInfo: SourceInfo): UInt = _impl_unary_-
 
   /** @group SourceInfoTransformMacro */
+  @deprecated("Use unary_- which has the same behavior", "Chisel 6.8.0")
   def do_unary_-%(implicit sourceInfo: SourceInfo): UInt = _impl_unary_-%
 
   override def do_+(that: UInt)(implicit sourceInfo: SourceInfo): UInt = _impl_+(that)
@@ -553,12 +555,14 @@ private[chisel3] trait SIntIntf { self: SInt =>
     * $constantWidth
     * @group Arithmetic
     */
+  @deprecated("Use unary_- which has the same behavior", "Chisel 6.8.0")
   final def unary_-% : SInt = macro SourceInfoTransform.noArg
 
   /** @group SourceInfoTransformMacro */
   def do_unary_-(implicit sourceInfo: SourceInfo): SInt = _impl_unary_-
 
   /** @group SourceInfoTransformMacro */
+  @deprecated("Use unary_- which has the same behavior", "Chisel 6.8.0")
   def do_unary_-%(implicit sourceInfo: SourceInfo): SInt = _impl_unary_-%
 
   /** add (default - no growth) operator */

--- a/core/src/main/scala-3/chisel3/BitsIntf.scala
+++ b/core/src/main/scala-3/chisel3/BitsIntf.scala
@@ -190,7 +190,7 @@ private[chisel3] trait BitsIntf extends ToBoolable { self: Bits =>
 private[chisel3] trait UIntIntf { self: UInt =>
 
   // TODO: refactor to share documentation with Num or add independent scaladoc
-  /** Unary negation (expanding width)
+  /** Unary negation (constant width)
     *
     * @return a $coll equal to zero minus this $coll
     * $constantWidth
@@ -204,6 +204,7 @@ private[chisel3] trait UIntIntf { self: UInt =>
     * $constantWidth
     * @group Arithmetic
     */
+  @deprecated("Use unary_- which has the same behavior", "Chisel 6.8.0")
   def unary_-%(using SourceInfo): UInt = _impl_unary_-%
 
   override def +(that: UInt): UInt = _impl_+(that)
@@ -398,10 +399,11 @@ private[chisel3] trait SIntIntf { self: SInt =>
 
   /** Unary negation (constant width)
     *
-    * @return a hardware $coll equal to zero minus `this` shifted right by one
+    * @return a hardware $coll equal to zero minus `this` $coll
     * $constantWidth
     * @group Arithmetic
     */
+  @deprecated("Use unary_- which has the same behavior", "Chisel 6.8.0")
   def unary_-%(using SourceInfo): SInt = _impl_unary_-%
 
   /** add (default - no growth) operator */


### PR DESCRIPTION
Fixing a ScalaDoc inconsistency noted on Element.

Note that unary operators are only allowed to be single characters, `-`, `!`, `~` and `+`, so `unary_-%` has always been invalid to call as a unary operator, you have to call it as `myUInt.unary_-%` which is just pointless and silly.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Deprecate invalid unary operator unary_-%.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
