### PR TITLE
Remove deprecated BoringUtils APIs

### DIFF
--- a/src/main/scala/chisel3/util/experimental/BoringUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/BoringUtils.scala
@@ -7,12 +7,9 @@ import chisel3.probe.{Probe, RWProbe}
 import chisel3.reflect.DataMirror
 import chisel3.Data.ProbeInfo
 import chisel3.experimental.{annotate, requireIsHardware, skipPrefix, BaseModule, SourceInfo}
-import chisel3.internal.{Builder, BuilderContextCache, NamedComponent, Namespace}
+import chisel3.internal.Builder
 import chisel3.internal.binding.{BlockBinding, CrossModuleBinding, PortBinding, SecretPortBinding}
-import firrtl.transforms.{DontTouchAnnotation, NoDedupAnnotation}
 import chisel3.internal.firrtl.ir.Block
-import firrtl.passes.wiring.{SinkAnnotation, SourceAnnotation}
-import firrtl.annotations.{ComponentName, ModuleName}
 
 /** An exception related to BoringUtils
   * @param message the exception message
@@ -111,102 +108,6 @@ class BoringUtilsException(message: String) extends Exception(message)
   * across circuit elaborations.
   */
 object BoringUtils {
-  /* A global namespace for boring ids */
-  private[chisel3] case object CacheKey extends BuilderContextCache.Key[Namespace]
-  private def boringNamespace = Builder.contextCache.getOrElseUpdate(CacheKey, Namespace.empty)
-
-  /* Get a new name (value) from the namespace */
-  private def newName(value: String): String = {
-    boringNamespace.name(value)
-  }
-  /* True if the requested name (value) exists in the namespace */
-  private def checkName(value: String): Boolean = boringNamespace.contains(value)
-
-  /** Add a named source cross module reference
-    * @param component source circuit component
-    * @param name unique identifier for this source
-    * @param disableDedup disable deduplication of this source component (this should be true if you are trying to wire
-    * from specific identical sources differently)
-    * @param uniqueName if true, this will use a non-conflicting name from the global namespace
-    * @return the name used
-    * @note if a uniqueName is not specified, the returned name may differ from the user-provided name
-    */
-  @deprecated(
-    "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
-    "Chisel 6.0"
-  )
-  def addSource(
-    component:    NamedComponent,
-    name:         String,
-    disableDedup: Boolean = false,
-    uniqueName:   Boolean = false
-  ): String = {
-
-    val id = if (uniqueName) { newName(name) }
-    else { name }
-    annotate(component)(
-      Seq(SourceAnnotation(component.toNamed, id), DontTouchAnnotation(component.toNamed)) ++ Option.when(disableDedup)(
-        NoDedupAnnotation(component.toNamed.module)
-      )
-    )
-    id
-  }
-
-  /** Add a named sink cross module reference. Multiple sinks may map to the same source.
-    * @param component sink circuit component
-    * @param name unique identifier for this sink that must resolve to
-    * @param disableDedup disable deduplication of this sink component (this should be true if you are trying to wire
-    * specific, identical sinks differently)
-    * @param forceExists if true, require that the provided `name` parameter already exists in the global namespace
-    * @throws BoringUtilsException if name is expected to exist and it doesn't
-    */
-  @deprecated(
-    "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
-    "Chisel 6.0"
-  )
-  def addSink(
-    component:    InstanceId,
-    name:         String,
-    disableDedup: Boolean = false,
-    forceExists:  Boolean = false
-  ): Unit = {
-
-    if (forceExists && !checkName(name)) {
-      throw new BoringUtilsException(s"Sink ID '$name' not found in BoringUtils ID namespace")
-    }
-    def moduleName = component.toNamed match {
-      case c: ModuleName    => c
-      case c: ComponentName => c.module
-      case _ => throw new ChiselException("Can only add a Module or Component sink", null)
-    }
-    // annotate doesn't support InstanceId (which is deprecated) because InstanceId doesn't implement toRelativeTarget
-    // this API is deprecated anyway so probably fine to not check it.
-    annotate()(Seq(SinkAnnotation(component.toNamed, name)) ++ Option.when(disableDedup)(NoDedupAnnotation(moduleName)))
-  }
-
-  /** Connect a source to one or more sinks
-    * @param source a source component
-    * @param sinks one or more sink components
-    * @return the name of the signal used to connect the source to the
-    * sinks
-    * @note the returned name will be based on the name of the source
-    * component
-    */
-  @deprecated(
-    "Please use the new Boring API instead (BoringUtils.bore(source)). This will be removed in Chisel 7.0",
-    "Chisel 6.0"
-  )
-  def bore(source: Data, sinks: Seq[Data]): String = {
-    val boringName =
-      try {
-        source.instanceName
-      } catch {
-        case _: Exception => "bore"
-      }
-    val genName = addSource(source, boringName, true, true)
-    sinks.foreach(addSink(_, genName, true, true))
-    genName
-  }
 
   private def boreOrTap[A <: Data](
     source:      A,

--- a/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
@@ -18,6 +18,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileCheck with ChiselSim {
+  val args = Array("--throw-on-first-error", "--full-stacktrace")
+
   behavior.of("BoringUtils.bore")
 
   it should "pass a basic test" in {
@@ -139,7 +141,7 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
       BoringUtils.bore(bar.a_wire)
     }
     val e = intercept[Exception] {
-      circt.stage.ChiselStage.emitCHIRRTL(new Foo, Array("--throw-on-first-error"))
+      circt.stage.ChiselStage.emitCHIRRTL(new Foo, args)
     }
     e.getMessage should include("Cannot bore across a Definition/Instance boundary")
   }
@@ -225,7 +227,7 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
       val postBore = DataMirror.modulePorts(bar)
       postBore.size should be(1)
     }
-    circt.stage.ChiselStage.emitCHIRRTL(new Foo)
+    circt.stage.ChiselStage.emitCHIRRTL(new Foo, args)
   }
   it should "fail if bore after calling DataMirror.modulePorts" in {
     import chisel3.reflect.DataMirror

--- a/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
@@ -17,116 +17,10 @@ import firrtl.transforms.DontTouchAnnotation
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-abstract class ShouldntAssertTester(cyclesToWait: BigInt = 4) extends Module {
-  val dut: BaseModule
-  val (_, done) = Counter(true.B, 2)
-  when(done) { stop() }
-}
-
 class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileCheck with ChiselSim {
-  val args = Array("--throw-on-first-error", "--full-stacktrace")
-
-  class BoringInverter extends Module {
-    val io = IO(new Bundle {})
-    val a = Wire(UInt(1.W))
-    val notA = Wire(UInt(1.W))
-    val b = Wire(UInt(1.W))
-    a := 0.U
-    notA := ~a
-    b := a
-    chisel3.assert(b === 1.U)
-    BoringUtils.addSource(notA, "x")
-    BoringUtils.addSink(b, "x")
-  }
-
-  behavior.of("BoringUtils.addSink and BoringUtils.addSource")
-
-  it should "connect two wires within a module" in {
-    simulate(new ShouldntAssertTester { val dut = Module(new BoringInverter) })(RunUntilFinished(3))
-  }
-
-  trait WireX { this: BaseModule =>
-    val x = dontTouch(Wire(UInt(4.W)))
-  }
-
-  class Source extends RawModule with WireX {
-    val in = IO(Input(UInt()))
-    x := in
-  }
-
-  class Sink extends RawModule with WireX {
-    val out = IO(Output(UInt()))
-    x := 0.U // Default value. Output is zero unless we bore...
-    out := x
-  }
-
-  class Top(val width: Int) extends Module {
-    /* From the perspective of deduplication, all sources are identical and all sinks are identical. */
-    val sources = Seq.fill(3)(Module(new Source))
-    val sinks = Seq.fill(6)(Module(new Sink))
-
-    /* Sources are differentiated by their input connections only. */
-    sources.zip(Seq(0, 1, 2)).map { case (a, b) => a.in := b.U }
-
-    /* Sinks are differentiated by their post-boring outputs. */
-    sinks.zip(Seq(0, 1, 1, 2, 2, 2)).map { case (a, b) => chisel3.assert(a.out === b.U) }
-  }
-
-  /** This is testing a complicated wiring pattern and exercising
-    * the necessity of disabling deduplication for sources and sinks.
-    * Without disabling deduplication, this test will fail.
-    */
-  class TopTester extends ShouldntAssertTester {
-    val dut = Module(new Top(4))
-    BoringUtils.bore(dut.sources(1).x, Seq(dut.sinks(1).x, dut.sinks(2).x))
-    BoringUtils.bore(dut.sources(2).x, Seq(dut.sinks(3).x, dut.sinks(4).x, dut.sinks(5).x))
-  }
-
-  class TopTesterFail extends ShouldntAssertTester {
-    val dut = Module(new Top(4))
-    BoringUtils.addSource(dut.sources(1).x, "foo", disableDedup = true)
-    BoringUtils.addSink(dut.sinks(1).x, "foo", disableDedup = true)
-    BoringUtils.addSink(dut.sinks(2).x, "foo", disableDedup = true)
-
-    BoringUtils.addSource(dut.sources(2).x, "bar", disableDedup = true)
-    BoringUtils.addSink(dut.sinks(3).x, "bar", disableDedup = true)
-    BoringUtils.addSink(dut.sinks(4).x, "bar", disableDedup = true)
-    BoringUtils.addSink(dut.sinks(5).x, "bar", disableDedup = true)
-  }
-
   behavior.of("BoringUtils.bore")
 
-  it should "connect across modules using BoringUtils.bore" in {
-    simulate(new TopTester)(RunUntilFinished(3))
-  }
-
-  // TODO: this test is not really testing anything as MFC does boring during
-  // LowerAnnotations (which happens right after parsing).  Consider reworking
-  // this into a test that uses D/I (or some other mechanism of having a
-  // pre-deduplicated circuit).  This is likely better handled as a test in
-  // CIRCT than in Chisel.
-  it should "still work even with dedup off" in {
-    simulate(new TopTesterFail)(RunUntilFinished(3))
-  }
-
-  class InternalBore extends RawModule {
-    val in = IO(Input(Bool()))
-    val out = IO(Output(Bool()))
-    out := false.B
-    BoringUtils.bore(in, Seq(out))
-  }
-
-  class InternalBoreTester extends ShouldntAssertTester {
-    val dut = Module(new InternalBore)
-    dut.in := true.B
-    chisel3.assert(dut.out === true.B)
-  }
-
-  it should "work for an internal, same module, BoringUtils.bore" in {
-    simulate(new InternalBoreTester)(RunUntilFinished(3))
-  }
-
-  it should "work using new API" in {
+  it should "pass a basic test" in {
     class Baz extends RawModule {
       val a_wire = WireInit(UInt(1.W), DontCare)
       dontTouch(a_wire)
@@ -245,7 +139,7 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
       BoringUtils.bore(bar.a_wire)
     }
     val e = intercept[Exception] {
-      circt.stage.ChiselStage.emitCHIRRTL(new Foo, args)
+      circt.stage.ChiselStage.emitCHIRRTL(new Foo, Array("--throw-on-first-error"))
     }
     e.getMessage should include("Cannot bore across a Definition/Instance boundary")
   }
@@ -331,7 +225,7 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
       val postBore = DataMirror.modulePorts(bar)
       postBore.size should be(1)
     }
-    circt.stage.ChiselStage.emitCHIRRTL(new Foo, args)
+    circt.stage.ChiselStage.emitCHIRRTL(new Foo)
   }
   it should "fail if bore after calling DataMirror.modulePorts" in {
     import chisel3.reflect.DataMirror


### PR DESCRIPTION
Remove BoringUtils APIs that were deprecated in Chisel 6.  This is done in preparation for the Chisel 7 release.  This is secondarily done to remove a user of the Named APIs.

#### Release Notes

Remove BoringUtils APIs deprecated in Chisel 6.