### PR TITLE
ChiselEnum convenience functions; support string interaction

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -30,3 +30,4 @@ newlines.sometimesBeforeColonInMethodReturnType = true
 optIn.annotationNewlines = true
 
 rewrite.rules = [SortImports, PreferCurlyFors, AvoidInfix]
+rewrite.avoidInfix.excludeFilters."+" = ["nameContains"]

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -30,4 +30,3 @@ newlines.sometimesBeforeColonInMethodReturnType = true
 optIn.annotationNewlines = true
 
 rewrite.rules = [SortImports, PreferCurlyFors, AvoidInfix]
-rewrite.avoidInfix.excludeFilters."+" = ["nameContains"]

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -282,6 +282,11 @@ abstract class ChiselEnum extends ChiselEnumIntf {
 
   def apply(): Type = new Type
 
+  /** Return the Enum value of which the name exactly matches the specified String. If @name does not match a valid Enum, fail */
+  def apply(name: String): Type =
+    allWithNames.collectFirst { case (enumValue, enumName) if enumName == name => enumValue }
+      .getOrElse(throwException(s"Enum value $name is not defined"))
+
   private def castImpl(
     n:    UInt,
     warn: Boolean

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -248,8 +248,12 @@ abstract class ChiselEnum extends ChiselEnumIntf {
   /** All Enum values with their names */
   def allWithNames: Seq[(Type, String)] = all.zip(allNames)
 
-  /** All Enum values with their names, printed one per line. Compatible with gtkwave filter file */
-  override def toString(): String = allWithNames.map(e => s"${e._1.litValue} ${e._2}").mkString("", "\n", "\n")
+  /** Print Enum type name, followed by with all Enum values with their names to a string like this:
+   *  `Opcodes(add=0, sub=1, mul=2, div=3)`
+   */
+  override def toString: String =
+    getClass.getSimpleName.init +
+      allWithNames.map(e => s"${e._2}=${e._1.litValue}").mkString("(", ", ", ")")
 
   private[chisel3] def nameOfValue(id: BigInt): Option[String] = {
     enumRecords.find(_.inst.litValue == id).map(_.name)

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -125,7 +125,7 @@ abstract class EnumType(private[chisel3] val factory: ChiselEnum) extends Elemen
     *
     * @param s the substring to search for in the Enum value's name
     */
-  def contains(s: String)(implicit sourceInfo: SourceInfo): Bool =
+  def nameContains(s: String)(implicit sourceInfo: SourceInfo): Bool =
     isOneOf(factory.allWithNames.filter(m => m._2 contains s).map(m => m._1))
 
   def next(implicit sourceInfo: SourceInfo): this.type = {

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -118,6 +118,13 @@ abstract class EnumType(private[chisel3] val factory: ChiselEnum) extends Elemen
     implicit sourceInfo: SourceInfo
   ): Bool = isOneOf(u1 +: u2.toSeq)
 
+  /** Creates circuitry that outputs True iff the Enum is equal to one of the values that has `s` in its name
+    *
+    * @param s the substring to search for in the Enum value's name
+    */
+  def contains(s: String)(implicit sourceInfo: SourceInfo): Bool =
+    isOneOf(factory.allWithNames.filter(m => m._2 contains s).map(m => m._1))
+
   def next(implicit sourceInfo: SourceInfo): this.type = {
     if (litOption.isDefined) {
       val index = factory.all.indexOf(this)

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -255,6 +255,13 @@ abstract class ChiselEnum extends ChiselEnumIntf {
     getClass.getSimpleName.init +
       allWithNames.map(e => s"${e._2}=${e._1.litValue}").mkString("(", ", ", ")")
 
+  /** Return all Enum (value, name) combinations in a string, one per line.
+   *  Intended for parsing by external tools, e.g. sim environment, or as gtkwave text filter
+   */
+  def asTable: String =
+    "# " + getClass.getSimpleName.init + "\n" + // comment line, ignored by gtkwave
+      allWithNames.map(e => s"${e._1.litValue} ${e._2}").mkString("", "\n", "\n")
+
   private[chisel3] def nameOfValue(id: BigInt): Option[String] = {
     enumRecords.find(_.inst.litValue == id).map(_.name)
   }

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -229,9 +229,14 @@ abstract class ChiselEnum extends ChiselEnumIntf {
 
   def getWidth: Int = width.get
 
+  /** All Enum values */
   def all: Seq[Type] = enumInstances
-  /* Accessor for Seq of names in enumRecords */
+
+  /** All Enum names */
   def allNames: Seq[String] = enumNames
+
+  /** All Enum values with their names */
+  def allWithNames: Seq[(Type, String)] = all.zip(allNames)
 
   private[chisel3] def nameOfValue(id: BigInt): Option[String] = {
     enumRecords.find(_.inst.litValue == id).map(_.name)

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -245,6 +245,9 @@ abstract class ChiselEnum extends ChiselEnumIntf {
   /** All Enum values with their names */
   def allWithNames: Seq[(Type, String)] = all.zip(allNames)
 
+  /** All Enum values with their names, printed one per line. Compatible with gtkwave filter file */
+  override def toString(): String = allWithNames.map(e => s"${e._1.litValue} ${e._2}").mkString("", "\n", "\n")
+
   private[chisel3] def nameOfValue(id: BigInt): Option[String] = {
     enumRecords.find(_.inst.litValue == id).map(_.name)
   }

--- a/core/src/main/scala/chisel3/ChiselEnum.scala
+++ b/core/src/main/scala/chisel3/ChiselEnum.scala
@@ -102,7 +102,10 @@ abstract class EnumType(private[chisel3] val factory: ChiselEnum) extends Elemen
     * @return a hardware [[Bool]] that indicates if this value matches any of the given values
     */
   final def isOneOf(s: Seq[EnumType])(implicit sourceInfo: SourceInfo): Bool = {
-    VecInit(s.map(this === _)).asUInt.orR
+    s.length match {
+      case 0 => false.B
+      case _ => VecInit(s.map(this === _)).asUInt.orR
+    }
   }
 
   /** Test if this enumeration is equal to any of the values given as arguments

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -394,16 +394,16 @@ class IsOneOfTester extends Module {
   assert(!e0.isOneOf(e1))
   assert(!e2.isOneOf(e101))
 
-  // contains-a-string method
-  assert(e100 contains "10")
-  assert(e101 contains "10")
-  assert(!(e0 contains "e1"))
-  assert(!(e0 contains "noMatchAnywhere"))
+  // enum-name-contains-a-string method
+  assert(e100 nameContains "10")
+  assert(e101 nameContains "10")
+  assert(!(e0 nameContains "e1"))
+  assert(!(e0 nameContains "noMatchAnywhere"))
 
   // every enum value contains the empty string
-  assert(EnumExample.all.map(_ contains "").reduce(_ && _))
+  assert(EnumExample.all.map(_ nameContains "").reduce(_ && _))
   // every enum value contains its own full name
-  assert(EnumExample.allWithNames.map(m => m._1 contains m._2).reduce(_ && _))
+  assert(EnumExample.allWithNames.map(m => m._1 nameContains m._2).reduce(_ && _))
 
   // check enum value specified as string
   assert(OtherEnum.otherEnum == OtherEnum("otherEnum"))

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -575,6 +575,10 @@ class ChiselEnumSpec extends AnyFlatSpec with Matchers with LogUtils with Chisel
     "object UnnamedEnum extends ChiselEnum { Value }" shouldNot compile
   }
 
+  it should "dump enum name=value pairs as string" in {
+    s"$EnumExample" should be("EnumExample(e0=0, e1=1, e2=2, e100=100, e101=101)")
+  }
+
   "ChiselEnum FSM" should "work" in {
     simulate(new ChiselEnumFSMTester)(RunUntilFinished(11))
   }

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -395,15 +395,15 @@ class IsOneOfTester extends Module {
   assert(!e2.isOneOf(e101))
 
   // enum-name-contains-a-string method
-  assert(e100 nameContains "10")
-  assert(e101 nameContains "10")
-  assert(!(e0 nameContains "e1"))
-  assert(!(e0 nameContains "noMatchAnywhere"))
+  assert(e100.nameContains("10"))
+  assert(e101.nameContains("10"))
+  assert(!(e0.nameContains("e1")))
+  assert(!(e0.nameContains("noMatchAnywhere")))
 
   // every enum value contains the empty string
-  assert(EnumExample.all.map(_ nameContains "").reduce(_ && _))
+  assert(EnumExample.all.map(_.nameContains("")).reduce(_ && _))
   // every enum value contains its own full name
-  assert(EnumExample.allWithNames.map(m => m._1 nameContains m._2).reduce(_ && _))
+  assert(EnumExample.allWithNames.map(m => m._1.nameContains(m._2)).reduce(_ && _))
 
   // check enum value specified as string
   assert(OtherEnum.otherEnum == OtherEnum("otherEnum"))

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -579,6 +579,16 @@ class ChiselEnumSpec extends AnyFlatSpec with Matchers with LogUtils with Chisel
     s"$EnumExample" should be("EnumExample(e0=0, e1=1, e2=2, e100=100, e101=101)")
   }
 
+  it should "dump enum mappings as machine-readable table, usable by gtkwave as plaintext filter" in {
+    EnumExample.asTable should be("""# EnumExample
+                                    |0 e0
+                                    |1 e1
+                                    |2 e2
+                                    |100 e100
+                                    |101 e101
+                                    |""".stripMargin)
+  }
+
   "ChiselEnum FSM" should "work" in {
     simulate(new ChiselEnumFSMTester)(RunUntilFinished(11))
   }

--- a/src/test/scala-2/chiselTests/ChiselEnum.scala
+++ b/src/test/scala-2/chiselTests/ChiselEnum.scala
@@ -68,6 +68,16 @@ class CastFromLit(in: UInt) extends Module {
   io.valid := io.out.isValid
 }
 
+class CastFromStringLit(in: String) extends Module {
+  val io = IO(new Bundle {
+    val out = Output(EnumExample())
+    val valid = Output(Bool())
+  })
+
+  io.out := EnumExample(in)
+  io.valid := io.out.isValid
+}
+
 class CastFromNonLit extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(EnumExample.getWidth.W))
@@ -204,6 +214,11 @@ class CastFromLitTester extends Module {
     assert(mod.io.out === enumVal)
     assert(mod.io.valid === true.B)
   }
+  for ((enumVal, enumName) <- EnumExample.allWithNames) {
+    val mod = Module(new CastFromStringLit(enumName))
+    assert(mod.io.out === enumVal)
+    assert(mod.io.valid === true.B)
+  }
   stop()
 }
 
@@ -252,6 +267,10 @@ class SafeCastFromNonLitTester extends Module {
 class CastToInvalidEnumTester extends Module {
   val invalid_value: UInt = EnumExample.litValues.last + 1.U
   Module(new CastFromLit(invalid_value))
+}
+
+class CastStringToInvalidEnumTester extends Module {
+  Module(new CastFromStringLit("nonExistingEnumValue"))
 }
 
 class EnumOpsTester extends Module {
@@ -375,6 +394,22 @@ class IsOneOfTester extends Module {
   assert(!e0.isOneOf(e1))
   assert(!e2.isOneOf(e101))
 
+  // contains-a-string method
+  assert(e100 contains "10")
+  assert(e101 contains "10")
+  assert(!(e0 contains "e1"))
+  assert(!(e0 contains "noMatchAnywhere"))
+
+  // every enum value contains the empty string
+  assert(EnumExample.all.map(_ contains "").reduce(_ && _))
+  // every enum value contains its own full name
+  assert(EnumExample.allWithNames.map(m => m._1 contains m._2).reduce(_ && _))
+
+  // check enum value specified as string
+  assert(OtherEnum.otherEnum == OtherEnum("otherEnum"))
+  assert(OtherEnum.otherEnum === OtherEnum("otherEnum"))
+  assert(EnumExample.allWithNames.map(m => EnumExample(m._2) === m._1).reduce(_ && _))
+
   stop()
 }
 
@@ -467,7 +502,7 @@ class ChiselEnumSpec extends AnyFlatSpec with Matchers with LogUtils with Chisel
     verilog should include("assign out3 = 8'h81;")
   }
 
-  it should "cast literal UInts to enums correctly" in {
+  it should "cast literal UInts and Strings to enums correctly" in {
     simulate(new CastFromLitTester)(RunUntilFinished(3))
   }
 
@@ -482,6 +517,9 @@ class ChiselEnumSpec extends AnyFlatSpec with Matchers with LogUtils with Chisel
   it should "prevent illegal literal casts to enums" in {
     intercept[ChiselException] {
       ChiselStage.emitCHIRRTL(new CastToInvalidEnumTester)
+    }
+    intercept[ChiselException] {
+      ChiselStage.emitCHIRRTL(new CastStringToInvalidEnumTester)
     }
   }
 


### PR DESCRIPTION
### Contributor Checklist

- [X] Did you add Scaladoc to every public function/method?
- [X] Did you add at least one test demonstrating the PR?
- [X] Did you delete any extraneous printlns/debugging code?
- [X] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`?
- [X] Did you request a desired merge strategy?
- [X] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

<!-- Choose one or more from the following (delete those that do not apply): -->
- Feature (or new API)
- API modification: yes, I propose to override the `toString` method on `ChiselEnum`. I wonder if anybody out there depends on the current behavior. If so, we could rename to `listValues`

#### Desired Merge Strategy

- Squash: The PR will be squashed and merged (choose this if you have no preference).

#### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Convenience functions to interact between ChiselEnum and String. Allows RTL readability improvements, especially if Enum values are not yet known at compile time (e.g. decode tables in separate files)

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
