### PR TITLE
[firrtl] Drop Circuit from Target/Named

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -692,7 +692,7 @@ package experimental {
       *
       * @note Should not be called until circuit elaboration is complete
       */
-    final def toNamed: ModuleName = ModuleTarget(this.circuitName, this.name).toNamed
+    final def toNamed: ModuleName = ModuleTarget(this.name).toNamed
 
     /** Returns a FIRRTL ModuleTarget that references this object
       *
@@ -703,7 +703,7 @@ package experimental {
         throwException(s"Internal Error! It's not legal to call .toTarget on an InstanceClone. $m")
       case m: experimental.hierarchy.DefinitionClone[_] =>
         throwException(s"Internal Error! It's not legal to call .toTarget on an DefinitionClone. $m")
-      case _ => ModuleTarget(this.circuitName, this.name)
+      case _ => ModuleTarget(this.name)
     }
 
     /** Returns the real target of a Module which may be an [[InstanceTarget]]
@@ -724,7 +724,7 @@ package experimental {
         m._parent.get.getTarget.instOf(instanceName, name)
       // Without this, we get the wrong CircuitName for the Definition
       case m: experimental.hierarchy.DefinitionClone[_] if m._circuit.nonEmpty =>
-        ModuleTarget(this._circuit.get.circuitName, this.name)
+        ModuleTarget(this.name)
       case _ => this.toTarget
     }
 
@@ -813,7 +813,6 @@ package experimental {
       else {
         val thisAbsolute = this.toAbsoluteTarget
         val rootAbsolute = root.get.toAbsoluteTarget
-        if (thisAbsolute.circuit != thisAbsolute.circuit) fail()
         recurse(thisAbsolute, rootAbsolute)
       }
     }

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -12,7 +12,7 @@ import chisel3.internal.binding._
 import chisel3.internal.firrtl.ir._
 import chisel3.internal.firrtl.Converter
 import chisel3.internal.naming._
-import _root_.firrtl.annotations.{Annotation, CircuitName, ComponentName, IsMember, ModuleName, Named, ReferenceTarget}
+import _root_.firrtl.annotations.{Annotation, ComponentName, IsMember, ModuleName, Named, ReferenceTarget}
 import _root_.firrtl.annotations.AnnotationUtils.validComponentName
 import _root_.firrtl.{annoSeqToSeq, AnnotationSeq}
 import _root_.firrtl.renamemap.MutableRenameMap
@@ -344,20 +344,6 @@ private[chisel3] trait HasId extends chisel3.InstanceId {
     case Some(p)          => p.name
     case None             => throwException(s"$instanceName doesn't have a parent")
   }
-  def circuitName: String = _parent match {
-    case None =>
-      // Only modules have circuits
-      this match {
-        case b: BaseModule =>
-          b._circuit match {
-            case Some(c) => c.circuitName
-            case None    => instanceName
-          }
-        case _ => instanceName
-      }
-    case Some(ViewParent) => reifyParent.circuitName
-    case Some(p)          => p.circuitName
-  }
 }
 
 /** Holds the implementation of toNamed for Data and MemBase */
@@ -368,7 +354,7 @@ private[chisel3] trait NamedComponent extends HasId {
     */
   final def toNamed: ComponentName = {
     assertValidTarget()
-    ComponentName(this.instanceName, ModuleName(this.parentModName, CircuitName(this.circuitName)))
+    ComponentName(this.instanceName, ModuleName(this.parentModName))
   }
 
   /** Returns a FIRRTL ReferenceTarget that references this object
@@ -953,8 +939,8 @@ private[chisel3] object Builder extends LazyLogging {
   // Builds a RenameMap for all Views that do not correspond to a single Data
   // These Data give a fake ReferenceTarget for .toTarget and .toReferenceTarget that the returned
   // RenameMap can split into the constituent parts
-  private[chisel3] def makeViewRenameMap: MutableRenameMap = {
-    val renames = MutableRenameMap()
+  private[chisel3] def makeViewRenameMap(circuitName: String): MutableRenameMap = {
+    val renames = MutableRenameMap(circuitName)
     for (view <- unnamedViews if !view.isLit) { // Aggregates can be literals too!
       reifySingleTarget(view) match {
         // If the target reifies to a single target, we don't need to rename.
@@ -1131,7 +1117,7 @@ private[chisel3] object Builder extends LazyLogging {
           components.last.name,
           components.toSeq,
           annotations.toSeq,
-          makeViewRenameMap,
+          makeViewRenameMap(circuitName = components.last.name),
           typeAliases,
           layerAdjacencyList(layer.Layer.Root).map(foldLayers).toSeq,
           optionDefs

--- a/core/src/main/scala/chisel3/internal/package.scala
+++ b/core/src/main/scala/chisel3/internal/package.scala
@@ -109,7 +109,7 @@ package object internal {
     // the Converter
     // Note that this is not overriding .toAbsoluteTarget, that is a final def in BaseModule that delegates
     // to this method
-    private[chisel3] val absoluteTarget: IsModule = ModuleTarget(this.circuitName, "_$$AbsoluteView$$_")
+    private[chisel3] val absoluteTarget: IsModule = ModuleTarget("_$$AbsoluteView$$_")
 
     // This module is not instantiable
     override private[chisel3] def generateComponent():  Option[Component] = None

--- a/firrtl/src/main/scala/firrtl/annotations/Annotation.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/Annotation.scala
@@ -48,11 +48,10 @@ trait SingleTargetAnnotation[T <: Named] extends Annotation {
         ret
           .map(_.map { newT =>
             val result = newT match {
-              case c: InstanceTarget => ModuleName(c.ofModule, CircuitName(c.circuit))
+              case c: InstanceTarget => ModuleName(c.ofModule)
               case c: IsMember =>
                 val local = Target.referringModule(c)
                 c.setPathTarget(local)
-              case c: CircuitTarget => c.toNamed
               case other => throw Target.NamedException(s"Cannot convert $other to [[Named]]")
             }
             (Target.convertTarget2Named(result): @unchecked) match {

--- a/firrtl/src/main/scala/firrtl/annotations/JsonProtocol.scala
+++ b/firrtl/src/main/scala/firrtl/annotations/JsonProtocol.scala
@@ -38,13 +38,6 @@ object JsonProtocol extends LazyLogging {
           { case named: Named => JString(named.toTarget.serialize) }
         )
       )
-  class CircuitNameSerializer
-      extends CustomSerializer[CircuitName](format =>
-        (
-          { case JString(s) => Target.deserialize(s).toNamed.asInstanceOf[CircuitName] },
-          { case named: CircuitName => JString(named.toTarget.serialize) }
-        )
-      )
   class ModuleNameSerializer
       extends CustomSerializer[ModuleName](format =>
         (
@@ -79,13 +72,6 @@ object JsonProtocol extends LazyLogging {
         (
           { case JString(s) => Target.deserialize(s).asInstanceOf[GenericTarget] },
           { case named: GenericTarget => JString(named.serialize) }
-        )
-      )
-  class CircuitTargetSerializer
-      extends CustomSerializer[CircuitTarget](format =>
-        (
-          { case JString(s) => Target.deserialize(s).asInstanceOf[CircuitTarget] },
-          { case named: CircuitTarget => JString(named.serialize) }
         )
       )
   class ModuleTargetSerializer
@@ -142,9 +128,9 @@ object JsonProtocol extends LazyLogging {
   /** Construct Json formatter for annotations */
   def jsonFormat(tags: Seq[Class[_]]) = {
     Serialization.formats(FullTypeHints(tags.toList, "class")) +
-      new NamedSerializer + new CircuitNameSerializer +
+      new NamedSerializer +
       new ModuleNameSerializer + new ComponentNameSerializer + new TargetSerializer +
-      new GenericTargetSerializer + new CircuitTargetSerializer + new ModuleTargetSerializer +
+      new GenericTargetSerializer + new ModuleTargetSerializer +
       new InstanceTargetSerializer + new ReferenceTargetSerializer +
       new LoadMemoryFileTypeSerializer + new IsModuleSerializer + new IsMemberSerializer +
       new CompleteTargetSerializer + new UnrecognizedAnnotationSerializer

--- a/firrtl/src/main/scala/firrtl/passes/Inline.scala
+++ b/firrtl/src/main/scala/firrtl/passes/Inline.scala
@@ -19,12 +19,10 @@ object InlineAnnotation extends HasShellOptions {
       toAnnotationSeq = (a: Seq[String]) =>
         a.map { value =>
           value.split('.') match {
-            case Array(circuit) =>
-              InlineAnnotation(CircuitName(circuit))
             case Array(circuit, module) =>
-              InlineAnnotation(ModuleName(module, CircuitName(circuit)))
+              InlineAnnotation(ModuleName(module))
             case Array(circuit, module, inst) =>
-              InlineAnnotation(ComponentName(inst, ModuleName(module, CircuitName(circuit))))
+              InlineAnnotation(ComponentName(inst, ModuleName(module)))
           }
         },
       helpText = "Inline selected modules",

--- a/firrtl/src/test/scala/firrtlTests/annotationTests/AttributeAnnotationSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/annotationTests/AttributeAnnotationSpec.scala
@@ -11,7 +11,7 @@ import org.json4s.convertToJsonInput
 class AttributeAnnotationSpec extends AnyFreeSpec with Matchers {
   "AttributeAnnotation should be correctly parsed from a string" in {
     val attribAnno = new AttributeAnnotation(
-      ComponentName("attrib", ModuleName("ModuleAttrib", CircuitName("CircuitAttrib"))),
+      ComponentName("attrib", ModuleName("ModuleAttrib")),
       "X_INTERFACE_INFO = \"some:interface:type:1.0 SIGNAL\""
     )
 

--- a/firrtl/src/test/scala/firrtlTests/annotationTests/JsonProtocolSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/annotationTests/JsonProtocolSpec.scala
@@ -35,7 +35,7 @@ class JsonProtocolSpec extends AnyFlatSpec with Matchers {
   }
   "JsonProtocol.serializeRecover" should "emit even annotations that cannot be serialized" in {
     case class MyAnno(x: Int) extends NoTargetAnnotation
-    val target = CircuitTarget("Top").module("Foo").ref("x")
+    val target = ModuleTarget("Foo").ref("x")
     val annos = MyAnno(3) :: DontTouchAnnotation(target) :: Nil
     val res = JsonProtocol.serializeRecover(annos)
     res should include(""""class":"firrtl.annotations.UnserializeableAnnotation",""")

--- a/firrtl/src/test/scala/firrtlTests/annotationTests/LoadMemoryAnnotationSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/annotationTests/LoadMemoryAnnotationSpec.scala
@@ -11,7 +11,7 @@ class LoadMemoryAnnotationSpec extends AnyFreeSpec with Matchers {
   "LoadMemoryAnnotation getFileName" - {
     "add name of subcomponent to file name when a memory was split" in {
       val lma = new LoadMemoryAnnotation(
-        ComponentName("init_mem_subdata", ModuleName("b", CircuitName("c"))),
+        ComponentName("init_mem_subdata", ModuleName("b")),
         "somepath/init_mem",
         originalMemoryNameOpt = Some("init_mem")
       )
@@ -20,7 +20,7 @@ class LoadMemoryAnnotationSpec extends AnyFreeSpec with Matchers {
     }
     "and do that properly when there are dots in earlier sections of the path" in {
       val lma = new LoadMemoryAnnotation(
-        ComponentName("init_mem_subdata", ModuleName("b", CircuitName("c"))),
+        ComponentName("init_mem_subdata", ModuleName("b")),
         "./target/scala-2.12/test-classes/init_mem",
         originalMemoryNameOpt = Some("init_mem")
       )
@@ -30,7 +30,7 @@ class LoadMemoryAnnotationSpec extends AnyFreeSpec with Matchers {
   }
   "LoadMemoryAnnotation should be correctly parsed from a string" in {
     val lma = new LoadMemoryAnnotation(
-      ComponentName("ram", ModuleName("ModuleMem", CircuitName("CircuitMem"))),
+      ComponentName("ram", ModuleName("ModuleMem")),
       "CircuitMem.ModuleMem.ram.dat",
       hexOrBinary = MemoryLoadFileType.Binary,
       originalMemoryNameOpt = Some("memory")

--- a/firrtl/src/test/scala/firrtlTests/annotationTests/TargetSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/annotationTests/TargetSpec.scala
@@ -2,7 +2,7 @@
 
 package firrtlTests.annotationTests
 
-import firrtl.annotations.{CircuitTarget, GenericTarget, ModuleTarget, Target}
+import firrtl.annotations.{GenericTarget, ModuleTarget, Target}
 import firrtl.annotations.TargetToken._
 import firrtl.testutils.FirrtlPropSpec
 
@@ -13,47 +13,42 @@ class TargetSpec extends FirrtlPropSpec {
     assert(comp.toGenericTarget.complete == comp2)
   }
   property("Serialization of Targets should work") {
-    val circuit = CircuitTarget("Circuit")
-    val top = circuit.module("Top")
+    val top = ModuleTarget("Top")
     val targets: Seq[(Target, String)] =
       Seq(
-        (circuit, "~Circuit"),
-        (top, "~Circuit|Top"),
-        (top.instOf("i", "I"), "~Circuit|Top/i:I"),
-        (top.ref("r"), "~Circuit|Top>r"),
-        (top.ref("r").index(1).field("hi"), "~Circuit|Top>r[1].hi"),
-        (GenericTarget(None, None, Vector(Ref("r"))), "~???|???>r")
+        (top, "~|Top"),
+        (top.instOf("i", "I"), "~|Top/i:I"),
+        (top.ref("r"), "~|Top>r"),
+        (top.ref("r").index(1).field("hi"), "~|Top>r[1].hi"),
+        (GenericTarget(None, Vector(Ref("r"))), "~|???>r")
       )
     targets.foreach { case (t, str) =>
       assert(t.serialize == str, s"$t does not properly serialize")
     }
   }
   property("Should convert to/from Named") {
-    check(Target(Some("Top"), None, Nil))
-    check(Target(Some("Top"), Some("Top"), Nil))
-    check(Target(Some("Top"), Some("Other"), Nil))
+    check(Target(Some("Top"), Nil))
+    check(Target(Some("Other"), Nil))
     val r1 = Seq(Ref("r1"), Field("I"))
     val r2 = Seq(Ref("r2"), Index(0))
-    check(Target(Some("Top"), Some("Top"), r1))
-    check(Target(Some("Top"), Some("Top"), r2))
+    check(Target(Some("Top"), r1))
+    check(Target(Some("Top"), r2))
   }
   property("Should enable creating from API") {
-    val top = ModuleTarget("Top", "Top")
+    val top = ModuleTarget("Top")
     val x_reg0_data = top.instOf("x", "X").ref("reg0").field("data")
     top.instOf("x", "x")
     top.ref("y")
   }
   property("Should serialize and deserialize") {
-    val circuit = CircuitTarget("Circuit")
-    val top = circuit.module("Top")
+    val top = ModuleTarget("Top")
     val targets: Seq[Target] =
       Seq(
-        circuit,
         top,
         top.instOf("i", "I"),
         top.ref("r"),
         top.ref("r").index(1).field("hi"),
-        GenericTarget(None, None, Vector(Ref("r")))
+        GenericTarget(None, Vector(Ref("r")))
       )
     targets.foreach { t =>
       assert(Target.deserialize(t.serialize) == t, s"$t does not properly serialize/deserialize")

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -1924,8 +1924,8 @@ object PanamaCIRCTConverter {
   def visitDefBlackBox(defBlackBox: DefBlackBox)(implicit cvt: PanamaCIRCTConverter): Unit = {
     cvt.visitDefBlackBox(defBlackBox)
   }
-  def visitDefModule(defModule: DefModule)(implicit cvt: PanamaCIRCTConverter): Unit = {
-    cvt.visitDefModule(defModule)
+  def visitDefModule(defModule: DefModule, circuitName: String)(implicit cvt: PanamaCIRCTConverter): Unit = {
+    cvt.visitDefModule(defModule, circuitName)
     val commands = defModule.block.getAllCommands()
     commands.foreach(visitCommand(defModule, _))
   }

--- a/panamaconverter/src/PanamaCIRCTConverter.scala
+++ b/panamaconverter/src/PanamaCIRCTConverter.scala
@@ -1086,10 +1086,10 @@ class PanamaCIRCTConverter(val circt: PanamaCIRCT, fos: Option[FirtoolOptions], 
     firCtx.innerSymCache.setPortSlots(firModule.op, defPorts)
   }
 
-  def visitDefModule(defModule: DefModule): Unit = {
+  def visitDefModule(defModule: DefModule, circuitName: String): Unit = {
     val defPorts = defModule.ports ++ defModule.id.secretPorts
     val ports = util.convert(defPorts)
-    val isMainModule = defModule.id.circuitName == defModule.name
+    val isMainModule = circuitName == defModule.name
 
     val builder = util
       .OpBuilder("firrtl.module", firCtx.circuitBlock, circt.unkLoc)
@@ -1917,7 +1917,7 @@ object PanamaCIRCTConverter {
     cvt.visitCircuit(circuit.name)
     circuit.components.foreach {
       case defBlackBox:        DefBlackBox        => visitDefBlackBox(defBlackBox)
-      case defModule:          DefModule          => visitDefModule(defModule)
+      case defModule:          DefModule          => visitDefModule(defModule, circuit.name)
       case defIntrinsicModule: DefIntrinsicModule => visitDefIntrinsicModule(defIntrinsicModule)
     }
   }

--- a/src/main/scala/chisel3/simulator/LayerControl.scala
+++ b/src/main/scala/chisel3/simulator/LayerControl.scala
@@ -35,7 +35,7 @@ object LayerControl {
     ): Seq[VerilogPreprocessorDefine] = getLayerSubset(allLayers).flatMap { case layer =>
       layer.config.abi match {
         case abi: chisel3.layer.ABI.PreprocessorDefine.type =>
-          Some(VerilogPreprocessorDefine(abi.toMacroIdentifier(layer, module.circuitName)))
+          Some(VerilogPreprocessorDefine(abi.toMacroIdentifier(layer, module.name)))
         case _ => None
       }
     }
@@ -123,7 +123,7 @@ object LayerControl {
       val layerFilenames: Seq[String] = getLayerSubset(allLayers).flatMap { case layer =>
         layer.config.abi match {
           case abi: chisel3.layer.ABI.FileInclude.type =>
-            Some(abi.toFilename(layer, module.circuitName))
+            Some(abi.toFilename(layer, module.name))
           case _ => None
         }
       }

--- a/src/test/scala-2/chisel3/stage/ChiselOptionsViewSpec.scala
+++ b/src/test/scala-2/chisel3/stage/ChiselOptionsViewSpec.scala
@@ -16,7 +16,7 @@ class ChiselOptionsViewSpec extends AnyFlatSpec with Matchers {
   behavior.of(ChiselOptionsView.getClass.getName)
 
   it should "construct a view from an AnnotationSeq" in {
-    val bar = Circuit("bar", Seq.empty, Seq.empty, RenameMap(), Seq.empty, Seq.empty, Seq.empty)
+    val bar = Circuit("bar", Seq.empty, Seq.empty, RenameMap("bar"), Seq.empty, Seq.empty, Seq.empty)
     val circuit = ElaboratedCircuit(bar, Seq.empty)
     val annotations = Seq(
       PrintFullStackTraceAnnotation,

--- a/src/test/scala-2/chiselTests/AnnotatingDiamondSpec.scala
+++ b/src/test/scala-2/chiselTests/AnnotatingDiamondSpec.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.experimental.{annotate, AnyTargetable}
 import chisel3.stage.ChiselGeneratorAnnotation
 import circt.stage.ChiselStage
-import firrtl.annotations.{CircuitTarget, SingleTargetAnnotation, Target}
+import firrtl.annotations.{ModuleTarget, SingleTargetAnnotation, Target}
 import org.scalatest._
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -130,11 +130,11 @@ class AnnotatingDiamondSpec extends AnyFreeSpec with Matchers {
       info("Found ten (10) 'IdentityAnnotation's")
       (annos should have).length(10)
 
-      info("Found IdentityAnnotation targeting '~*|ModC' with value 'ModC(16)'")
-      annos should contain(IdentityAnnotation(CircuitTarget("TopOfDiamond").module("ModC"), "ModC(16)"))
+      info("Found IdentityAnnotation targeting '~|ModC' with value 'ModC(16)'")
+      annos should contain(IdentityAnnotation(ModuleTarget("ModC"), "ModC(16)"))
 
-      info("Found IdentityAnnotation targeting '~*|ModC_1:seen' with value 'ModC(32)'")
-      annos should contain(IdentityAnnotation(CircuitTarget("TopOfDiamond").module("ModC_1"), "ModC(32)"))
+      info("Found IdentityAnnotation targeting '~|ModC_1:seen' with value 'ModC(32)'")
+      annos should contain(IdentityAnnotation(ModuleTarget("ModC_1"), "ModC(32)"))
     }
   }
 }

--- a/src/test/scala-2/chiselTests/CloneModuleSpec.scala
+++ b/src/test/scala-2/chiselTests/CloneModuleSpec.scala
@@ -123,10 +123,10 @@ class CloneModuleSpec extends AnyPropSpec with PropertyUtils with Matchers with 
     }
     // ********** Checking the output of CloneModuleAsRecord **********
     // Note that we overrode desiredName so that Top is named "Top"
-    mod.q1.io.enq.toTarget.serialize should be("~Top|Queue4_UInt8>io.enq")
-    mod.q2_io.deq.toTarget.serialize should be("~Top|Queue4_UInt8>io.deq")
-    mod.q1.io.enq.toAbsoluteTarget.serialize should be("~Top|Top/q1:Queue4_UInt8>io.enq")
-    mod.q2_io.deq.toAbsoluteTarget.serialize should be("~Top|Top/q2:Queue4_UInt8>io.deq")
+    mod.q1.io.enq.toTarget.serialize should be("~|Queue4_UInt8>io.enq")
+    mod.q2_io.deq.toTarget.serialize should be("~|Queue4_UInt8>io.deq")
+    mod.q1.io.enq.toAbsoluteTarget.serialize should be("~|Top/q1:Queue4_UInt8>io.enq")
+    mod.q2_io.deq.toAbsoluteTarget.serialize should be("~|Top/q2:Queue4_UInt8>io.deq")
     // Legacy APIs that nevertheless were tricky to get right
     mod.q1.io.enq.instanceName should be("io.enq")
     mod.q2_io.deq.instanceName should be("io.deq")
@@ -139,10 +139,10 @@ class CloneModuleSpec extends AnyPropSpec with PropertyUtils with Matchers with 
 
     // ********** Checking the wire cloned from the output of CloneModuleAsRecord **********
     val wire_io = mod.q2_wire("io").asInstanceOf[QueueIO[UInt]]
-    mod.q2_wire.toTarget.serialize should be("~Top|Top>q2_wire")
-    wire_io.enq.toTarget.serialize should be("~Top|Top>q2_wire.io.enq")
-    mod.q2_wire.toAbsoluteTarget.serialize should be("~Top|Top>q2_wire")
-    wire_io.enq.toAbsoluteTarget.serialize should be("~Top|Top>q2_wire.io.enq")
+    mod.q2_wire.toTarget.serialize should be("~|Top>q2_wire")
+    wire_io.enq.toTarget.serialize should be("~|Top>q2_wire.io.enq")
+    mod.q2_wire.toAbsoluteTarget.serialize should be("~|Top>q2_wire")
+    wire_io.enq.toAbsoluteTarget.serialize should be("~|Top>q2_wire.io.enq")
     // Legacy APIs
     mod.q2_wire.instanceName should be("q2_wire")
     wire_io.enq.instanceName should be("q2_wire.io.enq")

--- a/src/test/scala-2/chiselTests/DedupSpec.scala
+++ b/src/test/scala-2/chiselTests/DedupSpec.scala
@@ -175,7 +175,7 @@ class DedupSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     chirrtl.fileCheck()(
       """|CHECK:      "class":"firrtl.transforms.DedupGroupAnnotation"
-         |CHECK-NEXT: "target":"~ModuleWithIntrinsic|ModuleWithIntrinsic"
+         |CHECK-NEXT: "target":"~|ModuleWithIntrinsic"
          |CHECK-NEXT: "group":"ModuleWithIntrinsic"
          |""".stripMargin
     )
@@ -197,7 +197,7 @@ class DedupSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     chirrtl.fileCheck()(
       """|CHECK:      "class":"firrtl.transforms.DedupGroupAnnotation"
-         |CHECK-NEXT: "target":"~ModuleWithClass|ModuleWithClass"
+         |CHECK-NEXT: "target":"~|ModuleWithClass"
          |CHECK-NEXT: "group":"ModuleWithClass"
          |""".stripMargin
     )

--- a/src/test/scala-2/chiselTests/DontTouchSpec.scala
+++ b/src/test/scala-2/chiselTests/DontTouchSpec.scala
@@ -121,12 +121,12 @@ class DontTouchSpec extends AnyFlatSpec with Matchers with FileCheck {
       .emitCHIRRTL(new HasDeadCodeLeaves())
       .fileCheck(
         "--implicit-check-not",
-        """"target":"~HasDeadCodeLeaves|HasDeadCodeChildLeaves>io.a""""
+        """"target":"~|HasDeadCodeChildLeaves>io.a""""
       )(
         """|CHECK:      "class":"firrtl.transforms.DontTouchAnnotation",
-           |CHECK-NEXT: "target":"~HasDeadCodeLeaves|HasDeadCodeChildLeaves>io.a.a2"
+           |CHECK-NEXT: "target":"~|HasDeadCodeChildLeaves>io.a.a2"
            |CHECK:      "class":"firrtl.transforms.DontTouchAnnotation",
-           |CHECK-NEXT: "target":"~HasDeadCodeLeaves|HasDeadCodeChildLeaves>io.a.a1"
+           |CHECK-NEXT: "target":"~|HasDeadCodeChildLeaves>io.a.a1"
            |""".stripMargin
       )
   }
@@ -138,12 +138,12 @@ class DontTouchSpec extends AnyFlatSpec with Matchers with FileCheck {
       )
       .fileCheck(
         "--implicit-check-not",
-        """"target":"~HasProbesAndProperties|HasProbesAndProperties>io.probe"""",
+        """"target":"~|HasProbesAndProperties>io.probe"""",
         "--implicit-check-not",
-        """"target":"~HasProbesAndProperties|HasProbesAndProperties>io.prop""""
+        """"target":"~|HasProbesAndProperties>io.prop""""
       )(
         """|CHECK:      "class":"firrtl.transforms.DontTouchAnnotation",
-           |CHECK-NEXT: "target":"~HasProbesAndProperties|HasProbesAndProperties>io.a"
+           |CHECK-NEXT: "target":"~|HasProbesAndProperties>io.a"
            |""".stripMargin
       )
 

--- a/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
+++ b/src/test/scala-2/chiselTests/ModulePrefixSpec.scala
@@ -179,17 +179,17 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       .fileCheck()(
         """|CHECK:      {
            |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
-           |CHECK-NEXT:   "target":"~Top|Top>smem",
+           |CHECK-NEXT:   "target":"~|Top>smem",
            |CHECK-NEXT:   "prefix":"Foo_"
            |CHECK-NEXT: },
            |CHECK-NEXT: {
            |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
-           |CHECK-NEXT:   "target":"~Top|Top>cmem",
+           |CHECK-NEXT:   "target":"~|Top>cmem",
            |CHECK-NEXT:   "prefix":"Bar_"
            |CHECK-NEXT: },
            |CHECK-NEXT: {
            |CHECK-NEXT:   "class":"chisel3.ModulePrefixAnnotation",
-           |CHECK-NEXT:   "target":"~Top|Top>sram_sram",
+           |CHECK-NEXT:   "target":"~|Top>sram_sram",
            |CHECK-NEXT:   "prefix":"Baz_"
            |CHECK-NEXT: }
            |""".stripMargin
@@ -444,11 +444,11 @@ class ModulePrefixSpec extends AnyFlatSpec with Matchers with FileCheck {
       .emitLazily(annotations.collect { case a: DedupGroupAnnotation => a })
       .mkString
     firrtl.fileCheck()(
-      """|CHECK:      "target":"~Top|Outer_Inner_Foo"
+      """|CHECK:      "target":"~|Outer_Inner_Foo"
          |CHECK-NEXT: "group":"Outer_Inner_Foo"
-         |CHECK:      "target":"~Top|Outer_Bar"
+         |CHECK:      "target":"~|Outer_Bar"
          |CHECK-NEXT: "group":"Outer_Bar"
-         |CHECK:      "target":"~Top|Top"
+         |CHECK:      "target":"~|Top"
          |CHECK-NEXT: "group":"Top"
          |""".stripMargin
     )

--- a/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
+++ b/src/test/scala-2/chiselTests/NewAnnotationsSpec.scala
@@ -69,10 +69,10 @@ class NewAnnotationsSpec extends AnyFreeSpec with Matchers with Utils with FileC
       val dontTouchAnnosCombined = dontTouchAnnos.mkString(",")
       val noDedupAnnosCombined = noDedupAnnos.mkString(",")
 
-      noDedupAnnosCombined should include("~UsesMuchUsedModule|MuchUsedModule_2")
-      noDedupAnnosCombined should include("~UsesMuchUsedModule|MuchUsedModule_3")
-      dontTouchAnnosCombined should include("~UsesMuchUsedModule|MuchUsedModule_1>io.out")
-      dontTouchAnnosCombined should include("~UsesMuchUsedModule|MuchUsedModule_1>io.in")
+      noDedupAnnosCombined should include("~|MuchUsedModule_2")
+      noDedupAnnosCombined should include("~|MuchUsedModule_3")
+      dontTouchAnnosCombined should include("~|MuchUsedModule_1>io.out")
+      dontTouchAnnosCombined should include("~|MuchUsedModule_1>io.in")
     }
 
     "It should be possible to annotate heterogeneous Targetable things" in {
@@ -97,11 +97,11 @@ class NewAnnotationsSpec extends AnyFreeSpec with Matchers with Utils with FileC
         })
         .fileCheck()(
           """|CHECK:      "class":"firrtl.transforms.DontTouchAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top>in"
+             |CHECK-NEXT: "target":"~|Top>in"
              |CHECK:      "class":"firrtl.transforms.DontTouchAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top>out"
+             |CHECK-NEXT: "target":"~|Top>out"
              |CHECK:      "class":"firrtl.transforms.NoDedupAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top"
+             |CHECK-NEXT: "target":"~|Top"
              |""".stripMargin
         )
     }

--- a/src/test/scala-2/chiselTests/ToTargetSpec.scala
+++ b/src/test/scala-2/chiselTests/ToTargetSpec.scala
@@ -166,7 +166,7 @@ class ToTargetSpec extends AnyFlatSpec with Matchers {
   ChiselStage.emitCHIRRTL { m = new InstanceNameModule; m }
 
   val mn = "InstanceNameModule"
-  val top = s"~$mn|$mn"
+  val top = s"~|$mn"
 
   behavior.of(".toTarget")
 
@@ -194,7 +194,7 @@ class ToTargetSpec extends AnyFlatSpec with Matchers {
 
   it should "work with modules" in {
     val q = m.q.toTarget.toString
-    assert(q == s"~$mn|Queue4_UInt32")
+    assert(q == s"~|Queue4_UInt32")
   }
 
   it should "error on non-hardware types and provide information" in {
@@ -222,35 +222,35 @@ class ToTargetSpec extends AnyFlatSpec with Matchers {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeOuterRootModule)
 
     chirrtl should include(
-      "~RelativeOuterRootModule|RelativeOuterRootModule/middle:RelativeMiddleModule/inner:RelativeInnerModule>wire"
+      "~|RelativeOuterRootModule/middle:RelativeMiddleModule/inner:RelativeInnerModule>wire"
     )
   }
 
   it should "work relative to modules being elaborated for HasIds within the module" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeCurrentModule)
 
-    chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule>wire")
-    chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule/child:Child>io")
-    chirrtl should include("~RelativeCurrentModule|RelativeCurrentModule>io")
+    chirrtl should include("~|RelativeCurrentModule>wire")
+    chirrtl should include("~|RelativeCurrentModule/child:Child>io")
+    chirrtl should include("~|RelativeCurrentModule>io")
   }
 
   it should "work relative to non top-level modules that have been elaborated" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeOuterMiddleModule)
 
-    chirrtl should include("~RelativeOuterMiddleModule|RelativeMiddleModule/inner:RelativeInnerModule>wire")
+    chirrtl should include("~|RelativeMiddleModule/inner:RelativeInnerModule>wire")
   }
 
   it should "work relative to non top-level modules for components local to the root" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeOuterLocalModule)
 
-    chirrtl should include("~RelativeOuterLocalModule|RelativeInnerModule>wire")
+    chirrtl should include("~|RelativeInnerModule>wire")
   }
 
   it should "default to the root module in the requested hierarchy" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeDefaultModule)
 
     chirrtl should include(
-      "~RelativeDefaultModule|RelativeDefaultModule/middle:RelativeMiddleModule/inner:RelativeInnerModule>wire"
+      "~|RelativeDefaultModule/middle:RelativeMiddleModule/inner:RelativeInnerModule>wire"
     )
   }
 
@@ -268,14 +268,14 @@ class ToTargetSpec extends AnyFlatSpec with Matchers {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeSiblingsInstancesParent)
 
     chirrtl should include(
-      "propassign referenceInstanceOut, path(\"OMInstanceTarget:~RelativeSiblingsInstancesParent|RelativeMiddleModule/inner:RelativeInnerModule"
+      "propassign referenceInstanceOut, path(\"OMInstanceTarget:~|RelativeMiddleModule/inner:RelativeInnerModule"
     )
   }
   it should "work to get relative targets to a wire in an Instance" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeSiblingsInstancesParent)
 
     chirrtl should include(
-      "propassign referenceInstanceWireOut, path(\"OMReferenceTarget:~RelativeSiblingsInstancesParent|RelativeMiddleModule/inner:RelativeInnerModule>wire"
+      "propassign referenceInstanceWireOut, path(\"OMReferenceTarget:~|RelativeMiddleModule/inner:RelativeInnerModule>wire"
     )
   }
 
@@ -283,7 +283,7 @@ class ToTargetSpec extends AnyFlatSpec with Matchers {
     val chirrtl = ChiselStage.emitCHIRRTL(new RelativeSiblingsInstancesParent)
 
     chirrtl should include(
-      "propassign referenceDefinitionWireOut, path(\"OMReferenceTarget:~RelativeSiblingsInstancesParent|RelativeMiddleModule/inner:RelativeInnerModule>wire"
+      "propassign referenceDefinitionWireOut, path(\"OMReferenceTarget:~|RelativeMiddleModule/inner:RelativeInnerModule>wire"
     )
   }
 
@@ -308,7 +308,7 @@ class ToTargetSpec extends AnyFlatSpec with Matchers {
 
   it should ("get correct Path from an Instance") in {
     val chirrtl = ChiselStage.emitCHIRRTL(new PathFromInstanceToTarget)
-    chirrtl should include("OMInstanceTarget:~PathFromInstanceToTarget|Hierarchy2/target:RelativeInnerModule")
+    chirrtl should include("OMInstanceTarget:~|Hierarchy2/target:RelativeInnerModule")
   }
 
 }

--- a/src/test/scala-2/chiselTests/experimental/DataViewIntegrationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/DataViewIntegrationSpec.scala
@@ -55,7 +55,7 @@ class DataViewIntegrationSpec extends AnyFlatSpec with Matchers with FileCheck {
     ChiselStage
       .emitCHIRRTL(new MyModule)
       .fileCheck()(
-        """CHECK: "target":"~MyModule|Queue4_UInt8>enq_ptr_value""""
+        """CHECK: "target":"~|Queue4_UInt8>enq_ptr_value""""
       )
   }
 }

--- a/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/DataViewTargetSpec.scala
@@ -127,13 +127,13 @@ class DataViewTargetSpec extends AnyFlatSpec with Matchers with FileCheck {
     ChiselStage
       .emitCHIRRTL(new MyParent)
       .fileCheck()(
-        """|CHECK:      "target":"~MyParent|MyChild>out.foo"
+        """|CHECK:      "target":"~|MyChild>out.foo"
            |CHECK-NEXT: "id":0
-           |CHECK:      "target":"~MyParent|MyChild>out.foo"
+           |CHECK:      "target":"~|MyChild>out.foo"
            |CHECK-NEXT: "id":1
-           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out.foo"
+           |CHECK:      "target":"~|MyParent/inst:MyChild>out.foo"
            |CHECK-NEXT: "id":2
-           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
+           |CHECK:      "target":"~|MyParent/inst:MyChild>out"
            |CHECK-NEXT: "id":3
            |""".stripMargin
       )
@@ -165,25 +165,25 @@ class DataViewTargetSpec extends AnyFlatSpec with Matchers with FileCheck {
     ChiselStage
       .emitCHIRRTL(new MyParent)
       .fileCheck()(
-        """|CHECK:      "target":"~MyParent|MyChild>io.b"
+        """|CHECK:      "target":"~|MyChild>io.b"
            |CHECK-NEXT: "id":0
-           |CHECK:      "target":"~MyParent|MyChild>io.a"
+           |CHECK:      "target":"~|MyChild>io.a"
            |CHECK-NEXT: "id":0
-           |CHECK:      "target":"~MyParent|MyChild>io.d"
+           |CHECK:      "target":"~|MyChild>io.d"
            |CHECK-NEXT: "id":1
-           |CHECK:      "target":"~MyParent|MyChild>io.c"
+           |CHECK:      "target":"~|MyChild>io.c"
            |CHECK-NEXT: "id":1
-           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.b"
+           |CHECK:      "target":"~|MyParent/inst:MyChild>io.b"
            |CHECK-NEXT: "id":2
-           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.a"
+           |CHECK:      "target":"~|MyParent/inst:MyChild>io.a"
            |CHECK-NEXT: "id":2
-           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.d"
+           |CHECK:      "target":"~|MyParent/inst:MyChild>io.d"
            |CHECK-NEXT: "id":3
-           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>io.c"
+           |CHECK:      "target":"~|MyParent/inst:MyChild>io.c"
            |CHECK-NEXT: "id":3
-           |CHECK:      "target":"~MyParent|MyChild>io.d"
+           |CHECK:      "target":"~|MyChild>io.d"
            |CHECK-NEXT: "id":4
-           |CHECK:      "target":"~MyParent|MyChild>io.b"
+           |CHECK:      "target":"~|MyChild>io.b"
            |CHECK-NEXT: "id":4
            |""".stripMargin
       )
@@ -212,11 +212,11 @@ class DataViewTargetSpec extends AnyFlatSpec with Matchers with FileCheck {
     ChiselStage
       .emitCHIRRTL(new MyParent)
       .fileCheck()(
-        """|CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
+        """|CHECK:      "target":"~|MyParent/inst:MyChild>out"
            |CHECK-NEXT: "id":0
-           |CHECK:      "target":"~MyParent|MyChild>out"
+           |CHECK:      "target":"~|MyChild>out"
            |CHECK-NEXT: "id":1
-           |CHECK:      "target":"~MyParent|MyParent/inst:MyChild>out"
+           |CHECK:      "target":"~|MyParent/inst:MyChild>out"
            |CHECK-NEXT: "id":2
            |""".stripMargin
       )

--- a/src/test/scala-2/chiselTests/experimental/OpaqueTypeSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/OpaqueTypeSpec.scala
@@ -152,7 +152,7 @@ class OpaqueTypeSpec extends AnyFlatSpec with Matchers {
       mod.inst.io.foo.k.elements.head._2.toTarget.serialize,
       mod.inst.io.foo.k.k.elements.head._2.toTarget.serialize
     )
-    testStrings.foreach(x => assert(x == "~NestedRecordModule|InnerModule>io.foo"))
+    testStrings.foreach(x => assert(x == "~|InnerModule>io.foo"))
   }
 
   they should "work correctly with DataMirror in nested OpaqueType Records" in {
@@ -222,7 +222,7 @@ class OpaqueTypeSpec extends AnyFlatSpec with Matchers {
     var m: SingleElementRecordModule = null
     ChiselStage.emitCHIRRTL { m = new SingleElementRecordModule; m }
     val q = m.in1.toTarget.toString
-    assert(q == "~SingleElementRecordModule|SingleElementRecordModule>in1")
+    assert(q == "~|SingleElementRecordModule>in1")
   }
 
   they should "NOT work with .toTarget on non-data OpaqueType Record" in {

--- a/src/test/scala-2/chiselTests/experimental/TraceSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/TraceSpec.scala
@@ -18,10 +18,10 @@ import org.scalatest.matchers.should.Matchers
 class TraceSpec extends AnyFlatSpec with Matchers with TestingDirectory {
 
   def refTarget(topName: String, ref: String, path: Seq[(Instance, OfModule)] = Seq()) =
-    ReferenceTarget(topName, topName, path, ref, Seq())
+    ReferenceTarget(topName, path, ref, Seq())
 
   def instTarget(topName: String, instance: String, ofModule: String, path: Seq[(Instance, OfModule)] = Seq()) =
-    InstanceTarget(topName, topName, path, instance, ofModule)
+    InstanceTarget(topName, path, instance, ofModule)
 
   def compile(testName: String, gen: () => Module)(
     implicit testingDirectory: HasTestingDirectory
@@ -104,8 +104,9 @@ class TraceSpec extends AnyFlatSpec with Matchers with TestingDirectory {
 
     def verilatorTemplate(data: Seq[Data], annos: AnnotationSeq): String = {
       val vpiNames = data.flatMap(finalTarget(annos)).map { ct =>
-        s"""TOP.${ct.circuit}.${ct.path.map { case (Instance(i), _) => i }.mkString(".")}.${ct.tokens.collectFirst {
-            case Ref(r) => r
+        s"""TOP.${topName}.${ct.path.map { case (Instance(i), _) => i }.mkString(".")}.${ct.tokens.collectFirst {
+            case Ref(r) =>
+              r
           }.get}"""
       }
       s"""

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -14,7 +14,6 @@ import org.scalatest.matchers.should.Matchers
 
 // TODO/Notes
 // - In backport, clock/reset are not automatically assigned. I think this is fixed in 3.5
-// - CircuitTarget for annotations on the definition are wrong - needs to be fixed.
 class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
   import Annotations._
   import Examples._
@@ -131,7 +130,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOne"
+             |CHECK-NEXT: "target":"~|AddOne"
              |CHECK-NEXT: "tag":"mark"
              |""".stripMargin
         )
@@ -145,7 +144,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddOne>innerWire"
              |CHECK-NEXT: "tag":"i0.innerWire"
              |""".stripMargin
         )
@@ -159,7 +158,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOne"
+             |CHECK-NEXT: "target":"~|AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -173,7 +172,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -188,7 +187,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOne"
+             |CHECK-NEXT: "target":"~|AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -202,7 +201,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"i0.i0.innerWire"
              |""".stripMargin
         )
@@ -216,7 +215,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwoMixedModules/i1:AddOne_1"
+             |CHECK-NEXT: "target":"~|AddTwoMixedModules/i1:AddOne_1"
              |CHECK-NEXT: "tag":"i0.i1"
              |""".stripMargin
         )
@@ -232,7 +231,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableWire>innerWire"
+             |CHECK-NEXT: "target":"~|AddOneWithInstantiableWire>innerWire"
              |CHECK-NEXT: "tag":"i0.innerWire"
              |""".stripMargin
         )
@@ -246,7 +245,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableModule/i0:AddOne"
+             |CHECK-NEXT: "target":"~|AddOneWithInstantiableModule/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -260,7 +259,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstance/i0:AddOne"
+             |CHECK-NEXT: "target":"~|AddOneWithInstantiableInstance/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -274,7 +273,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "target":"~|AddOneWithInstantiableInstantiable/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -288,7 +287,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "target":"~|AddOneWithInstantiableInstantiable/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -301,7 +300,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithAnnotation>innerWire"
+             |CHECK-NEXT: "target":"~|AddOneWithAnnotation>innerWire"
              |CHECK-NEXT: "tag":"innerWire"
              |""".stripMargin
         )
@@ -319,13 +318,13 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasUserDefinedType>wire"
+             |CHECK-NEXT: "target":"~|HasUserDefinedType>wire"
              |CHECK-NEXT: "tag":"data"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasUserDefinedType/inst0:AddOne"
+             |CHECK-NEXT: "target":"~|HasUserDefinedType/inst0:AddOne"
              |CHECK-NEXT: "tag":"inst"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasUserDefinedType/inst1:AddOne"
+             |CHECK-NEXT: "target":"~|HasUserDefinedType/inst1:AddOne"
              |CHECK-NEXT: "tag":"inst2"
              |""".stripMargin
         )
@@ -342,7 +341,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top(first))
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"first"
              |""".stripMargin
         )
@@ -355,7 +354,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top(first))
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"second"
              |""".stripMargin
         )
@@ -369,7 +368,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top(first))
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"third"
              |""".stripMargin
         )
@@ -385,7 +384,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|MultiVal>x"
+             |CHECK-NEXT: "target":"~|MultiVal>x"
              |CHECK-NEXT: "tag":"mv.x"
              |""".stripMargin
         )
@@ -399,7 +398,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|LazyVal>x"
+             |CHECK-NEXT: "target":"~|LazyVal>x"
              |CHECK-NEXT: "tag":"Hi"
              |""".stripMargin
         )
@@ -414,7 +413,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|UsesParameters>x"
+             |CHECK-NEXT: "target":"~|UsesParameters>x"
              |CHECK-NEXT: "tag":"hi0"
              |""".stripMargin
         )
@@ -428,7 +427,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasList>x_1"
+             |CHECK-NEXT: "target":"~|HasList>x_1"
              |CHECK-NEXT: "tag":"2"
              |""".stripMargin
         )
@@ -442,7 +441,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasSeq>x_1"
+             |CHECK-NEXT: "target":"~|HasSeq>x_1"
              |CHECK-NEXT: "tag":"2"
              |""".stripMargin
         )
@@ -456,7 +455,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasOption>x"
+             |CHECK-NEXT: "target":"~|HasOption>x"
              |CHECK-NEXT: "tag":"x"
              |""".stripMargin
         )
@@ -470,7 +469,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasVec>x"
+             |CHECK-NEXT: "target":"~|HasVec>x"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -484,7 +483,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasVec>x[1]"
+             |CHECK-NEXT: "target":"~|HasVec>x[1]"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -498,7 +497,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasIndexedVec>x[1]"
+             |CHECK-NEXT: "target":"~|HasIndexedVec>x[1]"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -512,7 +511,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasPublicConstructorArgs>x"
+             |CHECK-NEXT: "target":"~|HasPublicConstructorArgs>x"
              |CHECK-NEXT: "tag":"10"
              |""".stripMargin
         )
@@ -529,7 +528,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ConcreteHasBlah"
+             |CHECK-NEXT: "target":"~|ConcreteHasBlah"
              |CHECK-NEXT: "tag":"10"
              |""".stripMargin
         )
@@ -544,10 +543,10 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasEither>x"
+             |CHECK-NEXT: "target":"~|HasEither>x"
              |CHECK-NEXT: "tag":"xright"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasEither>y"
+             |CHECK-NEXT: "target":"~|HasEither>y"
              |CHECK-NEXT: "tag":"yleft"
              |""".stripMargin
         )
@@ -562,10 +561,10 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasTuple2>x"
+             |CHECK-NEXT: "target":"~|HasTuple2>x"
              |CHECK-NEXT: "tag":"x"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasTuple2>y"
+             |CHECK-NEXT: "target":"~|HasTuple2>y"
              |CHECK-NEXT: "tag":"y"
              |""".stripMargin
         )
@@ -580,10 +579,10 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasMems>mem"
+             |CHECK-NEXT: "target":"~|HasMems>mem"
              |CHECK-NEXT: "tag":"Mem"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasMems>syncReadMem"
+             |CHECK-NEXT: "target":"~|HasMems>syncReadMem"
              |CHECK-NEXT: "tag":"SyncReadMem"
              |""".stripMargin
         )
@@ -608,7 +607,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasHasTarget>sram_sram"
+             |CHECK-NEXT: "target":"~|HasHasTarget>sram_sram"
              |CHECK-NEXT: "tag":"x"
              |""".stripMargin
         )
@@ -625,10 +624,10 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasTuple5>wire"
+             |CHECK-NEXT: "target":"~|HasTuple5>wire"
              |CHECK-NEXT: "tag":"wire"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasTuple5/inst:AddOne"
+             |CHECK-NEXT: "target":"~|HasTuple5/inst:AddOne"
              |CHECK-NEXT: "tag":"inst"
              |""".stripMargin
         )
@@ -645,7 +644,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -660,7 +659,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -675,7 +674,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -691,7 +690,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo>in"
+             |CHECK-NEXT: "target":"~|AddTwo>in"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -705,7 +704,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -719,7 +718,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwoMixedModules/i1:AddOne_1>in"
+             |CHECK-NEXT: "target":"~|AddTwoMixedModules/i1:AddOne_1>in"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -733,7 +732,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|InstantiatesHasVec/i1:HasVec_1>x[0]"
+             |CHECK-NEXT: "target":"~|InstantiatesHasVec/i1:HasVec_1>x[0]"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -767,10 +766,10 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntf>io.in"
              |CHECK-NEXT: "tag":"gotcha"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntf"
              |CHECK-NEXT: "tag":"inst"
              |""".stripMargin
         )
@@ -788,13 +787,13 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntf>io.in"
              |CHECK-NEXT: "tag":"gotcha"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf>sum"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntf>sum"
              |CHECK-NEXT: "tag":"also this"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntf"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntf"
              |CHECK-NEXT: "tag":"inst"
              |""".stripMargin
         )
@@ -810,10 +809,10 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "target":"~|BlackBoxWithCommonIntf>in"
              |CHECK-NEXT: "tag":"gotcha"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf"
+             |CHECK-NEXT: "target":"~|BlackBoxWithCommonIntf"
              |CHECK-NEXT: "tag":"module"
              |""".stripMargin
         )
@@ -834,13 +833,13 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfY>io.in"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntfY>io.in"
              |CHECK-NEXT: "tag":"foo"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "target":"~|BlackBoxWithCommonIntf>in"
              |CHECK-NEXT: "tag":"bar"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfX>io.in"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntfX>io.in"
              |CHECK-NEXT: "tag":"fizz"
              |""".stripMargin
         )
@@ -873,13 +872,13 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|MyModule>out"
+             |CHECK-NEXT: "target":"~|MyModule>out"
              |CHECK-NEXT: "tag":"out"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|MyModule>in"
+             |CHECK-NEXT: "target":"~|MyModule>in"
              |CHECK-NEXT: "tag":"foo"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|MyModule>sum"
+             |CHECK-NEXT: "target":"~|MyModule>sum"
              |CHECK-NEXT: "tag":"bar"
              |
              |CHECK:      public module Top :
@@ -912,10 +911,10 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|MyModule>a"
+             |CHECK-NEXT: "target":"~|MyModule>a"
              |CHECK-NEXT: "tag":"in"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|MyModule>a.foo"
+             |CHECK-NEXT: "target":"~|MyModule>a.foo"
              |CHECK-NEXT: "tag":"in_bar"
              |
              |CHECK:      public module Top :

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -16,7 +16,6 @@ import org.scalatest.matchers.should.Matchers
 
 // TODO/Notes
 // - In backport, clock/reset are not automatically assigned. I think this is fixed in 3.5
-// - CircuitTarget for annotations on the definition are wrong - needs to be fixed.
 class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
   import Annotations._
   import Examples._
@@ -117,7 +116,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:AddOne"
              |CHECK-NEXT: "tag":"i0"
              |""".stripMargin
         )
@@ -132,7 +131,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|Top/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"i0.innerWire"
              |""".stripMargin
         )
@@ -147,7 +146,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddTwo/i0:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:AddTwo/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -162,7 +161,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|Top/i0:AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"i0.i0.innerWire"
              |""".stripMargin
         )
@@ -177,7 +176,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddTwoMixedModules/i1:AddOne_1"
+             |CHECK-NEXT: "target":"~|Top/i0:AddTwoMixedModules/i1:AddOne_1"
              |CHECK-NEXT: "tag":"i0.i1"
              |""".stripMargin
         )
@@ -192,7 +191,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableWire>innerWire"
+             |CHECK-NEXT: "target":"~|Top/i0:AddOneWithInstantiableWire>innerWire"
              |CHECK-NEXT: "tag":"i0.innerWire"
              |""".stripMargin
         )
@@ -207,7 +206,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableModule/i0:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:AddOneWithInstantiableModule/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -222,7 +221,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstance/i0:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:AddOneWithInstantiableInstance/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -237,7 +236,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -252,7 +251,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:AddOneWithInstantiableInstantiable/i0:AddOne"
              |CHECK-NEXT: "tag":"i0.i0"
              |""".stripMargin
         )
@@ -267,7 +266,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithAnnotation>innerWire"
+             |CHECK-NEXT: "target":"~|AddOneWithAnnotation>innerWire"
              |CHECK-NEXT: "tag":"innerWire"
              |""".stripMargin
         )
@@ -282,7 +281,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:HasTypeParams>blah"
+             |CHECK-NEXT: "target":"~|Top/i0:HasTypeParams>blah"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -299,7 +298,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:HasAnalogWire>wire"
+             |CHECK-NEXT: "target":"~|Top/i0:HasAnalogWire>wire"
              |CHECK-NEXT: "tag":"blah"
              |
              |CHECK:      public module Top :
@@ -321,13 +320,13 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType>wire"
+             |CHECK-NEXT: "target":"~|Top/i0:HasUserDefinedType>wire"
              |CHECK-NEXT: "tag":"data"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType/inst0:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:HasUserDefinedType/inst0:AddOne"
              |CHECK-NEXT: "tag":"inst"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i0:HasUserDefinedType/inst1:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i0:HasUserDefinedType/inst1:AddOne"
              |CHECK-NEXT: "tag":"inst2"
              |""".stripMargin
         )
@@ -351,7 +350,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top(first))
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"first"
              |""".stripMargin
         )
@@ -364,7 +363,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top(first))
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"second"
              |""".stripMargin
         )
@@ -379,7 +378,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top(first))
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~AddTwo|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"third"
              |""".stripMargin
         )
@@ -395,7 +394,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/mv:MultiVal>x"
+             |CHECK-NEXT: "target":"~|Top/mv:MultiVal>x"
              |CHECK-NEXT: "tag":"mv.x"
              |""".stripMargin
         )
@@ -409,7 +408,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/lv:LazyVal>x"
+             |CHECK-NEXT: "target":"~|Top/lv:LazyVal>x"
              |CHECK-NEXT: "tag":"Hi"
              |""".stripMargin
         )
@@ -424,7 +423,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/up:UsesParameters>x"
+             |CHECK-NEXT: "target":"~|Top/up:UsesParameters>x"
              |CHECK-NEXT: "tag":"hi0"
              |""".stripMargin
         )
@@ -438,7 +437,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasList>x_1"
+             |CHECK-NEXT: "target":"~|Top/i:HasList>x_1"
              |CHECK-NEXT: "tag":"2"
              |""".stripMargin
         )
@@ -452,7 +451,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasSeq>x_1"
+             |CHECK-NEXT: "target":"~|Top/i:HasSeq>x_1"
              |CHECK-NEXT: "tag":"2"
              |""".stripMargin
         )
@@ -466,7 +465,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasOption>x"
+             |CHECK-NEXT: "target":"~|Top/i:HasOption>x"
              |CHECK-NEXT: "tag":"x"
              |""".stripMargin
         )
@@ -480,7 +479,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasVec>x"
+             |CHECK-NEXT: "target":"~|Top/i:HasVec>x"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -494,7 +493,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasVec>x[1]"
+             |CHECK-NEXT: "target":"~|Top/i:HasVec>x[1]"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -508,7 +507,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasIndexedVec>x[1]"
+             |CHECK-NEXT: "target":"~|Top/i:HasIndexedVec>x[1]"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -526,10 +525,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasSubFieldAccess>in.valid"
+             |CHECK-NEXT: "target":"~|Top/i:HasSubFieldAccess>in.valid"
              |CHECK-NEXT: "tag":"valid"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasSubFieldAccess>in.bits"
+             |CHECK-NEXT: "target":"~|Top/i:HasSubFieldAccess>in.bits"
              |CHECK-NEXT: "tag":"bits"
              |
              |CHECK:      public module Top :
@@ -547,7 +546,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasPublicConstructorArgs>x"
+             |CHECK-NEXT: "target":"~|Top/i:HasPublicConstructorArgs>x"
              |CHECK-NEXT: "tag":"10"
              |""".stripMargin
         )
@@ -562,10 +561,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasEither>x"
+             |CHECK-NEXT: "target":"~|Top/i:HasEither>x"
              |CHECK-NEXT: "tag":"xright"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasEither>y"
+             |CHECK-NEXT: "target":"~|Top/i:HasEither>y"
              |CHECK-NEXT: "tag":"yleft"
              |""".stripMargin
         )
@@ -580,10 +579,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple2>x"
+             |CHECK-NEXT: "target":"~|Top/i:HasTuple2>x"
              |CHECK-NEXT: "tag":"x"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple2>y"
+             |CHECK-NEXT: "target":"~|Top/i:HasTuple2>y"
              |CHECK-NEXT: "tag":"y"
              |""".stripMargin
         )
@@ -621,10 +620,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasMems>mem"
+             |CHECK-NEXT: "target":"~|Top/i:HasMems>mem"
              |CHECK-NEXT: "tag":"Mem"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasMems>syncReadMem"
+             |CHECK-NEXT: "target":"~|Top/i:HasMems>syncReadMem"
              |CHECK-NEXT: "tag":"SyncReadMem"
              |""".stripMargin
         )
@@ -656,7 +655,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasHasTarget>sram_sram"
+             |CHECK-NEXT: "target":"~|Top/i:HasHasTarget>sram_sram"
              |CHECK-NEXT: "tag":"x"
              |""".stripMargin
         )
@@ -672,7 +671,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasPublicUnit>y_1"
+             |CHECK-NEXT: "target":"~|Top/i:HasPublicUnit>y_1"
              |CHECK-NEXT: "tag":"y_1"
              |""".stripMargin
         )
@@ -689,10 +688,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple5>wire"
+             |CHECK-NEXT: "target":"~|Top/i:HasTuple5>wire"
              |CHECK-NEXT: "tag":"wire"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasTuple5/inst:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i:HasTuple5/inst:AddOne"
              |CHECK-NEXT: "tag":"inst"
              |""".stripMargin
         )
@@ -705,12 +704,12 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         f(i.toInstance)
       }
       def f(i: Instance[AddOne]): Unit = mark(i.innerWire, "blah")
-      // TODO: Should this be ~Top|Top/i:AddOne>innerWire ???
+      // TODO: Should this be ~|Top/i:AddOne>innerWire ???
       ChiselStage
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -726,7 +725,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -737,12 +736,12 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         mark(f(is), "blah")
       }
       def f(i: Seq[Instance[AddTwo]]): Data = i.head.i0.innerWire
-      // TODO: Should this be ~Top|Top... ??
+      // TODO: Should this be ~|Top... ??
       ChiselStage
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -758,7 +757,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -773,7 +772,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -789,7 +788,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:AddTwo>in"
+             |CHECK-NEXT: "target":"~|Top/i:AddTwo>in"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -803,7 +802,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:AddTwo/i0:AddOne>innerWire"
+             |CHECK-NEXT: "target":"~|Top/i:AddTwo/i0:AddOne>innerWire"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -817,7 +816,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:AddTwoMixedModules/i1:AddOne_1>in"
+             |CHECK-NEXT: "target":"~|Top/i:AddTwoMixedModules/i1:AddOne_1>in"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -831,7 +830,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0]"
+             |CHECK-NEXT: "target":"~|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0]"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -855,7 +854,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0].x"
+             |CHECK-NEXT: "target":"~|Top/i:InstantiatesHasVec/i1:HasVec_1>x[0].x"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -869,7 +868,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:AddTwo/i1:AddOne"
+             |CHECK-NEXT: "target":"~|Top/i:AddTwo/i1:AddOne"
              |CHECK-NEXT: "tag":"blah"
              |""".stripMargin
         )
@@ -883,7 +882,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|AddOneWithAbsoluteAnnotation>innerWire"
+             |CHECK-NEXT: "target":"~|AddOneWithAbsoluteAnnotation>innerWire"
              |CHECK-NEXT: "tag":"innerWire"
              |""".stripMargin
         )
@@ -917,10 +916,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "target":"~|Top/i:ModuleWithCommonIntf>io.in"
              |CHECK-NEXT: "tag":"gotcha"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf"
+             |CHECK-NEXT: "target":"~|Top/i:ModuleWithCommonIntf"
              |CHECK-NEXT: "tag":"inst"
              |""".stripMargin
         )
