### PR TITLE
Error eagerly when attempting to annotate dynamic indices

### DIFF
--- a/core/src/main/scala/chisel3/Aggregate.scala
+++ b/core/src/main/scala/chisel3/Aggregate.scala
@@ -415,7 +415,7 @@ sealed class Vec[T <: Data] private[chisel3] (gen: => T, val length: Int)
     // TODO port technically isn't directly child of this data structure, but the result of some
     // muxes / demuxes. However, this does make access consistent with the top-level bindings.
     // Perhaps there's a cleaner way of accomplishing this...
-    port.bind(ChildBinding(this), reconstructedResolvedDirection)
+    port.bind(DynamicIndexBinding(this), reconstructedResolvedDirection)
 
     val i = Vec.truncateIndex(p, length)(UnlocatableSourceInfo)
     port.setRef(Node(this), i)

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -510,6 +510,7 @@ abstract class Data extends HasId with NamedComponent with DataIntf {
       case ElementLitBinding(litArg) => "(unhandled literal)"
       case BundleLitBinding(litMap)  => "(unhandled bundle literal)"
       case VecLitBinding(litMap)     => "(unhandled vec literal)"
+      case DynamicIndexBinding(vec)  => _bindingToString(vec.topBinding)
       case _                         => ""
     }
 
@@ -687,9 +688,10 @@ abstract class Data extends HasId with NamedComponent with DataIntf {
         true
       case Some(ViewBinding(target, _))           => target.isVisibleFromModule
       case Some(AggregateViewBinding(mapping, _)) => mapping.values.forall(_.isVisibleFromModule)
-      case Some(pb: SecretPortBinding)            => true // Ignore secret to not require visibility
-      case Some(_: UnconstrainedBinding)          => true
-      case _                                      => false
+      case Some(DynamicIndexBinding(vec)) => vec.isVisibleFromModule // Use underlying Vec visibility for dynamic index
+      case Some(pb: SecretPortBinding)    => true // Ignore secret to not require visibility
+      case Some(_: UnconstrainedBinding)  => true
+      case _                              => false
     }
   }
   private[chisel3] def visibleFromBlock: Option[SourceInfo] = MonoConnect.checkBlockVisibility(this)

--- a/core/src/main/scala/chisel3/experimental/package.scala
+++ b/core/src/main/scala/chisel3/experimental/package.scala
@@ -4,6 +4,7 @@ package chisel3
 
 import chisel3.reflect.DataMirror.internal.chiselTypeClone
 import chisel3.experimental.SourceInfo
+import chisel3.internal.binding.DynamicIndexBinding
 
 /** Package for experimental features, which may have their API changed, be removed, etc.
   *
@@ -66,11 +67,16 @@ package object experimental {
     */
   object requireIsAnnotatable {
     def apply(node: Data, msg: String = ""): Unit = {
+      def prefix = if (msg.nonEmpty) s"$msg " else ""
       requireIsHardware(node, msg)
       if (node.isLit) {
-        val prefix = if (msg.nonEmpty) s"$msg " else ""
         throw ExpectedAnnotatableException(
           s"$prefix'$node' must not be a literal."
+        )
+      }
+      if (node.topBinding.isInstanceOf[DynamicIndexBinding]) {
+        throw ExpectedAnnotatableException(
+          s"$prefix'$node' must not be a dynamic index into a Vec. Try assigning it to a Wire."
         )
       }
     }

--- a/core/src/main/scala/chisel3/internal/Binding.scala
+++ b/core/src/main/scala/chisel3/internal/Binding.scala
@@ -37,7 +37,9 @@ private[chisel3] object binding {
             case ActualDirection.Input  => Input
             case dir                    => throw new RuntimeException(s"Unexpected port element direction '$dir'")
           }
-        case _ => Internal
+        // Dynamic indices use the direction of the underlying Vec
+        case DynamicIndexBinding(vec) => from(vec.topBinding, direction)
+        case _                        => Internal
       }
     }
   }
@@ -88,6 +90,15 @@ private[chisel3] object binding {
       with BlockBinding
   case class RegBinding(enclosure: RawModule, parentBlock: Option[Block]) extends ConstrainedBinding with BlockBinding
   case class WireBinding(enclosure: RawModule, parentBlock: Option[Block]) extends ConstrainedBinding with BlockBinding
+
+  /** Special binding for Vec dynamic indexing */
+  case class DynamicIndexBinding(vec: Vec[_]) extends ConstrainedBinding with BlockBinding {
+    def parentBlock: Option[Block] = vec.topBinding match {
+      case b: BlockBinding => b.parentBlock
+      case _ => None
+    }
+    def enclosure: BaseModule = vec._parent.get
+  }
 
   case class ClassBinding(enclosure: Class) extends ConstrainedBinding with ReadOnlyBinding
 

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -645,6 +645,7 @@ private[chisel3] object Builder extends LazyLogging {
             // And name of the field if we have one, we don't for dynamic indexing of Vecs
             getSubName(data).map(p + "_" + _).getOrElse(p)
           }
+        case DynamicIndexBinding(vec)                                => recData(vec)
         case SampleElementBinding(parent)                            => recData(parent)
         case PortBinding(mod) if Builder.currentModule.contains(mod) => data.seedOpt
         case PortBinding(mod)                                        => map2(mod.seedOpt, data.seedOpt)(_ + "_" + _)

--- a/core/src/main/scala/chisel3/internal/MonoConnect.scala
+++ b/core/src/main/scala/chisel3/internal/MonoConnect.scala
@@ -95,6 +95,7 @@ private[chisel3] object MonoConnect {
     x.topBinding match {
       case mp: MemoryPortBinding =>
         None // TODO (albert-magyar): remove this "bridge" for odd enable logic of current CHIRRTL memories
+      case DynamicIndexBinding(vec) => checkBlockVisibility(vec) // This goes with the MemoryPortBinding hack
       case bb: BlockBinding => bb.parentBlock.collect { case b: Block if !visible(b) => b.sourceInfo }
       case _ => None
     }


### PR DESCRIPTION
This is done by adding DynamicIndexBinding so that Chisel can more precisely track when a Data is part of a dynamic index.

Erroring eagerly is only possible since making breaking changes to the annotation API a couple of months ago: https://github.com/chipsalliance/chisel/pull/4717.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Fixes a longstanding wart by at least giving a more useful error message at the site of the problematic user code.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
