### PR TITLE
Enhance coverage of PopCountTest

### DIFF
--- a/src/test/scala-2/chiselTests/PopCount.scala
+++ b/src/test/scala-2/chiselTests/PopCount.scala
@@ -36,7 +36,9 @@ class PopCountTester(n: Int) extends Module {
 }
 
 class PopCountSpec extends AnyPropSpec with PropertyUtils with ChiselSim {
-  property("PopCount circuitry should return the correct result") {
-    forAll(smallPosInts) { (n: Int) => simulate(new PopCountTester(n))(RunUntilFinished(math.pow(2, n).toInt + 2)) }
+  for (n <- 1 until 8) {
+    property(s"PopCount circuitry should return the correct result for width = $n") {
+      simulate(new PopCountTester(n))(RunUntilFinished(math.pow(2, n).toInt + 2))
+    }
   }
 }


### PR DESCRIPTION
Previously it would randomly pick widths [1, 4] and run several duplicate tests, now it tests everything in the inclusive range 1 to 7 exactly once which also takes less time.

`smallPosInts` and its use with ScalaCheck is a bit silly, we should just do more loops over parameters.

#### Type of Improvement

- Internal or build-related (includes code refactoring/cleanup)


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