@@ -938,13 +937,13 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>io.in"
+             |CHECK-NEXT: "target":"~|Top/i:ModuleWithCommonIntf>io.in"
              |CHECK-NEXT: "tag":"gotcha"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf>sum"
+             |CHECK-NEXT: "target":"~|Top/i:ModuleWithCommonIntf>sum"
              |CHECK-NEXT: "tag":"also this"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:ModuleWithCommonIntf"
+             |CHECK-NEXT: "target":"~|Top/i:ModuleWithCommonIntf"
              |CHECK-NEXT: "tag":"inst"
              |""".stripMargin
         )
@@ -959,10 +958,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "target":"~|BlackBoxWithCommonIntf>in"
              |CHECK-NEXT: "tag":"gotcha"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf"
+             |CHECK-NEXT: "target":"~|BlackBoxWithCommonIntf"
              |CHECK-NEXT: "tag":"module"
              |""".stripMargin
         )
@@ -983,13 +982,13 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|ModuleWithCommonIntfY>io.in"
+             |CHECK-NEXT: "target":"~|ModuleWithCommonIntfY>io.in"
              |CHECK-NEXT: "tag":"foo"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|BlackBoxWithCommonIntf>in"
+             |CHECK-NEXT: "target":"~|BlackBoxWithCommonIntf>in"
              |CHECK-NEXT: "tag":"bar"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/insts_2:ModuleWithCommonIntfX>io.in"
