### PR TITLE
[core] Add Temporal inline layer, trait

### DIFF
--- a/core/src/main/scala/chisel3/layers/Layers.scala
+++ b/core/src/main/scala/chisel3/layers/Layers.scala
@@ -4,6 +4,30 @@ import chisel3.experimental.UnlocatableSourceInfo
 import chisel3.layer.{CustomOutputDir, Layer, LayerConfig}
 import java.nio.file.Paths
 
+/** Trait that adds a `Temporal` layer inside another layer.
+  *
+  * This temporal layer can used to guard statements which are unsupported,
+  * expensive, or otherwise needed to be excluded from normal design
+  * verification code in certain tools or environments.  E.g., this is intended
+  * to work around lack of support for certain SystemVerilog Assertions in
+  * simulators.
+  *
+  * @note While this is used to provide temporal sub-layers in Chisel's default
+  * layers, it is entirely reasonable for users to mix-in this trait into their
+  * own user-defined layers to provide similar, recognizable functionality.
+  */
+trait HasTemporalInlineLayer { this: Layer =>
+
+  /** The [chisel3.layer.Layer]] where complicated assertions that may not be
+    * supported by all tools are placed.
+      */
+  object Temporal
+      extends Layer(LayerConfig.Inline)(
+        _parent = implicitly[Layer],
+        _sourceInfo = UnlocatableSourceInfo
+      )
+}
+
 /** The root [[chisel3.layer.Layer]] for all shared verification collateral. */
 object Verification
     extends Layer(LayerConfig.Extract(CustomOutputDir(Paths.get("verification"))))(
@@ -17,6 +41,7 @@ object Verification
         _parent = implicitly[Layer],
         _sourceInfo = UnlocatableSourceInfo
       )
+      with HasTemporalInlineLayer
 
   /** The [[chisel3.layer.Layer]] where all assumptions will be placed. */
   object Assume
@@ -24,6 +49,7 @@ object Verification
         _parent = implicitly[Layer],
         _sourceInfo = UnlocatableSourceInfo
       )
+      with HasTemporalInlineLayer
 
   /** The [[chisel3.layer.Layer]] where all covers will be placed. */
   object Cover
@@ -31,4 +57,5 @@ object Verification
         _parent = implicitly[Layer],
         _sourceInfo = UnlocatableSourceInfo
       )
+      with HasTemporalInlineLayer
 }

--- a/core/src/main/scala/chisel3/layers/package.scala
+++ b/core/src/main/scala/chisel3/layers/package.scala
@@ -13,8 +13,11 @@ package object layers {
   val defaultLayers: Seq[layer.Layer] = Seq(
     Verification,
     Verification.Assert,
+    Verification.Assert.Temporal,
     Verification.Assume,
-    Verification.Cover
+    Verification.Assume.Temporal,
+    Verification.Cover,
+    Verification.Cover.Temporal
   )
 
 }

--- a/src/test/scala-2/chiselTests/LayerSpec.scala
+++ b/src/test/scala-2/chiselTests/LayerSpec.scala
@@ -482,6 +482,31 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck {
     (chirrtl should not).include("layer B")
   }
 
+  they should "include a Temporal inline layers for Assert, Assume, and Cover" in {
+    class Foo extends RawModule {
+      layer.block(layers.Verification.Assert.Temporal) {
+        val a = Wire(UInt(1.W))
+      }
+      layer.block(layers.Verification.Assume.Temporal) {
+        val a = Wire(UInt(2.W))
+      }
+      layer.block(layers.Verification.Cover.Temporal) {
+        val a = Wire(UInt(3.W))
+      }
+    }
+
+    ChiselStage.emitCHIRRTL(new Foo).fileCheck() {
+      s"""|CHECK:      layer Verification, {{.*}} :
+          |CHECK-NEXT:   layer Assert, {{.*}} :
+          |CHECK-NEXT:     layer Temporal, inline :
+          |CHECK-NEXT:   layer Assume, {{.*}} :
+          |CHECK-NEXT:     layer Temporal, inline :
+          |CHECK-NEXT:   layer Cover, {{.*}} :
+          |CHECK-NEXT:     layer Temporal, inline :
+          |""".stripMargin
+    }
+  }
+
   "Layers error checking" should "require that the current layer is an ancestor of the desired layer" in {
 
     class Foo extends RawModule {

--- a/src/test/scala-2/chiselTests/LayerSpec.scala
+++ b/src/test/scala-2/chiselTests/LayerSpec.scala
@@ -476,8 +476,11 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck with ChiselSim 
     chirrtl.fileCheck() {
       s"""|CHECK:      layer Verification, bind, "verification" :
           |CHECK-NEXT:   layer Assert, bind, "verification${sep}assert" :
+          |CHECK-NEXT:     layer Temporal, inline :
           |CHECK-NEXT:   layer Assume, bind, "verification${sep}assume" :
+          |CHECK-NEXT:     layer Temporal, inline :
           |CHECK-NEXT:   layer Cover, bind, "verification${sep}cover" :
+          |CHECK-NEXT:     layer Temporal, inline :
           |""".stripMargin
     }
 

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -541,7 +541,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils with T
         .fileCheck()(
           """|CHECK: circuit Foo :
              |CHECK: layer A, bind
-             |CHECK: extmodule Bar knownlayer Verification, Verification.Assert, Verification.Assume, Verification.Cover, A :
+             |CHECK: extmodule Bar knownlayer Verification, Verification.Assert, Verification.Assert.Temporal, Verification.Assume, Verification.Assume.Temporal, Verification.Cover, Verification.Cover.Temporal, A :
              |""".stripMargin
         )
     }


### PR DESCRIPTION
Add a new `Temporal` inline layers that are nested under each of the
builtin Assert, Assume, and Cover layers.  These layers exist because we
have observed situations where assertions which _should_ be legal in all
designs are unsupported by specific tools, though they are legal
properties by the SystemVerilog spec.

E.g., `s_eventually` is entirely unsupported by Verilator and has only
limited support in VCS.  The motivation for this PR is to have a location
where we can put these assertions and guard them off with tools that do
not support them.

Because this is expected to be problematic for all of the existing builtin
layers, this is added to each of Assert, Assume, and Cover.  Additionally,
as users have user-defined layers, the pattern of creating this `Temporal`
layer is factored into a trait, `HasTemporalInlineLayer` so that it can be
reused by others.

#### Release Notes

- Add a `Temporal` layer under each of the builtin `Assert`, `Assume`, and
  `Cover` layers.  This is intended to be used to guard complex or unsupported
  properties due to spotty simulator support.
- Add `HasTemporalInlineLayer` trait to allow users to easily add a recognizable
  `Temporal` child layer to their user-defined layers.
