### PR TITLE
Rename private[chisel3] SourceInfo$Intf to SourceInfoIntf

### DIFF
--- a/core/src/main/scala-2/chisel3/experimental/SourceInfoIntf.scala
+++ b/core/src/main/scala-2/chisel3/experimental/SourceInfoIntf.scala
@@ -18,6 +18,8 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 import chisel3.internal.sourceinfo.SourceInfoMacro
 
-private[chisel3] trait SourceInfo$Intf { self: SourceInfo.type =>
+// Technically this should be called "SourceInfo$Intf" but that causes issues for IntelliJ so we
+// omit the '$'.
+private[chisel3] trait SourceInfoIntf { self: SourceInfo.type =>
   implicit def materialize: SourceInfo = macro SourceInfoMacro.generate_source_info
 }

--- a/core/src/main/scala-2/chisel3/experimental/SourceInfoIntf.scala
+++ b/core/src/main/scala-2/chisel3/experimental/SourceInfoIntf.scala
@@ -18,8 +18,11 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 import chisel3.internal.sourceinfo.SourceInfoMacro
 
+// Kept for binary compatibility, probably could be waived instead but just in case.
+private[chisel3] trait SourceInfo$Intf
+
 // Technically this should be called "SourceInfo$Intf" but that causes issues for IntelliJ so we
 // omit the '$'.
-private[chisel3] trait SourceInfoIntf { self: SourceInfo.type =>
+private[chisel3] trait SourceInfoIntf extends SourceInfo$Intf { self: SourceInfo.type =>
   implicit def materialize: SourceInfo = macro SourceInfoMacro.generate_source_info
 }

--- a/core/src/main/scala-3/chisel3/experimental/SourceInfoIntf.scala
+++ b/core/src/main/scala-3/chisel3/experimental/SourceInfoIntf.scala
@@ -14,6 +14,8 @@
 
 package chisel3.experimental
 
-private[chisel3] trait SourceInfo$Intf { self: SourceInfo.type =>
+// Technically this should be called "SourceInfo$Intf" but that causes issues for IntelliJ so we
+// omit the '$'.
+private[chisel3] trait SourceInfoIntf { self: SourceInfo.type =>
   implicit def materialize: SourceInfo = UnlocatableSourceInfo
 }

--- a/core/src/main/scala/chisel3/experimental/SourceInfo.scala
+++ b/core/src/main/scala/chisel3/experimental/SourceInfo.scala
@@ -50,7 +50,7 @@ case class SourceLine(filename: String, line: Int, col: Int) extends SourceInfo 
   }
 }
 
-object SourceInfo extends SourceInfo$Intf {
+object SourceInfo extends SourceInfoIntf {
 
   /** Returns the best guess at the first stack frame that belongs to user code.
     */


### PR DESCRIPTION


It turns out there was a really easy solution: https://youtrack.jetbrains.com/issue/SCL-24377/Incorrect-No-implicits-found-for-code-using-Chisel-v7.0.0#focus=Comments-27-12709369.0-0

Fixes https://github.com/chipsalliance/chisel/issues/4929

### Contributor Checklist

- [x] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Bugfix


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

This works around an issue in IntelliJ around using the macro to materialize SourceInfo.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
