### PR TITLE
Support customizing output CHIRRTL file name

### DIFF
--- a/src/main/scala/circt/stage/Shell.scala
+++ b/src/main/scala/circt/stage/Shell.scala
@@ -5,6 +5,7 @@ package circt.stage
 import chisel3.stage.{
   ChiselCircuitAnnotation,
   ChiselGeneratorAnnotation,
+  ChiselOutputFileAnnotation,
   CircuitSerializationAnnotation,
   IncludeInlineTestsForModule,
   IncludeInlineTestsWithName,
@@ -40,6 +41,7 @@ trait CLI extends BareShell { this: BareShell =>
   parser.note("Chisel options")
   Seq(
     ChiselGeneratorAnnotation,
+    ChiselOutputFileAnnotation,
     PrintFullStackTraceAnnotation,
     ThrowOnFirstErrorAnnotation,
     UseLegacyWidthBehavior,

--- a/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala-2/circtTests/stage/ChiselStageSpec.scala
@@ -1145,6 +1145,32 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.LogUtils
       info(s"'$expectedOutput' exists")
     }
 
+    it("should emit CHIRRTL files with custom names") {
+      val targetDir = new File("test_run_dir/ChiselStageSpec/emitCHIRRTLFile")
+      val fileBaseName = "Foo"
+
+      val args: Array[String] = Array(
+        "--target-dir",
+        targetDir.toString,
+        "--chisel-output-file",
+        fileBaseName
+      )
+
+      ChiselStage
+        .emitCHIRRTLFile(
+          new ChiselStageSpec.Bar,
+          args
+        )
+        .collectFirst { case a: CircuitSerializationAnnotation =>
+          a.filename
+        }
+        .get should be(fileBaseName)
+
+      val expectedOutput = new File(targetDir, s"${fileBaseName}.fir")
+      expectedOutput should (exist)
+      info(s"'$expectedOutput' exists")
+    }
+
     it("should emit FIRRTL dialect") {
 
       ChiselStage.emitFIRRTLDialect(new ChiselStageSpec.Foo) should include(" firrtl.module")


### PR DESCRIPTION
Resolves #4893.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Users can use the `--chisel-output-file` argument to `ChiselStage` to customize the output file name.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
