### PR TITLE
[core] Add Bool "implies" method

### DIFF
--- a/core/src/main/scala-2/chisel3/BitsIntf.scala
+++ b/core/src/main/scala-2/chisel3/BitsIntf.scala
@@ -891,4 +891,14 @@ private[chisel3] trait BoolIntf extends ToBoolable { self: Bool =>
 
   /** @group SourceInfoTransformMacro */
   def do_asAsyncReset(implicit sourceInfo: SourceInfo): AsyncReset = _asAsyncResetImpl
+
+  /** Logical implication
+   *
+   * @param that a boolean signal
+   * @return [[!this || that]]
+   */
+  def implies(that: Bool): Bool = macro SourceInfoTransform.thatArg
+
+  /** @group SourceInfoTransformMacro */
+  def do_implies(that: Bool)(implicit sourceInfo: SourceInfo): Bool = (!this) | that
 }

--- a/src/test/scala-2/chiselTests/BoolSpec.scala
+++ b/src/test/scala-2/chiselTests/BoolSpec.scala
@@ -1,0 +1,36 @@
+// See LICENSE for license details.
+
+package chiselTests
+
+import chisel3._
+import chisel3.simulator.scalatest.ChiselSim
+import chisel3.simulator.stimulus.RunUntilFinished
+import org.scalatest.flatspec.AnyFlatSpec
+
+class BoolSpec extends AnyFlatSpec with ChiselSim {
+
+  "implication" should "work in RTL" in {
+
+    val truthTable = Seq(
+      ((0, 0), 1),
+      ((0, 1), 1),
+      ((1, 0), 0),
+      ((1, 1), 1)
+    )
+
+    simulateRaw(
+      new RawModule {
+        val a, b = IO(Input(Bool()))
+        val c = IO(Output(Bool()))
+        c :<= a.implies(b)
+      }
+    ) { dut =>
+      truthTable.foreach { case ((a, b), c) =>
+        info(s"$a -> $b == $c")
+        dut.a.poke(a)
+        dut.b.poke(b)
+        dut.c.expect(c)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a metho to Bool for logical implication.  Use a prose method
name ("implies") as opposed to a terse operator to avoid
problems/confusion that was brought up in original PR review.

Fixes #1500.


#### Release Notes

Add `implies` method to `Bool` for logical implication.
