### PR TITLE
Add SimulationTime (%T) format specifier

### DIFF
--- a/core/src/main/scala/chisel3/package.scala
+++ b/core/src/main/scala/chisel3/package.scala
@@ -248,6 +248,8 @@ package object chisel3 {
                 Percent
               } else if (s(end + 1) == 'm') {
                 HierarchicalModuleName
+              } else if (s(end + 1) == 'T') {
+                SimulationTime
               } else {
                 throw new UnknownFormatConversionException("Un-escaped %")
               }

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -62,11 +62,15 @@ printf(cf"myUInt = $myUInt%c") // myUInt = !
 There are special values you can include in your `cf` interpolated string:
 
 * `HierarchicalModuleName` (`%m`): The hierarchical name of the current module
+* `SimulationTime` (`%T`): The current simulation time (unlike Verilog's `%t`, this does not take an argument)
 * `Percent` (`%%`): A literal `%`
 
 ```scala mdoc:compile-only
 printf(cf"hierarchical path = $HierarchicalModuleName\n") // hierarchical path = <verilog.module.path>
 printf(cf"hierarchical path = %m\n") // equivalent to the above
+
+printf(cf"simulation time = $SimulationTime\n") // simulation time = <simulation.time>
+printf(cf"simulation time = %T\n") // equivalent to the above
 
 printf(cf"100$Percent\n") // 100%
 printf(cf"100%%\n") // equivalent to the above
@@ -167,6 +171,7 @@ Chisel provides `printf` in a similar style to its C namesake. It accepts a doub
 | `%c` | 8-bit ASCII character |
 | `%%` | literal percent |
 | `%m` | hierarchical name |
+| `%T` | simulation time |
 
 `%d`, `%x`, and `%b` support the modifiers described in the [Format modifiers](#format-modifiers) section above.
 

--- a/src/test/scala-2/chiselTests/PrintableSpec.scala
+++ b/src/test/scala-2/chiselTests/PrintableSpec.scala
@@ -318,18 +318,18 @@ class PrintableSpec extends AnyFlatSpec with Matchers with FileCheck {
   it should "support all legal format specifiers" in {
     class MyModule extends Module {
       val in = IO(Input(UInt(8.W)))
-      printf(cf"$HierarchicalModuleName $in%d $in%x $in%b $in%c %%\n")
+      printf(cf"$SimulationTime $HierarchicalModuleName $in%d $in%x $in%b $in%c %%\n")
     }
     ChiselStage
       .emitCHIRRTL(new MyModule)
       .fileCheck()(
-        """CHECK{LITERAL}: printf(clock, UInt<1>(0h1), "{{HierarchicalModuleName}} %d %x %b %c %%\n", in, in, in, in)"""
+        """CHECK{LITERAL}: printf(clock, UInt<1>(0h1), "{{SimulationTime}} {{HierarchicalModuleName}} %d %x %b %c %%\n", in, in, in, in)"""
       )
     // Also check Verilog
     ChiselStage
       .emitSystemVerilog(new MyModule)
       .fileCheck()(
-        """CHECK: $fwrite(`PRINTF_FD_, "%m %d %x %b %c %%\n", in, in, in, in);"""
+        """CHECK: $fwrite(`PRINTF_FD_, "%0t %m %d %x %b %c %%\n", $time, in, in, in, in);"""
       )
 
   }
@@ -391,6 +391,7 @@ class PrintableSpec extends AnyFlatSpec with Matchers with FileCheck {
       (PString("foo"), ("foo", Seq())),
       (Percent, ("%%", Seq())),
       (HierarchicalModuleName, ("%m", Seq())),
+      (SimulationTime, ("%T", Seq())),
       (Name(x), ("%n", Seq(x))),
       (FullName(x), ("%N", Seq(x)))
     )

--- a/src/test/scala-2/chiselTests/Printf.scala
+++ b/src/test/scala-2/chiselTests/Printf.scala
@@ -76,18 +76,18 @@ class PrintfSpec extends AnyFlatSpec with Matchers with FileCheck {
   "printf" should "support all legal format specifiers" in {
     class MyModule extends Module {
       val in = IO(Input(UInt(8.W)))
-      printf("%m %d %x %b %c %%\n", in, in, in, in)
+      printf("%T %m %d %x %b %c %%\n", in, in, in, in)
     }
     ChiselStage
       .emitCHIRRTL(new MyModule)
       .fileCheck()(
-        """CHECK{LITERAL}: printf(clock, UInt<1>(0h1), "{{HierarchicalModuleName}} %d %x %b %c %%\n", in, in, in, in)"""
+        """CHECK{LITERAL}: printf(clock, UInt<1>(0h1), "{{SimulationTime}} {{HierarchicalModuleName}} %d %x %b %c %%\n", in, in, in, in)"""
       )
     // Also check Verilog
     ChiselStage
       .emitSystemVerilog(new MyModule)
       .fileCheck()(
-        """CHECK: $fwrite(`PRINTF_FD_, "%m %d %x %b %c %%\n", in, in, in, in);"""
+        """CHECK: $fwrite(`PRINTF_FD_, "%0t %m %d %x %b %c %%\n", $time, in, in, in, in);"""
       )
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Unlike `%t` in Verilog, SimulationTime (`%T`) does not take an argument.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
