### PR TITLE
[FIRRTL] Serialize Named as Target

### DIFF
--- a/firrtl/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -34,29 +34,29 @@ object JsonProtocol extends LazyLogging {
   class NamedSerializer
       extends CustomSerializer[Named](format =>
         (
-          { case JString(s) => AnnotationUtils.toNamed(s) },
-          { case named: Named => JString(named.serialize) }
+          { case JString(s) => Target.deserialize(s).toNamed },
+          { case named: Named => JString(named.toTarget.serialize) }
         )
       )
   class CircuitNameSerializer
       extends CustomSerializer[CircuitName](format =>
         (
-          { case JString(s) => AnnotationUtils.toNamed(s).asInstanceOf[CircuitName] },
-          { case named: CircuitName => JString(named.serialize) }
+          { case JString(s) => Target.deserialize(s).toNamed.asInstanceOf[CircuitName] },
+          { case named: CircuitName => JString(named.toTarget.serialize) }
         )
       )
   class ModuleNameSerializer
       extends CustomSerializer[ModuleName](format =>
         (
-          { case JString(s) => AnnotationUtils.toNamed(s).asInstanceOf[ModuleName] },
-          { case named: ModuleName => JString(named.serialize) }
+          { case JString(s) => Target.deserialize(s).toNamed.asInstanceOf[ModuleName] },
+          { case named: ModuleName => JString(named.toTarget.serialize) }
         )
       )
   class ComponentNameSerializer
       extends CustomSerializer[ComponentName](format =>
         (
-          { case JString(s) => AnnotationUtils.toNamed(s).asInstanceOf[ComponentName] },
-          { case named: ComponentName => JString(named.serialize) }
+          { case JString(s) => Target.deserialize(s).toNamed.asInstanceOf[ComponentName] },
+          { case named: ComponentName => JString(named.toTarget.serialize) }
         )
       )
   class LoadMemoryFileTypeSerializer

--- a/firrtl/src/test/scala/firrtlTests/annotationTests/UnrecognizedAnnotationSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/annotationTests/UnrecognizedAnnotationSpec.scala
@@ -150,7 +150,7 @@ object UnrecognizedAnnotationTextGenerator {
     s"""|[$serializedAllowUnrecognized
         |  {
         |    "class": "firrtl.transforms.BlackBoxInlineAnno",
-        |    "target": "TestHarness.plusarg_reader_27",
+        |    "target": "~TestHarness|plusarg_reader_27",
         |    "name": "plusarg_reader.v",
         |    "text": "License text"
         |  },


### PR DESCRIPTION
Change the way that `Named` is serialized into JSON to have this serialize as a `Target`.  This prevents a legacy serialization from ever showing up without actually removing `Named`.

This is done to free up the ability for us to change the serialization of `Target` to drop the circuit name without introducing a collision with the `Named` syntax.

E.g., I want to change the syntax for a target from:

    ~Foo|Foo

To:

    Foo

However, this aliases with a `CircuitName` of `Foo`.  However, by ensuring that everything is funneled through `Target`, this can then be changed on a FIRRTL version bumpd without worrying about backwards compatibiliy with `Named`.

#### Release Notes

Serialize annotations which use `Named` instead of `Target` using `Target` syntax. This has no effect (as long as users are using the CIRCT compiler).