### PR TITLE
Overload Stage methods to use Seq[Annotation]

### DIFF
--- a/firrtl/src/main/scala/firrtl/options/Stage.scala
+++ b/firrtl/src/main/scala/firrtl/options/Stage.scala
@@ -2,7 +2,8 @@
 
 package firrtl.options
 
-import firrtl.{seqToAnnoSeq, AnnotationSeq}
+import firrtl.{annoSeqToSeq, seqToAnnoSeq, AnnotationSeq}
+import firrtl.annotations.Annotation
 
 import logger.Logger
 
@@ -31,7 +32,17 @@ abstract class Stage extends Phase {
     * @return output annotations
     * @throws firrtl.options.OptionsException if command line or annotation validation fails
     */
+  @deprecated("Use the form that taks Seq[Annotation]", "Chisel 7.1.0")
   final def transform(annotations: AnnotationSeq): AnnotationSeq = {
+    seqToAnnoSeq(transform(annotations.toSeq))
+  }
+
+  /** Execute this stage on some input annotations. Annotations will be read from any input annotation files.
+    * @param annotations input annotations
+    * @return output annotations
+    * @throws firrtl.options.OptionsException if command line or annotation validation fails
+    */
+  final def transform(annotations: Seq[Annotation]): Seq[Annotation] = {
     val annotationsx =
       Seq(new phases.GetIncludes)
         .foldLeft(annotations)((a, p) => p.transform(a))
@@ -53,9 +64,18 @@ abstract class Stage extends Phase {
     * @return output annotations
     * @throws firrtl.options.OptionsException if command line or annotation validation fails
     */
+  @deprecated("Use the form that taks Seq[Annotation]", "Chisel 7.1.0")
   final def execute(args: Array[String], annotations: AnnotationSeq): AnnotationSeq =
-    transform(shell.parse(args, annotations))
+    seqToAnnoSeq(execute(args, annotations.toSeq))
 
+  /** Run this stage on on a mix of arguments and annotations
+    * @param args command line arguments
+    * @param initialAnnotations annotation
+    * @return output annotations
+    * @throws firrtl.options.OptionsException if command line or annotation validation fails
+    */
+  final def execute(args: Array[String], annotations: Seq[Annotation]): Seq[Annotation] =
+    transform(shell.parse(args, annotations))
 }
 
 /** Provides a main method for a [[Stage]]


### PR DESCRIPTION


Fixes https://github.com/chipsalliance/chisel/issues/5022

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement


- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

Also deprecate the older forms using AnnotationSeq.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
