### PR TITLE
[core] Add knownLayers API to BlackBox, ExtModule

### DIFF
--- a/core/src/main/scala/chisel3/Layer.scala
+++ b/core/src/main/scala/chisel3/Layer.scala
@@ -196,6 +196,12 @@ object layer {
       Builder.layers += layer
       currentLayer = parent
     }
+
+    // If this API is used in a BlackBox, then modify it's `knownLayers` member.
+    Builder.currentModule.map {
+      case module: internal.BaseBlackBox => module.addKnownLayer(layer)
+      case _ =>
+    }
   }
 
   /** A type class that describes how to post-process the return value from a layer block. */

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -1028,7 +1028,7 @@ package experimental {
       */
     private[chisel3] def layers: Seq[Layer] = {
       require(isClosed, "Can't get layers before module is closed")
-      return _layers
+      _layers
     }
 
   }

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -10,6 +10,7 @@ import chisel3.internal._
 import chisel3.internal.binding._
 import chisel3.internal.Builder._
 import chisel3.internal.firrtl.ir._
+import chisel3.layer.Layer
 import chisel3.experimental.{requireIsChiselType, BaseModule, SourceInfo, Targetable, UnlocatableSourceInfo}
 import chisel3.properties.{Class, Property}
 import chisel3.reflect.DataMirror
@@ -953,6 +954,83 @@ package experimental {
     localModulePrefix.foreach { prefix =>
       Builder.pushModulePrefix(prefix, localModulePrefixUseSeparator)
     }
+
+    /** Hook to invoke hardware generators after the rest of the Module is constructed.
+    *
+    * This is a power-user API, and should not normally be needed.
+    *
+    * In rare cases, it is necessary to run hardware generators at a late stage, but still within the scope of the
+    * Module. In these situations, atModuleBodyEnd may be used to register such generators. For example:
+    *
+    *  {{{
+    *    class Example extends RawModule {
+    *      atModuleBodyEnd {
+    *        val extraPort0 = IO(Output(Bool()))
+    *        extraPort0 := 0.B
+    *      }
+    *    }
+    *  }}}
+    *
+    * Any generators registered with atModuleBodyEnd are the last code to execute when the Module is constructed. The
+    * execution order is:
+    *
+    *   - The constructors of any super classes or traits the Module extends
+    *   - The constructor of the Module itself
+    *   - The atModuleBodyEnd generators
+    *
+    * The atModuleBodyEnd generators execute in the lexical order they appear in the Module constructor.
+    *
+    * For example:
+    *
+    *  {{{
+    *    trait Parent {
+    *      // Executes first.
+    *      val foo = ...
+    *    }
+    *
+    *    class Example extends Parent {
+    *      // Executes second.
+    *      val bar = ...
+    *
+    *      atModuleBodyEnd {
+    *        // Executes fourth.
+    *        val qux = ...
+    *      }
+    *
+    *      atModuleBodyEnd {
+    *        // Executes fifth.
+    *        val quux = ...
+    *      }
+    *
+    *      // Executes third..
+    *      val baz = ...
+    *    }
+    *  }}}
+    *
+    * If atModuleBodyEnd is used in a Definition, any generated hardware will be included in the Definition. However, it
+    * is currently not possible to annotate any val within atModuleBodyEnd as @public.
+    */
+    protected def atModuleBodyEnd(gen: => Unit): Unit = {
+      _atModuleBodyEnd += { () => gen }
+    }
+    private val _atModuleBodyEnd = new ArrayBuffer[() => Unit]
+
+    protected[chisel3] def evaluateAtModuleBodyEnd(): Unit = _atModuleBodyEnd.foreach(_())
+
+    /** Record the layers in the circuit when this module was created. */
+    private var _layers: Seq[Layer] = null
+
+    atModuleBodyEnd { _layers = Builder.layers.toSeq }
+
+    /** Return the layers for this module after.
+      *
+      * This requires that the module is closed.
+      */
+    private[chisel3] def layers: Seq[Layer] = {
+      require(isClosed, "Can't get layers before module is closed")
+      return _layers
+    }
+
   }
 }
 