+             |CHECK-NEXT: "target":"~|Top/insts_2:ModuleWithCommonIntfX>io.in"
              |CHECK-NEXT: "tag":"fizz"
              |""".stripMargin
         )
@@ -1022,13 +1021,13 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>out"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>out"
              |CHECK-NEXT: "tag":"out"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>in"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>in"
              |CHECK-NEXT: "tag":"foo"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>sum"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>sum"
              |CHECK-NEXT: "tag":"bar"
              |
              |CHECK:      public module Top :
@@ -1068,19 +1067,19 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>a"
              |CHECK-NEXT: "tag":"enq"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.fizz"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>a.fizz"
              |CHECK-NEXT: "tag":"enq.bits"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.buzz"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>a.buzz"
              |CHECK-NEXT: "tag":"enq.bits"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b.fizz"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>b.fizz"
              |CHECK-NEXT: "tag":"deq.bits.fizz"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a.valid"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>a.valid"
              |CHECK-NEXT: "tag":"enq_valid"
              |
              |CHECK:      public module Top :
@@ -1120,10 +1119,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>a"
              |CHECK-NEXT: "tag":"in"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b.foo"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>b.foo"
              |CHECK-NEXT: "tag":"out_bar"
              |
              |CHECK:      public module Top :
@@ -1153,10 +1152,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>a"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>a"
              |CHECK-NEXT: "tag":"i.ports"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyModule>b"
+             |CHECK-NEXT: "target":"~|Top/i:MyModule>b"
              |CHECK-NEXT: "tag":"i.ports"
              |
              |CHECK:      public module Top :
@@ -1193,16 +1192,16 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>in"
+             |CHECK-NEXT: "target":"~|Top/i:MyBlackBox>in"
              |CHECK-NEXT: "tag":"i.foo"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>out"
+             |CHECK-NEXT: "target":"~|Top/i:MyBlackBox>out"
              |CHECK-NEXT: "tag":"i.bar"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>in"
+             |CHECK-NEXT: "target":"~|Top/i:MyBlackBox>in"
              |CHECK-NEXT: "tag":"i.innerView.in"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:MyBlackBox>out"
+             |CHECK-NEXT: "target":"~|Top/i:MyBlackBox>out"
              |CHECK-NEXT: "tag":"outerView.out"
              |
              |CHECK:      public module Top :
@@ -1232,10 +1231,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasCMAR/c:AggregatePortModule>io"
+             |CHECK-NEXT: "target":"~|HasCMAR/c:AggregatePortModule>io"
              |CHECK-NEXT: "tag":"c.io"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|HasCMAR/c:AggregatePortModule>io.out"
+             |CHECK-NEXT: "target":"~|HasCMAR/c:AggregatePortModule>io.out"
              |CHECK-NEXT: "tag":"c.io.out"
              |""".stripMargin
         )
