### PR TITLE
Publish snapshots

### DIFF
--- a/.github/scripts/publish.sh
+++ b/.github/scripts/publish.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Ideally Snapshots could use mill.javalib.SonatypeCentralPublishModule/ too
+# but it does not work for them on 1.0.1. It seems to publish to the wrong place.
+IS_SNAPSHOT=$(./mill show unipublish.isSnapshot)
+PLUGIN_VERSIONS=$(./mill show plugin.publishableVersions)
+PLUGIN_MODULES=$(jq -r 'map("plugin.cross[" + . + "]")' <<< "${PLUGIN_VERSIONS}")
+MODULES=$(jq -r '. + ["unipublish"]' <<< "${PLUGIN_MODULES}")
+if [[ "${IS_SNAPSHOT}" = "true" ]]; then
+  for mod in $(jq -r '.[]' <<< "$MODULES"); do
+    ./mill ${mod}.publish
+  done
+else
+  VERSION=$(./mill show unipublish.publishVersion | tr -d \")
+  BUNDLE_NAME=$(./mill show unipublish.artifactMetadata | jq -r '.group + "." + .id + "-" + .version')
+  MODULES_LIST=$(jq -r 'join(",")' <<< "${MODULES}")
+  ./mill mill.javalib.SonatypeCentralPublishModule/ \
+    --shouldRelease "false" \
+    --bundleName "$BUNDLE_NAME" \
+    --publishArtifacts "{${MODULES_LIST}}.publishArtifacts"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,7 @@ jobs:
   publish:
     needs: [all_tests_passed]
     runs-on: ubuntu-24.04
-    # Only publish on release until Mill supports publishing snapshots to Maven Central
-    # https://github.com/com-lihaoyi/mill/issues/4421
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -87,12 +85,12 @@ jobs:
         with:
           jvm: temurin:11
       - name: Publish
-        run: ./mill publish.publishAll
+        run: .github/scripts/publish.sh
         env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MILL_PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          MILL_PGP_SECRET_BASE64: ${{ secrets.PGP_SECRET }}
+          MILL_SONATYPE_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MILL_SONATYPE_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       - run: |
           VERSION=$(./mill show unipublish.publishVersion | tr -d \")
           echo "Published version: $VERSION" >> $GITHUB_STEP_SUMMARY

--- a/build.mill
+++ b/build.mill
@@ -7,11 +7,8 @@ package build
 
 import mill._
 import mill.api.{BuildCtx, Result}
-import mill.javalib.SonatypeCentralPublishModule
 import mill.scalalib._
 import mill.scalalib.scalafmt._
-import mill.scalalib.publish.{Artifact, SonatypePublisher}
-import com.lumidion.sonatype.central.client.core.{PublishingType, SonatypeCredentials}
 
 object v extends Module {
 
@@ -68,10 +65,6 @@ object v extends Module {
       )
     }
   }
-
-  // Projects that we publish to Maven
-  def publishedProjects: Seq[SonatypeCentralPublishModule] =
-    pluginScalaCrossVersions.filterNot(isScala3).map(plugin.cross(_)) ++ Seq(unipublish)
 
   val scalaVersion = scalaCrossVersions.head
   val jmhVersion = "1.37"
@@ -363,63 +356,3 @@ trait Chisel extends CrossSbtModule with HasScala2MacroAnno with HasScalaPlugin 
 }
 
 object unipublish extends Unipublish
