### PR TITLE
Track tests in HasTests to support metadata needs

### DIFF
--- a/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
+++ b/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
@@ -115,7 +115,7 @@ trait HasTests[M <: RawModule] { module: M =>
     *  testharness has clock and synchronous reset IOs and contains the test
     *  body.
     *
-    *  @param testBody the circuit to generate inside the testharness
+    *  @param testBody the circuit to elaborate inside the testharness
     */
   protected final def test[R](
     testName: String

--- a/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
+++ b/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
@@ -189,7 +189,7 @@ trait HasTests { module: RawModule =>
     getRegisteredTests.filter(_.shouldElaborateToCircuit).map(_.params)
 
   /** Map from test name to elaborated test. */
-  private val elaboratedTests = new mutable.HashMap[String, ElaboratedTest[M, _]]
+  private val elaboratedTests = new mutable.LinkedHashMap[String, ElaboratedTest[M, _]]
 
   /** Get the all tests elaborated to the ciruit. */
   private[chisel3] def getElaboratedTests: Seq[ElaboratedTest[M, _]] =

--- a/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
+++ b/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
@@ -34,7 +34,7 @@ final class TestParameters[M <: RawModule, R] private[inlinetest] (
   }
 
   /** The [[desiredName]] for the testharness module. */
-  private[inlinetest] final def testHarnessDesiredName = s"test_${dutName()}_${testName}"
+  def testHarnessDesiredName = s"test_${dutName()}_${testName}"
 }
 
 sealed class TestResultBundle extends Bundle {

--- a/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
+++ b/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable
 
 import chisel3._
 import chisel3.experimental.hierarchy.{Definition, Instance}
+import chisel3.simulator.{stimulus, Simulator}
 
 /** Per-test parametrization needed to build a testharness that instantiates
   * the DUT and elaborates a test body.
@@ -24,6 +25,7 @@ final class TestParameters[M <: RawModule, R] private[inlinetest] (
   private[inlinetest] val testBody: Instance[M] => R,
   /** The reset type of the DUT module. */
   private[inlinetest] val dutResetType: Option[Module.ResetType.Type]
+  /** The expected result when simulating this test. */
 ) {
 
   /** The concrete reset type of the testharness module. */
@@ -37,7 +39,8 @@ final class TestParameters[M <: RawModule, R] private[inlinetest] (
   def testHarnessDesiredName = s"test_${dutName()}_${testName}"
 }
 
-sealed class TestResultBundle extends Bundle {
+/** IO that reports the status of the test implemented by a testharness. */
+final class TestResultBundle extends Bundle {
 
   /** The test shall be considered complete on the first positive edge of
    *  [[finish]] by the simulation. The [[TestHarness]] must drive this.
@@ -92,6 +95,12 @@ abstract class TestHarnessWithResult[M <: RawModule](test: TestParameters[M, Tes
   io.success := testResult.success
 }
 
+/** A test that has been elaborated to the circuit. */
+private[chisel3] case class ElaboratedTest[M <: RawModule, R](
+  params:      TestParameters[M, R],
+  testHarness: TestHarness[M, R]
+)
+
 /** An implementation of a testharness generator. This is a type class that defines how to
  *  generate a testharness. It is passed to each invocation of [[HasTests.test]].
   *
@@ -123,9 +132,12 @@ object TestHarnessGenerator {
   }
 }
 
-private final class TestGenerator[M <: RawModule, R](
+/** A test that was registered, but is not necessarily selected for elaboration. */
+private final class RegisteredTest[M <: RawModule, R](
   /** The user-provided name of the test. */
   val testName: String,
+  /** Whether or not this test should be elaborated. */
+  val shouldElaborateToCircuit: Boolean,
   /** Thunk that returns a [[Definition]] of the DUT */
   dutDefinition: () => Definition[M],
   /** The (eventually) legalized name for the DUT module */
@@ -137,8 +149,11 @@ private final class TestGenerator[M <: RawModule, R](
   /** The testharness generator. */
   testHarnessGenerator: TestHarnessGenerator[M, R]
 ) {
-  val params = new TestParameters(dutName, testName, dutDefinition, testBody, dutResetType)
-  def generate() = testHarnessGenerator.generate(params)
+  val params: TestParameters[M, R] = new TestParameters(dutName, testName, dutDefinition, testBody, dutResetType)
+  def elaborate() = ElaboratedTest(
+    params,
+    testHarnessGenerator.generate(params)
+  )
 }
 
 /** Provides methods to build unit testharnesses inline after this module is elaborated.
@@ -152,28 +167,40 @@ trait HasTests { module: RawModule =>
   /** Whether inline tests will be elaborated as a top-level definition to the circuit. */
   protected def elaborateTests: Boolean = true
 
+  /** From options, what modules and tests should be included in this run. */
   private val inlineTestIncluder = internal.Builder.captureContext().inlineTestIncluder
 
-  private def shouldElaborateTest(testName: String) =
+  /** Whether a test is enabled. */
+  private def shouldElaborateTest(testName: String): Boolean =
     elaborateTests && inlineTestIncluder.shouldElaborateTest(module.desiredName, testName)
 
   /** This module as a definition. Lazy in order to prevent evaluation unless used by a test. */
   private lazy val moduleDefinition = module.toDefinition.asInstanceOf[Definition[M]]
 
   /** Generators for inline tests by name. LinkedHashMap preserves test insertion order. */
-  private val testGenerators = new mutable.LinkedHashMap[String, TestGenerator[M, _]]
-
-  /** Get the generators for the currently registered tests for this module and whether they are queued
-   *  for elaboration. */
-  private def getRegisteredTestGenerators: Seq[(TestGenerator[M, _], Boolean)] =
-    testGenerators.values.toSeq.map { testGenerator =>
-      (testGenerator, shouldElaborateTest(testGenerator.params.testName))
-    }
+  private val registeredTests = new mutable.LinkedHashMap[String, RegisteredTest[M, _]]
 
   /** Get the currently registered tests for this module and whether they are queued for elaboration. */
-  def getRegisteredTests: Seq[(TestParameters[M, _], Boolean)] =
-    getRegisteredTestGenerators.map { case (testGenerator, shouldElaborate) =>
-      (testGenerator.params, shouldElaborate)
+  private def getRegisteredTests: Seq[RegisteredTest[M, _]] =
+    registeredTests.values.toSeq
+
+  /** Get all enabled tests for this module. */
+  def getTests: Seq[TestParameters[M, _]] =
+    getRegisteredTests.filter(_.shouldElaborateToCircuit).map(_.params)
+
+  /** Map from test name to elaborated test. */
+  private val elaboratedTests = new mutable.HashMap[String, ElaboratedTest[M, _]]
+
+  /** Get the all tests elaborated to the ciruit. */
+  private[chisel3] def getElaboratedTests: Seq[ElaboratedTest[M, _]] =
+    elaboratedTests.values.toSeq
+
+  /** Elaborate a test to the circuit as a public definition. */
+  private def elaborateTestToCircuit[R](test: RegisteredTest[M, R]): Unit =
+    Definition {
+      val elaboratedTest = test.elaborate()
+      elaboratedTests += test.params.testName -> elaboratedTest
+      elaboratedTest.testHarness
     }
 
   /** Generate a public module that instantiates this module. The default
@@ -185,27 +212,28 @@ trait HasTests { module: RawModule =>
   protected final def test[R](
     testName: String
   )(testBody: Instance[M] => R)(implicit testHarnessGenerator: TestHarnessGenerator[M, R]): Unit = {
-    require(!testGenerators.contains(testName), s"test '${testName}' already declared")
+    require(!registeredTests.contains(testName), s"test '${testName}' already declared")
     val dutResetType = module match {
       case module: Module => Some(module.resetType)
       case _ => None
     }
-    val testGenerator =
-      new TestGenerator(
+    val test =
+      new RegisteredTest(
         testName,
+        module.shouldElaborateTest(testName),
         () => moduleDefinition,
         () => module.name,
         testBody,
         dutResetType,
         testHarnessGenerator
       )
-    testGenerators += testName -> testGenerator
+    registeredTests += testName -> test
   }
 
   afterModuleBuilt {
-    getRegisteredTestGenerators.foreach { case (testGenerator, shouldElaborate) =>
-      if (shouldElaborate) {
-        Definition(testGenerator.generate())
+    getRegisteredTests.foreach { test =>
+      if (test.shouldElaborateToCircuit) {
+        elaborateTestToCircuit(test)
       }
     }
   }

--- a/src/test/scala/chiselTests/experimental/InlineTestSpec.scala
+++ b/src/test/scala/chiselTests/experimental/InlineTestSpec.scala
@@ -69,11 +69,7 @@ trait HasTestsProperty { this: RawModule with HasTests =>
 
   atModuleBodyEnd {
     testNames.foreach { testNames =>
-      testNames := Property {
-        getRegisteredTests.flatMap { case (test, willElaborate) =>
-          Option.when(willElaborate)(test.testName)
-        }
-      }
+      testNames := Property(this.getTests.map(_.testName))
     }
   }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

- Refactor `HasTests` to track tests in buffer before elaborating
  - The use case for this is to support capturing metadata about the tests that belong to a `HasTests` module. At the moment, `testName` is the only public member of the `TestParameters`, but this may be expanded in the future.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