@@ -1258,10 +1257,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         .emitCHIRRTL(new Top)
         .fileCheck()(
           """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasCMAR/c:AggregatePortModule>io"
+             |CHECK-NEXT: "target":"~|Top/i:HasCMAR/c:AggregatePortModule>io"
              |CHECK-NEXT: "tag":"i.c.io"
              |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
-             |CHECK-NEXT: "target":"~Top|Top/i:HasCMAR/c:AggregatePortModule>io.out"
+             |CHECK-NEXT: "target":"~|Top/i:HasCMAR/c:AggregatePortModule>io.out"
              |CHECK-NEXT: "tag":"i.c.io.out"
              |""".stripMargin
         )
@@ -1326,8 +1325,8 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       }).elaborate(1).asInstanceOf[DesignAnnotation[AddTwoMixedModules]].design
       aop.Select.instancesOf[AddOne](m.toDefinition).map { (i: Instance[AddOne]) => i.toTarget } should be(
         Seq(
-          "~AddTwoMixedModules|AddTwoMixedModules/i0:AddOne".it,
-          "~AddTwoMixedModules|AddTwoMixedModules/i1:AddOne_1".it
+          "~|AddTwoMixedModules/i0:AddOne".it,
+          "~|AddTwoMixedModules/i1:AddOne_1".it
         )
       )
     }
