### PR TITLE
[Scala3] [bugfix] BundlePhase: update isBundle with the correct recursion guard

### DIFF
--- a/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
+++ b/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
@@ -178,7 +178,10 @@ object BundleHelpers {
         sym.info.parents.flatMap { parentTpe =>
           parentTpe.classSymbol match {
             case parentSym: ClassSymbol
-                if !ChiselTypeHelpers.isExactBundle(parentSym) && ChiselTypeHelpers.isBundle(parentTpe) =>
+                if !ChiselTypeHelpers.isExactBundle(parentSym)
+                  && parentSym != defn.ObjectClass
+                  && parentSym != defn.AnyClass
+                  && parentSym != defn.AnyValClass =>
               getAllBundleFields(parentSym, depth + 1)
             case _ => Nil
           }

--- a/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
+++ b/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
@@ -157,6 +157,14 @@ object BundleHelpers {
       )
     }
 
+    // Stop collecting fields if this is the topmost Bundle
+    def isRootBundle(parentSym: ClassSymbol): Boolean = {
+      ChiselTypeHelpers.isExactBundle(parentSym)
+      || parentSym == defn.ObjectClass
+      || parentSym == defn.AnyClass
+      || parentSym == defn.AnyValClass
+    }
+
     // Recursively get all bundle fields from this class and its parents
     def getAllBundleFields(sym: ClassSymbol, depth: Int = 0): List[tpd.Tree] = {
       val thisRef: tpd.Tree = tpd.This(bundleSym)
@@ -177,11 +185,7 @@ object BundleHelpers {
       val parentFields: List[tpd.Tree] = if (!ChiselTypeHelpers.isExactBundle(sym)) {
         sym.info.parents.flatMap { parentTpe =>
           parentTpe.classSymbol match {
-            case parentSym: ClassSymbol
-                if !ChiselTypeHelpers.isExactBundle(parentSym)
-                  && parentSym != defn.ObjectClass
-                  && parentSym != defn.AnyClass
-                  && parentSym != defn.AnyValClass =>
+            case parentSym: ClassSymbol if !isRootBundle(parentSym) =>
               getAllBundleFields(parentSym, depth + 1)
             case _ => Nil
           }


### PR DESCRIPTION
### Summary
ChiselBundlePhase only recursed into parents that were themselves Bundles through `ChiselTypeHelpers.isBundle(parentTpe)`. This skips non-Bundle mixin traits in BundleElementsSpec. As a result, the Scala 3 plugin was producing `_elementsImpl` lists that omitted fields declared in mixins entirely

Bugfix is to replace `ChiselTypeHelpers.isBundle(parentTpe)` recursion guard with explicit exclusions for `defn.ObjectClass`, `defn.AnyClass`, and `defn.AnyValClass`

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Bugfix in Scala 3 BundlePhase with handling of Bundle fields declared in mixins
<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

### Development notes
- AI tool(s) used: Claude Code + Claude Opus 4.7
