### PR TITLE
[ci] Bump all actions to Ubuntu 24.04

### DIFF
--- a/.github/workflows/backport-fixup.yml
+++ b/.github/workflows/backport-fixup.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   resolve_prs:
     name: Resolve PRs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # If triggering PR actually is a backport, then original_pr will be set
     outputs:
         backport_pr: ${{ steps.backport.outputs.pr }}
@@ -52,7 +52,7 @@ jobs:
 
   fixup_backport:
     name: Fixup the backport PR
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-25.04
     needs: [resolve_prs]
     if: ${{ needs.resolve_prs.outputs.original_pr }}
 

--- a/.github/workflows/build-scala-cli-example.yml
+++ b/.github/workflows/build-scala-cli-example.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_example:
     name: Build and Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/cd-circt.yml
+++ b/.github/workflows/cd-circt.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cd-circt:
     name: 'Check Version, Create PR'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'circt/update-circt'
         uses: circt/update-circt@eacb8963f4f0872649ef5bb3245894929ddebe58 # v1.1.1

--- a/.github/workflows/ci-circt-nightly.yml
+++ b/.github/workflows/ci-circt-nightly.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   determine-branch:
     name: 'Update Staging Branch and Determine Target Branch'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Update Staging Branch
         uses: circt/update-staging-branch@c05f7e8f8357e1f05f351694593c8c13f835fe76 # v1.2.0
@@ -47,7 +47,7 @@ jobs:
     needs: [determine-branch]
     strategy:
       matrix:
-        system: ["ubuntu-22.04"]
+        system: ["ubuntu-24.04"]
         jvm: [21]
         scala: ["2.13.16"]
         espresso: ["2.4"]
@@ -70,7 +70,7 @@ jobs:
   check-tests:
     name: "check tests"
     needs: [ci]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
     steps:
@@ -85,7 +85,7 @@ jobs:
   # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
   all_tests_passed:
     name: "all tests passed"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: always() # Always run so that we never skip this check
     needs: check-tests
       # Pass only if check-tests set its output value

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: ci
     strategy:
       matrix:
-        system: ["ubuntu-22.04"]
+        system: ["ubuntu-24.04"]
         jvm: [21]
         scala: ["2.13.16"]
         espresso: ["2.4"]
@@ -36,7 +36,7 @@ jobs:
   check-tests:
     name: "check tests"
     needs: ci
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       success: ${{ steps.setoutput.outputs.success }}
     steps:
@@ -51,7 +51,7 @@ jobs:
   # See: https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
   all_tests_passed:
     name: "all tests passed"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: always() # Always run so that we never skip this check
     needs: check-tests
       # Pass only if check-tests set its output value
@@ -70,7 +70,7 @@ jobs:
   # separate from a Scala versions build matrix to avoid duplicate publishing
   publish:
     needs: [all_tests_passed]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push'
 
     steps:
@@ -98,7 +98,7 @@ jobs:
 
   deploy_website:
     name: Deploy Website
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     needs: [all_tests_passed]

--- a/.github/workflows/enable-bincompat-checking.yml
+++ b/.github/workflows/enable-bincompat-checking.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   determine_version:
     name: Determine Version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
         version: ${{ steps.dowork.outputs.version }}
 
@@ -31,7 +31,7 @@ jobs:
 
   determine_branches:
     name: Determine Branches
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [determine_version]
     outputs:
       branches: ${{ steps.determine-branches.outputs.branches }}
@@ -63,7 +63,7 @@ jobs:
 
   open_prs:
     name: Open Pull Requests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [determine_version, determine_branches]
     strategy:
       matrix:
@@ -86,4 +86,3 @@ jobs:
           body: "Enable MiMa for ${{ needs.determine_version.outputs.version }}"
           labels: Internal
           token: ${{ secrets.CHISEL_BOT_TOKEN }}
-

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   generate_release_notes:
     name: Generate Release Notes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
 
@@ -49,4 +49,3 @@ jobs:
       - name: Error on uncategorized PRs
         if: steps.release-notes.outputs.uncategorized_prs != 0
         run: exit 1
-

--- a/.github/workflows/require-label.yml
+++ b/.github/workflows/require-label.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   check_labels:
     name: Check Labels
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:v1.6.32
         with:

--- a/.github/workflows/scala-cli-example.yml
+++ b/.github/workflows/scala-cli-example.yml
@@ -13,7 +13,7 @@ jobs:
   publish_example:
     name: Generate Chisel Scala CLI Example
     needs: [generate_scala_cli_example]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Install FileCheck
         run: |
           sudo apt update
-          sudo apt install llvm-12-tools
-          echo "/usr/lib/llvm-12/bin" >> $GITHUB_PATH
+          sudo apt install llvm-19-tools
+          echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       system:
         description: 'The GitHub runner to use'
-        default: 'ubuntu-22.04'
+        default: 'ubuntu-24.04'
         required: true
         type: string
       jvm:
@@ -93,7 +93,7 @@ jobs:
 
   mill:
     name: compile project with mill
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
 
   doc:
     name: Formatting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,7 +149,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -183,7 +183,7 @@ jobs:
   # Currently just a sanity check that the benchmarking flow works
   benchmark:
     name: Benchmarking Sanity Check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -199,7 +199,7 @@ jobs:
 
   std:
     name: Standard Library
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         scala: ["2.13.16"]
@@ -220,7 +220,7 @@ jobs:
 
   website:
     name: Build Mdoc & Website
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Change all actions from 22.04 to 24.04.  This requires newer artifacts published from llvm/circt also using 24.04.