### PR TITLE
[chiselsim] Allow overriding CLI options

### DIFF
--- a/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
@@ -162,6 +162,15 @@ trait HasCliOptions extends HasConfigMap { this: TestSuite =>
     options += option.name -> option
   }
 
+  final def overrideOption(option: CliOption[_]): Unit = {
+    if (!options.contains(option.name))
+      throw new Exception(
+        s"unable to override existing option with name '${option.name}' because this option was not previously defined"
+      )
+
+    options += option.name -> option
+  }
+
   final def getOption[A](name: String): Option[A] = {
     val value: Option[Any] = configMap.get(name)
     value.map(_.asInstanceOf[String]).map(options(name).convert(_)).map(_.asInstanceOf[A])


### PR DESCRIPTION
Add a new methodcalled `overrideOption` which behaves like `addOption`,
excpet it is requiring that you are overriding an existing option.  This
is intended to be used internally to allow for us to do some more
complicated overrides of the simulator options.

#### Release Notes

Add `overrideOption` method to allow ChiselSim CLIs to override an existing
option.  This is primarily used for changing the "modifications" of the
`Simulator` upstream option.
