### PR TITLE
[firrtl] Remove serialize and miscellaneous APIs

### DIFF
--- a/firrtl/src/main/scala/firrtl/RenameMap.scala
+++ b/firrtl/src/main/scala/firrtl/RenameMap.scala
@@ -582,11 +582,6 @@ package object renamemap {
 
     /** Initialize a new RenameMap */
     def apply(): MutableRenameMap = new MutableRenameMap
-
-    // This is a private internal API for transforms where the .distinct operation is very expensive
-    // (eg. LowerTypes). The onus is on the user of this API to be very careful and not inject
-    // duplicates. This is a bad, hacky API that no one should use
-    private[firrtl] def noDistinct(): MutableRenameMap = new MutableRenameMap(doDistinct = false)
   }
 
   final class MutableRenameMap private[firrtl] (

--- a/firrtl/src/main/scala/firrtl/annotations/AnnotationUtils.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/AnnotationUtils.scala
@@ -60,28 +60,6 @@ object AnnotationUtils {
     case None            => Seq(s)
   }
 
-  def toNamed(s: String): Named = s.split("\\.", 3) match {
-    case Array(n)       => CircuitName(n)
-    case Array(c, m)    => ModuleName(m, CircuitName(c))
-    case Array(c, m, x) => ComponentName(x, ModuleName(m, CircuitName(c)))
-  }
-
-  /** Converts a serialized FIRRTL component into a sequence of target tokens
-    * @param s
-    * @return
-    */
-  def toSubComponents(s: String): Seq[TargetToken] = {
-    import TargetToken._
-    def exp2subcomp(e: ir.Expression): Seq[TargetToken] = e match {
-      case ir.Reference(name, _)      => Seq(Ref(name))
-      case ir.SubField(expr, name, _) => exp2subcomp(expr) :+ Field(name)
-      case ir.SubIndex(expr, idx, _)  => exp2subcomp(expr) :+ Index(idx)
-      case ir.SubAccess(expr, idx, _) =>
-        Utils.throwInternalError(s"For string $s, cannot convert a subaccess $e into a Target")
-    }
-    exp2subcomp(toExp(s))
-  }
-
   /** Given a serialized component/subcomponent reference, subindex, subaccess,
     *  or subfield, return the corresponding IR expression.
     *  E.g. "foo.bar" becomes SubField(Reference("foo", UnknownType), "bar", UnknownType)

--- a/firrtl/src/main/scala/firrtl/annotations/LoadMemoryAnnotation.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/LoadMemoryAnnotation.scala
@@ -65,7 +65,7 @@ case class LoadMemoryAnnotation(
       case componentName: ComponentName =>
         this.copy(target = componentName, originalMemoryNameOpt = Some(target.name))
       case _ =>
-        throw new Exception(s"Cannot annotate anything but a memory, invalid target ${newNamed.serialize}")
+        throw new Exception(s"Cannot annotate anything but a memory, invalid target ${newNamed.toTarget.serialize}")
     }
   }
 }

--- a/firrtl/src/main/scala/firrtl/annotations/Target.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/Target.scala
@@ -758,22 +758,22 @@ case class InstanceTarget(
 
 /** Named classes associate an annotation with a component in a Firrtl circuit */
 sealed trait Named {
-  def toTarget:  CompleteTarget
+  def toTarget: CompleteTarget
 }
 
 final case class CircuitName(name: String) extends Named {
   if (!validModuleName(name)) throw AnnotationException(s"Illegal circuit name: $name")
-  def toTarget:  CircuitTarget = CircuitTarget(name)
+  def toTarget: CircuitTarget = CircuitTarget(name)
 }
 
 final case class ModuleName(name: String, circuit: CircuitName) extends Named {
   if (!validModuleName(name)) throw AnnotationException(s"Illegal module name: $name")
-  def toTarget:  ModuleTarget = ModuleTarget(circuit.name, name)
+  def toTarget: ModuleTarget = ModuleTarget(circuit.name, name)
 }
 
 final case class ComponentName(name: String, module: ModuleName) extends Named {
   if (!validComponentName(name)) throw AnnotationException(s"Illegal component name: $name")
-  def expr:      Expression = toExp(name)
+  def expr: Expression = toExp(name)
   def toTarget: ReferenceTarget = {
     Target.toTargetTokens(name).toList match {
       case Ref(r) :: components => ReferenceTarget(module.circuit.name, module.name, Nil, r, components)

--- a/firrtl/src/main/scala/firrtl/annotations/Target.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/Target.scala
@@ -758,26 +758,22 @@ case class InstanceTarget(
 
 /** Named classes associate an annotation with a component in a Firrtl circuit */
 sealed trait Named {
-  def serialize: String
   def toTarget:  CompleteTarget
 }
 
 final case class CircuitName(name: String) extends Named {
   if (!validModuleName(name)) throw AnnotationException(s"Illegal circuit name: $name")
-  def serialize: String = name
   def toTarget:  CircuitTarget = CircuitTarget(name)
 }
 
 final case class ModuleName(name: String, circuit: CircuitName) extends Named {
   if (!validModuleName(name)) throw AnnotationException(s"Illegal module name: $name")
-  def serialize: String = circuit.serialize + "." + name
   def toTarget:  ModuleTarget = ModuleTarget(circuit.name, name)
 }
 
 final case class ComponentName(name: String, module: ModuleName) extends Named {
   if (!validComponentName(name)) throw AnnotationException(s"Illegal component name: $name")
   def expr:      Expression = toExp(name)
-  def serialize: String = module.serialize + "." + name
   def toTarget: ReferenceTarget = {
     Target.toTargetTokens(name).toList match {
       case Ref(r) :: components => ReferenceTarget(module.circuit.name, module.name, Nil, r, components)

--- a/src/test/scala-2/chiselTests/CloneModuleSpec.scala
+++ b/src/test/scala-2/chiselTests/CloneModuleSpec.scala
@@ -128,8 +128,6 @@ class CloneModuleSpec extends AnyPropSpec with PropertyUtils with Matchers with 
     mod.q1.io.enq.toAbsoluteTarget.serialize should be("~Top|Top/q1:Queue4_UInt8>io.enq")
     mod.q2_io.deq.toAbsoluteTarget.serialize should be("~Top|Top/q2:Queue4_UInt8>io.deq")
     // Legacy APIs that nevertheless were tricky to get right
-    mod.q1.io.enq.toNamed.serialize should be("Top.Queue4_UInt8.io.enq")
-    mod.q2_io.deq.toNamed.serialize should be("Top.Queue4_UInt8.io.deq")
     mod.q1.io.enq.instanceName should be("io.enq")
     mod.q2_io.deq.instanceName should be("io.deq")
     mod.q1.io.enq.pathName should be("Top.q1.io.enq")
@@ -146,8 +144,6 @@ class CloneModuleSpec extends AnyPropSpec with PropertyUtils with Matchers with 
     mod.q2_wire.toAbsoluteTarget.serialize should be("~Top|Top>q2_wire")
     wire_io.enq.toAbsoluteTarget.serialize should be("~Top|Top>q2_wire.io.enq")
     // Legacy APIs
-    mod.q2_wire.toNamed.serialize should be("Top.Top.q2_wire")
-    wire_io.enq.toNamed.serialize should be("Top.Top.q2_wire.io.enq")
     mod.q2_wire.instanceName should be("q2_wire")
     wire_io.enq.instanceName should be("q2_wire.io.enq")
     mod.q2_wire.pathName should be("Top.q2_wire")


### PR DESCRIPTION
- Remove the ability to serialize a `Named`.
- Drop a private factory for the `RenameMap` that has no users.

#### Release Notes

- Remove `Named.serialize` API. If for whatever crazy reason you are using this, please use `Named.toTarget.serialize`.
- Remove `firrtl.annotation.AnnotationUtils.{toNamed, toSubComponents}`