### PR TITLE
[chiselsim] Drop Temporal layers for Verilator Cli

### DIFF
--- a/src/main/scala/chisel3/simulator/scalatest/Cli.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/Cli.scala
@@ -291,7 +291,7 @@ object Cli {
     * If `Some` then the provided default will be used.  If `None`, then a
     * simulator must be provided.
     */
-    protected def defaultCliSimulator: Option[HasSimulator] = Some(HasSimulator.default)
+    protected def defaultCliSimulator: Option[HasSimulator] = Some(HasSimulator.simulators.verilator())
 
     implicit def cliSimulator: HasSimulator = configMap.getOptional[String]("simulator") match {
       case None =>

--- a/src/main/scala/chisel3/simulator/scalatest/Cli.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/Cli.scala
@@ -38,7 +38,11 @@ object Cli {
         updateChiselOptions = (value, old) => old ++ value,
         updateFirtoolOptions = (_, a) => a,
         updateCommonSettings = (_, a) => a,
-        updateBackendSettings = (_, a) => a
+        updateBackendSettings = (_, a) => a,
+        updateUnsetChiselOptions = (a: Array[String]) => a,
+        updateUnsetFirtoolOptions = (a: Array[String]) => a,
+        updateUnsetCommonSettings = (a: CommonCompilationSettings) => a,
+        updateUnsetBackendSettings = (a: svsim.Backend.Settings) => a
       )
     )
 
@@ -209,7 +213,11 @@ object Cli {
         updateChiselOptions = (_, a) => a,
         updateFirtoolOptions = (value, old) => old ++ value,
         updateCommonSettings = (_, a) => a,
-        updateBackendSettings = (_, a) => a
+        updateBackendSettings = (_, a) => a,
+        updateUnsetChiselOptions = (a: Array[String]) => a,
+        updateUnsetFirtoolOptions = (a: Array[String]) => a,
+        updateUnsetCommonSettings = (a: CommonCompilationSettings) => a,
+        updateUnsetBackendSettings = (a: svsim.Backend.Settings) => a
       )
     )
 

