### PR TITLE
[chiselsim] Add a "flag" CLI option factory

### DIFF
--- a/docs/src/explanations/testing.md
+++ b/docs/src/explanations/testing.md
@@ -322,11 +322,11 @@ can add a custom option to your test using one of several methods provided in
 the simulation including the Chisel elaboration, FIRRTL compilation, or generic
 or backend-specific settings.
 
-More commonly, you just want to add an integer, double, or string option to a
-test.  For this, simpler options
-(`chisel3.simulator.scalatest.CliOption.{simple, double, int, string}`) are
-provided.  After an option has been declared, it can be accessed _within a test_
-using the `getOption` method.
+More commonly, you just want to add an integer, double, string, or flag-like
+options to a test.  For this, simpler option _factories_
+(`chisel3.simulator.scalatest.CliOption.{simple, double, int, string, flag}`)
+are provided.  After an option has been declared, it can be accessed _within a
+test_ using the `getOption` method.
 
 :::warning
 

--- a/src/main/scala/chisel3/simulator/scalatest/Cli.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/Cli.scala
@@ -55,52 +55,44 @@ object Cli {
   trait EmitFsdb { this: HasCliOptions =>
 
     addOption(
-      CliOption[Unit](
-        name = "emitFsdb",
-        help = "compile with FSDB waveform support and start dumping waves at time zero",
-        convert = value => {
-          val trueValue = Set("true", "1")
-          trueValue.contains(value) match {
-            case true => ()
-            case false =>
-              throw new IllegalArgumentException(
-                s"""invalid argument '$value' for option 'emitFsdb', must be one of ${trueValue
-                    .mkString("[", ", ", "]")}"""
-              ) with NoStackTrace
-          }
-        },
-        updateChiselOptions = (_, a) => a,
-        updateFirtoolOptions = (_, a) => a,
-        updateCommonSettings = (_, options) => {
-          options.copy(
-            verilogPreprocessorDefines =
-              options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableFsdbTracingSupport),
-            simulationSettings = options.simulationSettings.copy(
-              enableWavesAtTimeZero = true
+      CliOption
+        .flag(
+          name = "emitFsdb",
+          help = "compile with FSDB waveform support and start dumping waves at time zero"
+        )
+        .copy[Unit](
+          updateChiselOptions = (_, a) => a,
+          updateFirtoolOptions = (_, a) => a,
+          updateCommonSettings = (_, options) => {
+            options.copy(
+              verilogPreprocessorDefines =
+                options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableFsdbTracingSupport),
+              simulationSettings = options.simulationSettings.copy(
+                enableWavesAtTimeZero = true
+              )
             )
-          )
-        },
-        updateBackendSettings = (_, options) =>
-          options match {
-            case options: svsim.vcs.Backend.CompilationSettings =>
-              options.copy(
-                traceSettings = options.traceSettings.copy(fsdbSettings =
-                  Some(
-                    svsim.vcs.Backend.CompilationSettings.TraceSettings.FsdbSettings(
-                      sys.env.getOrElse(
-                        "VERDI_HOME",
-                        throw new RuntimeException(
-                          "Cannot enable FSDB support as the environment variable 'VERDI_HOME' was not set."
+          },
+          updateBackendSettings = (_, options) =>
+            options match {
+              case options: svsim.vcs.Backend.CompilationSettings =>
+                options.copy(
+                  traceSettings = options.traceSettings.copy(fsdbSettings =
+                    Some(
+                      svsim.vcs.Backend.CompilationSettings.TraceSettings.FsdbSettings(
+                        sys.env.getOrElse(
+                          "VERDI_HOME",
+                          throw new RuntimeException(
+                            "Cannot enable FSDB support as the environment variable 'VERDI_HOME' was not set."
+                          )
                         )
                       )
                     )
                   )
                 )
-              )
-            case options: svsim.verilator.Backend.CompilationSettings =>
-              throw new IllegalArgumentException("Verilator does not support FSDB waveforms.")
-          }
-      )
+              case options: svsim.verilator.Backend.CompilationSettings =>
+                throw new IllegalArgumentException("Verilator does not support FSDB waveforms.")
+            }
+        )
     )
 
   }
@@ -115,46 +107,36 @@ object Cli {
   trait EmitVcd { this: HasCliOptions =>
 
     addOption(
-      CliOption[Unit](
-        name = "emitVcd",
-        help = "compile with VCD waveform support and start dumping waves at time zero",
-        convert = value => {
-          val trueValue = Set("true", "1")
-          trueValue.contains(value) match {
-            case true => ()
-            case false =>
-              throw new IllegalArgumentException(
-                s"""invalid argument '$value' for option 'emitVcd', must be one of ${trueValue
-                    .mkString("[", ", ", "]")}"""
-              ) with NoStackTrace
-          }
-        },
-        updateChiselOptions = (_, a) => a,
-        updateFirtoolOptions = (_, a) => a,
-        updateCommonSettings = (_, options) => {
-          options.copy(
-            verilogPreprocessorDefines =
-              options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVcdTracingSupport),
-            simulationSettings = options.simulationSettings.copy(
-              enableWavesAtTimeZero = true
+      CliOption
+        .flag(name = "emitVcd", help = "compile with VCD waveform support and start dumping waves at time zero")
+        .copy[Unit](
+          updateChiselOptions = (_, a) => a,
+          updateFirtoolOptions = (_, a) => a,
+          updateCommonSettings = (_, options) => {
+            options.copy(
+              verilogPreprocessorDefines =
+                options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVcdTracingSupport),
+              simulationSettings = options.simulationSettings.copy(
+                enableWavesAtTimeZero = true
+              )
             )
-          )
-        },
-        updateBackendSettings = (_, options) =>
-          options match {
-            case options: svsim.vcs.Backend.CompilationSettings =>
-              options.copy(
-                traceSettings = options.traceSettings.copy(enableVcd = true)
-              )
-            case options: svsim.verilator.Backend.CompilationSettings =>
-              options.copy(
-                traceStyle = options.traceStyle match {
-                  case None => Some(svsim.verilator.Backend.CompilationSettings.TraceStyle.Vcd(filename = "trace.vcd"))
-                  case alreadySet => alreadySet
-                }
-              )
-          }
-      )
+          },
+          updateBackendSettings = (_, options) =>
+            options match {
+              case options: svsim.vcs.Backend.CompilationSettings =>
+                options.copy(
+                  traceSettings = options.traceSettings.copy(enableVcd = true)
+                )
+              case options: svsim.verilator.Backend.CompilationSettings =>
+                options.copy(
+                  traceStyle = options.traceStyle match {
+                    case None =>
+                      Some(svsim.verilator.Backend.CompilationSettings.TraceStyle.Vcd(filename = "trace.vcd"))
+                    case alreadySet => alreadySet
+                  }
+                )
+            }
+        )
     )
 
   }
@@ -172,41 +154,33 @@ object Cli {
   trait EmitVpd { this: HasCliOptions =>
 
     addOption(
-      CliOption[Unit](
-        name = "emitVpd",
-        help = "compile with VPD waveform support and start dumping waves at time zero",
-        convert = value => {
-          val trueValue = Set("true", "1")
-          trueValue.contains(value) match {
-            case true => ()
-            case false =>
-              throw new IllegalArgumentException(
-                s"""invalid argument '$value' for option 'emitVpd', must be one of ${trueValue
-                    .mkString("[", ", ", "]")}"""
-              ) with NoStackTrace
-          }
-        },
-        updateChiselOptions = (_, a) => a,
-        updateFirtoolOptions = (_, a) => a,
-        updateCommonSettings = (_, options) => {
-          options.copy(
-            verilogPreprocessorDefines =
-              options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVpdTracingSupport),
-            simulationSettings = options.simulationSettings.copy(
-              enableWavesAtTimeZero = true
-            )
-          )
-        },
-        updateBackendSettings = (_, options) =>
-          options match {
-            case options: svsim.vcs.Backend.CompilationSettings =>
-              options.copy(
-                traceSettings = options.traceSettings.copy(enableVpd = true)
+      CliOption
+        .flag(
+          name = "emitVpd",
+          help = "compile with VPD waveform support and start dumping waves at time zero"
+        )
+        .copy[Unit](
+          updateChiselOptions = (_, a) => a,
+          updateFirtoolOptions = (_, a) => a,
+          updateCommonSettings = (_, options) => {
+            options.copy(
+              verilogPreprocessorDefines =
+                options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVpdTracingSupport),
+              simulationSettings = options.simulationSettings.copy(
+                enableWavesAtTimeZero = true
               )
-            case options: svsim.verilator.Backend.CompilationSettings =>
-              throw new IllegalArgumentException("Verilator does not support VPD waveforms.")
-          }
-      )
+            )
+          },
+          updateBackendSettings = (_, options) =>
+            options match {
+              case options: svsim.vcs.Backend.CompilationSettings =>
+                options.copy(
+                  traceSettings = options.traceSettings.copy(enableVpd = true)
+                )
+              case options: svsim.verilator.Backend.CompilationSettings =>
+                throw new IllegalArgumentException("Verilator does not support VPD waveforms.")
+            }
+        )
     )
 
   }

--- a/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
@@ -113,6 +113,36 @@ object HasCliOptions {
       help = help,
       convert = identity
     )
+
+    /** Add a flag option to a test.
+      *
+      * This is an option which can only take one of two "truthy" values: `1` or
+      * `true`.  Any "falsey" values are not allowed.  This option is a stand-in
+      * for any option which is supposed to be a flag to a test which has some
+      * effect if set.
+      *
+      * This option exists because Scalatest forces options to have a value.  It
+      * is illegal to pass an option like `-Dfoo`.  This [[flag]] option exists
+      * to problem a single flag-style option as opposed to having users roll
+      * their own.
+      *
+      * @param name the name of the option
+      * @param help help text to show to tell the user how to use this option
+      */
+    def flag(name: String, help: String): CliOption[Unit] = simple[Unit](
+      name = name,
+      help = help,
+      convert = value => {
+        val trueValue = Set("true", "1")
+        trueValue.contains(value) match {
+          case true => ()
+          case false =>
+            throw new IllegalArgumentException(
+              s"""invalid argument '$value' for option '$name', must be one of ${trueValue.mkString("[", ", ", "]")}"""
+            ) with NoStackTrace
+        }
+      }
+    )
   }
 
 }


### PR DESCRIPTION
Add another factory for creating options that is intended to be used for
creating "flag"-style options.  This exists to unify this pattern as
opposed to forcing users to invent their own when they need it.

As can be seen, this unifies a number of existing flag-like options
relating to waveform emission.

CC: @andrew-gouldey-sifive: This will be available in the next internal
Chisel release for your use.

Signed-off-by: Schuyler Eldridge <schuyler.eldridge@sifive.com>

#### Release Notes

Add `CliOption.flag` to facilitate the creation of ChiselSim Scalatest flag-like options.
