### PR TITLE
[chiselsim] Stop using CIRCT filelists

### DIFF
--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -219,31 +219,15 @@ package object simulator {
             movedFiles += abs
         }
       }
-      def moveFiles(filelist: Path) =
-        // Extract all lines (files) from the filelist.
-        Files
-          .lines(filelist)
-          .map(Paths.get(_))
-          .forEach(moveFile)
 
-      // Move a file in a filelist which may not exist.  Do nothing if the
-      // filelist does not exist.
-      def maybeMoveFiles(filelist: Path): Unit = filelist match {
-        case _ if Files.exists(filelist) => moveFiles(filelist)
-        case _                           =>
-      }
-
-      // Move files indicated by 'filelist.f' (which must exist).  Move files
-      // indicated by a black box filelist (which may exist).
-      moveFiles(supportArtifactsPath.resolve("filelist.f"))
-      maybeMoveFiles(supportArtifactsPath.resolve("firrtl_black_box_resource_files.f"))
-
-      // Additionally, move other files which are not in the filelist, but are
-      // ABI-meaningful.
+      // Move all files from the build flow except for some specifically
+      // excluded files:
+      //   - Any filelist like file
+      val skip_re = "^.*\\.f$".r
       Files
         .walk(supportArtifactsPath)
         .filter(_.toFile.isFile)
-        .filter(_.getFileName.toString.startsWith("layers-"))
+        .filter(f => !skip_re.matches(f.getFileName.toString))
         .forEach(moveFile)
 
       GeneratedWorkspaceInfo(


### PR DESCRIPTION
Change ChiselSim to stop using undocumented CIRCT-generated filelists to
know what files to include in simulator compile.  Specifically, don't rely
on the existence of `filelist.f` or `firrtl_black_box_resource_files.f`.

This is needed because the latter file was removed from (the unreleased)
CIRCT 1.125.0 [[1]] for reasons that it wasn't supposed to be load
bearing.  Removing the reliance on the former is just good to do.

Note: this may result in some breakages as users may have been
inadvertently relying on this behavior to exclude some generated files
from their compilation.  E.g., a user could generate some Chisel-time
metadata file which gets put into the build area, but then is excluded
from the compile.  To work around this, users should dump these files in
an alternative area.

[1]: https://github.com/llvm/circt/commit/c7e10d7c35f860c406a342ef54d21c84a132c7a3
