### PR TITLE
[Scala3] Move D/I tests

### DIFF
--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -8,6 +8,7 @@ import chisel3.experimental.BaseModule
 import chisel3.experimental.hierarchy.{instantiable, public, Definition, Instance}
 import chisel3.testing.scalatest.FileCheck
 import chiselTests.experimental.ExtensionMethods.ChiselStageHelpers
+import firrtl.annoSeqToSeq
 import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -12,7 +12,7 @@ import scala.collection.immutable.SeqMap
 object Examples {
   import Annotations._
   @instantiable
-  class AddOne extends Module with IsInstantiable {
+  class AddOne extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val innerWire = Wire(UInt(32.W))
@@ -20,7 +20,7 @@ object Examples {
     out := innerWire
   }
   @instantiable
-  class AddOneWithAnnotation extends Module with IsInstantiable {
+  class AddOneWithAnnotation extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val innerWire = Wire(UInt(32.W))
@@ -29,7 +29,7 @@ object Examples {
     out := innerWire
   }
   @instantiable
-  class AddOneWithAbsoluteAnnotation extends Module with IsInstantiable {
+  class AddOneWithAbsoluteAnnotation extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val innerWire = Wire(UInt(32.W))
@@ -38,12 +38,12 @@ object Examples {
     out := innerWire
   }
   @instantiable
-  class AddOneParameterized(width: Int) extends Module with IsInstantiable {
+  class AddOneParameterized(width: Int) extends Module {
     @public val in = IO(Input(UInt(width.W)))
     @public val out = IO(Output(UInt(width.W)))
     out := in + 1.U
   }
-  class AddOneWithNested(width: Int) extends Module with IsInstantiable {
+  class AddOneWithNested(width: Int) extends Module {
     @public val in = IO(Input(UInt(width.W)))
     @public val out = IO(Output(UInt(width.W)))
     val addOneDef = Seq.fill(3)(Definition(new AddOne))
@@ -58,7 +58,7 @@ object Examples {
   }
 
   @instantiable
-  class AddTwo extends Module with IsInstantiable {
+  class AddTwo extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val definition = Definition(new AddOne)
@@ -69,7 +69,7 @@ object Examples {
     out := i1.out
   }
   @instantiable
-  class AddTwoMixedModules extends Module with IsInstantiable {
+  class AddTwoMixedModules extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     val definition = Definition(new AddOne)
@@ -82,7 +82,7 @@ object Examples {
   @instantiable
   class AddTwoParameterized(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneParameterized]])
       extends Module
-      with IsInstantiable {
+       {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOnes = makeParameterizedOnes(width)
@@ -93,13 +93,13 @@ object Examples {
   @instantiable
   class AddTwoWithNested(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneWithNested]])
       extends Module
-      with IsInstantiable {
+       {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOnes = makeParameterizedOnes(width)
   }
   @instantiable
-  class AddTwoDefinitionArgument(definition: Definition[AddOne]) extends Module with IsInstantiable {
+  class AddTwoDefinitionArgument(definition: Definition[AddOne]) extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val i0: Instance[AddOne] = Instance(definition)
@@ -110,7 +110,7 @@ object Examples {
   }
 
   @instantiable
-  class AddFour extends Module with IsInstantiable {
+  class AddFour extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val definition = Definition(new AddTwoMixedModules)
@@ -121,7 +121,7 @@ object Examples {
     out := i1.out
   }
   @instantiable
-  class AggregatePortModule extends Module with IsInstantiable {
+  class AggregatePortModule extends Module {
     @public val io = IO(new Bundle {
       val in = Input(UInt(32.W))
       val out = Output(UInt(32.W))
@@ -133,7 +133,7 @@ object Examples {
     @public val innerWire = Wire(UInt(32.W))
   }
   @instantiable
-  class AddOneWithInstantiableWire extends Module with IsInstantiable {
+  class AddOneWithInstantiableWire extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val wireContainer = new WireContainer()
@@ -145,7 +145,7 @@ object Examples {
     @public val i0 = Module(new AddOne)
   }
   @instantiable
-  class AddOneWithInstantiableModule extends Module with IsInstantiable {
+  class AddOneWithInstantiableModule extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val moduleContainer = new AddOneContainer()
@@ -158,7 +158,7 @@ object Examples {
     @public val i0 = Instance(definition)
   }
   @instantiable
-  class AddOneWithInstantiableInstance extends Module with IsInstantiable {
+  class AddOneWithInstantiableInstance extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val instanceContainer = new AddOneInstanceContainer()
@@ -170,7 +170,7 @@ object Examples {
     @public val container = new AddOneContainer
   }
   @instantiable
-  class AddOneWithInstantiableInstantiable extends Module with IsInstantiable {
+  class AddOneWithInstantiableInstantiable extends Module {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val containerContainer = new AddOneContainerContainer()
@@ -183,7 +183,7 @@ object Examples {
     if (markPlease) mark(x.i0.innerWire, "first")
   }
   @instantiable
-  class ViewerParent(val x: AddTwo, markHere: Boolean, markThere: Boolean) extends Module with IsInstantiable {
+  class ViewerParent(val x: AddTwo, markHere: Boolean, markThere: Boolean) extends Module {
     @public val viewer = new Viewer(x, markThere)
     if (markHere) mark(viewer.x.i0.innerWire, "second")
   }
@@ -192,7 +192,7 @@ object Examples {
     @public val (x, y) = (Wire(UInt(3.W)), Wire(UInt(3.W)))
   }
   @instantiable
-  class LazyVal() extends Module with IsInstantiable {
+  class LazyVal() extends Module {
     @public val x = Wire(UInt(3.W))
     @public lazy val y = "Hi"
   }
@@ -203,73 +203,73 @@ object Examples {
     @public val x = Wire(UInt(3.W))
   }
   @instantiable
-  class HasList() extends Module with IsInstantiable {
+  class HasList() extends Module  {
     @public val y = List(1, 2, 3)
     @public val x = List.fill(3)(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasSeq() extends Module with IsInstantiable {
+  class HasSeq() extends Module  {
     @public val y = Seq(1, 2, 3)
     @public val x = Seq.fill(3)(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasOption() extends Module with IsInstantiable {
+  class HasOption() extends Module  {
     @public val x: Option[UInt] = Some(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasEither() extends Module with IsInstantiable {
+  class HasEither() extends Module  {
     @public val x: Either[Bool, UInt] = Right(Wire(UInt(3.W)).suggestName("x"))
     @public val y: Either[Bool, UInt] = Left(Wire(Bool()).suggestName("y"))
   }
   @instantiable
-  class HasTuple2() extends Module with IsInstantiable {
+  class HasTuple2() extends Module  {
     val x = Wire(UInt(3.W))
     val y = Wire(Bool())
     @public val xy = (x, y)
   }
   @instantiable
-  class HasTuple5() extends Module with IsInstantiable {
+  class HasTuple5() extends Module  {
     val wire = Wire(UInt(3.W))
     val inst = Module(new AddOne)
     @public val tup = (3, wire, "hi", inst, List(1, 2, 3))
   }
   @instantiable
-  class HasHasTarget() extends Module with IsInstantiable {
+  class HasHasTarget() extends Module  {
     val sram = SRAM(1024, UInt(8.W), 1, 1, 0)
     @public val x: HasTarget = sram.underlying.get
   }
   @instantiable
-  class HasVec() extends Module with IsInstantiable {
+  class HasVec() extends Module  {
     @public val x = VecInit(1.U, 2.U, 3.U)
   }
   @instantiable
-  class HasIndexedVec() extends Module with IsInstantiable {
+  class HasIndexedVec() extends Module  {
     val x = VecInit(1.U, 2.U, 3.U)
     @public val y = x(1)
   }
   @instantiable
-  class HasSubFieldAccess extends Module with IsInstantiable {
+  class HasSubFieldAccess extends Module  {
     val in = IO(Input(Valid(UInt(8.W))))
     @public val valid = in.valid
     @public val bits = in.bits
   }
   @instantiable
-  class HasPublicConstructorArgs(@public val int: Int) extends Module with IsInstantiable {
+  class HasPublicConstructorArgs(@public val int: Int) extends Module  {
     @public val x = Wire(UInt(3.W))
   }
   @instantiable
-  class InstantiatesHasVec() extends Module with IsInstantiable {
+  class InstantiatesHasVec() extends Module  {
     @public val i0 = Instance(Definition(new HasVec()))
     @public val i1 = Module(new HasVec())
   }
   @instantiable
-  class HasUninferredReset() extends Module with IsInstantiable {
+  class HasUninferredReset() extends Module  {
     @public val in = IO(Input(UInt(3.W)))
     @public val out = IO(Output(UInt(3.W)))
     out := RegNext(in)
   }
   @instantiable
-  abstract class HasBlah() extends Module with IsInstantiable {
+  abstract class HasBlah() extends Module  {
     @public val blah: Int
   }
 
@@ -278,12 +278,12 @@ object Examples {
     val blah = 10
   }
   @instantiable
-  class HasTypeParams[D <: Data](d: D) extends Module with IsInstantiable {
+  class HasTypeParams[D <: Data](d: D) extends Module  {
     @public val blah = Wire(d)
   }
 
   @instantiable
-  class HasMultipleTypeParamsInside extends Module with IsInstantiable {
+  class HasMultipleTypeParamsInside extends Module  {
     val tpDef0 = Definition(new HasTypeParams(Bool()))
     val tpDef1 = Definition(new HasTypeParams(UInt(4.W)))
     val i00 = Instance(tpDef0)
@@ -293,7 +293,7 @@ object Examples {
   }
 
   @instantiable
-  class HasMems() extends Module with IsInstantiable {
+  class HasMems() extends Module  {
     @public val mem = Mem(8, UInt(32.W))
     @public val syncReadMem = SyncReadMem(8, UInt(32.W))
   }
@@ -310,7 +310,7 @@ object Examples {
   }
 
   @instantiable
-  class AddOneNestedInstantiableData(width: Int) extends Module with IsInstantiable {
+  class AddOneNestedInstantiableData(width: Int) extends Module  {
     @public val in = IO(Input(UInt(width.W)))
     @public val out = IO(Output(UInt(width.W)))
     out := in + 1.U
@@ -321,7 +321,7 @@ object Examples {
 
   }
   @instantiable
-  class HasUnsanitaryBundleField extends Module with IsInstantiable {
+  class HasUnsanitaryBundleField extends Module  {
     class Interface extends Bundle {
       val `a-x` = UInt(8.W)
     }
@@ -333,13 +333,13 @@ object Examples {
   }
 
   @instantiable
-  class HasAnalogWire extends RawModule with IsInstantiable {
+  class HasAnalogWire extends RawModule  {
     @public val port = IO(Analog(8.W))
     @public val wire = Wire(Analog(32.W))
     attach(port, wire)
   }
 
-  class AddTwoNestedInstantiableData(width: Int) extends Module with IsInstantiable {
+  class AddTwoNestedInstantiableData(width: Int) extends Module  {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOneDef = Definition(new AddOneNestedInstantiableData(width))
@@ -356,7 +356,7 @@ object Examples {
 
   class AddTwoNestedInstantiableDataSubmodule(addOneDef: Definition[AddOneNestedInstantiableData])
       extends Module
-      with IsInstantiable {
+       {
     val in = IO(Input(UInt(addOneDef.in.getWidth.W)))
     val out = IO(Output(UInt(addOneDef.out.getWidth.W)))
     val i0 = Instance(addOneDef)
@@ -370,7 +370,7 @@ object Examples {
     i1.nested.in.bundle := i0.nested.out.bundle
   }
 
-  class AddTwoNestedInstantiableDataWrapper(width: Int) extends Module with IsInstantiable {
+  class AddTwoNestedInstantiableDataWrapper(width: Int) extends Module  {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
 
@@ -384,14 +384,14 @@ object Examples {
   }
 
   @instantiable
-  class HasPublicUnit extends Module with IsInstantiable {
+  class HasPublicUnit extends Module  {
     @public val x: Unit = ()
     // Should also work in type-parameterized lookupable things
     @public val y: (Data, Unit) = (Wire(UInt(3.W)), ())
   }
 
   @instantiable
-  class HasPublicActualDirection extends Module with IsInstantiable {
+  class HasPublicActualDirection extends Module  {
     val io = IO(new Bundle {
       val input = Input(UInt(8.W))
       val output = Output(UInt(8.W))
@@ -421,7 +421,7 @@ object Examples {
   }
 
   @instantiable
-  class HasUserDefinedType extends Module with IsInstantiable {
+  class HasUserDefinedType extends Module  {
     val defn = Definition(new AddOne)
     val inst0: Instance[AddOne] = Instance(defn)
     val inst1: Instance[AddOne] = Instance(defn)

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -12,7 +12,7 @@ import scala.collection.immutable.SeqMap
 object Examples {
   import Annotations._
   @instantiable
-  class AddOne extends Module {
+  class AddOne extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val innerWire = Wire(UInt(32.W))
@@ -20,7 +20,7 @@ object Examples {
     out := innerWire
   }
   @instantiable
-  class AddOneWithAnnotation extends Module {
+  class AddOneWithAnnotation extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val innerWire = Wire(UInt(32.W))
@@ -29,7 +29,7 @@ object Examples {
     out := innerWire
   }
   @instantiable
-  class AddOneWithAbsoluteAnnotation extends Module {
+  class AddOneWithAbsoluteAnnotation extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val innerWire = Wire(UInt(32.W))
@@ -38,19 +38,19 @@ object Examples {
     out := innerWire
   }
   @instantiable
-  class AddOneParameterized(width: Int) extends Module {
+  class AddOneParameterized(width: Int) extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(width.W)))
     @public val out = IO(Output(UInt(width.W)))
     out := in + 1.U
   }
-  class AddOneWithNested(width: Int) extends Module {
+  class AddOneWithNested(width: Int) extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(width.W)))
     @public val out = IO(Output(UInt(width.W)))
     val addOneDef = Seq.fill(3)(Definition(new AddOne))
     out := in + 1.U
   }
   @instantiable
-  class AddOneBlackBox extends ExtModule {
+  class AddOneBlackBox extends ExtModule with IsInstantiable {
     @public val io = FlatIO(new Bundle {
       val in = Input(UInt(32.W))
       val out = Output(UInt(32.W))
@@ -58,7 +58,7 @@ object Examples {
   }
 
   @instantiable
-  class AddTwo extends Module {
+  class AddTwo extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val definition = Definition(new AddOne)
@@ -69,7 +69,7 @@ object Examples {
     out := i1.out
   }
   @instantiable
-  class AddTwoMixedModules extends Module {
+  class AddTwoMixedModules extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     val definition = Definition(new AddOne)
@@ -81,7 +81,8 @@ object Examples {
   }
   @instantiable
   class AddTwoParameterized(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneParameterized]])
-      extends Module {
+      extends Module
+      with IsInstantiable {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOnes = makeParameterizedOnes(width)
@@ -90,13 +91,15 @@ object Examples {
     addOnes.zip(addOnes.tail).foreach { case (head, tail) => tail.in := head.out }
   }
   @instantiable
-  class AddTwoWithNested(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneWithNested]]) extends Module {
+  class AddTwoWithNested(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneWithNested]])
+      extends Module
+      with IsInstantiable {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOnes = makeParameterizedOnes(width)
   }
   @instantiable
-  class AddTwoDefinitionArgument(definition: Definition[AddOne]) extends Module {
+  class AddTwoDefinitionArgument(definition: Definition[AddOne]) extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val i0: Instance[AddOne] = Instance(definition)
@@ -107,7 +110,7 @@ object Examples {
   }
 
   @instantiable
-  class AddFour extends Module {
+  class AddFour extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val definition = Definition(new AddTwoMixedModules)
@@ -118,7 +121,7 @@ object Examples {
     out := i1.out
   }
   @instantiable
-  class AggregatePortModule extends Module {
+  class AggregatePortModule extends Module with IsInstantiable {
     @public val io = IO(new Bundle {
       val in = Input(UInt(32.W))
       val out = Output(UInt(32.W))
@@ -126,11 +129,11 @@ object Examples {
     io.out := io.in
   }
   @instantiable
-  class WireContainer {
+  class WireContainer extends IsInstantiable {
     @public val innerWire = Wire(UInt(32.W))
   }
   @instantiable
-  class AddOneWithInstantiableWire extends Module {
+  class AddOneWithInstantiableWire extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val wireContainer = new WireContainer()
@@ -138,11 +141,11 @@ object Examples {
     out := wireContainer.innerWire
   }
   @instantiable
-  class AddOneContainer {
+  class AddOneContainer extends IsInstantiable {
     @public val i0 = Module(new AddOne)
   }
   @instantiable
-  class AddOneWithInstantiableModule extends Module {
+  class AddOneWithInstantiableModule extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val moduleContainer = new AddOneContainer()
@@ -150,12 +153,12 @@ object Examples {
     out := moduleContainer.i0.out
   }
   @instantiable
-  class AddOneInstanceContainer {
+  class AddOneInstanceContainer extends IsInstantiable {
     val definition = Definition(new AddOne)
     @public val i0 = Instance(definition)
   }
   @instantiable
-  class AddOneWithInstantiableInstance extends Module {
+  class AddOneWithInstantiableInstance extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val instanceContainer = new AddOneInstanceContainer()
@@ -163,11 +166,11 @@ object Examples {
     out := instanceContainer.i0.out
   }
   @instantiable
-  class AddOneContainerContainer {
+  class AddOneContainerContainer extends IsInstantiable {
     @public val container = new AddOneContainer
   }
   @instantiable
-  class AddOneWithInstantiableInstantiable extends Module {
+  class AddOneWithInstantiableInstantiable extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(32.W)))
     @public val out = IO(Output(UInt(32.W)))
     @public val containerContainer = new AddOneContainerContainer()
@@ -175,12 +178,12 @@ object Examples {
     out := containerContainer.container.i0.out
   }
   @instantiable
-  class Viewer(val y: AddTwo, markPlease: Boolean) {
+  class Viewer(val y: AddTwo, markPlease: Boolean) extends IsInstantiable {
     @public val x = y
     if (markPlease) mark(x.i0.innerWire, "first")
   }
   @instantiable
-  class ViewerParent(val x: AddTwo, markHere: Boolean, markThere: Boolean) extends Module {
+  class ViewerParent(val x: AddTwo, markHere: Boolean, markThere: Boolean) extends Module with IsInstantiable {
     @public val viewer = new Viewer(x, markThere)
     if (markHere) mark(viewer.x.i0.innerWire, "second")
   }
@@ -189,7 +192,7 @@ object Examples {
     @public val (x, y) = (Wire(UInt(3.W)), Wire(UInt(3.W)))
   }
   @instantiable
-  class LazyVal() extends Module {
+  class LazyVal() extends Module with IsInstantiable {
     @public val x = Wire(UInt(3.W))
     @public lazy val y = "Hi"
   }
@@ -200,73 +203,73 @@ object Examples {
     @public val x = Wire(UInt(3.W))
   }
   @instantiable
-  class HasList() extends Module {
+  class HasList() extends Module with IsInstantiable {
     @public val y = List(1, 2, 3)
     @public val x = List.fill(3)(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasSeq() extends Module {
+  class HasSeq() extends Module with IsInstantiable {
     @public val y = Seq(1, 2, 3)
     @public val x = Seq.fill(3)(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasOption() extends Module {
+  class HasOption() extends Module with IsInstantiable {
     @public val x: Option[UInt] = Some(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasEither() extends Module {
+  class HasEither() extends Module with IsInstantiable {
     @public val x: Either[Bool, UInt] = Right(Wire(UInt(3.W)).suggestName("x"))
     @public val y: Either[Bool, UInt] = Left(Wire(Bool()).suggestName("y"))
   }
   @instantiable
-  class HasTuple2() extends Module {
+  class HasTuple2() extends Module with IsInstantiable {
     val x = Wire(UInt(3.W))
     val y = Wire(Bool())
     @public val xy = (x, y)
   }
   @instantiable
-  class HasTuple5() extends Module {
+  class HasTuple5() extends Module with IsInstantiable {
     val wire = Wire(UInt(3.W))
     val inst = Module(new AddOne)
     @public val tup = (3, wire, "hi", inst, List(1, 2, 3))
   }
   @instantiable
-  class HasHasTarget() extends Module {
+  class HasHasTarget() extends Module with IsInstantiable {
     val sram = SRAM(1024, UInt(8.W), 1, 1, 0)
     @public val x: HasTarget = sram.underlying.get
   }
   @instantiable
-  class HasVec() extends Module {
+  class HasVec() extends Module with IsInstantiable {
     @public val x = VecInit(1.U, 2.U, 3.U)
   }
   @instantiable
-  class HasIndexedVec() extends Module {
+  class HasIndexedVec() extends Module with IsInstantiable {
     val x = VecInit(1.U, 2.U, 3.U)
     @public val y = x(1)
   }
   @instantiable
-  class HasSubFieldAccess extends Module {
+  class HasSubFieldAccess extends Module with IsInstantiable {
     val in = IO(Input(Valid(UInt(8.W))))
     @public val valid = in.valid
     @public val bits = in.bits
   }
   @instantiable
-  class HasPublicConstructorArgs(@public val int: Int) extends Module {
+  class HasPublicConstructorArgs(@public val int: Int) extends Module with IsInstantiable {
     @public val x = Wire(UInt(3.W))
   }
   @instantiable
-  class InstantiatesHasVec() extends Module {
+  class InstantiatesHasVec() extends Module with IsInstantiable {
     @public val i0 = Instance(Definition(new HasVec()))
     @public val i1 = Module(new HasVec())
   }
   @instantiable
-  class HasUninferredReset() extends Module {
+  class HasUninferredReset() extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(3.W)))
     @public val out = IO(Output(UInt(3.W)))
     out := RegNext(in)
   }
   @instantiable
-  abstract class HasBlah() extends Module {
+  abstract class HasBlah() extends Module with IsInstantiable {
     @public val blah: Int
   }
 
@@ -275,12 +278,12 @@ object Examples {
     val blah = 10
   }
   @instantiable
-  class HasTypeParams[D <: Data](d: D) extends Module {
+  class HasTypeParams[D <: Data](d: D) extends Module with IsInstantiable {
     @public val blah = Wire(d)
   }
 
   @instantiable
-  class HasMultipleTypeParamsInside extends Module {
+  class HasMultipleTypeParamsInside extends Module with IsInstantiable {
     val tpDef0 = Definition(new HasTypeParams(Bool()))
     val tpDef1 = Definition(new HasTypeParams(UInt(4.W)))
     val i00 = Instance(tpDef0)
@@ -290,35 +293,35 @@ object Examples {
   }
 
   @instantiable
-  class HasMems() extends Module {
+  class HasMems() extends Module with IsInstantiable {
     @public val mem = Mem(8, UInt(32.W))
     @public val syncReadMem = SyncReadMem(8, UInt(32.W))
   }
 
   @instantiable
-  class LeafInstantiable(val bundle: Data) {
-    @public val bundle = bundle
+  class LeafInstantiable(val _bundle: Data) extends IsInstantiable {
+    @public val bundle = _bundle
   }
 
   @instantiable
-  class NestedInstantiable(val in: LeafInstantiable, val out: LeafInstantiable) {
-    @public val in = in
-    @public val out = out
+  class NestedInstantiable(val _in: LeafInstantiable, val _out: LeafInstantiable) extends IsInstantiable {
+    @public val in = _in
+    @public val out = _out
   }
 
   @instantiable
-  class AddOneNestedInstantiableData(width: Int) extends Module {
+  class AddOneNestedInstantiableData(width: Int) extends Module with IsInstantiable {
     @public val in = IO(Input(UInt(width.W)))
     @public val out = IO(Output(UInt(width.W)))
     out := in + 1.U
 
     @public val leafOut = new LeafInstantiable(out)
     @public val leafIn = new LeafInstantiable(in)
-    @public val nested = new NestedInstantiable(in = leafIn, out = leafOut)
+    @public val nested = new NestedInstantiable(_in = leafIn, _out = leafOut)
 
   }
   @instantiable
-  class HasUnsanitaryBundleField extends Module {
+  class HasUnsanitaryBundleField extends Module with IsInstantiable {
     class Interface extends Bundle {
       val `a-x` = UInt(8.W)
     }
@@ -330,13 +333,13 @@ object Examples {
   }
 
   @instantiable
-  class HasAnalogWire extends RawModule {
+  class HasAnalogWire extends RawModule with IsInstantiable {
     @public val port = IO(Analog(8.W))
     @public val wire = Wire(Analog(32.W))
     attach(port, wire)
   }
 
-  class AddTwoNestedInstantiableData(width: Int) extends Module {
+  class AddTwoNestedInstantiableData(width: Int) extends Module with IsInstantiable {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOneDef = Definition(new AddOneNestedInstantiableData(width))
@@ -351,7 +354,9 @@ object Examples {
     i1.nested.in.bundle := i0.nested.out.bundle
   }
 
-  class AddTwoNestedInstantiableDataSubmodule(addOneDef: Definition[AddOneNestedInstantiableData]) extends Module {
+  class AddTwoNestedInstantiableDataSubmodule(addOneDef: Definition[AddOneNestedInstantiableData])
+      extends Module
+      with IsInstantiable {
     val in = IO(Input(UInt(addOneDef.in.getWidth.W)))
     val out = IO(Output(UInt(addOneDef.out.getWidth.W)))
     val i0 = Instance(addOneDef)
@@ -365,7 +370,7 @@ object Examples {
     i1.nested.in.bundle := i0.nested.out.bundle
   }
 
-  class AddTwoNestedInstantiableDataWrapper(width: Int) extends Module {
+  class AddTwoNestedInstantiableDataWrapper(width: Int) extends Module with IsInstantiable {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
 
@@ -379,14 +384,14 @@ object Examples {
   }
 
   @instantiable
-  class HasPublicUnit extends Module {
+  class HasPublicUnit extends Module with IsInstantiable {
     @public val x: Unit = ()
     // Should also work in type-parameterized lookupable things
     @public val y: (Data, Unit) = (Wire(UInt(3.W)), ())
   }
 
   @instantiable
-  class HasPublicActualDirection extends Module {
+  class HasPublicActualDirection extends Module with IsInstantiable {
     val io = IO(new Bundle {
       val input = Input(UInt(8.W))
       val output = Output(UInt(8.W))
@@ -416,7 +421,7 @@ object Examples {
   }
 
   @instantiable
-  class HasUserDefinedType extends Module {
+  class HasUserDefinedType extends Module with IsInstantiable {
     val defn = Definition(new AddOne)
     val inst0: Instance[AddOne] = Instance(defn)
     val inst1: Instance[AddOne] = Instance(defn)
@@ -450,11 +455,11 @@ object Examples {
 
   // For test 9.c in DefinitionSpec - testing .toDefinition on Instance from imported Definition
   @instantiable
-  class BarForImport extends RawModule {
+  class BarForImport extends RawModule with IsInstantiable {
     @public val a = WireInit(false.B)
   }
   @instantiable
-  class FooForImport extends RawModule {
+  class FooForImport extends RawModule with IsInstantiable {
     @public val bar = Module(new BarForImport)
   }
 }

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -81,8 +81,7 @@ object Examples {
   }
   @instantiable
   class AddTwoParameterized(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneParameterized]])
-      extends Module
-       {
+      extends Module {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOnes = makeParameterizedOnes(width)
@@ -91,9 +90,7 @@ object Examples {
     addOnes.zip(addOnes.tail).foreach { case (head, tail) => tail.in := head.out }
   }
   @instantiable
-  class AddTwoWithNested(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneWithNested]])
-      extends Module
-       {
+  class AddTwoWithNested(width: Int, makeParameterizedOnes: Int => Seq[Instance[AddOneWithNested]]) extends Module {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOnes = makeParameterizedOnes(width)
@@ -203,73 +200,73 @@ object Examples {
     @public val x = Wire(UInt(3.W))
   }
   @instantiable
-  class HasList() extends Module  {
+  class HasList() extends Module {
     @public val y = List(1, 2, 3)
     @public val x = List.fill(3)(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasSeq() extends Module  {
+  class HasSeq() extends Module {
     @public val y = Seq(1, 2, 3)
     @public val x = Seq.fill(3)(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasOption() extends Module  {
+  class HasOption() extends Module {
     @public val x: Option[UInt] = Some(Wire(UInt(3.W)))
   }
   @instantiable
-  class HasEither() extends Module  {
+  class HasEither() extends Module {
     @public val x: Either[Bool, UInt] = Right(Wire(UInt(3.W)).suggestName("x"))
     @public val y: Either[Bool, UInt] = Left(Wire(Bool()).suggestName("y"))
   }
   @instantiable
-  class HasTuple2() extends Module  {
+  class HasTuple2() extends Module {
     val x = Wire(UInt(3.W))
     val y = Wire(Bool())
     @public val xy = (x, y)
   }
   @instantiable
-  class HasTuple5() extends Module  {
+  class HasTuple5() extends Module {
     val wire = Wire(UInt(3.W))
     val inst = Module(new AddOne)
     @public val tup = (3, wire, "hi", inst, List(1, 2, 3))
   }
   @instantiable
-  class HasHasTarget() extends Module  {
+  class HasHasTarget() extends Module {
     val sram = SRAM(1024, UInt(8.W), 1, 1, 0)
     @public val x: HasTarget = sram.underlying.get
   }
   @instantiable
-  class HasVec() extends Module  {
+  class HasVec() extends Module {
     @public val x = VecInit(1.U, 2.U, 3.U)
   }
   @instantiable
-  class HasIndexedVec() extends Module  {
+  class HasIndexedVec() extends Module {
     val x = VecInit(1.U, 2.U, 3.U)
     @public val y = x(1)
   }
   @instantiable
-  class HasSubFieldAccess extends Module  {
+  class HasSubFieldAccess extends Module {
     val in = IO(Input(Valid(UInt(8.W))))
     @public val valid = in.valid
     @public val bits = in.bits
   }
   @instantiable
-  class HasPublicConstructorArgs(@public val int: Int) extends Module  {
+  class HasPublicConstructorArgs(@public val int: Int) extends Module {
     @public val x = Wire(UInt(3.W))
   }
   @instantiable
-  class InstantiatesHasVec() extends Module  {
+  class InstantiatesHasVec() extends Module {
     @public val i0 = Instance(Definition(new HasVec()))
     @public val i1 = Module(new HasVec())
   }
   @instantiable
-  class HasUninferredReset() extends Module  {
+  class HasUninferredReset() extends Module {
     @public val in = IO(Input(UInt(3.W)))
     @public val out = IO(Output(UInt(3.W)))
     out := RegNext(in)
   }
   @instantiable
-  abstract class HasBlah() extends Module  {
+  abstract class HasBlah() extends Module {
     @public val blah: Int
   }
 
@@ -278,12 +275,12 @@ object Examples {
     val blah = 10
   }
   @instantiable
-  class HasTypeParams[D <: Data](d: D) extends Module  {
+  class HasTypeParams[D <: Data](d: D) extends Module {
     @public val blah = Wire(d)
   }
 
   @instantiable
-  class HasMultipleTypeParamsInside extends Module  {
+  class HasMultipleTypeParamsInside extends Module {
     val tpDef0 = Definition(new HasTypeParams(Bool()))
     val tpDef1 = Definition(new HasTypeParams(UInt(4.W)))
     val i00 = Instance(tpDef0)
@@ -293,7 +290,7 @@ object Examples {
   }
 
   @instantiable
-  class HasMems() extends Module  {
+  class HasMems() extends Module {
     @public val mem = Mem(8, UInt(32.W))
     @public val syncReadMem = SyncReadMem(8, UInt(32.W))
   }
@@ -310,7 +307,7 @@ object Examples {
   }
 
   @instantiable
-  class AddOneNestedInstantiableData(width: Int) extends Module  {
+  class AddOneNestedInstantiableData(width: Int) extends Module {
     @public val in = IO(Input(UInt(width.W)))
     @public val out = IO(Output(UInt(width.W)))
     out := in + 1.U
@@ -321,7 +318,7 @@ object Examples {
 
   }
   @instantiable
-  class HasUnsanitaryBundleField extends Module  {
+  class HasUnsanitaryBundleField extends Module {
     class Interface extends Bundle {
       val `a-x` = UInt(8.W)
     }
@@ -333,13 +330,13 @@ object Examples {
   }
 
   @instantiable
-  class HasAnalogWire extends RawModule  {
+  class HasAnalogWire extends RawModule {
     @public val port = IO(Analog(8.W))
     @public val wire = Wire(Analog(32.W))
     attach(port, wire)
   }
 
-  class AddTwoNestedInstantiableData(width: Int) extends Module  {
+  class AddTwoNestedInstantiableData(width: Int) extends Module {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
     val addOneDef = Definition(new AddOneNestedInstantiableData(width))
@@ -354,9 +351,7 @@ object Examples {
     i1.nested.in.bundle := i0.nested.out.bundle
   }
 
-  class AddTwoNestedInstantiableDataSubmodule(addOneDef: Definition[AddOneNestedInstantiableData])
-      extends Module
-       {
+  class AddTwoNestedInstantiableDataSubmodule(addOneDef: Definition[AddOneNestedInstantiableData]) extends Module {
     val in = IO(Input(UInt(addOneDef.in.getWidth.W)))
     val out = IO(Output(UInt(addOneDef.out.getWidth.W)))
     val i0 = Instance(addOneDef)
@@ -370,7 +365,7 @@ object Examples {
     i1.nested.in.bundle := i0.nested.out.bundle
   }
 
-  class AddTwoNestedInstantiableDataWrapper(width: Int) extends Module  {
+  class AddTwoNestedInstantiableDataWrapper(width: Int) extends Module {
     val in = IO(Input(UInt(width.W)))
     val out = IO(Output(UInt(width.W)))
 
@@ -384,14 +379,14 @@ object Examples {
   }
 
   @instantiable
-  class HasPublicUnit extends Module  {
+  class HasPublicUnit extends Module {
     @public val x: Unit = ()
     // Should also work in type-parameterized lookupable things
     @public val y: (Data, Unit) = (Wire(UInt(3.W)), ())
   }
 
   @instantiable
-  class HasPublicActualDirection extends Module  {
+  class HasPublicActualDirection extends Module {
     val io = IO(new Bundle {
       val input = Input(UInt(8.W))
       val output = Output(UInt(8.W))
@@ -421,7 +416,7 @@ object Examples {
   }
 
   @instantiable
-  class HasUserDefinedType extends Module  {
+  class HasUserDefinedType extends Module {
     val defn = Definition(new AddOne)
     val inst0: Instance[AddOne] = Instance(defn)
     val inst1: Instance[AddOne] = Instance(defn)

--- a/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/Examples.scala
@@ -50,7 +50,7 @@ object Examples {
     out := in + 1.U
   }
   @instantiable
-  class AddOneBlackBox extends ExtModule with IsInstantiable {
+  class AddOneBlackBox extends ExtModule {
     @public val io = FlatIO(new Bundle {
       val in = Input(UInt(32.W))
       val out = Output(UInt(32.W))
@@ -450,11 +450,11 @@ object Examples {
 
   // For test 9.c in DefinitionSpec - testing .toDefinition on Instance from imported Definition
   @instantiable
-  class BarForImport extends RawModule with IsInstantiable {
+  class BarForImport extends RawModule {
     @public val a = WireInit(false.B)
   }
   @instantiable
-  class FooForImport extends RawModule with IsInstantiable {
+  class FooForImport extends RawModule {
     @public val bar = Module(new BarForImport)
   }
 }

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -10,6 +10,7 @@ import chisel3.testing.scalatest.FileCheck
 import chisel3.util.{DecoupledIO, Valid}
 import chisel3.experimental.{attach, Analog}
 import chisel3.stage.{ChiselGeneratorAnnotation, DesignAnnotation}
+import firrtl.annoSeqToSeq
 import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -639,7 +640,7 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
         @public override val overriddenVal = 12
         @public final val finalVal = 12
         @public lazy val lazyValue = 12
-        @public val value = value
+        @public override val value = value
         @public final override lazy val x: Int = 3
         @public override final lazy val y: Int = 4
       }
@@ -1317,7 +1318,9 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
       }
       ChiselStage.emitCHIRRTL(new Top)
     }
-    it("(9.b): it should not work on inner classes") {
+    // Due to the differences between ClassTag in Scala 3 and TypeTag
+    // in Scala 2, isA should work on inner classes in  Scala 3
+    ignore("(9.b): it should not work on inner classes") {
       class InnerClass extends Module
       class Top extends Module {
         val d = Definition(new InnerClass)

--- a/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -1320,14 +1320,16 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
     }
     // Due to the differences between ClassTag in Scala 3 and TypeTag
     // in Scala 2, isA should work on inner classes in  Scala 3
-    ignore("(9.b): it should not work on inner classes") {
-      class InnerClass extends Module
-      class Top extends Module {
-        val d = Definition(new InnerClass)
-        "require(d.isA[Module])" should compile // ensures that the test below is checking something useful
-        "require(d.isA[InnerClass])" shouldNot compile
+    if (chisel3.BuildInfo.scalaVersion(0).toInt < 3) {
+      it("(9.b): it should not work on inner classes") {
+        class InnerClass extends Module
+        class Top extends Module {
+          val d = Definition(new InnerClass)
+          "require(d.isA[Module])" should compile // ensures that the test below is checking something useful
+          "require(d.isA[InnerClass])" shouldNot compile
+        }
+        ChiselStage.emitCHIRRTL(new Top)
       }
-      ChiselStage.emitCHIRRTL(new Top)
     }
     it("(9.c): it should work on super classes") {
       class InnerClass extends Module

--- a/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -12,7 +12,7 @@ import chisel3.stage.{ChiselCircuitAnnotation, ChiselGeneratorAnnotation, Design
 import chisel3.testing.{FileCheck, HasTestingDirectory}
 import chisel3.testing.scalatest.TestingDirectory
 import circt.stage.{CIRCTTarget, CIRCTTargetAnnotation, ChiselStage}
-import firrtl.AnnotationSeq
+import firrtl.{annoSeqToSeq, seqToAnnoSeq, AnnotationSeq}
 import java.nio.file.Paths
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
### Summary

Move D/I tests to run with Scala 3. For all modules with the `@instantiable` annotation, add the mixin `IsInstantiable`. Supersedes #5376 

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Add D/I tests to Scala 3
<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

<!--
### Development notes
- AI tool(s) used: 
- Merge strategy (defaults to squash): 
- Milestone: 
-->
