### PR TITLE
Make `ChiselEnum` width inference consider known-width `Value()` literals

### DIFF
--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -208,8 +208,9 @@ abstract class ChiselEnum extends ChiselEnumIntf {
     def apply(): Type = ChiselEnum.this.apply()
   }
 
-  private var id:             BigInt = 0
-  private[chisel3] var width: Width = 0.W
+  private var id:                    BigInt = 0
+  private[chisel3] var width:        Width = 0.W
+  private[chisel3] var maxUserWidth: Int = 0
 
   private case class EnumRecord(inst: Type, name: String)
   private val enumRecords = mutable.ArrayBuffer.empty[EnumRecord]
@@ -244,7 +245,7 @@ abstract class ChiselEnum extends ChiselEnumIntf {
 
     enumRecords.append(EnumRecord(result, name))
 
-    width = (1.max(id.bitLength)).W
+    width = (1.max(id.bitLength).max(maxUserWidth)).W
     id += 1
 
     result
@@ -260,6 +261,9 @@ abstract class ChiselEnum extends ChiselEnumIntf {
       throwException(s"Enums must be strictly increasing: $enumTypeName")
     }
 
+    if (id.isWidthKnown) {
+      maxUserWidth = maxUserWidth.max(id.getWidth)
+    }
     this.id = id.litValue
     do_Value(name)
   }

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -308,6 +308,18 @@ class WidthTester extends Module {
   stop()
 }
 
+class KnownWidthTester extends Module {
+  object EnumWithKnownWidth extends ChiselEnum {
+    val Member0 = Value(0.U(1.W))
+    val Member1 = Value(1.U(2.W))
+    val Member2 = Value(2.U(3.W))
+    val Member3 = Value(3.U(4.W))
+  }
+  assert(EnumWithKnownWidth.getWidth == 4)
+  assert(EnumWithKnownWidth.all.forall(_.getWidth == 4))
+  stop()
+}
+
 class ChiselEnumFSMTester extends Module {
   import ChiselEnumFSM.State._
 
@@ -508,6 +520,10 @@ class ChiselEnumSpec extends AnyFlatSpec with Matchers with LogUtils with Chisel
 
   it should "return the correct widths for enums" in {
     simulate(new WidthTester)(RunUntilFinished(3))
+  }
+
+  it should "return the correct widths for enums with known-width values" in {
+    simulate(new KnownWidthTester)(RunUntilFinished(3))
   }
 
   it should "maintain Scala-level type-safety" in {


### PR DESCRIPTION
### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)

#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

The inferred width for a `ChiselEnum` using `Value()` now correctly accommodates both known-width values and the largest specified literal integer. Closes #4989.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
