### PR TITLE
fix: queue depth parameter name

### DIFF
--- a/docs/src/developers/style.md
+++ b/docs/src/developers/style.md
@@ -127,7 +127,7 @@ output. The factory method takes the input IO to the queue and an optional param
 for depth.
 
 ```scala
-val queueOut = Queue(queueIn, depth=10)
+val queueOut = Queue(queueIn, entries=10)
 ```
 
 The latter can be used for composing multiple functions into a single line.
@@ -136,10 +136,10 @@ The latter can be used for composing multiple functions into a single line.
 val queueOut = Queue(
   Arbitrate.byRoundRobin(
     Queue(a), // depth assumed to be 1
-    Queue(b, depth=3),
-    Queue(c, depth=4)
+    Queue(b, entries=3),
+    Queue(c, entries=4)
   ),
-  depth=10
+  entries=10
 )
 ```
 


### PR DESCRIPTION
The parameter name is `entries` not `depth`.

#### Type of Improvement
Documentation or website-related

#### Desired Merge Strategy

Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
