### PR TITLE
Remove type parameter from chisel3.experimental.inlinetest.HasTests

### DIFF
--- a/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
+++ b/src/main/scala/chisel3/experimental/inlinetest/InlineTest.scala
@@ -93,7 +93,8 @@ object TestHarnessGenerator {
   *  @tparam TestResult the type returned from each test body generator, typically
   *  hardware indicating completion and/or exit code to the testharness.
   */
-trait HasTests[M <: RawModule] { module: M =>
+trait HasTests { module: RawModule =>
+  type M = module.type
 
   /** A Definition of the DUT to be used for each of the tests. */
   private lazy val moduleDefinition =

--- a/src/test/scala/chiselTests/experimental/InlineTestSpec.scala
+++ b/src/test/scala/chiselTests/experimental/InlineTestSpec.scala
@@ -72,7 +72,7 @@ class ProtocolMonitor(bundleType: ProtocolBundle) extends Module {
 class ModuleWithTests(ioWidth: Int = 32, override val resetType: Module.ResetType.Type = Module.ResetType.Synchronous)
     extends Module
     with HasMonitorSocket
-    with HasTests[ModuleWithTests] {
+    with HasTests {
   @public val io = IO(new ProtocolBundle(ioWidth))
 
   override val monProbe = makeProbe(io)
@@ -118,7 +118,7 @@ class ModuleWithTests(ioWidth: Int = 32, override val resetType: Module.ResetTyp
 }
 
 @instantiable
-class RawModuleWithTests(ioWidth: Int = 32) extends RawModule with HasTests[RawModuleWithTests] {
+class RawModuleWithTests(ioWidth: Int = 32) extends RawModule with HasTests {
   @public val io = IO(new ProtocolBundle(ioWidth))
   io.out := io.in
   test("foo") { instance =>


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

- Remove type parameters from `HasTests`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
