### PR TITLE
Add API to include comments in the FIRRTL

### DIFF
--- a/core/src/main/scala/chisel3/experimental/FirrtlComment.scala
+++ b/core/src/main/scala/chisel3/experimental/FirrtlComment.scala
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.experimental
+
+import chisel3.internal.{Builder, HasId}
+import chisel3.internal.firrtl.ir.FirrtlComment
+
+/** Use to leave a comment in the generated FIRRTL.
+  * 
+  * These can be useful for debugging complex generators.
+  * Note that these are comments and thus are ignored by the FIRRTL compiler.
+  * 
+  * @example {{{
+  * 
+  * firrtlComment("This is a comment")
+  * val w = Wire(Bool())
+  * firrtlComment("This is another comment")
+  * 
+  * }}}
+  */
+object firrtlComment {
+
+  /** Leave a comment in the generated FIRRTL.
+    * 
+    * @param text The text of the comment
+    */
+  def apply(text: String): Unit = {
+    Builder.pushCommand(FirrtlComment(text))
+  }
+}

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -272,6 +272,8 @@ private[chisel3] object Converter {
       fir.EmptyStmt // dummy until the converter removed
     case Placeholder(info, block) =>
       convert(block, ctx, typeAliases)
+    case FirrtlComment(text) =>
+      fir.Comment(text)
   }
 
   /** Convert Chisel IR Commands into FIRRTL Statements

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -527,6 +527,11 @@ private[chisel3] object ir {
     pable:      Printable
   ) extends Definition
 
+  case class FirrtlComment(text: String) extends Command {
+    // Comments don't have source info, user can materialize it into the text if they want to.
+    override def sourceInfo: SourceInfo = UnlocatableSourceInfo
+  }
+
   abstract class Component extends Arg {
     def id:          BaseModule
     def name:        String

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -297,6 +297,17 @@ private[chisel3] object Serializer {
       serializeIntrinsic(ctx, info, None, None, intrinsic, args, params, typeAliases)
     case i @ DefIntrinsicExpr(info, intrinsic, id, args, params) =>
       serializeIntrinsic(ctx, info, Some(i.name), Some(id), intrinsic, args, params, typeAliases)
+    case FirrtlComment(text) =>
+      // Because of split, iterator will always be non-empty even if text is empty
+      val it = text.split("\n").iterator
+      while ({
+        val line = it.next()
+        b ++= "; "; b ++= line
+        if (it.hasNext) {
+          newLineAndIndent()
+        }
+        it.hasNext
+      }) ()
   }
 
   private def serializeCommand(cmd: Command, ctx: Component, typeAliases: Seq[String])(

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -552,6 +552,9 @@ case class Verification(
 case object EmptyStmt extends Statement with UseSerializer
 
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case class Comment(text: String) extends Statement with UseSerializer
+
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 abstract class Width extends FirrtlNode {
   def +(x: Width): Width = (this, x) match {
     case (a: IntWidth, b: IntWidth) => IntWidth(a.width + b.width)

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -366,7 +366,18 @@ object Serializer {
     case ProbeRelease(info, clock, cond, probe) =>
       b ++= "release("; s(clock); b ++= ", "; s(cond); b ++= ", "; s(probe); b += ')'; s(info)
     case IntrinsicStmt(info, intrinsic, args, params, tpe) => sIntrinsic(info, intrinsic, args, params, tpe)
-    case other                                             => b ++= other.serialize // Handle user-defined nodes
+    case Comment(text)                                     =>
+      // Because of split, iterator will always be non-empty even if text is empty
+      val it = text.split("\n").iterator
+      while ({
+        val line = it.next()
+        b ++= "; "; b ++= line
+        if (it.hasNext) {
+          newLineAndIndent()
+        }
+        it.hasNext
+      }) ()
+    case other => b ++= other.serialize // Handle user-defined nodes
   }
 
   private def sStmtName(lbl: String)(implicit b: StringBuilder): Unit = {

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -429,4 +429,8 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
       Flush(NoInfo, None, Seq.empty, Reference("clock"))
     ) should include("""fflush(clock, UInt<1>(0h1))""")
   }
+
+  it should "support comments" in {
+    Serializer.serialize(Comment("hello")) should be("; hello")
+  }
 }

--- a/src/test/scala-2/chiselTests/experimental/FirrtlCommentSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/FirrtlCommentSpec.scala
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.experimental
+
+import chisel3._
+import chisel3.experimental.firrtlComment
+import chisel3.testing.scalatest.FileCheck
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+
+class FirrtlCommentSpec extends AnyFlatSpec with FileCheck {
+
+  behavior.of("firrtlComment")
+
+  it should "enable leaving comments in the firrtl text" in {
+    class Foo extends Module {
+      val in = IO(Input(UInt(8.W)))
+      val out = IO(Output(UInt(8.W)))
+      firrtlComment("This is a comment")
+      out := in
+      firrtlComment("This is another comment")
+    }
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        s"""|CHECK:      ; This is a comment
+            |CHECK-NEXT: connect out, in
+            |CHECK-NEXT: ; This is another comment
+            |""".stripMargin
+      )
+  }
+
+  it should "support empty comments" in {
+    class Foo extends Module {
+      val in = IO(Input(UInt(8.W)))
+      val out = IO(Output(UInt(8.W)))
+      firrtlComment("")
+      out := in
+    }
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        s"""|CHECK:      ;
+            |CHECK-NEXT: connect out, in
+            |""".stripMargin
+      )
+  }
+
+  it should "support multi-line comments" in {
+    class Foo extends Module {
+      val in = IO(Input(UInt(8.W)))
+      val out = IO(Output(UInt(8.W)))
+      firrtlComment("This is a comment\n  This is another comment with spacing.")
+      out := in
+    }
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        s"""|CHECK:      ; This is a comment
+            |CHECK-NEXT: ;   This is another comment with spacing.
+            |CHECK-NEXT: connect out, in
+            |""".stripMargin
+      )
+  }
+}


### PR DESCRIPTION
I was working on something complicated and this would help a lot with development.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This is for debugging generated FIRRTL only--comments are ignored by the FIRRTL compiler.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
