### PR TITLE
Bump to Scala 2.13.17

### DIFF
--- a/.github/scripts/chisel-example.scala
+++ b/.github/scripts/chisel-example.scala
@@ -1,5 +1,5 @@
 //> using repository https://central.sonatype.com/repository/maven-snapshots
-//> using scala 2.13.16
+//> using scala 2.13.17
 //> using dep org.chipsalliance::chisel:@VERSION@
 //> using plugin org.chipsalliance:::chisel-plugin:@VERSION@
 //> using options -unchecked -deprecation -language:reflectiveCalls -feature -Xcheckinit

--- a/.github/workflows/ci-circt-nightly.yml
+++ b/.github/workflows/ci-circt-nightly.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         system: ["ubuntu-24.04"]
         jvm: [21]
-        scala: ["2.13.16"]
+        scala: ["2.13.17"]
         espresso: ["2.4"]
         slang: ["7.0"]
         circt: ["nightly"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         system: ["ubuntu-24.04"]
         jvm: [21]
-        scala: ["2.13.16"]
+        scala: ["2.13.17"]
         espresso: ["2.4"]
         slang: ["7.0"]
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
         type: number
       scala:
         description: 'The Scala version to use'
-        default: '2.13.16'
+        default: '2.13.17'
         required: true
         type: string
       espresso:
@@ -219,7 +219,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        scala: ["2.13.16"]
+        scala: ["2.13.17"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Most testing can be done on just the Chisel build unit:
 ```
 
 The `[]` exists because we are cross-compiling between Scala 2.13 and Scala 3.
-You can pick a specific version, e.g. `./mill chisel[2.13.16]`.
+You can pick a specific version, e.g. `./mill chisel[2.13.17]`.
 Using `[]` will pick the first version in the list of supported versions which one can think about as the "default" version.
 
 You can test everything with:

--- a/build.mill
+++ b/build.mill
@@ -108,7 +108,10 @@ object v extends Module {
     "cat=deprecation&msg=Use of @instantiable on user-defined types is deprecated:s",
     // FirtoolResolver uses package shading which causes issues with metadata for inlining.
     // We don't want to inline from it anyway so just suppress the warning.
-    "msg=reading InlineInfoAttribute from firtoolresolver:s"
+    "msg=reading InlineInfoAttribute from firtoolresolver:s",
+    // Scala 2.13.17 adds warning for inferred structural types but this is not
+    // a problem because in Scala 3 we use Selectable.
+    "msg=will no longer have a structural type:s"
   )
 
   // ScalacOptions

--- a/build.mill
+++ b/build.mill
@@ -32,7 +32,7 @@ object v extends Module {
   // Only publish plugin for 2.13.11+ when using Java > 11, but still
   // publish all versions when Java version <= 11.
   val pluginScalaCrossVersions = {
-    val latest213 = 16
+    val latest213 = 17
     val java21Min213 = 11
     val minVersion = if (javaVersion > 11) java21Min213 else 0
     val versions = minVersion to latest213
@@ -41,7 +41,7 @@ object v extends Module {
   }
 
   val scalaCrossVersions = Seq(
-    "2.13.16",
+    "2.13.17",
     "3.3.4"
   )
 

--- a/docs/src/cookbooks/testing.md
+++ b/docs/src/cookbooks/testing.md
@@ -33,7 +33,7 @@ class FooSpec extends FunSpec with ChiselSim {
 If using Scalatest and ChiselSim, pass the `-DemitVcd=1` argument to Scalatest, e.g.:
 
 ``` shell
-./mill 'chisel[2.13.16].test.testOnly' chiselTests.ShiftRegistersSpec -- -DemitVcd=1
+./mill 'chisel[2.13.17].test.testOnly' chiselTests.ShiftRegistersSpec -- -DemitVcd=1
 ```
 
 ## How do I see what options a ChiselSim Scalatest test supports?
@@ -41,5 +41,5 @@ If using Scalatest and ChiselSim, pass the `-DemitVcd=1` argument to Scalatest, 
 Pass `-Dhelp=1` to Scalatest, e.g.:
 
 ``` shell
-./mill 'chisel[2.13.16].test.testOnly' chiselTests.ShiftRegistersSpec -- -Dhelp=1
+./mill 'chisel[2.13.17].test.testOnly' chiselTests.ShiftRegistersSpec -- -Dhelp=1
 ```

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -117,7 +117,7 @@ current highest supported versions are:
 | 3.6.1  | 2.13.14 | 22
 | 5.3.x  | 2.13.14 | 22
 | 6.6.x  | 2.13.16 | 23
-| 7.0.0-RC1 | 2.13.16 | 23
+| 7.1.x  | 2.13.16 | 23
 
 Note that `brew` on Mac currently installs Java 23, which is not supported by Scala 2.13.14 and lower.
 

--- a/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
+++ b/src/main/scala/chisel3/testing/scalatest/HasConfigMap.scala
@@ -12,7 +12,7 @@ import scala.util.DynamicVariable
   *
   * For example, you can invoke Scalatest passing the `foo=bar` option like so:
   * {{{
-  * ./mill 'chisel[2.13.16].test.testOnly' fooTest -Dfoo=bar
+  * ./mill 'chisel[2.13.17].test.testOnly' fooTest -Dfoo=bar
   * }}}
   *
   * Inside your test, if the `configMap` member function is accessed this will

--- a/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/TruthTable.scala
@@ -5,6 +5,7 @@ package chisel3.util.experimental.decode
 import chisel3.util.BitPat
 import chisel3.internal.groupByIntoSeq
 
+import scala.annotation.nowarn
 import scala.util.hashing.MurmurHash3
 
 sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: BitPat) {
@@ -29,6 +30,10 @@ sealed class TruthTable private (val table: Seq[(BitPat, BitPat)], val default: 
     }
   }
 
+  // MurmurHash3.productHash is deprecated in case you hash a case class that could be extended.
+  // We are hashing a Tuple2 so that is no problem here. We cannot change this to caseClassHash
+  // until we can bump to a Scala 3 release that also includes the new caseClassHash.
+  @nowarn("msg=method productHash in object MurmurHash3 is deprecated")
   override lazy val hashCode: Int = MurmurHash3.productHash((table, default))
 }
 


### PR DESCRIPTION
Suppress MurmurHash3.productHash deprecation until we can also bump Scala 3 to include the replacement API.
It's also not a problem at all, see comment in code.

### Contributor Checklist

- [ ] Did you add Scaladoc to every public function/method?
- [ ] Did you add at least one test demonstrating the PR?
- [x] Did you delete any extraneous printlns/debugging code?
- [x] Did you specify the type of improvement?
- [ ] Did you add appropriate documentation in `docs/src`? (TODO once 7.2.0 is released)
- [x] Did you request a desired merge strategy?
- [x] Did you add text to be included in the Release Notes for this change?

<!--
If you PR has any impact on the user API or affects backend code generation,
please describe the change in the "Release Notes" section below.
-->

#### Type of Improvement

- Dependency update


#### Desired Merge Strategy

<!-- If approved, how should this PR be merged? Delete those that do not apply -->
- Squash

#### Release Notes

**Note:** Scala 2.13.17 has a new warning for inferred structural types as a Scala 3 compatibility issue. This warning applies to the common `val io = IO(new Bundle { ... })` pattern in Chisel. It is not actually a problem because Chisel uses [Programmatic Structural Types](https://docs.scala-lang.org/scala3/reference/changed-features/structural-types-spec.html) in Scala 3. You can suppress this warning in your build by adding`-Wconf:msg=will no longer have a structural type:s` to your scalacOptions. See [configurable warnings](https://www.scala-lang.org/2021/01/12/configuring-and-suppressing-warnings.html) for more details on `-Wconf`.

### Reviewer Checklist (only modified by reviewer)
- [ ] Did you add the appropriate labels? (Select the most appropriate one based on the "Type of Improvement")
- [ ] Did you mark the proper milestone (Bug fix: `3.6.x`, `5.x`, or `6.x` depending on impact, API modification or big change: `7.0`)?
- [ ] Did you review?
- [ ] Did you check whether all relevant Contributor checkboxes have been checked?
- [ ] Did you do one of the following when ready to merge:
  - [ ] Squash: You/ the contributor `Enable auto-merge (squash)` and clean up the commit message.
  - [ ] Merge: Ensure that contributor has cleaned up their commit history, then merge with `Create a merge commit`.
