### PR TITLE
Add Simlog.flush

### DIFF
--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -53,7 +53,7 @@ private[chisel3] object MonoConnect {
       s"""${formatName(sink)} cannot be written from module ${source.parentNameOpt.getOrElse("(unknown)")}."""
     )
   def escapedScopeErrorMsg(data: Data, blockInfo: SourceInfo) = {
-    s"'$data' has escaped the scope of the block (${blockInfo.makeMessage()}) in which it was constructed."
+    s"operand '$data' has escaped the scope of the block (${blockInfo.makeMessage()}) in which it was constructed."
   }
   def UnknownRelationException =
     MonoConnectException("Sink or source unavailable to current module.")

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -201,6 +201,10 @@ private[chisel3] object Converter {
         firrtl.Utils.one,
         e.name
       )
+    case e @ Flush(info, filename, clock) =>
+      val (fmt, args) = filename.map(unpack(_, ctx, info)).getOrElse(("", Seq.empty))
+      val fn = Option.when(fmt.nonEmpty)(fir.StringLit(fmt))
+      fir.Flush(convert(info), fn, args.map(a => convert(a, ctx, info)), convert(clock, ctx, info))
     case e @ ProbeDefine(sourceInfo, sink, probeExpr) =>
       fir.ProbeDefine(convert(sourceInfo), convert(sink, ctx, sourceInfo), convert(probeExpr, ctx, sourceInfo))
     case e @ ProbeForceInitial(sourceInfo, probe, value) =>

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -500,6 +500,12 @@ private[chisel3] object ir {
     pable:      Printable
   ) extends Definition
 
+  case class Flush(
+    sourceInfo: SourceInfo,
+    filename:   Option[Printable],
+    clock:      Arg
+  ) extends Command
+
   case class ProbeDefine(sourceInfo: SourceInfo, sink: Arg, probe: Arg) extends Command
   case class ProbeForceInitial(sourceInfo: SourceInfo, probe: Arg, value: Arg) extends Command
   case class ProbeReleaseInitial(sourceInfo: SourceInfo, probe: Arg) extends Command

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -265,6 +265,14 @@ private[chisel3] object Serializer {
       val lbl = e.name
       if (lbl.nonEmpty) { b ++= " : "; b ++= legalize(lbl) }
       serialize(e.sourceInfo)
+    case e @ Flush(info, filename, clock) =>
+      b ++= "fflush("; serialize(clock, ctx, info); b ++= ", UInt<1>(0h1)";
+      filename.foreach { fable =>
+        val (ffmt, fargs) = unpack(fable, ctx, info)
+        b ++= ", "; b ++= fir.StringLit(ffmt).escape
+        fargs.foreach { a => b ++= ", "; serialize(a, ctx, info) }
+      }
+      b += ')'; serialize(info)
     case e @ ProbeDefine(sourceInfo, sink, probeExpr) =>
       b ++= "define "; serialize(sink, ctx, sourceInfo); b ++= " = "; serialize(probeExpr, ctx, sourceInfo);
       serialize(sourceInfo)

--- a/docs/src/explanations/printing.md
+++ b/docs/src/explanations/printing.md
@@ -265,3 +265,21 @@ val withFile = Module(new MyLogger(SimLog.file("data.log")))
 // Use with stderr
 val withStderr = Module(new MyLogger(SimLog.StdErr))
 ```
+
+### Flush
+
+`SimLog` objects can be flushed to ensure that all buffered output is written.
+This is useful in simulations using the logged output as input to a co-simulated components like a checker or golden model.
+
+```scala mdoc:compile-only
+val log = SimLog.file("logfile.log")
+val in = IO(Input(UInt(8.W)))
+log.printf(cf"in = $in%d\n")
+log.flush() // Flush buffered output right away.
+```
+
+You can also flush standard error:
+
+```scala mdoc:compile-only
+SimLog.StdErr.flush() // This will flush all standard printfs.
+```

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -451,6 +451,12 @@ case class Fprint(
     with UseSerializer
 
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case class Flush(val info: Info, val filename: Option[StringLit], args: Seq[Expression], val clk: Expression)
+    extends Statement
+    with HasInfo
+    with UseSerializer
+
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class ProbeDefine(info: Info, sink: Expression, probeExpr: Expression) extends Statement with UseSerializer
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class ProbeExpr(expr: Expression, tpe: Type = UnknownType) extends Expression with UseSerializer

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -290,6 +290,10 @@ object Serializer {
       b ++= string.escape
       if (args.nonEmpty) b ++= ", "; s(args, ", "); b += ')'
       sStmtName(print.name); s(info)
+    case flush @ Flush(info, filename, args, clk) =>
+      b ++= "fflush("; s(clk); b ++= ", UInt<1>(0h1)";
+      filename.foreach { f => b ++= ", "; b ++= f.escape; b ++= ", "; s(args, ", ") }
+      b += ')'; s(info)
     case IsInvalid(info, expr)    => b ++= "invalidate "; s(expr); s(info)
     case DefWire(info, name, tpe) => b ++= "wire "; b ++= legalize(name); b ++= " : "; s(tpe); s(info)
     case DefRegister(info, name, tpe, clock) =>

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -421,5 +421,12 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
         "label"
       )
     ) should include("""fprintf(clock, enable, "filename_%0d", x, "hello %x", arg) : label""")
+    info("flush okay!")
+    Serializer.serialize(
+      Flush(NoInfo, Some(StringLit("filename_%0d")), Seq(Reference("x")), Reference("clock"))
+    ) should include("""fflush(clock, UInt<1>(0h1), "filename_%0d", x)""")
+    Serializer.serialize(
+      Flush(NoInfo, None, Seq.empty, Reference("clock"))
+    ) should include("""fflush(clock, UInt<1>(0h1))""")
   }
 }


### PR DESCRIPTION
Staged on top of https://github.com/chipsalliance/chisel/pull/4892

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

`SimLog` objects now support `.flush()`. You can flush stderr with `SimLog.StdErr.flush()`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
