### PR TITLE
Allow bare Chisel types to be looked up from a Hierarchy

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -221,6 +221,7 @@ object Lookupable {
     implicit sourceInfo: SourceInfo
   ): B = {
     def impl[C <: Data](d: C): C = d match {
+      case x: Data if !x.isSynthesizable                      => x.asInstanceOf[C]
       case x: Data if ioMap.nonEmpty && ioMap.get.contains(x) => ioMap.get(x).asInstanceOf[C]
       case x: Data if cache.contains(x)                       => cache(x).asInstanceOf[C]
       case _ =>


### PR DESCRIPTION

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes

- Allow lookup of bare Chisel types from a Hierarchy

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
