### PR TITLE
Fix naming plugin support for unapply

### DIFF
--- a/plugin/src/main/scala-2/chisel3/internal/plugin/ChiselComponent.scala
+++ b/plugin/src/main/scala-2/chisel3/internal/plugin/ChiselComponent.scala
@@ -227,7 +227,7 @@ class ChiselComponent(val global: Global, arguments: ChiselPluginArguments)
         }
       case dd @ ValDef(mods, name, tpt, rhs @ Match(_, _)) if okUnapply(dd) =>
         val tpe = inferType(tpt)
-        val fieldsOfInterest: List[Boolean] = tpe.typeArgs.map(shouldMatchData)
+        val fieldsOfInterest: List[Boolean] = tpe.typeArgs.map(shouldMatchNamedComp)
         // Only transform if at least one field is of interest
         if (fieldsOfInterest.reduce(_ || _)) {
           findUnapplyNames(rhs) match {

--- a/src/test/scala-2/chiselTests/naming/NamePluginSpec.scala
+++ b/src/test/scala-2/chiselTests/naming/NamePluginSpec.scala
@@ -503,6 +503,23 @@ class NamePluginSpec extends AnyFlatSpec with Matchers with FileCheck {
     ChiselStage.emitCHIRRTL(new Test) should include("wire x :")
   }
 
+  "AffectsChiselName" should "work in unapply" in {
+    case class SomeClass(d: UInt) extends AffectsChiselName
+    class Test extends Module {
+      val (x, y) = {
+        val bad = SomeClass(Wire(UInt(8.W)))
+        (3, bad)
+      }
+    }
+    ChiselStage
+      .emitCHIRRTL(new Test)
+      .fileCheck()(
+        """|CHECK-NOT: bad
+           |CHECK:     wire y_d :
+           |""".stripMargin
+      )
+  }
+
   "withNames" should "require the same number of names as fields" in {
     case class Foo(x: Int, y: Int, z: Int)
     an[IllegalArgumentException] should be thrownBy {


### PR DESCRIPTION

`AffectsChiselName` is new in 7.0 so no reason to backport.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Previously, naming support on unapply only worked for subtypes of Data, but now it works for all namable types, including user-extensible AffectsChiselName as well as non-Data Chisel built-in types: Mem, VerificationStatement, properties.DynamicObject, and Disable.


### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