@@ -1340,14 +1339,14 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       val rel = insts.map { (i: Instance[BaseModule]) => i.toTarget }
       abs should be(
         Seq(
-          "~AddTwoMixedModules|AddTwoMixedModules/i0:AddOne".it,
-          "~AddTwoMixedModules|AddTwoMixedModules/i1:AddOne_1".it
+          "~|AddTwoMixedModules/i0:AddOne".it,
+          "~|AddTwoMixedModules/i1:AddOne_1".it
         )
       )
       rel should be(
         Seq(
-          "~AddTwoMixedModules|AddTwoMixedModules/i0:AddOne".it,
-          "~AddTwoMixedModules|AddTwoMixedModules/i1:AddOne_1".it
+          "~|AddTwoMixedModules/i0:AddOne".it,
+          "~|AddTwoMixedModules/i1:AddOne_1".it
         )
       )
     }
@@ -1360,18 +1359,18 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       val rel = insts.map { (i: Instance[AddOne]) => i.in.toTarget }
       rel should be(
         Seq(
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt
         )
       )
       abs should be(
         Seq(
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt
         )
       )
     }
@@ -1382,8 +1381,8 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       val targets = aop.Select.definitionsOf[AddOne](m.toDefinition).map { (i: Definition[AddOne]) => i.in.toTarget }
       targets should be(
         Seq(
-          "~AddTwoMixedModules|AddOne>in".rt,
-          "~AddTwoMixedModules|AddOne_1>in".rt
+          "~|AddOne>in".rt,
+          "~|AddOne_1>in".rt
         )
       )
     }