--- a/src/main/scala/chisel3/simulator/scalatest/Cli.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/Cli.scala
@@ -64,12 +64,8 @@ object Cli {
       CliOption
         .flag(
           name = "emitFsdb",
-          help = "compile with FSDB waveform support and start dumping waves at time zero"
-        )
-        .copy[Unit](
-          updateChiselOptions = (_, a) => a,
-          updateFirtoolOptions = (_, a) => a,
-          updateCommonSettings = (_, options) => {
+          help = "compile with FSDB waveform support and start dumping waves at time zero",
+          updateCommonSettings = (options) => {
             options.copy(
               verilogPreprocessorDefines =
                 options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableFsdbTracingSupport),
@@ -78,7 +74,7 @@ object Cli {
               )
             )
           },
-          updateBackendSettings = (_, options) =>
+          updateBackendSettings = (options) =>
             options match {
               case options: svsim.vcs.Backend.CompilationSettings =>
                 options.copy(
@@ -114,11 +110,10 @@ object Cli {
 
     addOption(
       CliOption
-        .flag(name = "emitVcd", help = "compile with VCD waveform support and start dumping waves at time zero")
-        .copy[Unit](
-          updateChiselOptions = (_, a) => a,
-          updateFirtoolOptions = (_, a) => a,
-          updateCommonSettings = (_, options) => {
+        .flag(
+          name = "emitVcd",
+          help = "compile with VCD waveform support and start dumping waves at time zero",
+          updateCommonSettings = (options) => {
             options.copy(
               verilogPreprocessorDefines =
                 options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVcdTracingSupport),
@@ -127,7 +122,7 @@ object Cli {
               )
             )
           },
-          updateBackendSettings = (_, options) =>
+          updateBackendSettings = (options) =>
             options match {
               case options: svsim.vcs.Backend.CompilationSettings =>
                 options.copy(
@@ -166,12 +161,8 @@ object Cli {
       CliOption
         .flag(
           name = "emitVpd",
-          help = "compile with VPD waveform support and start dumping waves at time zero"
-        )
-        .copy[Unit](
-          updateChiselOptions = (_, a) => a,
-          updateFirtoolOptions = (_, a) => a,
-          updateCommonSettings = (_, options) => {
+          help = "compile with VPD waveform support and start dumping waves at time zero",
+          updateCommonSettings = (options) => {
             options.copy(
               verilogPreprocessorDefines =
                 options.verilogPreprocessorDefines :+ VerilogPreprocessorDefine(enableVpdTracingSupport),
@@ -180,7 +171,7 @@ object Cli {
               )
             )
           },
-          updateBackendSettings = (_, options) =>
+          updateBackendSettings = (options) =>
             options match {
               case options: svsim.vcs.Backend.CompilationSettings =>
                 options.copy(

--- a/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
@@ -66,13 +66,13 @@ object HasCliOptions {
 
     @deprecated("avoid use of copy", "Chisel 7.1.0")
     def copy[A](
-      name:                  String = name,
-      help:                  String = help,
-      convert:               (String) => A = convert,
-      updateChiselOptions:   (A, Array[String]) => Array[String] = updateChiselOptions,
-      updateFirtoolOptions:  (A, Array[String]) => Array[String] = updateFirtoolOptions,
-      updateCommonSettings:  (A, CommonCompilationSettings) => CommonCompilationSettings = updateCommonSettings,
-      updateBackendSettings: (A, Backend.Settings) => Backend.Settings = updateBackendSettings
+      name:                  String,
+      help:                  String,
+      convert:               (String) => A,
+      updateChiselOptions:   (A, Array[String]) => Array[String],
+      updateFirtoolOptions:  (A, Array[String]) => Array[String],
+      updateCommonSettings:  (A, CommonCompilationSettings) => CommonCompilationSettings,
+      updateBackendSettings: (A, Backend.Settings) => Backend.Settings
     ): CliOption[A] = CliOption[A](
       name = name,
       help = help,

--- a/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
@@ -45,6 +45,7 @@ object HasCliOptions {
 
   object CliOption {
 
+    @deprecated("Use newer CliOption case class apply", "Chisel 7.1.0")
     def apply[A](
       name:                  String,
       help:                  String,
@@ -68,6 +69,30 @@ object HasCliOptions {
         updateUnsetBackendSettings = identity
       )
     }
+
+    @deprecated("Use newer CliOption case class unapply", "Chisel 7.1.0")
+    def unapply[A](cliOption: CliOption[A]): Option[
+      (
+        String,
+        String,
+        (String) => A,
+        (A, Array[String]) => Array[String],
+        (A, Array[String]) => Array[String],
+        (A, CommonCompilationSettings) => CommonCompilationSettings,
+        (A, Backend.Settings) => Backend.Settings
+      )
+    ] =
+      Some(
+        (
+          cliOption.name,
+          cliOption.help,
+          cliOption.convert,
+          cliOption.updateChiselOptions,
+          cliOption.updateFirtoolOptions,
+          cliOption.updateCommonSettings,
+          cliOption.updateBackendSettings
+        )
+      )
 
     /** A simple command line option which does not affect common or backend settings.
       *

--- a/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
+++ b/src/main/scala/chisel3/simulator/scalatest/HasCliOptions.scala
@@ -41,11 +41,56 @@ object HasCliOptions {
     updateUnsetFirtoolOptions:  (Array[String]) => Array[String],
     updateUnsetCommonSettings:  (CommonCompilationSettings) => CommonCompilationSettings,
     updateUnsetBackendSettings: (Backend.Settings) => Backend.Settings
-  )
+  ) {
+    def this(
+      name:                  String,
+      help:                  String,
+      convert:               (String) => A,
+      updateChiselOptions:   (A, Array[String]) => Array[String],
+      updateFirtoolOptions:  (A, Array[String]) => Array[String],
+      updateCommonSettings:  (A, CommonCompilationSettings) => CommonCompilationSettings,
+      updateBackendSettings: (A, Backend.Settings) => Backend.Settings
+    ) = this(
+      name,
+      help,
+      convert,
+      updateChiselOptions,
+      updateFirtoolOptions,
+      updateCommonSettings,
+      updateBackendSettings,
+      identity,
+      identity,
+      identity,
+      identity
+    )
+
+    @deprecated("avoid use of copy", "Chisel 7.1.0")
+    def copy[A](
+      name:                  String = name,
+      help:                  String = help,
+      convert:               (String) => A = convert,
+      updateChiselOptions:   (A, Array[String]) => Array[String] = updateChiselOptions,
+      updateFirtoolOptions:  (A, Array[String]) => Array[String] = updateFirtoolOptions,
+      updateCommonSettings:  (A, CommonCompilationSettings) => CommonCompilationSettings = updateCommonSettings,
+      updateBackendSettings: (A, Backend.Settings) => Backend.Settings = updateBackendSettings
+    ): CliOption[A] = CliOption[A](
+      name = name,
+      help = help,
+      convert = convert,
+      updateChiselOptions = updateChiselOptions,
+      updateFirtoolOptions = updateFirtoolOptions,
+      updateCommonSettings = updateCommonSettings,
+      updateBackendSettings = updateBackendSettings,
+      updateUnsetChiselOptions = updateUnsetChiselOptions,
+      updateUnsetFirtoolOptions = updateUnsetFirtoolOptions,
+      updateUnsetCommonSettings = updateUnsetCommonSettings,
+      updateUnsetBackendSettings = updateUnsetBackendSettings
+    )
+  }
 
   object CliOption {
 
-    @deprecated("Use newer CliOption case class apply", "Chisel 7.1.0")
+    @deprecated("use newer CliOption case class apply", "Chisel 7.1.0")
     def apply[A](
       name:                  String,
       help:                  String,
@@ -70,7 +115,7 @@ object HasCliOptions {
       )
     }
 
-    @deprecated("Use newer CliOption case class unapply", "Chisel 7.1.0")
+    @deprecated("avoid use of unapply", "Chisel 7.1.0")
     def unapply[A](cliOption: CliOption[A]): Option[
       (
         String,
@@ -186,7 +231,18 @@ object HasCliOptions {
       * @param name the name of the option
       * @param help help text to show to tell the user how to use this option
       */
-    def flag(name: String, help: String): CliOption[Unit] = simple[Unit](
+    def flag(
+      name:                       String,
+      help:                       String,
+      updateChiselOptions:        (Array[String]) => Array[String] = identity,
+      updateFirtoolOptions:       (Array[String]) => Array[String] = identity,
+      updateCommonSettings:       (CommonCompilationSettings) => CommonCompilationSettings = identity,
+      updateBackendSettings:      (Backend.Settings) => Backend.Settings = identity,
+      updateUnsetChiselOptions:   (Array[String]) => Array[String] = identity,
+      updateUnsetFirtoolOptions:  (Array[String]) => Array[String] = identity,
+      updateUnsetCommonSettings:  (CommonCompilationSettings) => CommonCompilationSettings = identity,
+      updateUnsetBackendSettings: (Backend.Settings) => Backend.Settings = identity
+    ): CliOption[Unit] = CliOption[Unit](
       name = name,
       help = help,
       convert = value => {
@@ -198,7 +254,15 @@ object HasCliOptions {
               s"""invalid argument '$value' for option '$name', must be one of ${trueValue.mkString("[", ", ", "]")}"""
             ) with NoStackTrace
         }
-      }
+      },
+      updateChiselOptions = (_, a) => updateChiselOptions(a),
+      updateFirtoolOptions = (_, a) => updateFirtoolOptions(a),
+      updateCommonSettings = (_, a) => updateCommonSettings(a),
+      updateBackendSettings = (_, a) => updateBackendSettings(a),
+      updateUnsetChiselOptions = updateUnsetChiselOptions,
+      updateUnsetFirtoolOptions = updateUnsetFirtoolOptions,
+      updateUnsetCommonSettings = updateUnsetCommonSettings,
+      updateUnsetBackendSettings = updateUnsetBackendSettings
     )
   }
 

--- a/src/test/scala-2/chiselTests/simulator/scalatest/HasCliOptionsSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/HasCliOptionsSpec.scala
@@ -41,7 +41,7 @@ class HasCliOptionsSpecVerilatorTemporalLayers extends AnyFlatSpec with ChiselSi
       layer.block(layers.Verification.Assert.Temporal) {
         AssertProperty(a.eventually)
       }
-      when (Counter(true.B, 2)._2) {
+      when(Counter(true.B, 2)._2) {
         stop()
       }
     }

--- a/src/test/scala-2/chiselTests/simulator/scalatest/HasCliOptionsSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/HasCliOptionsSpec.scala
@@ -2,9 +2,14 @@
 
 package chiselTests.simulator.scalatest
 
+import chisel3._
+import chisel3.ltl.AssertProperty
+import chisel3.ltl.Sequence.BoolSequence
 import chisel3.simulator.HasSimulator
-import chisel3.simulator.scalatest.{Cli, HasCliOptions}
+import chisel3.simulator.scalatest.{ChiselSim, Cli, HasCliOptions}
+import chisel3.simulator.stimulus.RunUntilFinished
 import chisel3.testing.scalatest.HasConfigMap
+import chisel3.util.Counter
 import org.scalatest.TestSuite
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -20,6 +25,31 @@ class HasCliOptionsSpec extends AnyFlatSpec with Matchers with HasCliOptions wit
     intercept[IllegalArgumentException] {
       implicitly[HasSimulator]
     }.getMessage should include("a simulator must be provided to this test using '-Dsimulator=<simulator-name>'")
+
+  }
+
+}
+
+class HasCliOptionsSpecVerilatorTemporalLayers extends AnyFlatSpec with ChiselSim with Cli.Simulator {
+
+  behavior of "Simulator CLI"
+
+  it should "disable temporal layers automatically for Verilator" in {
+
+    class Foo extends Module {
+      val a = IO(Input(Bool()))
+      layer.block(layers.Verification.Assert.Temporal) {
+        AssertProperty(a.eventually)
+      }
+      when (Counter(true.B, 2)._2) {
+        stop()
+      }
+    }
+
+    simulate(new Foo) { foo =>
+      foo.a.poke(true.B)
+      RunUntilFinished(4)
+    }
 
   }
 


### PR DESCRIPTION
Disable Temporal layers (either internal or those that use the
`HasTemporalInlineLayer` trait) when use ChiselSim with Verilator via the
`Cli.Simulator` trait.

This required adding a number of additional functions to the `CliOption` class
that can be used to control what happens when an option is _not_ set.  This was
a big hole in this API as it created a discontinuity between arguments like
`-Dsimulator=verilator` which would run settings modification functions and the
absence of any simulator being specified which would _not_ run any settings
modifications.  If the settings modifications were non-identity, then this was
incongruous.

Closes #5023.

#### Release Notes

Disable Temporal layers (either internal or those that use the
`HasTemporalInlineLayer` trait) when use ChiselSim with Verilator via the
`Cli.Simulator` trait.