### PR TITLE
Fix construction of PseudoModules to have correct parent

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Definition.scala
@@ -51,11 +51,10 @@ final case class Definition[+A] private[chisel3] (private[chisel3] val underlyin
   /** @return the context of any Data's return from inside the instance */
   private[chisel3] def getInnerDataContext: Option[BaseModule] = proto match {
     case value: BaseModule =>
-      val newChild = Module.do_pseudo_apply(new experimental.hierarchy.DefinitionClone(value))(
+      val newChild = Module.do_pseudo_apply(new experimental.hierarchy.DefinitionClone(value), None)(
         chisel3.experimental.UnlocatableSourceInfo
       )
       newChild._circuit = value._circuit.orElse(Some(value))
-      newChild._parent = None
       Some(newChild)
     case value: IsInstantiable => None
   }

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -359,8 +359,7 @@ object Lookupable {
     // Recursive call
     def rec[A <: BaseModule](m: A): Underlying[A] = {
       def clone(x: A, p: Option[BaseModule], name: () => String): Underlying[A] = {
-        val newChild = Module.do_pseudo_apply(new experimental.hierarchy.InstanceClone(x, name))
-        newChild._parent = p
+        val newChild = Module.do_pseudo_apply(new experimental.hierarchy.InstanceClone(x, name), p)
         Clone(newChild)
       }
       (m, context) match {
@@ -386,8 +385,7 @@ object Lookupable {
         rec(m) match {
           case Proto(mx) => Clone(mx)
           case Clone(i: InstanceClone[_]) =>
-            val newChild = Module.do_pseudo_apply(new InstanceClone(m.getProto, () => m.instanceName))
-            newChild._parent = i._parent
+            val newChild = Module.do_pseudo_apply(new InstanceClone(m.getProto, () => m.instanceName), i._parent)
             Clone(newChild)
           case _ => throw new InternalErrorException(s"Match error: rec(m)=${rec(m)}")
         }
@@ -395,8 +393,7 @@ object Lookupable {
         rec(m) match {
           case Proto(mx) => Clone(mx)
           case Clone(i: InstanceClone[_]) =>
-            val newChild = Module.do_pseudo_apply(new InstanceClone(m.getProto, () => m.instanceName))
-            newChild._parent = i._parent
+            val newChild = Module.do_pseudo_apply(new InstanceClone(m.getProto, () => m.instanceName), i._parent)
             Clone(newChild)
           case _ => throw new InternalErrorException(s"Match error: rec(m)=${rec(m)}")
         }


### PR DESCRIPTION
This is mostly used when constructing PseudoModules when looking up Instances within other Instances or Definitions. Previously, we would construct the PseudoModule then manually set the _parent field. The problem with this is that _parent is used during construction of the object and defaults to Builder.currentModule. Instead, we properly set the Builder state to hold the desired _parent and then construct the PseudoModule.

This also cleaned up tech debt in Module.do_pseudo_apply which duplicated logic from the standard Module.apply path in a way that had already gotten out of sync and likely would result in other very subtle bugs.

Fixes https://github.com/chipsalliance/chisel/issues/5011

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Bugfix


#### Desired Merge Strategy


- Squash

#### Release Notes

This fixes subtle bugs where accessing children of an `Instance` (whether directly or by using `Select` APIs) could change the result of future `Select` to be incorrect. For example, a call to `Select.unsafe.allCurrentInstancesIn` could cause `Select.unsafe.currentInstancesIn` to also incorrectly include grandchildren and all other transitive children.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
