### PR TITLE
Fix layer.enable applying to all later modules

### DIFF
--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1227,7 +1227,8 @@ private[chisel3] object Builder extends LazyLogging {
       Builder.setPrefix(state.prefix)
       Builder.currentClock = state.clock
       Builder.currentReset = state.reset
-      Builder.enabledLayers = enabledLayers
+      Builder.enabledLayers.clear()
+      Builder.enabledLayers ++= state.enabledLayers
     }
 
     /** Run the `thunk` with the context provided by `state`.  Save the [[Builder]]

--- a/src/test/scala-2/chiselTests/LayerSpec.scala
+++ b/src/test/scala-2/chiselTests/LayerSpec.scala
@@ -216,6 +216,23 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck {
 
   }
 
+  they should ", when enabled, not propagate to child modules" in {
+
+    class Bar extends RawModule
+
+    class Foo extends RawModule {
+      layer.enable(A)
+      val bar = Module(new Bar)
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      """|CHECK: module Bar :
+         |CHECK: module Foo enablelayer A :
+         |""".stripMargin
+    }
+
+  }
+
   they should "work correctly with Definition/Instance" in {
 
     @instantiable


### PR DESCRIPTION
Fix a bug where use of the `layer.enable` API would incorrect cause a propagation of layers being enabled to all subsequent modules.  This was due to a bug in how the state save/restore logic worked.

Fixes #4839.

#### Release Notes

Fix a bug where `layer.enable` would apply to all later modules.