### PR TITLE
Deprecate Printable.unpack and .unpackArgs, replace with new version

### DIFF
--- a/core/src/main/scala-2/chisel3/VerificationStatementMacros.scala
+++ b/core/src/main/scala-2/chisel3/VerificationStatementMacros.scala
@@ -104,7 +104,8 @@ object VerifStmtMacrosCompat {
     ): chisel3.assert.Assert = {
       block(layers.Verification.Assert, skipIfAlreadyInBlock = true, skipIfLayersEnabled = true) {
         val id = Builder.forcedUserModule // It should be safe since we push commands anyway.
-        IfElseFatalIntrinsic(id, format, "chisel3_builtin", clock, predicate, enable, format.unpackArgs: _*)(sourceInfo)
+        val args = Printable.unpackFirrtlArgs(format)
+        IfElseFatalIntrinsic(id, format, "chisel3_builtin", clock, predicate, enable, args: _*)(sourceInfo)
       }
       new chisel3.assert.Assert()
     }

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -77,19 +77,9 @@ private[chisel3] object Serializer {
   // Cannot just use Printable.unpack because it doesn't work right with nested expressions
   def unpack(pable: Printable, ctx: Component, sourceInfo: SourceInfo): (String, Seq[Arg]) = {
     implicit val info: SourceInfo = sourceInfo
-    pable match {
-      case Printables(pables) =>
-        val (fmts, args) = pables.map(p => unpack(p, ctx, sourceInfo)).unzip
-        (fmts.mkString, args.flatten.toSeq)
-      case PString(str) => (str.replaceAll("%", "%%"), List.empty)
-      case format: FirrtlFormat =>
-        val (str, bits) = format.unpack
-        (str, List(bits.ref))
-      case Name(data)       => (data.ref.name, List.empty)
-      case FullName(data)   => (data.ref.fullName(ctx), List.empty)
-      case Percent          => ("%%", List.empty)
-      case HierarchicalName => ("%m", List.empty)
-    }
+    val resolved = Printable.resolve(pable, ctx)
+    val (fmt, data) = resolved.unpack
+    (fmt, data.map(_.ref))
   }
 
   private def serializeArgs(args: Seq[Arg], ctx: Component, info: SourceInfo)(implicit b: StringBuilder): Unit = {

--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -232,6 +232,11 @@ package object chisel3 {
       // Handle special escapes like %% and %m
       def escapeHandler(s: String): Seq[Printable] = {
         val pieces = mutable.ListBuffer.empty[Printable]
+        def maybeAdd(start: Int, end: Int): Unit = {
+          if (end > start) {
+            pieces += PString(s.substring(start, end))
+          }
+        }
         var start = 0
         var end = 0
         while (end < s.length) {
@@ -246,7 +251,7 @@ package object chisel3 {
               } else {
                 throw new UnknownFormatConversionException("Un-escaped %")
               }
-            pieces += PString(s.substring(start, end))
+            maybeAdd(start, end)
             pieces += piece
             start = end + 2
             end = start
@@ -254,7 +259,7 @@ package object chisel3 {
             end += 1
           }
         }
-        pieces += PString(s.substring(start, end))
+        maybeAdd(start, end)
         pieces.toList
       }
 
@@ -318,7 +323,8 @@ package object chisel3 {
           Seq(fmtArg) ++ escapeHandler(modP)
         }
       }
-      Printables(escapeHandler(parts.head) ++ pables)
+      val result = escapeHandler(parts.head) ++ pables
+      if (result.sizeIs == 1) result.head else Printables(result)
     }
   }
 

--- a/src/test/scala-2/chiselTests/PrintableSpec.scala
+++ b/src/test/scala-2/chiselTests/PrintableSpec.scala
@@ -373,4 +373,30 @@ class PrintableSpec extends AnyFlatSpec with Matchers with FileCheck {
     )
     FirrtlFormat.parse("%5c", x) should be(Left("'%c' does not support width modifiers!"))
   }
+
+  "Printable.unpack" should "be the inverse of Printable.pack" in {
+    val x = 123.U
+    val pairs: Seq[(Printable, (String, Seq[Data]))] = Seq(
+      (Decimal(x), ("%d", Seq(x))),
+      (Hexadecimal(x), ("%x", Seq(x))),
+      (Binary(x), ("%b", Seq(x))),
+      (Character(x), ("%c", Seq(x))),
+      (PString("foo"), ("foo", Seq())),
+      (Percent, ("%%", Seq())),
+      (HierarchicalName, ("%m", Seq())),
+      (Name(x), ("%n", Seq(x))),
+      (FullName(x), ("%N", Seq(x)))
+    )
+    for ((pable, (fmt, args)) <- pairs) {
+      pable.unpack should be((fmt, args))
+      Printable.pack(fmt, args: _*) should be(pable)
+    }
+    // Now all together
+    val (pables, fmts, args) = pairs.map { case (p, (f, a)) => (p, f, a) }.unzip3
+    val pable = pables.reduce(_ + _)
+    val fmt = fmts.mkString
+    val arg = args.flatten
+    pable.unpack should be((fmt, arg))
+    Printable.pack(fmt, arg: _*) should be(pable)
+  }
 }

