### PR TITLE
[firrtl] Bump serializer version to 5.1.0

### DIFF
--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -17,7 +17,7 @@ object Serializer {
   val Indent = "  "
 
   // The version supported by the serializer.
-  val version = Version(4, 2, 0)
+  val version = Version(5, 1, 0)
 
   /** Converts a `FirrtlNode` into its string representation with
     * default indentation.

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -8,7 +8,7 @@ import firrtl.testutils._
 class ExtModuleTests extends FirrtlFlatSpec {
   "extmodule" should "serialize and re-parse equivalently" in {
     val input =
-      """|FIRRTL version 4.2.0
+      """|FIRRTL version 5.1.0
          |circuit Top :
          |  extmodule Top :
          |    input y : UInt<0>


### PR DESCRIPTION
Bump the version of serialized FIRRTL to version 5.1.0.  This was
mistakenly not bumped when the version was updated in Chisel.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>