-
-/** Tasks for publishing to Sonatype */
-object publish extends Module {
-
-  def getEnvVar(name: String) = Task.Command {
-    Task.env.get(name) match {
-      case Some(value) => Result.Success(value)
-      case None        => Result.Failure(s"Must define environment variable $name")
-    }
-  }
-
-  def sonatypeCredentials: Task[SonatypeCredentials] = Task.Anon {
-    val username = getEnvVar("MAVEN_CENTRAL_USERNAME")()
-    val password = getEnvVar("MAVEN_CENTRAL_PASSWORD")()
-    SonatypeCredentials(username, password)
-  }
-
-  def importPgp = Task.Anon {
-    val secret = getEnvVar("PGP_SECRET")()
-    os.call(
-      ("gpg", "--import", "--no-tty", "--batch", "--yes"),
-      stdin = java.util.Base64.getDecoder.decode(secret)
-    )
-  }
-
-  // We can't directly use mill.scalalib.SonatypeCentralPublishModule.publishAll because
-  // there's no easy way to programmatically pick which Modules to publish, and
-  // we don't want to publish everything.
-  // We aren't yet publishing Scala 3 cross-builds nor the CIRCT bindings.
-  def publishAll(): Command[Unit] = Task.Command {
-    val artifacts: Seq[(Seq[(os.Path, String)], Artifact)] =
-      Task.traverse(v.publishedProjects)(_.publishArtifacts)().map { case PublishModule.PublishData(a, s) =>
-        (s.map { case (p, f) => (p.path, f) }, a)
-      }
-    // unipublish is the main Chisel artifact, use it to make bundle name
-    val PublishModule.PublishData(Artifact(group, id, version), _) = unipublish.publishArtifacts()
-    val bundleName = Some(s"$group.$id-$version")
-
-    val sonatypeCreds = sonatypeCredentials()
-    // Import GPG, this is mutating the environment
-    importPgp()
-    val pgpPass = getEnvVar("PGP_PASSPHRASE")()
-    val gpgArgs = PublishModule.defaultGpgArgsForPassphrase(Some(pgpPass))
-
-    new SonatypeCentralPublisher(
-      sonatypeCreds,
-      gpgArgs,
-      readTimeout = 10 * 60 * 1000,
-      connectTimeout = 10 * 1000,
-      Task.log,
-      BuildCtx.workspaceRoot,
-      Task.env,
-      awaitTimeout = 10 * 60 * 1000
-    ).publishAll(
-      publishingType = PublishingType.USER_MANAGED, // confirm in UI
-      singleBundleName = bundleName,
-      artifacts*
-    )
-  }
-}

--- a/plugin/package.mill
+++ b/plugin/package.mill
@@ -10,6 +10,10 @@ import build._
 object `package` extends Module {
   // https://github.com/com-lihaoyi/mill/issues/3693
   object cross extends Cross[Plugin](v.pluginScalaCrossVersions)
+
+  def publishableVersions = Task {
+    v.pluginScalaCrossVersions.filter(!v.isScala3(_))
+  }
 }
 
 trait Plugin extends CrossSbtModule with ScalafmtModule with ChiselPublishModule {

--- a/release.mill
+++ b/release.mill
@@ -3,7 +3,6 @@ package build
 import mill._
 import mill.api.{BuildCtx, Result}
 import mill.javalib.SonatypeCentralPublishModule
-import mill.javalib.api.JvmWorkerUtil.matchingVersions
 import mill.scalalib._
 import mill.scalalib.scalafmt._
 import mill.scalalib.publish._
@@ -37,6 +36,9 @@ trait ChiselPublishModule extends SonatypeCentralPublishModule {
 trait Unipublish extends ScalaModule with ChiselPublishModule {
 
   def scalaVersion = v.scalaVersion
+
+  /** Is this a SNAPSHOT release?  */
+  def isSnapshot = Task { publishVersion().endsWith("-SNAPSHOT") }
 
   // This is published as chisel
   override def artifactName = "chisel"


### PR DESCRIPTION
Remove custom publishing logic, use upstream flow instead.

This involves generating the list of plugin versions we publish. Once we start publishing Scala 3 versions we can remove this logic.

I tried doing this programmatically in Mill code, if you look at the individual commits you can see how unwieldy this got and I'm not super keen on maintaining that code. I think this approach is the least bad option.

Draft PR for now so I can test the Github Actions flow.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Users can access these SNAPSHOTs using the Maven Central Snapshots repository: https://central.sonatype.com/repository/maven-snapshots/

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
