### PR TITLE
Add timing parameter support to Verilator backend

### DIFF
--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -13,11 +13,10 @@ object Backend {
       case class Vcd(traceUnderscore: Boolean = false, filename: String = "") extends TraceStyle
     }
 
-    sealed trait Timing
     object Timing {
-      case object TimingEnabled extends Timing
-      case object TimingDisabled extends Timing
-      type Type = Timing
+      sealed trait Type
+      case object TimingEnabled extends Type
+      case object TimingDisabled extends Type
     }
   }
 

--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -12,6 +12,13 @@ object Backend {
     object TraceStyle {
       case class Vcd(traceUnderscore: Boolean = false, filename: String = "") extends TraceStyle
     }
+
+    sealed trait Timing
+    object Timing {
+      case object TimingEnabled extends Timing
+      case object TimingDisabled extends Timing
+      type Type = Timing
+    }
   }
 
   case class CompilationSettings(
@@ -20,7 +27,8 @@ object Backend {
     outputSplitCFuncs:          Option[Int] = None,
     disabledWarnings:           Seq[String] = Seq(),
     disableFatalExitOnWarnings: Boolean = false,
-    enableAllAssertions:        Boolean = false
+    enableAllAssertions:        Boolean = false,
+    timing:                     Option[CompilationSettings.Timing.Type] = None
   ) extends svsim.Backend.Settings
 
   def initializeFromProcessEnvironment() = {
@@ -89,6 +97,12 @@ final class Backend(executablePath: String) extends svsim.Backend {
                 Seq("--trace")
               }
             case None => Seq()
+          },
+
+          backendSpecificSettings.timing match {
+            case Some(Timing.TimingEnabled)   => Seq("--timing")
+            case Some(Timing.TimingDisabled)  => Seq("--no-timing")
+            case None                         => Seq()
           },
 
           Seq(


### PR DESCRIPTION
### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [ ] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [ ] Did you request a desired merge strategy?
- [ ] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- API modification

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Added extra option Verilator Backend for Timing option. User now has choice to either add `--timing` or `--no-timing` or nothing for this parameter, in the Verilator Args Seq

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [x ] Did you review?
- [x] Did you check whether all relevant Contributor checkboxes have been checked?
- [x] Did you do one of the following when ready to merge:
  - [x] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
