### PR TITLE
Support Printable SimLog filenames

### DIFF
--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -694,12 +694,14 @@ abstract class Data extends HasId with NamedComponent with DataIntf {
   }
   private[chisel3] def visibleFromBlock: Option[SourceInfo] = MonoConnect.checkBlockVisibility(this)
   private[chisel3] def requireVisible()(implicit info: SourceInfo): Unit = {
+    this.checkVisible.foreach(err => Builder.error(err))
+  }
+  // Some is an error message, None means no error
+  private[chisel3] def checkVisible(implicit info: SourceInfo): Option[String] = {
     if (!isVisibleFromModule) {
-      throwException(s"operand '$this' is not visible from the current module ${Builder.currentModule.get.name}")
-    }
-    visibleFromBlock match {
-      case Some(blockInfo) => MonoConnect.escapedScopeError(this, blockInfo)
-      case None            => ()
+      Some(s"operand '$this' is not visible from the current module ${Builder.currentModule.get.name}")
+    } else {
+      visibleFromBlock.map(MonoConnect.escapedScopeErrorMsg(this, _))
     }
   }
 

--- a/core/src/main/scala/chisel3/Printable.scala
+++ b/core/src/main/scala/chisel3/Printable.scala
@@ -3,6 +3,7 @@
 package chisel3
 
 import chisel3.experimental.SourceInfo
+import chisel3.internal.Builder
 import chisel3.internal.firrtl.ir.Component
 import chisel3.FirrtlFormat.FormatWidth
 
@@ -167,7 +168,7 @@ object Printable {
     }
   }
 
