### PR TITLE
[chiselsim] Use allowlist for compilation includes

### DIFF
--- a/src/main/scala/chisel3/simulator/package.scala
+++ b/src/main/scala/chisel3/simulator/package.scala
@@ -220,15 +220,15 @@ package object simulator {
         }
       }
 
-      // Move all files from the build flow except for some specifically
-      // excluded files:
-      //   - Any filelist like file (.f)
-      //   - Any FIRRTL file (.fir)
-      val skip_re = "^.*\\.(f|fir)$".r
+      // Move all files from the build flow that have file extensions that
+      // likley should be included:
+      //   - Verilog files: '*.v', '*.sv', or '*.vh'.
+      //   - C++ files: '.cc', '.cpp', '.h'
+      val include_re = "^.*\\.(s?v|vh?|cc|cpp|h)$".r
       Files
         .walk(supportArtifactsPath)
         .filter(_.toFile.isFile)
-        .filter(f => !skip_re.matches(f.getFileName.toString))
+        .filter(f => include_re.matches(f.getFileName.toString))
         .forEach(moveFile)
 
       GeneratedWorkspaceInfo(


### PR DESCRIPTION
Change the logic used for determining which files to incldue from a
blocklist to an allowlist.  The blocklist approach is problematic as
sometimes users will generate odd files (e.g., '.graphml') and these need
to be excluded from the build.  It is easier to just include reasonable
files which is all Verilog and C++ files.

This is an imperfect solution and should be changed in the future to
either: (1) allow customization of this, (2) split the Chisel build
directory from the FIRRTL build directory, or (3) use CIRCT tooling to
query the MLIR to get the full list of files that should be included.

#### Release Notes

- Switch to a Verilog and C++ allowlist for ChiselSim build directory includes. This makes Chisel compatible with CIRCT 1.25.0+.