### PR TITLE
Bump os-lib to 0.10.7

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -67,8 +67,8 @@ object v extends Module {
 
   val scalaVersion = scalaCrossVersions.head
   val jmhVersion = "1.37"
-  val osLib = ivy"com.lihaoyi::os-lib:0.10.0"
-  val upickle = ivy"com.lihaoyi::upickle:3.3.1"
+  val osLib = ivy"com.lihaoyi::os-lib:0.10.7" // 0.11 requires Java 11
+  val upickle = ivy"com.lihaoyi::upickle:3.3.1" // upickle 4.0 requires Scala 3.4 (we target Scala 3.3 LTS)
   val firtoolResolver = ivy"org.chipsalliance::firtool-resolver:2.0.1"
   val scalatest = ivy"org.scalatest::scalatest:3.2.19"
   val scalacheck = ivy"org.scalatestplus::scalacheck-1-18:3.2.19.0"
@@ -76,7 +76,7 @@ object v extends Module {
   val dataclass = ivy"io.github.alexarchambault::data-class:0.2.7"
   val commonText = ivy"org.apache.commons:commons-text:1.13.1"
   val scopt = ivy"com.github.scopt::scopt:4.1.0"
-  val mdoc = ivy"org.scalameta::mdoc:2.6.4"
+  val mdoc = ivy"org.scalameta::mdoc:2.7.1"
 
   def scalaReflect(scalaVersion:   String) = ivy"org.scala-lang:scala-reflect:$scalaVersion"
   def scala2Compiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:$scalaVersion"


### PR DESCRIPTION

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Dependency update


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Also bump mdoc to 2.7.1 (but this isn't visible to users).

Note that we are not yet bumping os-lib to 0.11 because it will raise the minimum supported JVM to 11. Similarly we are not bumping upickle to 4.0 because it does not support Scala 3.3 which is our target for Scala 3 support (because 3.3 is LTS).

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
