### PR TITLE
Fail boring into module with endIOCreation set

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -858,7 +858,8 @@ package experimental {
     private[chisel3] def createSecretIO[A <: Data](data: => A)(implicit sourceInfo: SourceInfo): A = {
       val iodef = data
       requireIsChiselType(iodef, "io type")
-      require(!isFullyClosed, "Cannot create secret ports if module is fully closed")
+      if (isFullyClosed) Builder.error(s"Cannot create secret ports into fully closed ${this.name} (from ${Builder.currentModule.get.name})")
+      if (!isIOCreationAllowed) Builder.error(s"Cannot create secret ports into ${this.name} (from ${Builder.currentModule.get.name}) if IO creation is not allowed")
 
       Module.assignCompatDir(iodef)
       iodef.bind(SecretPortBinding(this), iodef.specifiedDirection)

--- a/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala-2/chiselTests/BoringUtilsSpec.scala
@@ -689,4 +689,21 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
            |""".stripMargin
       )
   }
+  it should "fail if endIOCreation is set" in {
+
+    class Bar extends RawModule {
+      val baz = Module(new Baz)
+      BoringUtils.bore(baz.c)
+    }
+
+    class Baz extends RawModule {
+      val c = Wire(Property[Int]())
+      endIOCreation()
+    }
+
+    val e = intercept[Exception] {
+      circt.stage.ChiselStage.emitCHIRRTL(new Bar, args)
+    }
+    e.getMessage should include("Cannot create secret ports into Baz (from Bar) if IO creation is not allowed")
+  }
 }


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification


#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

Setting `endIOCreation` now also errors if any IOs are created using `BoringUtils`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