@@ -1394,8 +1393,8 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       val targets = aop.Select.definitionsIn(m.toDefinition).map { (i: Definition[BaseModule]) => i.toTarget }
       targets should be(
         Seq(
-          "~AddTwoMixedModules|AddOne".mt,
-          "~AddTwoMixedModules|AddOne_1".mt
+          "~|AddOne".mt,
+          "~|AddOne_1".mt
         )
       )
     }
@@ -1406,8 +1405,8 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       val targets = aop.Select.allDefinitionsOf[AddOne](m.toDefinition).map { (i: Definition[AddOne]) => i.in.toTarget }
       targets should be(
         Seq(
-          "~AddFour|AddOne>in".rt,
-          "~AddFour|AddOne_1>in".rt
+          "~|AddOne>in".rt,
+          "~|AddOne_1>in".rt
         )
       )
     }
@@ -1441,42 +1440,42 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       }
       abs should be(
         Seq(
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>clock".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>reset".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>out".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>clock".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>reset".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>out".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>clock".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>reset".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>out".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>clock".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>reset".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>out".rt
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>clock".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>reset".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>out".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>clock".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>reset".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>out".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>clock".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>reset".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>out".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>clock".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>reset".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>out".rt
         )
       )
       rel should be(
         Seq(
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>clock".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>reset".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i0:AddOne>out".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>clock".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>reset".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
-          "~AddFour|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>out".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>clock".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>reset".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i0:AddOne>out".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>clock".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>reset".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt,
-          "~AddFour|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>out".rt
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>clock".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>reset".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i0:AddOne>out".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>clock".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>reset".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>in".rt,
+          "~|AddFour/i0:AddTwoMixedModules/i1:AddOne_1>out".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>clock".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>reset".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i0:AddOne>out".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>clock".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>reset".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>in".rt,
+          "~|AddFour/i1:AddTwoMixedModules/i1:AddOne_1>out".rt
         )
       )
     }
