### PR TITLE
[testing] Mangle more directories

### DIFF
--- a/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
@@ -54,7 +54,7 @@ trait TestingDirectory extends TestSuiteMixin { self: TestSuite =>
 
     // A sequence of regular expressions and their replacements that should be
     // applied to the test name.
-    val res = Seq("\\s|\\(|\\)|\\$".r -> "-", "\"|\'|#|:".r -> "")
+    val res = Seq("\\s|\\(|\\)|\\$".r -> "-", "\"|\'|#|:|;|<|>".r -> "")
 
     /** Return the test name with minimal sanitization applied:
       *


### PR DESCRIPTION
Directories created with `[;<>]` are problematic for Makefiles and/or
Verilator.  Drop these if we see them.  This fixes issues where tests,
converted to ChiselSim, will fail to compile through Verilator due to
observed use of semicolons in test scopes or serialization of Chisel
types, e.g., `UInt<16>`.

Note: the continued patching of this indicates that we should setup an
allowlist of legal characters as opposed to continuing to exlcude
characters.


#### Release Notes

Drop `;`, `<`, and `>` if they show up in a ChiselSim Scalatest scope name.  This fixes a bug where Verilator (or the generated Makefile for ChiselSim) could fail to compile if it sees directories with these characters.