### PR TITLE
[Scala3] Add staging to Scala 3 test build in build.mill

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -101,6 +101,7 @@ object v extends Module {
   def scala2Compiler(scalaVersion: String) = mvn"org.scala-lang:scala-compiler:$scalaVersion"
   def scala3Compiler(scalaVersion: String) = mvn"org.scala-lang::scala3-compiler:$scalaVersion"
   def scalaLibrary(scalaVersion:   String) = mvn"org.scala-lang:scala-library:$scalaVersion"
+  def scala3Staging(scalaVersion:  String) = mvn"org.scala-lang::scala3-staging:$scalaVersion"
 
   def circt(version: String, os: String, platform: String) =
     s"https://github.com/llvm/circt/releases/download/firtool-${version}/circt-full-shared-${os}-${platform}.tar.gz"
@@ -320,7 +321,8 @@ trait Chisel extends CrossSbtModule with HasScala2MacroAnno with HasScalaPlugin 
   def compileMvnDeps = Seq(v.scalatest)
 
   object test extends CrossSbtTests with TestModule.ScalaTest with ScalafmtModule {
-    def mvnDeps = Seq(v.scalatest, v.scalacheck)
+    def mvnDeps = Seq(v.scalatest, v.scalacheck) ++
+      (if (v.isScala3(crossScalaVersion)) Seq(v.scala3Staging(_scalaVersion)) else Nil)
 
     // TODO: enable sandbox and run tests in parallel
     override def testSandboxWorkingDir = false


### PR DESCRIPTION
### Summary

Mitigate D/I testing failures in json4s in `firrtl.annotations.JsonProtocol` whose reflective serializer lives in scala3-staging that's not on the default Scala 3 classpath

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
`firrtl.annotations.JsonProtocol` uses a reflective serializer from `Json4s`, which in Scala 3 requires the `scala3-staging` dependency for affected projects. Added scala3-staging as dependency for Scala 3 testing

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

<!--
### Development notes
- AI tool(s) used: 
- Merge strategy (defaults to squash): 
- Milestone: 
-->
