### PR TITLE
[svsim] Update c++ CFLAGS for verilator from c++14 to c++17

### DIFF
--- a/svsim/src/main/scala/verilator/Backend.scala
+++ b/svsim/src/main/scala/verilator/Backend.scala
@@ -186,7 +186,7 @@ final class Backend(executablePath: String) extends svsim.Backend {
                   Seq("-O3", "-march=native", "-mtune=native")
               },
 
-              Seq("-std=c++14"),
+              Seq("-std=c++17"),
 
               additionalHeaderPaths.map { path => s"-I${path}" },
 


### PR DESCRIPTION
Verilator 5.034 fails to compile c++ sources as it uses syntax for c++17 while the CFLAGS passed to it specify c++14.

## Testing

Before this patch I got the following error when testing my design with:
``` scala
"UartTx should send" in {
  simulate(new UartTx(8, None, StopBitsOne())) { dut => {} }
}  
```

```
[info] g++ -Os  -I. -Wall -Wextra -Wfloat-conversion -Wlogical-op -Werror -MMD -I/usr/share/verilator/include -I/usr/share/verilator/include/vltstd -DVM_COVERAGE=0 -DVM_SC=0 -DVM_TIMING=0 -DVM_TRACE=0 -DVM_TRACE_FST=0 -DVM_TRACE_VCD=0 -faligned-new -fcf-protection=none -Wno-bool-operation -Wno-shadow -Wno-sign-compare -Wno-subobject-linkage -Wno-tautological-compare -Wno-uninitialized -Wno-unused-but-set-parameter -Wno-unused-but-set-variable -Wno-unused-parameter -Wno-unused-variable    -std=c++14 -I/home/lg/programming/chisel/chuart/build/chiselsim/UartSpec/UartTx-should-send/workdir-verilator -DSVSIM_ENABLE_VERILATOR_SUPPORT   -c -o VsvsimTestbench__ALL.o VsvsimTestbench__ALL.cpp
[info] simulation-driver.cpp: In function ‘int simulation_final()’:
[info] simulation-driver.cpp:877:9: error: structured bindings only available with ‘-std=c++17’ or ‘-std=gnu++17’ [-Werror=c++17-extensions]
[info]   877 |   auto &[command, cycles] = state.outstandingCommand;
```

After this patch, the test succeeds.

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [x] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [x] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement
- Bugfix

#### Desired Merge Strategy

- Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

#### Release Notes

Verilator CFLAGS bumped from c++14 to c++17

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