--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -1020,7 +1020,9 @@ package experimental {
     /** Record the layers in the circuit when this module was created. */
     private var _layers: Seq[Layer] = null
 
-    atModuleBodyEnd { _layers = Builder.layers.toSeq }
+    atModuleBodyEnd {
+      _layers = Builder.layers.toSeq
+    }
 
     /** Return the layers for this module after.
       *
@@ -1028,6 +1030,11 @@ package experimental {
       */
     private[chisel3] def layers: Seq[Layer] = {
       require(isClosed, "Can't get layers before module is closed")
+      if (_layers == null) {
+        throw new InternalErrorException(
+          s"a closed BaseModule '$desiredName' has null '_layers': this should be impossible"
+        )
+      }
       _layers
     }
 

--- a/core/src/main/scala/chisel3/RawModule.scala
+++ b/core/src/main/scala/chisel3/RawModule.scala
@@ -22,66 +22,6 @@ import scala.collection.mutable.ArrayBuffer
   */
 abstract class RawModule extends BaseModule {
 
-  /** Hook to invoke hardware generators after the rest of the Module is constructed.
-    *
-    * This is a power-user API, and should not normally be needed.
-    *
-    * In rare cases, it is necessary to run hardware generators at a late stage, but still within the scope of the
-    * Module. In these situations, atModuleBodyEnd may be used to register such generators. For example:
-    *
-    *  {{{
-    *    class Example extends RawModule {
-    *      atModuleBodyEnd {
-    *        val extraPort0 = IO(Output(Bool()))
-    *        extraPort0 := 0.B
-    *      }
-    *    }
-    *  }}}
-    *
-    * Any generators registered with atModuleBodyEnd are the last code to execute when the Module is constructed. The
-    * execution order is:
-    *
-    *   - The constructors of any super classes or traits the Module extends
-    *   - The constructor of the Module itself
-    *   - The atModuleBodyEnd generators
-    *
-    * The atModuleBodyEnd generators execute in the lexical order they appear in the Module constructor.
-    *
-    * For example:
-    *
-    *  {{{
-    *    trait Parent {
-    *      // Executes first.
-    *      val foo = ...
-    *    }
-    *
-    *    class Example extends Parent {
-    *      // Executes second.
-    *      val bar = ...
-    *
-    *      atModuleBodyEnd {
-    *        // Executes fourth.
-    *        val qux = ...
-    *      }
-    *
-    *      atModuleBodyEnd {
-    *        // Executes fifth.
-    *        val quux = ...
-    *      }
-    *
-    *      // Executes third..
-    *      val baz = ...
-    *    }
-    *  }}}
-    *
-    * If atModuleBodyEnd is used in a Definition, any generated hardware will be included in the Definition. However, it
-    * is currently not possible to annotate any val within atModuleBodyEnd as @public.
-    */
-  protected def atModuleBodyEnd(gen: => Unit): Unit = {
-    _atModuleBodyEnd += { () => gen }
-  }
-  private val _atModuleBodyEnd = new ArrayBuffer[() => Unit]
-
   /** Hook to invoke hardware generators after a Module has been constructed and closed.
     *
     * This is useful for running hardware generators after a Module's constructor has run and its Definition is available, while still having access to arguments and definitions in the constructor. The Module itself can no longer be modified at this point.
@@ -223,9 +163,7 @@ abstract class RawModule extends BaseModule {
     }
 
     // Evaluate any atModuleBodyEnd generators.
-    _atModuleBodyEnd.foreach { gen =>
-      gen()
-    }
+    evaluateAtModuleBodyEnd()
 
     _closed = true
 

--- a/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
+++ b/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
@@ -17,6 +17,7 @@ abstract class IntrinsicModule(intrinsicName: String, val params: Map[String, Pa
     extends BaseIntrinsicModule(intrinsicName) {
   private[chisel3] override def generateComponent(): Option[Component] = {
     require(!_closed, "Can't generate intmodule more than once")
+    evaluateAtModuleBodyEnd()
     _closed = true
 
     // Ports are named in the same way as regular Modules

--- a/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
+++ b/core/src/main/scala/chisel3/experimental/IntrinsicModule.scala
@@ -6,6 +6,7 @@ import chisel3.SpecifiedDirection
 import chisel3.experimental.{BaseModule, Param}
 import chisel3.internal.Builder.pushCommand
 import chisel3.internal.firrtl.ir._
+import chisel3.layer.Layer
 
 private[chisel3] abstract class BaseIntrinsicModule(intrinsicName: String) extends BaseModule {
   val intrinsic = intrinsicName

--- a/core/src/main/scala/chisel3/experimental/hierarchy/DefinitionClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/DefinitionClone.scala
@@ -5,6 +5,7 @@ package chisel3.experimental.hierarchy
 import chisel3.experimental.BaseModule
 import chisel3.internal.{HasId, PseudoModule}
 import chisel3.internal.firrtl.ir.{Component, Ref}
+import chisel3.layer.Layer
 
 /** Represents a Definition root module, when accessing something from a definition
   *
@@ -25,4 +26,5 @@ private[chisel3] class DefinitionClone[T <: BaseModule](val getProto: T) extends
   private[chisel3] def initializeInParent(): Unit = ()
   // Module name is the same as proto's module name
   override def desiredName: String = getProto.name
+  override def layers:      Seq[Layer] = getProto.layers
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/InstanceClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/InstanceClone.scala
@@ -5,6 +5,7 @@ package chisel3.experimental.hierarchy
 import chisel3.experimental.BaseModule
 import chisel3.internal.PseudoModule
 import chisel3.internal.firrtl.ir.{Component, Ref}
+import chisel3.layer.Layer
 
 /** Represents a module viewed from a different instance context.
   *
@@ -30,4 +31,5 @@ private[chisel3] final class InstanceClone[T <: BaseModule](val getProto: T, val
   override def instanceName = instName()
   // Module name is the same as proto's module name
   override def desiredName: String = getProto.name
+  override def layers:      Seq[Layer] = getProto.layers
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
@@ -27,6 +27,7 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si
   // Don't generate a component, but point to the one for the cloned Module
   private[chisel3] def generateComponent(): Option[Component] = {
     require(!_closed, "Can't generate module more than once")
+    evaluateAtModuleBodyEnd()
     _closed = true
     _component = getProto._component
     None

--- a/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/ModuleClone.scala
@@ -6,6 +6,7 @@ import chisel3.experimental.{BaseModule, SourceInfo}
 import chisel3.internal.{HasId, PseudoModule}
 import chisel3.internal.firrtl.ir.{Component, ModuleCloneIO, Ref}
 import chisel3.internal.{throwException, Namespace}
+import chisel3.layer.Layer
 import chisel3._
 
 // Private internal class to serve as a _parent for Data in cloned ports
@@ -77,4 +78,6 @@ private[chisel3] class ModuleClone[T <: BaseModule](val getProto: T)(implicit si
     _portsRecord.suggestName(seed)
     this
   }
+
+  override def layers: Seq[Layer] = getProto.layers
 }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -136,7 +136,14 @@ object Instance extends SourceInfoDoc {
         Port(port, port.specifiedDirection, sourceInfo): @nowarn // Deprecated code allowed for internal use
       }
       val component =
-        DefBlackBox(this, importedDefinition.proto.name, firrtlPorts, SpecifiedDirection.Unspecified, params)
+        DefBlackBox(
+          this,
+          importedDefinition.proto.name,
+          firrtlPorts,
+          SpecifiedDirection.Unspecified,
+          params,
+          importedDefinition.proto.layers
+        )
       Some(component)
     }
   }
@@ -176,6 +183,10 @@ object Instance extends SourceInfoDoc {
     val ports = experimental.CloneModuleAsRecord(definition.proto)
     val clone = ports._parent.get.asInstanceOf[ModuleClone[T]]
     clone._madeFromDefinition = true
+
+    // The definition may have known layers that are not yet known to the
+    // Builder.  Add them here.
+    definition.proto.layers.foreach(layer.addLayer)
 
     new Instance(Clone(clone))
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Instance.scala
@@ -131,6 +131,7 @@ object Instance extends SourceInfoDoc {
     override private[chisel3] def _isImportedDefinition = true
     override def generateComponent(): Option[Component] = {
       require(!_closed, s"Can't generate $desiredName module more than once")
+      evaluateAtModuleBodyEnd()
       _closed = true
       val firrtlPorts = importedDefinition.proto.getModulePortsAndLocators.map { case (port, sourceInfo) =>
         Port(port, port.specifiedDirection, sourceInfo): @nowarn // Deprecated code allowed for internal use

--- a/core/src/main/scala/chisel3/internal/Builder.scala
+++ b/core/src/main/scala/chisel3/internal/Builder.scala
@@ -1045,6 +1045,8 @@ private[chisel3] object Builder extends LazyLogging {
       // "java.lang.NoClassDefFoundError: Could not initialize class scala.util.control.NonFatal$".
       scala.util.control.NonFatal: Unit
       logger.info("Elaborating design...")
+      // Register all layers.  This will ensure that the FIRRTL produce always includes these layers.
+      chisel3.layers.defaultLayers.foreach(layer.addLayer)
       val mod =
         try {
           val m = f
@@ -1059,8 +1061,6 @@ private[chisel3] object Builder extends LazyLogging {
             errors.checkpoint(logger)
             throw e
         }
-      // Register all layers.  This will ensure that the FIRRTL produce always includes these layers.
-      chisel3.layers.defaultLayers.foreach(layer.addLayer)
       errors.checkpoint(logger)
       logger.info("Done elaborating.")
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -448,13 +448,14 @@ private[chisel3] object Converter {
         (ports ++ ctx.secretPorts).map(p => convert(p, typeAliases)),
         convert(block, ctx, typeAliases)
       )
-    case ctx @ DefBlackBox(id, name, ports, topDir, params) =>
+    case ctx @ DefBlackBox(id, name, ports, topDir, params, knownLayers) =>
       fir.ExtModule(
         convert(id._getSourceLocator),
         name,
         (ports ++ ctx.secretPorts).map(p => convert(p, typeAliases, topDir)),
         id.desiredName,
-        params.keys.toList.sorted.map { name => convert(name, params(name)) }
+        params.keys.toList.sorted.map { name => convert(name, params(name)) },
+        knownLayers.map(_.fullName)
       )
     case ctx @ DefIntrinsicModule(id, name, ports, topDir, params) =>
       fir.IntModule(

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -551,11 +551,12 @@ private[chisel3] object ir {
   ) extends Component
 
   case class DefBlackBox(
-    id:     BaseBlackBox,
-    name:   String,
-    ports:  Seq[Port],
-    topDir: SpecifiedDirection,
-    params: Map[String, Param]
+    id:          BaseBlackBox,
+    name:        String,
+    ports:       Seq[Port],
+    topDir:      SpecifiedDirection,
+    params:      Map[String, Param],
+    knownLayers: Seq[chisel3.layer.Layer]
   ) extends Component
 
   case class DefFormalTest(

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -573,9 +573,13 @@ private[chisel3] object Serializer {
         }
         Iterator(start) ++ serialize(block, ctx, typeAliases)(indent + 1)
 
-      case ctx @ DefBlackBox(id, name, ports, topDir, params) =>
+      case ctx @ DefBlackBox(id, name, ports, topDir, params, knownLayers) =>
         implicit val b = new StringBuilder
-        doIndent(0); b ++= "extmodule "; b ++= legalize(name); b ++= " :"; serialize(id._getSourceLocator)
+        doIndent(0); b ++= "extmodule "; b ++= legalize(name);
+        if (knownLayers.nonEmpty) {
+          b ++= knownLayers.map(_.fullName).mkString(" knownlayer ", ", ", "")
+        }
+        b ++= " :"; serialize(id._getSourceLocator)
         (ports ++ ctx.secretPorts).foreach { p => newLineAndIndent(1); serialize(p, typeAliases, topDir) }
         newLineAndIndent(1); b ++= "defname = "; b ++= id.desiredName
         params.keys.toList.sorted.foreach { name =>

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -26,6 +26,7 @@ class Class extends BaseModule {
     // Close the Class.
     require(!_closed, "Can't generate Class more than once")
 
+    evaluateAtModuleBodyEnd()
     _closed = true
 
     // Ports are named in the same way as regular Modules

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -10,6 +10,7 @@ import chisel3.internal.{throwException, Builder}
 import chisel3.internal.binding.{ClassBinding, OpBinding}
 import chisel3.internal.firrtl.ir.{Arg, Block, Command, Component, DefClass, DefObject, ModuleIO, Port, PropAssign}
 import chisel3.internal.firrtl.Converter
+import chisel3.layer.Layer
 
 import scala.collection.mutable.ArrayBuffer
 

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -777,8 +777,14 @@ case class Module(info: Info, name: String, public: Boolean, layers: Seq[String]
   * @param defname Defined name of the external module (ie. the name Firrtl will emit)
   */
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
-case class ExtModule(info: Info, name: String, ports: Seq[Port], defname: String, params: Seq[Param])
-    extends DefModule
+case class ExtModule(
+  info:    Info,
+  name:    String,
+  ports:   Seq[Port],
+  defname: String,
+  params:  Seq[Param],
+  layers:  Seq[String]
+) extends DefModule
     with UseSerializer
 
 /** Intrinsic Module

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -546,9 +546,13 @@ object Serializer {
         b.toString
       }
       Iterator(start) ++ sIt(body)(indent + 1)
-    case ExtModule(info, name, ports, defname, params) =>
+    case ExtModule(info, name, ports, defname, params, knownLayers) =>
       implicit val b = new StringBuilder
-      doIndent(0); b ++= "extmodule "; b ++= legalize(name); b ++= " :"; s(info)
+      doIndent(0); b ++= "extmodule "; b ++= legalize(name);
+      if (knownLayers.nonEmpty) {
+        b ++= knownLayers.mkString(" knownlayer ", ", ", "")
+      }
+      b ++= " :"; s(info)
       ports.foreach { p => newLineAndIndent(1); s(p) }
       newLineAndIndent(1); b ++= "defname = "; b ++= defname
       params.foreach { p => newLineAndIndent(1); b ++= "parameter "; s(p) }

--- a/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
+++ b/firrtl/src/test/scala/firrtlTests/ExtModuleTests.scala
@@ -10,7 +10,7 @@ class ExtModuleTests extends FirrtlFlatSpec {
     val input =
       """|FIRRTL version 5.1.0
          |circuit Top :
-         |  extmodule Top :
+         |  extmodule Top knownlayer A, B, C :
          |    input y : UInt<0>
          |    output x : UInt<1>
          |    defname = ParameterizedExtModule
@@ -35,7 +35,8 @@ class ExtModuleTests extends FirrtlFlatSpec {
             StringParam("STRING", StringLit("one")),
             DoubleParam("REAL", -1.7),
             RawStringParam("TYP", "bit")
-          )
+          ),
+          Seq("A", "B", "C")
         )
       ),
       "Top"

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -68,6 +68,7 @@ object SerializerSpec {
     "child",
     Seq(Port(NoInfo, "in", Input, UIntType(IntWidth(8))), Port(NoInfo, "out", Output, UIntType(IntWidth(8)))),
     "child",
+    Seq.empty,
     Seq.empty
   )
 
@@ -314,7 +315,7 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
       "module `42_module`"
     )
     // TODO: an external module with a numeric defname should probably be rejected
-    Serializer.serialize(ExtModule(NoInfo, "42_extmodule", Seq.empty, "<TODO>", Seq.empty)) should include(
+    Serializer.serialize(ExtModule(NoInfo, "42_extmodule", Seq.empty, "<TODO>", Seq.empty, Seq.empty)) should include(
       "extmodule `42_extmodule`"
     )
     Serializer.serialize(IntModule(NoInfo, "42_intmodule", Seq.empty, "foo", Seq.empty)) should include(

--- a/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
+++ b/src/main/scala/chisel3/stage/phases/AddDedupGroupAnnotations.scala
@@ -29,10 +29,10 @@ class AddDedupGroupAnnotations extends Phase {
     val skipAnnos = annotations.collect { case x: DedupGroupAnnotation => x.target }.toSet
 
     val annos = elaboratedCircuit._circuit.components.filter {
-      case x @ DefBlackBox(id, _, _, _, _)   => !id._isImportedDefinition
-      case DefIntrinsicModule(_, _, _, _, _) => false
-      case DefClass(_, _, _, _)              => false
-      case x                                 => true
+      case x @ DefBlackBox(id, _, _, _, _, _) => !id._isImportedDefinition
+      case DefIntrinsicModule(_, _, _, _, _)  => false
+      case DefClass(_, _, _, _)               => false
+      case x                                  => true
     }.collect {
       case x if !(skipAnnos.contains(x.id.toTarget)) => DedupGroupAnnotation(x.id.toTarget, x.id._proposedName)
     }

--- a/src/test/scala-2/chiselTests/BlackBox.scala
+++ b/src/test/scala-2/chiselTests/BlackBox.scala
@@ -399,7 +399,7 @@ class BlackBoxSpec extends AnyFlatSpec with Matchers with ChiselSim with FileChe
   they should "allow updates to knownLayers via adding layer-colored probe ports or via addLayer" in {
 
     class Bar extends BlackBox {
-      final val io = IO{
+      final val io = IO {
         new Bundle {
           val a = Output(probe.Probe(Bool(), layers.Verification))
         }
@@ -409,7 +409,7 @@ class BlackBoxSpec extends AnyFlatSpec with Matchers with ChiselSim with FileChe
     object A extends layer.Layer(layer.LayerConfig.Extract())
 
     class Baz extends BlackBox(knownLayers = Seq(A)) {
-      final val io = IO{
+      final val io = IO {
         new Bundle {
           val a = Output(probe.Probe(Bool(), layers.Verification))
         }
@@ -417,7 +417,7 @@ class BlackBoxSpec extends AnyFlatSpec with Matchers with ChiselSim with FileChe
     }
 
     class Qux extends BlackBox {
-      final val io = IO(new Bundle{})
+      final val io = IO(new Bundle {})
       layer.addLayer(A)
     }
 

--- a/src/test/scala-2/chiselTests/LayerSpec.scala
+++ b/src/test/scala-2/chiselTests/LayerSpec.scala
@@ -298,7 +298,7 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck {
 
     ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
       s"""|CHECK:      circuit Foo :
-          |CHECK-NEXT:   layer LayerWithDefaultOutputDir, bind, "LayerWithDefaultOutputDir" :
+          |CHECK:        layer LayerWithDefaultOutputDir, bind, "LayerWithDefaultOutputDir" :
           |CHECK-NEXT:     layer SublayerWithDefaultOutputDir, bind, "LayerWithDefaultOutputDir${sep}SublayerWithDefaultOutputDir" :
           |CHECK-NEXT:     layer SublayerWithCustomOutputDir, bind, "myOtherOutputDir" :
           |CHECK-NEXT:     layer SublayerWithNoOutputDir, bind :

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -539,7 +539,9 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils with T
         .getLines()
         .mkString("\n")
         .fileCheck()(
-          """|CHECK: extmodule Bar knownlayer Verification, Verification.Assert, Verification.Assume, Verification.Cover, A :
+          """|CHECK: circuit Foo :
+             |CHECK: layer A, bind
+             |CHECK: extmodule Bar knownlayer Verification, Verification.Assert, Verification.Assume, Verification.Cover, A :
              |""".stripMargin
         )
     }

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -520,10 +520,8 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils with T
 
       val testDir = implicitly[HasTestingDirectory].getDirectory.toString
 
-      val annotations = (new ChiselStage).execute(
-        Array("--target-dir", s"$testDir/Bar", "--target", "chirrtl"),
-        Seq(ChiselGeneratorAnnotation(() => new Bar))
-      )
+      val annotations =
+        ChiselStage.emitCHIRRTLFile(new Bar, Array("--target-dir", s"$testDir/Bar", "--target", "chirrtl"))
 
       val barDef = getDesignAnnotation(annotations).design.asInstanceOf[Bar].toDefinition
 


### PR DESCRIPTION
Add an API to add `knownlayer` specifications to FIRRTL `extmodule`s.
This is a mechanism to declare that an external module was compiled with
support for specific layers.  This then allows a FIRRTL comopiler compiler
to know that it should automatically enable these layers if needed.

#### Release Notes

Add `knownLayers` API to `BlackBox` and `ExternalModule`. This allows for external modules to declare that they will contain layers, e.g., that they contain debug collateral. This allows a FIRRTL compiler using them to know that they _should_ enable these layers in concert with the parent circuit.