@@ -1492,26 +1491,26 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       }
       abs should be(
         Seq(
-          "~AddFour|AddOne>clock".rt,
-          "~AddFour|AddOne>reset".rt,
-          "~AddFour|AddOne>in".rt,
-          "~AddFour|AddOne>out".rt,
-          "~AddFour|AddOne_1>clock".rt,
-          "~AddFour|AddOne_1>reset".rt,
-          "~AddFour|AddOne_1>in".rt,
-          "~AddFour|AddOne_1>out".rt
+          "~|AddOne>clock".rt,
+          "~|AddOne>reset".rt,
+          "~|AddOne>in".rt,
+          "~|AddOne>out".rt,
+          "~|AddOne_1>clock".rt,
+          "~|AddOne_1>reset".rt,
+          "~|AddOne_1>in".rt,
+          "~|AddOne_1>out".rt
         )
       )
       rel should be(
         Seq(
-          "~AddFour|AddOne>clock".rt,
-          "~AddFour|AddOne>reset".rt,
-          "~AddFour|AddOne>in".rt,
-          "~AddFour|AddOne>out".rt,
-          "~AddFour|AddOne_1>clock".rt,
-          "~AddFour|AddOne_1>reset".rt,
-          "~AddFour|AddOne_1>in".rt,
-          "~AddFour|AddOne_1>out".rt
+          "~|AddOne>clock".rt,
+          "~|AddOne>reset".rt,
+          "~|AddOne>in".rt,
+          "~|AddOne>out".rt,
+          "~|AddOne_1>clock".rt,
+          "~|AddOne_1>reset".rt,
+          "~|AddOne_1>in".rt,
+          "~|AddOne_1>out".rt
         )
       )
     }
@@ -1522,10 +1521,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       val targets = aop.Select.instancesIn(m.toDefinition).map { (i: Instance[BaseModule]) => i.toTarget }
       targets should be(
         Seq(
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i00:HasTypeParams".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i01:HasTypeParams".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i10:HasTypeParams_1".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i11:HasTypeParams_1".it
+          "~|HasMultipleTypeParamsInside/i00:HasTypeParams".it,
+          "~|HasMultipleTypeParamsInside/i01:HasTypeParams".it,
+          "~|HasMultipleTypeParamsInside/i10:HasTypeParams_1".it,
+          "~|HasMultipleTypeParamsInside/i11:HasTypeParams_1".it
         )
       )
 
@@ -1538,10 +1537,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         aop.Select.instancesOf[HasTypeParams[_]](m.toDefinition).map { (i: Instance[HasTypeParams[_]]) => i.toTarget }
       targets should be(
         Seq(
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i00:HasTypeParams".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i01:HasTypeParams".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i10:HasTypeParams_1".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i11:HasTypeParams_1".it
+          "~|HasMultipleTypeParamsInside/i00:HasTypeParams".it,
+          "~|HasMultipleTypeParamsInside/i01:HasTypeParams".it,
+          "~|HasMultipleTypeParamsInside/i10:HasTypeParams_1".it,
+          "~|HasMultipleTypeParamsInside/i11:HasTypeParams_1".it
         )
       )
     }
