### PR TITLE
[svsim] Use -no_save instead of ASLR workarounds

### DIFF
--- a/svsim/src/main/scala/Backend.scala
+++ b/svsim/src/main/scala/Backend.scala
@@ -213,10 +213,6 @@ final object Backend {
     /** Verilator does not currently support delay (`#delay`) in DPI functions, so we omit the SystemVerilog definition of the `run_simulation` function and instead provide a C implementation.
       */
     val supportsDelayInPublicFunctions = "SVSIM_BACKEND_SUPPORTS_DELAY_IN_PUBLIC_FUNCTIONS"
-
-    /** VCS first checks whether address-space layout randomization (ASLR) is enabled, and if it is, _helpfully_ relaunches this executable with ASLR disabled. Unfortunately, this causes code executed prior to `simulation_main` to be executed twice, which is problematic, especially since we redirect `stdin` and `stdout`.
-      */
-    val backendEngagesInASLRShenanigans = "SVSIM_BACKEND_ENGAGES_IN_ASLR_SHENANIGANS"
   }
 
   object Exceptions {

--- a/svsim/src/main/scala/vcs/Backend.scala
+++ b/svsim/src/main/scala/vcs/Backend.scala
@@ -378,8 +378,6 @@ final class Backend(
               Seq(
                 // Enable VCS support
                 s"-D${svsim.Backend.HarnessCompilationFlags.enableVCSSupport}",
-                // VCS engages in ASLR shenanigans
-                s"-D${svsim.Backend.HarnessCompilationFlags.backendEngagesInASLRShenanigans}",
               )
             )),
           ).collect {
@@ -422,6 +420,14 @@ final class Backend(
           backendSpecificSettings.simulationSettings.coverageDirectory.map(_.toFlags).getOrElse(Seq.empty),
           backendSpecificSettings.simulationSettings.coverageName.map(_.toFlags).getOrElse(Seq.empty),
           commonSettings.simulationSettings.plusArgs.map(_.simulatorFlags),
+          // In order to support save/restore functionality, VCS will detect if
+          // Address Space Layout Randomization (ASLR) is ocurring when the
+          // simulation starts.  If it is, then VCS will relaunch the simulation
+          // with ASLR turned off.  This double-launch confuses svsim.  To avoid
+          // this, and because svsim doesn't support save/restore functionality,
+          // we turn off VCS save/restore features.  The simulation binary will
+          // then only run once.
+          Seq("-no_save")
         ).flatten,
         environment = environment
       )


### PR DESCRIPTION
For the internal installation of VCS and RHEL, our simulations do not work due to VCS' save/restore functionality which will launch a simulation, detect if ASLR is present, and then kill the simulation and relaunch it with ASLR disabled.  The workaround employed here has been empirically shown to be problematic for at least one user (#4837).  Drop the ASLR workaround and add the runtime option `-no_save` which turns off VCS save/restore functionality.  svsim doesn't support this and it's ill advised to use non-standard workarounds.

#### Release Notes

Fix problems for some users when using svsim with VCS where a simulation would fail to start due to non-standard ASLR workarounds employed. Change svsim to run VCS simulations with the `-no_save` option to avoid VCS simulation relaunches on machines with ASLR enabled.