### PR TITLE
Support concatenating Properties of Seq subtypes

### DIFF
--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -454,9 +454,9 @@ object PropertySequenceOps {
   import PropertyExpressionHelpers._
 
   // Type class instances for Property sequence operations.
-  implicit def seqOps[U]: PropertySequenceOps[Property[Seq[U]]] =
-    new PropertySequenceOps[Property[Seq[U]]] {
-      def concat(lhs: Property[Seq[U]], rhs: Property[Seq[U]])(implicit sourceInfo: SourceInfo) =
+  implicit def seqOps[U, S[U] <: Seq[U]]: PropertySequenceOps[Property[S[U]]] =
+    new PropertySequenceOps[Property[S[U]]] {
+      def concat(lhs: Property[S[U]], rhs: Property[S[U]])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.ListConcatOp, lhs, rhs)
     }
 }

--- a/src/test/scala-2/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertySpec.scala
@@ -360,6 +360,42 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
     )
   }
 
+  it should "support concatenation of Property[Seq[Int]]" in {
+    ChiselStage.emitCHIRRTL {
+      new RawModule {
+        val seqProp1 = IO(Input(Property[Seq[Int]]()))
+        val seqProp2 = IO(Input(Property[Seq[Int]]()))
+        val seqProp3 = IO(Output(Property[Seq[Int]]()))
+        seqProp3 := seqProp1 ++ seqProp2
+      }
+    }.fileCheck()(
+      """|CHECK: input seqProp1 : List<Integer>
+         |CHECK: input seqProp2 : List<Integer>
+         |CHECK: output seqProp3 : List<Integer>
+         |CHECK: wire _seqProp3_propExpr : List<Integer>
+         |CHECK: propassign _seqProp3_propExpr, list_concat(seqProp1, seqProp2)
+         |""".stripMargin
+    )
+  }
+
+  it should "support concatenation of Property[List[Int]]" in {
+    ChiselStage.emitCHIRRTL {
+      new RawModule {
+        val listProp1 = IO(Input(Property[List[Int]]()))
+        val listProp2 = IO(Input(Property[List[Int]]()))
+        val listProp3 = IO(Output(Property[List[Int]]()))
+        listProp3 := listProp1 ++ listProp2
+      }
+    }.fileCheck()(
+      """|CHECK: input listProp1 : List<Integer>
+         |CHECK: input listProp2 : List<Integer>
+         |CHECK: output listProp3 : List<Integer>
+         |CHECK: wire _listProp3_propExpr : List<Integer>
+         |CHECK: propassign _listProp3_propExpr, list_concat(listProp1, listProp2)
+         |""".stripMargin
+    )
+  }
+
   it should "not support types with nested Property[_]" in {
     assertTypeError("Property[Property[Property[Int]]]()")
     assertTypeError("Property[Property[Seq[Property[Int]]]]()")


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)
- API modification
- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
