### PR TITLE
Use dropdown menus per Chisel major version

### DIFF
--- a/docs/FirtoolVersionsTable.mill
+++ b/docs/FirtoolVersionsTable.mill
@@ -41,12 +41,26 @@ def firtoolGithubLink(version: String): String = s"https://github.com/llvm/circt
 // release == true only includes releases
 // release == false only includes pre-releases
 def generateTable(allVersions: Seq[(SemanticVersion, String)], release: Boolean, logger: Logger): String = {
-  // Finally apply a filter for releases vs. pre-releases
-  val result = allVersions.filter { case (v, _) => v.prerelease ^ release }
+  val filtered = allVersions.filter { case (v, _) => v.prerelease ^ release }
 
-  val header = Vector("| Chisel Version | Firtool Version |", "| --- | --- |")
-  val table = (header ++ result.map { case (sv, fv) =>
-    s"| ${sv.serialize} | [$fv](${firtoolGithubLink(fv)}) |"
-  }).mkString("\n")
-  table
+  // Group by major version, sorted newest first
+  val grouped = filtered.groupBy { case (v, _) => v.major }.toSeq.sortBy { case (major, _) => -major }
+
+  val sections = grouped.zipWithIndex.map { case ((major, versions), idx) =>
+    val openAttr = if (idx == 0) " open" else ""
+    val rows = versions.map { case (sv, fv) =>
+      s"| ${sv.serialize} | [$fv](${firtoolGithubLink(fv)}) |"
+    }.mkString("\n")
+
+    s"""|<details$openAttr>
+        |<summary>Chisel ${major}.x</summary>
+        |
+        || Chisel Version | Firtool Version |
+        || --- | --- |
+        |$rows
+        |
+        |</details>""".stripMargin
+  }
+
+  sections.mkString("\n\n")
 }


### PR DESCRIPTION
### Summary

The Firtool Version table has gotten pretty long: https://www.chisel-lang.org/docs/appendix/versioning#firtool-version
Before:

<img width="848" height="1140" alt="Screenshot 2026-05-19 at 10 26 24 AM" src="https://github.com/user-attachments/assets/f5329a91-cc80-4eb7-b276-ea27286f4ff1" />

After:

<img width="843" height="1257" alt="Screenshot 2026-05-19 at 10 26 35 AM" src="https://github.com/user-attachments/assets/94e3d95e-3fbb-45e7-aebb-afed1220caec" />


### Release Notes

### Development notes
- AI tool(s) used: Claude Code (Claude Sonnet 4.6)
- Merge strategy (defaults to squash): squash
- Milestone: none