@@ -1556,10 +1555,10 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       }
       targets should be(
         Seq(
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i00:HasTypeParams".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i01:HasTypeParams".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i10:HasTypeParams_1".it,
-          "~HasMultipleTypeParamsInside|HasMultipleTypeParamsInside/i11:HasTypeParams_1".it
+          "~|HasMultipleTypeParamsInside/i00:HasTypeParams".it,
+          "~|HasMultipleTypeParamsInside/i01:HasTypeParams".it,
+          "~|HasMultipleTypeParamsInside/i10:HasTypeParams_1".it,
+          "~|HasMultipleTypeParamsInside/i11:HasTypeParams_1".it
         )
       )
     }

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Utils.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Utils.scala
@@ -2,7 +2,7 @@
 
 package chiselTests.experimental.hierarchy
 
-import firrtl.annotations.{CircuitTarget, InstanceTarget, ModuleTarget, ReferenceTarget, Target}
+import firrtl.annotations.{InstanceTarget, ModuleTarget, ReferenceTarget, Target}
 
 trait Utils {
   // TODO promote to standard API (in FIRRTL) and perhaps even implement with a macro
@@ -10,6 +10,5 @@ trait Utils {
     def rt: ReferenceTarget = Target.deserialize(str).asInstanceOf[ReferenceTarget]
     def it: InstanceTarget = Target.deserialize(str).asInstanceOf[InstanceTarget]
     def mt: ModuleTarget = Target.deserialize(str).asInstanceOf[ModuleTarget]
-    def ct: CircuitTarget = Target.deserialize(str).asInstanceOf[CircuitTarget]
   }
 }

--- a/src/test/scala-2/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertySpec.scala
@@ -187,15 +187,15 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
       }
     }.fileCheck()(
       """|CHECK-LABEL: module Foo :
-         |CHECK:         propassign localPropOut, path("OMReferenceTarget:~Top|Foo>data")
+         |CHECK:         propassign localPropOut, path("OMReferenceTarget:~|Foo>data")
          |CHECK-LABEL: public module Top :
-         |CHECK:         propassign propOutA, path("OMInstanceTarget:~Top|Top/inst:Foo")
-         |CHECK:         propassign propOutB, path("OMReferenceTarget:~Top|Top/inst:Foo>data")
-         |CHECK:         propassign propOutC, path("OMReferenceTarget:~Top|Top/inst:Foo>mem")
-         |CHECK:         propassign propOutD, path("OMInstanceTarget:~Top|Top")
+         |CHECK:         propassign propOutA, path("OMInstanceTarget:~|Top/inst:Foo")
+         |CHECK:         propassign propOutB, path("OMReferenceTarget:~|Top/inst:Foo>data")
+         |CHECK:         propassign propOutC, path("OMReferenceTarget:~|Top/inst:Foo>mem")
+         |CHECK:         propassign propOutD, path("OMInstanceTarget:~|Top")
          |CHECK:         propassign propOutE, inst.localPropOut
-         |CHECK:         propassign propOutF, path("OMReferenceTarget:~Top|Top/inst:Foo>sram_sram")
-         |CHECK:         propassign propOutG, path("OMMemberReferenceTarget:~Top|Top/inst:Foo>sram_sram")
+         |CHECK:         propassign propOutF, path("OMReferenceTarget:~|Top/inst:Foo>sram_sram")
+         |CHECK:         propassign propOutG, path("OMMemberReferenceTarget:~|Top/inst:Foo>sram_sram")
          |""".stripMargin
     )
   }
@@ -222,11 +222,11 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
       }
     }.fileCheck()(
       """|CHECK-LABEL: module Foo :
-         |CHECK:         propassign localPropOut, path("OMMemberReferenceTarget:~Top|Foo>data")
+         |CHECK:         propassign localPropOut, path("OMMemberReferenceTarget:~|Foo>data")
          |CHECK-LABEL: public module Top :
-         |CHECK:         propassign propOutA, path("OMMemberInstanceTarget:~Top|Top/inst:Foo")
-         |CHECK:         propassign propOutB, path("OMMemberReferenceTarget:~Top|Top/inst:Foo>data")
-         |CHECK:         propassign propOutC, path("OMMemberReferenceTarget:~Top|Top/inst:Foo>mem")
+         |CHECK:         propassign propOutA, path("OMMemberInstanceTarget:~|Top/inst:Foo")
+         |CHECK:         propassign propOutB, path("OMMemberReferenceTarget:~|Top/inst:Foo>data")
+         |CHECK:         propassign propOutC, path("OMMemberReferenceTarget:~|Top/inst:Foo>mem")
          |CHECK:         propassign propOutD, inst.localPropOut
          |""".stripMargin
     )
@@ -759,7 +759,7 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
           val c = a + b
         })
 
-        mod.c.toTarget.toString should equal("~Top|Foo>c")
+        mod.c.toTarget.toString should equal("~|Foo>c")
       }
     }.fileCheck()(
       """|CHECK: wire c : Integer

--- a/src/test/scala-2/chiselTests/util/SRAMSpec.scala
+++ b/src/test/scala-2/chiselTests/util/SRAMSpec.scala
@@ -39,7 +39,7 @@ class SRAMSpec extends AnyFlatSpec with Matchers with FileCheck {
       .emitCHIRRTL(new Top, Array("--include-util-metadata"))
       .fileCheck()(
         """|CHECK:      "class":"chiselTests.util.SRAMSpec$DummyAnno"
-           |CHECK-NEXT: "target":"~Top|Top>sram_sram"
+           |CHECK-NEXT: "target":"~|Top>sram_sram"
            |
            |CHECK:      public module Top :
            |CHECK:        wire sram : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1], description : Inst<SRAMDescription>}
@@ -56,7 +56,7 @@ class SRAMSpec extends AnyFlatSpec with Matchers with FileCheck {
            |CHECK:        connect sram.readwritePorts[0].readData, sram_sram.RW0.rdata
            |CHECK:        connect sram_sram.RW0.wdata, sram.readwritePorts[0].writeData
            |CHECK:        connect sram_sram.RW0.wmode, sram.readwritePorts[0].isWrite
-           |CHECK:        propassign sram_descriptionInstance.hierarchyIn, path("OMReferenceTarget:~Top|Top>sram_sram")
+           |CHECK:        propassign sram_descriptionInstance.hierarchyIn, path("OMReferenceTarget:~|Top>sram_sram")
            |CHECK:        propassign sram.description, sram_descriptionInstance
            |""".stripMargin
       )
@@ -80,7 +80,7 @@ class SRAMSpec extends AnyFlatSpec with Matchers with FileCheck {
       .emitCHIRRTL(new Top)
       .fileCheck()(
         """|CHECK:      "class":"chiselTests.util.SRAMSpec$DummyAnno"
-           |CHECK-NEXT: "target":"~Top|Top>carrot"
+           |CHECK-NEXT: "target":"~|Top>carrot"
            |
            |CHECK:      public module Top :
            |CHECK:        wire sramInterface : { readPorts : { flip address : UInt<5>, flip enable : UInt<1>, data : UInt<8>}[0], writePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip data : UInt<8>}[0], readwritePorts : { flip address : UInt<5>, flip enable : UInt<1>, flip isWrite : UInt<1>, readData : UInt<8>, flip writeData : UInt<8>}[1]}

--- a/src/test/scala-2/circtTests/OutputDirAnnotationSpec.scala
+++ b/src/test/scala-2/circtTests/OutputDirAnnotationSpec.scala
@@ -20,7 +20,7 @@ class OutputDirAnnotationSpec extends AnyFunSpec with Matchers {
       val chirrtl = ChiselStage.emitCHIRRTL(new ParentModule)
       (chirrtl.split('\n').map(_.takeWhile(_ != '@').trim) should contain).allOf(
         """"class":"circt.OutputDirAnnotation",""",
-        """"target":"~ParentModule|TestModule",""",
+        """"target":"~|TestModule",""",
         """"dirname":"foo""""
       )
 

--- a/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
@@ -822,7 +822,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.LogUtils
       info("there is one final target")
       finalTargets should have size (1)
 
-      val expectedTarget = firrtl.annotations.CircuitTarget("Foo").module("Foo").ref("bar_a")
+      val expectedTarget = firrtl.annotations.ModuleTarget("Foo").ref("bar_a")
       info(s"the final target is $expectedTarget")
       finalTargets.head should be(expectedTarget)
 
@@ -855,7 +855,7 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.LogUtils
       info("there is one final target")
       finalTargets should have size (1)
 
-      val expectedTarget = firrtl.annotations.CircuitTarget("Foo").module("Foo").ref("bar_a")
+      val expectedTarget = firrtl.annotations.ModuleTarget("Foo").ref("bar_a")
       info(s"the final target is $expectedTarget")
       finalTargets.head should be(expectedTarget)
 


### PR DESCRIPTION
Remove the circuit from both `Target` and `Named`.  For the latter, this means that `CircuitName` is deleted.

Carry this to its logical conclusion.  The only parts that do require a change:

1. The RenameMap wants to know if a path is renamed to something "absolute".  It does this check by looking to see if a module name matches the circuit name.  (Note: this check is incorrect because it assumes that a circuit has a single root.  However, this has not been the case since D/I was implemented.)  Work around this by adding a "circuit name" parameter to the RenameMap so that this check can still be done.  Note: large code paths within the rename map that are checking for module or instance path renames should be completely unreachable.  The only user of the RenameMap at this point in-tree is `DataView` and this is not going to do renames involving paths.

2. The LayerControl API needs to know what the circuit name is since this is part of its ABI.  Previously, the circuit name was known because of a, now deleted, method on `RawModule`.  Change this to use the module name itself when determining the ABI setting (file name or macro name).  This should always be correct because the method to generate the ABI setting because ChiselSim is always given some top module that it wants to simulate.  This may be problematic for multi-rooted circuits like inline directed tests.

3. Users of the Trace API do not have a trivial access to the circuit name, i.e., the top module.  However, if you are a user of this, you should know what your top name is without relying on the returned `CompleteTarget`.  See the `TraceSpec` for an example of this.

See the associated FIRRTL spec change here: https://github.com/chipsalliance/firrtl-spec/commit/160bafef053f1fa28e8592ebf54400e81b90e210

#### Release Notes

- Remove the "circuit name" from all annotations and annotation-adjacent code. This has the effect of serializing all annotations using new target syntax that does _not_ have a circuit name. E.g., whereas a target may have previously looked like: `~Foo|Bar>a`, it will now look like: `~|Bar>a`. This is a change that is already compatible with CIRCT and requires no update to your FIRRTL compiler.
- Users that create a rename map will now need to pass a "circuit name" parameter to the rename map.
- `RawModule` no longer has a `circuitName` member.