### PR TITLE
[Scala3] Move ConnectableSpec

### DIFF
--- a/core/src/main/scala/chisel3/Module.scala
+++ b/core/src/main/scala/chisel3/Module.scala
@@ -714,11 +714,19 @@ package experimental {
       *
       * Includes the module prefix for user-defined modules (but not for blackboxes).
       */
-    private[chisel3] def _proposedName: String = this match {
-      // PseudoModules (e.g. Instances) and BlackBoxes have their names set by desiredName.
-      case _: PseudoModule => desiredName
-      case _: BaseBlackBox => desiredName
-      case _ => this.modulePrefix + desiredName
+    private[chisel3] def _proposedName: String = {
+      val dn = desiredName
+      // Handle Scala 3 null values
+      if (dn == null)
+        throw new NullPointerException(
+          s"desiredName of ${this.getClass.getName} is null"
+        )
+      this match {
+        // PseudoModules (e.g. Instances) and BlackBoxes have their names set by desiredName.
+        case _: PseudoModule => dn
+        case _: BaseBlackBox => dn
+        case _ => this.modulePrefix + dn
+      }
     }
 
     /** Legalized name of this module. */

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -1848,7 +1848,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         ChiselStage.emitCHIRRTL(new MyModule, args = Array("--throw-on-first-error"))
       }
       // names show up as `null` in Scala 3 and `<unknown>` in Scala 2
-      e.getMessage should include regex(
+      (e.getMessage should include).regex(
         "mismatched widths of .* and .* might require truncation of .*"
       )
     }

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -1847,8 +1847,9 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       val e = intercept[ChiselException] {
         ChiselStage.emitCHIRRTL(new MyModule, args = Array("--throw-on-first-error"))
       }
-      e.getMessage should include(
-        "mismatched widths of <unknown>.out: IO[UInt<4>] and <unknown>.in: IO[UInt<8>] might require truncation of <unknown>.in: IO[UInt<8>]"
+      // names show up as `null` in Scala 3 and `<unknown>` in Scala 2
+      e.getMessage should include regex(
+        "mismatched widths of .* and .* might require truncation of .*"
       )
     }
   }

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -1847,9 +1847,8 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       val e = intercept[ChiselException] {
         ChiselStage.emitCHIRRTL(new MyModule, args = Array("--throw-on-first-error"))
       }
-      // names show up as `null` in Scala 3 and `<unknown>` in Scala 2
-      (e.getMessage should include).regex(
-        "mismatched widths of .* and .* might require truncation of .*"
+      e.getMessage should include(
+        "mismatched widths of <unknown>.out: IO[UInt<4>] and <unknown>.in: IO[UInt<8>] might require truncation of <unknown>.in: IO[UInt<8>]"
       )
     }
   }


### PR DESCRIPTION
### Summary
Update _proposedName in Module.scala to explicitly handle Scala 3 null names which get handled by -Xcheckinit in Scala 2. Move ConnectSpec

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Update _proposedName in Module.scala to explicitly handle Scala 3 null names which get handled by -Xcheckinit in Scala 2. Cross run ConnectableSpec
<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

### Development notes
- AI tool(s) used: Claude Code + Claude Opus 4.7
