### PR TITLE
[scalatest] More conservative testdir mangling

### DIFF
--- a/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
@@ -54,7 +54,7 @@ trait TestingDirectory extends TestSuiteMixin { self: TestSuite =>
   final implicit def implementation: HasTestingDirectory = new HasTestingDirectory {
 
     // Match non-simple characters.
-    val regex = "[^-_A-Za-z0-9]".r
+    val regex = "[^-_.A-Za-z0-9]".r
 
     /** Return the test name with overly conservative sanitization applied.
       *

--- a/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
+++ b/src/main/scala/chisel3/testing/scalatest/WithTestingDirectory.scala
@@ -53,20 +53,21 @@ trait TestingDirectory extends TestSuiteMixin { self: TestSuite =>
     */
   final implicit def implementation: HasTestingDirectory = new HasTestingDirectory {
 
-    // A sequence of regular expressions and their replacements that should be
-    // applied to the test name.
-    val res = Seq("\\s|\\(|\\)|\\$|/|\\\\".r -> "-", "\"|\'|#|:|;|<|>".r -> "")
+    // Match non-simple characters.
+    val regex = "[^-_A-Za-z0-9]".r
 
-    /** Return the test name with minimal sanitization applied:
+    /** Return the test name with overly conservative sanitization applied.
       *
-      *   - Replace all whitespace as this is incompatible with GNU make [1]
-      *   - Replace any characters which Verilator Makefiles empirically have
-      *     problems with
+      * This should narrowly only need to replace whitespace (as this is
+      * incompatible with GNU make [1] and any character which Verilator
+      * empirically has problems with).  However, this has historically been a
+      * game of whack-a-mole and hence this replaces much more than it likely
+      * needs to.
       *
       * [1]: https://savannah.gnu.org/bugs/?712
       */
-    final def getTestName = testName.value.map { case a =>
-      res.foldLeft(a) { case (string, (regex, replacement)) => regex.replaceAllIn(string, replacement) }
+    final def getTestName = testName.value.map { case name =>
+      regex.replaceAllIn(name, _ => "-")
     }
 
     override def getDirectory: Path = FileSystems

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -82,7 +82,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
            |CHECK:      lineNo  line
            |CHECK-NEXT: ---
-           |CHECK-NEXT:      0  [40] %Error:
+           |CHECK-NEXT:      0  [30] %Error:
            |CHECK:      For more information, see the complete log file:
            |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3.assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
@@ -107,7 +107,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
            |CHECK:      lineNo  line
            |CHECK-NEXT: ---
-           |CHECK-NEXT:      0  [40] %Error:
+           |CHECK-NEXT:      0  [30] %Error:
            |CHECK:      For more information, see the complete log file:
            |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl.AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -82,9 +82,9 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
            |CHECK:      lineNo  line
            |CHECK-NEXT: ---
-           |CHECK-NEXT:      0  [30] %Error:
+           |CHECK-NEXT:      0  [40] %Error:
            |CHECK:      For more information, see the complete log file:
-           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3-assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
+           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3.assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )
@@ -107,9 +107,9 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
            |CHECK:      lineNo  line
            |CHECK-NEXT: ---
-           |CHECK-NEXT:      0  [30] %Error:
+           |CHECK-NEXT:      0  [40] %Error:
            |CHECK:      For more information, see the complete log file:
-           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl-AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
+           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl.AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )

--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -84,7 +84,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: ---
            |CHECK-NEXT:      0  [30] %Error:
            |CHECK:      For more information, see the complete log file:
-           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3.assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
+           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3-assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )
@@ -109,7 +109,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: ---
            |CHECK-NEXT:      0  [30] %Error:
            |CHECK:      For more information, see the complete log file:
-           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl.AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
+           |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl-AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
            |""".stripMargin
       )

--- a/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
@@ -64,27 +64,27 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
         "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
-        "should-generate-another-directory,-too"
+        "should-generate-another-directory--too"
       )
     }
 
-    it("should handle emojis, e.g., 🚀") {
+    it("should mangle emojis, e.g., 🚀") {
       checkDirectoryStructure(
         "build",
         "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
-        "should-handle-emojis,-e.g.,-🚀"
+        "should-mangle-emojis--e-g----"
       )
     }
 
-    it("should handle CJK characters, e.g., 好猫咪") {
+    it("should mangle CJK characters, e.g., 好猫咪") {
       checkDirectoryStructure(
         "build",
         "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
-        "should-handle-CJK-characters,-e.g.,-好猫咪"
+        "should-mangle-CJK-characters--e-g------"
       )
     }
 

--- a/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
+++ b/src/test/scala-2/chiselTests/testing/scalatest/TestingDirectorySpec.scala
@@ -74,7 +74,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
         "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
-        "should-mangle-emojis--e-g----"
+        "should-mangle-emojis--e.g.---"
       )
     }
 
@@ -84,7 +84,7 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
         "chiselsim",
         "TestingDirectorySpec",
         "A-test-suite-mixing-in-WithTestingDirectory",
-        "should-mangle-CJK-characters--e-g------"
+        "should-mangle-CJK-characters--e.g.-----"
       )
     }
 


### PR DESCRIPTION
Change the way that test directory names are mangled to be much more
conservative.  Mangle ny character which isn't a letter, number, or
underscore/dash.

This was empirically observed to be needed for Verilator v5.038 by
@ngraybeal.

#### Release Notes

- Change `scalatest.TestingDirectory` directory name mangling to be very conservative. Now, mangle anything not a letter, number, underscore, or dash. This is overly conservative, but avoids a whack-a-mole problem with Verilator. This has been empirically needed for Verilator v5.038.