### PR TITLE
Add API to create layer-colored RWProbes

### DIFF
--- a/core/src/main/scala-2/chisel3/probe/Probe.scala
+++ b/core/src/main/scala-2/chisel3/probe/Probe.scala
@@ -13,6 +13,8 @@ object Probe extends ProbeBase with SourceInfoDoc {
     */
   def apply[T <: Data](source: => T): T = macro chisel3.internal.sourceinfo.ProbeTransform.sourceApply[T]
 
+  /** Mark a Chisel type as with a probe modifier and a layer color.
+    */
   def apply[T <: Data](source: => T, color: layer.Layer): T =
     macro chisel3.internal.sourceinfo.ProbeTransform.sourceApplyWithColor[T]
 
@@ -31,6 +33,8 @@ object RWProbe extends ProbeBase with SourceInfoDoc {
     */
   def apply[T <: Data](source: => T): T = macro chisel3.internal.sourceinfo.ProbeTransform.sourceApply[T]
 
+  /** Mark a Chisel type with a writable probe modifier and a layer color.
+    */
   def apply[T <: Data](source: => T, color: layer.Layer): T =
     macro chisel3.internal.sourceinfo.ProbeTransform.sourceApplyWithColor[T]
 

--- a/core/src/main/scala-2/chisel3/probe/Probe.scala
+++ b/core/src/main/scala-2/chisel3/probe/Probe.scala
@@ -31,6 +31,14 @@ object RWProbe extends ProbeBase with SourceInfoDoc {
     */
   def apply[T <: Data](source: => T): T = macro chisel3.internal.sourceinfo.ProbeTransform.sourceApply[T]
 
+  def apply[T <: Data](source: => T, color: layer.Layer): T =
+    macro chisel3.internal.sourceinfo.ProbeTransform.sourceApplyWithColor[T]
+
   /** @group SourceInfoTransformMacro */
-  def do_apply[T <: Data](source: => T)(implicit sourceInfo: SourceInfo): T = super.apply(source, true)
+  def do_apply[T <: Data](source: => T)(implicit sourceInfo: SourceInfo): T =
+    super.apply(source, true, None)
+
+  /** @group SourceInfoTransformMacro */
+  def do_apply[T <: Data](source: => T, color: Option[layer.Layer])(implicit sourceInfo: SourceInfo): T =
+    super.apply(source, true, color)
 }

--- a/core/src/main/scala-3/chisel3/probe/Probe.scala
+++ b/core/src/main/scala-3/chisel3/probe/Probe.scala
@@ -7,11 +7,13 @@ import chisel3.experimental.SourceInfo
 
 object Probe extends ProbeBase {
 
-  /** Mark a Chisel type as with a probe modifier.
+  /** Mark a Chisel type with a probe modifier.
     */
   def apply[T <: Data](source: => T)(using SourceInfo): T =
     super.apply(source, false, None)
 
+  /** Mark a Chisel type with a probe modifier and layer color.
+    */
   def apply[T <: Data](source: => T, color: layer.Layer)(using SourceInfo): T =
     super.apply(source, false, Some(color))
 }
@@ -23,6 +25,8 @@ object RWProbe extends ProbeBase with SourceInfoDoc {
   def apply[T <: Data](source: => T)(using SourceInfo): T =
     super.apply(source, true, None)
 
+  /** Mark a Chisel type with a wirtable probe modifier and layer color.
+    */
   def apply[T <: Data](source: => T, color: layer.Layer)(using SourceInfo): T =
     super.apply(source, true, Some(color))
 }

--- a/core/src/main/scala-3/chisel3/probe/Probe.scala
+++ b/core/src/main/scala-3/chisel3/probe/Probe.scala
@@ -20,5 +20,9 @@ object RWProbe extends ProbeBase with SourceInfoDoc {
 
   /** Mark a Chisel type with a writable probe modifier.
     */
-  def apply[T <: Data](source: => T)(using SourceInfo): T = super.apply(source, true)
+  def apply[T <: Data](source: => T)(using SourceInfo): T =
+    super.apply(source, true, None)
+
+  def apply[T <: Data](source: => T, color: layer.Layer)(using SourceInfo): T =
+    super.apply(source, true, Some(color))
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

- Add API for creating layer-colored writable probes

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
