### PR TITLE
[test] Make ChiselSim log test robust to Verilator

### DIFF
--- a/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
+++ b/src/test/scala-2/chiselTests/simulator/scalatest/ChiselSimSpec.scala
@@ -82,7 +82,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
            |CHECK:      lineNo  line
            |CHECK-NEXT: ---
-           |CHECK-NEXT:      0  [30] %Error:
+           |CHECK-NEXT:      0  [{{[0-9]+}}] %Error:
            |CHECK:      For more information, see the complete log file:
            |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-a-chisel3.assert-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---
@@ -107,7 +107,7 @@ class ChiselSimSpec extends AnyFunSpec with Matchers with ChiselSim with FileChe
            |CHECK-NEXT: The following assertion failures were extracted from the log file:
            |CHECK:      lineNo  line
            |CHECK-NEXT: ---
-           |CHECK-NEXT:      0  [30] %Error:
+           |CHECK-NEXT:      0  [{{[0-9]+}}] %Error:
            |CHECK:      For more information, see the complete log file:
            |CHECK:        build/chiselsim/ChiselSimSpec/scalatest.ChiselSim/should-error-if-an-ltl.AssertProperty-fires-during-the-simulation/workdir-verilator/simulation-log.txt
            |CHECK-NEXT: ---


### PR DESCRIPTION
Fix a problem that could cause a failing test based on the Verilator
version.  Prior to Verilator 5.036, this test would report the assertion
at time 30.  After 5.036, this will report as time 40.  Just make the test
robust to accept any time here as the actual time isn't terribly
important.
