### PR TITLE
Support reset-initializing the lastGrant register in RRArbiter

### DIFF
--- a/src/main/scala/chisel3/util/Arbiter.scala
+++ b/src/main/scala/chisel3/util/Arbiter.scala
@@ -125,7 +125,13 @@ class LockingArbiter[T <: Data](gen: T, n: Int, count: Int, needsLock: Option[T 
   * }}}
   */
 class RRArbiter[T <: Data](val gen: T, val n: Int, initLastGrant: Boolean = false)
-    extends LockingRRArbiter[T](gen, n, 1, initLastGrant = initLastGrant)
+    extends LockingRRArbiter[T](gen, n, 1, initLastGrant = initLastGrant) {
+
+  /** Give this Arbiter a default, stable desired name using the supplied `Data`
+    * generator's `typeName` and input count parameter
+    */
+  override def desiredName = s"RRArbiter${n}_${gen.typeName}"
+}
 
 /** Hardware module that is used to sequence n producers into 1 consumer.
   * Priority is given to lower producer.


### PR DESCRIPTION
The default behavior remains the same: don't initialize the `lastGrant` register in `LockingRRArbiter`. See #267 for previous discussions on this.

As noted in that old PR, this register is frequently in the control path of a design, where X-propagation can lead to simulation errors. There are nice ways to work around this uninitialized register in RTL simulations (namely the `RANDOMIZE_REG_INIT` text macro in the emitted SystemVerilog). However I've run into issues with non-resettable registers in the control path during gate-level simulations, where it's a bit harder to control the random initialization of registers. Having the option to resolve that problem with an RTL change would be very useful.

A few other notes about this PR:

- I chose an API where a `Boolean` lets the user opt in to resetting this register to 0. We could also use an `Option[UInt]` argument (which defaults to `None`), which would let users reset the register to other values. My gut says the `Option[UInt]` style is more complexity than necessary, and passing `true` to this argument to get reset behavior is a simpler API than passing `Some(0.U)`.
- There aren't any tests for the arbiters. Also no documentation for the locking arbiters. I might have time to dig into that in the near future, but I first wanted to check if there's any prior code for that lying around somewhere I'm not aware of.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Add the `initLastGrant` argument to the round-robin arbiter classes (`RRArbiter` and `LockingRRArbiter`) to support reset-initializing a register which might be in the control path of designs.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