--- a/src/test/scala-2/chiselTests/VerificationSpec.scala
+++ b/src/test/scala-2/chiselTests/VerificationSpec.scala
@@ -3,9 +3,8 @@
 package chiselTests
 
 import chisel3._
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
-import java.io.File
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 
 class SimpleTest extends Module {
@@ -21,34 +20,26 @@ class SimpleTest extends Module {
   }
 }
 
-class VerificationSpec extends AnyPropSpec with Matchers {
-
-  def assertContains(s: Seq[String], x: String): Unit = {
-    val containsLine = s.map(_.contains(x)).reduce(_ || _)
-    assert(containsLine, s"\n  $x\nwas not found in`\n  ${s.mkString("\n  ")}``")
-  }
+class VerificationSpec extends AnyPropSpec with FileCheck {
 
   property("basic equality check should work") {
-    val fir = ChiselStage.emitCHIRRTL(new SimpleTest)
-    val lines = fir.split("(\n|@)").map(_.trim).toIndexedSeq
-
-    // reset guard around the verification statement
-    assertContains(lines, "when _T_1 :")
-    assertContains(lines, "cover(clock, _T, UInt<1>(0h1), \"\")")
-
-    assertContains(lines, "assume(clock, _T_3, UInt<1>(0h1), \"Assumption failed")
-    assertContains(lines, "node _T_5 = eq(io.out, io.in)")
-    assertContains(lines, "node _T_6 = eq(reset, UInt<1>(0h0))")
-    assertContains(
-      lines,
-      """intrinsic(circt_chisel_ifelsefatal<format = "Assertion failed: io.in:%d is equal to io.out:%d\n", label = "chisel3_builtin">, clock, _T_5, _T_6, io.in, io.out)"""
-    )
+    ChiselStage.emitCHIRRTL(new SimpleTest).fileCheck() {
+      """|CHECK:      node _T = eq(io.in, UInt<2>(0h3))
+         |CHECK:      when _T_1 :
+         |CHECK-NEXT:     cover(clock, _T, UInt<1>(0h1), "")
+         |CHECK:      node _T_3 = neq(io.in, UInt<2>(0h2))
+         |CHECK:      assume(clock, _T_3, UInt<1>(0h1), "Assumption failed at
+         |CHECK:      node _T_5 = eq(io.out, io.in)
+         |CHECK:      node _T_6 = eq(reset, UInt<1>(0h0))
+         |CHECK:      intrinsic(circt_chisel_ifelsefatal<format = "Assertion failed: io.in:%d is equal to io.out:%d\n", label = "chisel3_builtin">, clock, _T_5, _T_6, io.in, io.out)
+         |""".stripMargin
+    }
   }
 
-  property("annotation of verification constructs should work") {
+  property("labeling of verification constructs should work") {
 
-    /** Circuit that contains and annotates verification nodes. */
-    class AnnotationTest extends Module {
+    /** Circuit that contains and labels verification nodes. */
+    class LabelTest extends Module {
       val io = IO(new Bundle {
         val in = Input(UInt(8.W))
         val out = Output(UInt(8.W))
@@ -58,20 +49,13 @@ class VerificationSpec extends AnyPropSpec with Matchers {
       val assm = chisel3.assume(io.in =/= 2.U)
       val asst = chisel3.assert(io.out === io.in)
     }
-
-    // compile circuit
-    val testDir = new File("test_run_dir", "VerificationAnnotationTests")
-    ChiselStage.emitSystemVerilogFile(gen = new AnnotationTest, args = Array("-td", testDir.getPath))
-
-    // read in FIRRTL file
-    val svFile = new File(testDir, "AnnotationTest.sv")
-    svFile should exist
-    val svLines = scala.io.Source.fromFile(svFile).getLines().toList
-
     // check that verification appear in verilog output
-    exactly(1, svLines) should include("cover__cov: cov")
-    exactly(1, svLines) should include("assume__assm:")
-    exactly(1, svLines) should include("assume(io_in != 8'h2)")
-    exactly(1, svLines) should include("$error(\"Assumption failed")
+    ChiselStage.emitSystemVerilog(new LabelTest).fileCheck() {
+      """|CHECK:      cover__cov: cover(io_in == 8'h3);
+         |CHECK:      assume__assm:
+         |CHECK-NEXT:   assume(io_in != 8'h2)
+         |CHECK-NEXT:   $error("Assumption failed
+         |""".stripMargin
+    }
   }
 }


### PR DESCRIPTION
The old version conflated the concerns of lowering to FIRRTL format Strings with what should simply be the inverse operation of Printable.pack. Specifically, Name and FullName are not represented in FIRRTL so must be "erased" before lowering to FIRRTL. This removal requires use of internal Chisel types (Component) so was always weird to have on a public API. Rather than doing this in .unpack, we instead treat that as a separate operation.

This does delete an API (`FirrtlFormat.unpack` replaced by `Printable.unpack`) but it's one I just added in https://github.com/chipsalliance/chisel/pull/4821.

This isn't really an important PR from a feature perspective, but it fixes a wart with `Printable.unpack` that has bothered me since we first added Printable many years ago.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- API deprecation


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