-  private[chisel3] def checkScope(message: Printable)(implicit info: SourceInfo): Unit = {
+  private[chisel3] def checkScope(message: Printable, msg: String = "")(implicit info: SourceInfo): Unit = {
     def getData(x: Printable): Seq[Data] = {
       x match {
         case y: FirrtlFormat => Seq(y.bits)
@@ -177,7 +178,11 @@ object Printable {
         case _             => Seq() // Handles subtypes PString and Percent
       }
     }
-    getData(message).foreach(_.requireVisible())
+    for (data <- getData(message)) {
+      for (err <- data.checkVisible) {
+        Builder.error(msg + err)
+      }
+    }
   }
 
   /** Extract the Data that will be arguments to Firrtl

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -52,9 +52,8 @@ private[chisel3] object MonoConnect {
     MonoConnectException(
       s"""${formatName(sink)} cannot be written from module ${source.parentNameOpt.getOrElse("(unknown)")}."""
     )
-  def escapedScopeError(data: Data, blockInfo: SourceInfo)(implicit lineInfo: SourceInfo): Unit = {
-    val msg = s"'$data' has escaped the scope of the block (${blockInfo.makeMessage()}) in which it was constructed."
-    Builder.error(msg)
+  def escapedScopeErrorMsg(data: Data, blockInfo: SourceInfo) = {
+    s"'$data' has escaped the scope of the block (${blockInfo.makeMessage()}) in which it was constructed."
   }
   def UnknownRelationException =
     MonoConnectException("Sink or source unavailable to current module.")
@@ -284,12 +283,12 @@ private[chisel3] object MonoConnect {
     }
 
     checkBlockVisibility(sink) match {
-      case Some(blockInfo) => escapedScopeError(sink, blockInfo)
+      case Some(blockInfo) => Builder.error(escapedScopeErrorMsg(sink, blockInfo))
       case None            => ()
     }
 
     checkBlockVisibility(source) match {
-      case Some(blockInfo) => escapedScopeError(source, blockInfo)
+      case Some(blockInfo) => Builder.error(escapedScopeErrorMsg(source, blockInfo))
       case None            => ()
     }
 
@@ -516,7 +515,7 @@ private[chisel3] object checkConnect {
     // Import helpers and exception types.
     import MonoConnect.{
       checkBlockVisibility,
-      escapedScopeError,
+      escapedScopeErrorMsg,
       UnknownRelationException,
       UnreadableSourceException,
       UnwritableSinkException
@@ -594,12 +593,12 @@ private[chisel3] object checkConnect {
     else throw UnknownRelationException
 
     checkBlockVisibility(sink) match {
-      case Some(blockInfo) => escapedScopeError(sink, blockInfo)(sourceInfo)
+      case Some(blockInfo) => Builder.error(escapedScopeErrorMsg(sink, blockInfo))(sourceInfo)
       case None            => ()
     }
 
     checkBlockVisibility(source) match {
-      case Some(blockInfo) => escapedScopeError(source, blockInfo)(sourceInfo)
+      case Some(blockInfo) => Builder.error(escapedScopeErrorMsg(source, blockInfo))(sourceInfo)
       case None            => ()
     }
   }

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -187,8 +187,10 @@ private[chisel3] object Converter {
       fir.Stop(convert(info), ret, convert(clock, ctx, info), firrtl.Utils.one, e.name)
     case e @ Printf(_, info, filename, clock, pable) =>
       val mkPrintf = filename match {
-        case None    => fir.Print.apply _
-        case Some(f) => fir.Fprint.apply(_, f, _, _, _, _, _)
+        case None => fir.Print.apply _
+        case Some(f) =>
+          val (ffmt, fargs) = unpack(f, ctx, info)
+          fir.Fprint.apply(_, fir.StringLit(ffmt), fargs.map(a => convert(a, ctx, info)), _, _, _, _, _)
       }
       val (fmt, args) = unpack(pable, ctx, info)
       mkPrintf(

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -492,8 +492,13 @@ private[chisel3] object ir {
 
   case class Port(id: Data, dir: SpecifiedDirection, sourceInfo: SourceInfo)
 
-  case class Printf(id: printf.Printf, sourceInfo: SourceInfo, filename: Option[String], clock: Arg, pable: Printable)
-      extends Definition
+  case class Printf(
+    id:         printf.Printf,
+    sourceInfo: SourceInfo,
+    filename:   Option[Printable],
+    clock:      Arg,
+    pable:      Printable
+  ) extends Definition
 
   case class ProbeDefine(sourceInfo: SourceInfo, sink: Arg, probe: Arg) extends Command
   case class ProbeForceInitial(sourceInfo: SourceInfo, probe: Arg, value: Arg) extends Command

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -255,7 +255,11 @@ private[chisel3] object Serializer {
       val (fmt, args) = unpack(pable, ctx, info)
       if (filename.isEmpty) b ++= "printf("; else b ++= "fprintf(";
       serialize(clock, ctx, info); b ++= ", UInt<1>(0h1), ";
-      filename.foreach { f => b ++= "\""; b ++= f; b ++= "\", " }
+      filename.foreach { fable =>
+        val (ffmt, fargs) = unpack(fable, ctx, info)
+        b ++= fir.StringLit(ffmt).escape; b ++= ", "
+        fargs.foreach { a => serialize(a, ctx, info); b ++= ", " }
+      }
       b ++= fir.StringLit(fmt).escape;
       args.foreach { a => b ++= ", "; serialize(a, ctx, info) }; b += ')'
       val lbl = e.name

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -232,6 +232,23 @@ class MyModule extends Module {
 This is the same as standard `printf`.
 :::
 
+SimLog filenames can themselves be `Printable` values:
+
+```scala mdoc:compile-only
+class MyModule extends Module {
+  val idx = IO(Input(UInt(8.W)))
+  val log = SimLog.file(cf"logfile_$idx%0d.log")
+  val in = IO(Input(UInt(8.W)))
+  log.printf(cf"in = $in%d\n")
+}
+```
+
+It is strongly recommended to use `%0d` with UInts in filenames to avoid spaces in the filename.
+
+:::warning
+Be careful to avoid uninitialized registers in the filename.
+:::
+
 ### Writing Generic Code
 
 `SimLog` allows you to write code that can work with any log destination. This is useful when creating reusable components:

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -437,13 +437,14 @@ case class Print(
 
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class Fprint(
-  val info:     Info,
-  val filename: String,
-  val string:   StringLit,
-  val args:     Seq[Expression],
-  val clk:      Expression,
-  val en:       Expression,
-  val name:     String = ""
+  val info:         Info,
+  val filename:     StringLit,
+  val filenameArgs: Seq[Expression],
+  val string:       StringLit,
+  val args:         Seq[Expression],
+  val clk:          Expression,
+  val en:           Expression,
+  val name:         String = ""
 ) extends Statement
     with HasInfo
     with IsDeclaration

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -284,8 +284,10 @@ object Serializer {
       b ++= "printf("; s(clk); b ++= ", "; s(en); b ++= ", "; b ++= string.escape
       if (args.nonEmpty) b ++= ", "; s(args, ", "); b += ')'
       sStmtName(print.name); s(info)
-    case print @ Fprint(info, filename, string, args, clk, en, _) =>
-      b ++= "fprintf("; s(clk); b ++= ", "; s(en); b ++= ", \""; b ++= filename; b ++= "\", "; b ++= string.escape
+    case print @ Fprint(info, filename, fargs, string, args, clk, en, _) =>
+      b ++= "fprintf("; s(clk); b ++= ", "; s(en); b ++= ", "; b ++= filename.escape; b ++= ", "
+      s(fargs, ", "); if (fargs.nonEmpty) b ++= ", ";
+      b ++= string.escape
       if (args.nonEmpty) b ++= ", "; s(args, ", "); b += ')'
       sStmtName(print.name); s(info)
     case IsInvalid(info, expr)    => b ++= "invalidate "; s(expr); s(info)

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -412,13 +412,14 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
     Serializer.serialize(
       Fprint(
         NoInfo,
-        "filename",
+        StringLit("filename_%0d"),
+        Seq(Reference("x")),
         StringLit("hello %x"),
         Seq(Reference("arg")),
         Reference("clock"),
         Reference("enable"),
         "label"
       )
-    ) should include("""fprintf(clock, enable, "filename", "hello %x", arg) : label""")
+    ) should include("""fprintf(clock, enable, "filename_%0d", x, "hello %x", arg) : label""")
   }
 }


### PR DESCRIPTION
This requires not-yet-released firtool 1.114.0 to be able to emit Verilog.

Related CIRCT PR: https://github.com/llvm/circt/pull/8419

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

You can use Printables in SimLog filenames, e.g. `val log = SimLog.file(cf"logfile_$idx%0d.log")`

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
