### PR TITLE
[Scala3] Move BoringUtilsSpec

### DIFF
--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -77,13 +77,13 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
     * Without disabling deduplication, this test will fail.
     */
   class TopTester extends ShouldntAssertTester {
-    val dut = Module(new Top(4))
+    val dut: Top = Module(new Top(4))
     BoringUtils.bore(dut.sources(1).x, Seq(dut.sinks(1).x, dut.sinks(2).x))
     BoringUtils.bore(dut.sources(2).x, Seq(dut.sinks(3).x, dut.sinks(4).x, dut.sinks(5).x))
   }
 
   class TopTesterFail extends ShouldntAssertTester {
-    val dut = Module(new Top(4))
+    val dut: Top = Module(new Top(4))
     BoringUtils.addSource(dut.sources(1).x, "foo", disableDedup = true)
     BoringUtils.addSink(dut.sinks(1).x, "foo", disableDedup = true)
     BoringUtils.addSink(dut.sinks(2).x, "foo", disableDedup = true)
@@ -117,7 +117,7 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
   }
 
   class InternalBoreTester extends ShouldntAssertTester {
-    val dut = Module(new InternalBore)
+    val dut: InternalBore = Module(new InternalBore)
     dut.in := true.B
     chisel3.assert(dut.out === true.B)
   }

--- a/src/test/scala/chiselTests/BoringUtilsSpec.scala
+++ b/src/test/scala/chiselTests/BoringUtilsSpec.scala
@@ -77,12 +77,16 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
     * Without disabling deduplication, this test will fail.
     */
   class TopTester extends ShouldntAssertTester {
+    // A type annotation is needed here in because otherwise Scala 3
+    // infers the type as BaseModule
     val dut: Top = Module(new Top(4))
     BoringUtils.bore(dut.sources(1).x, Seq(dut.sinks(1).x, dut.sinks(2).x))
     BoringUtils.bore(dut.sources(2).x, Seq(dut.sinks(3).x, dut.sinks(4).x, dut.sinks(5).x))
   }
 
   class TopTesterFail extends ShouldntAssertTester {
+    // A type annotation is needed here in because otherwise Scala 3
+    // infers the type as BaseModule
     val dut: Top = Module(new Top(4))
     BoringUtils.addSource(dut.sources(1).x, "foo", disableDedup = true)
     BoringUtils.addSink(dut.sinks(1).x, "foo", disableDedup = true)
@@ -117,6 +121,8 @@ class BoringUtilsSpec extends AnyFlatSpec with Matchers with LogUtils with FileC
   }
 
   class InternalBoreTester extends ShouldntAssertTester {
+    // A type annotation is needed here in because otherwise Scala 3
+    // infers the type as BaseModule
     val dut: InternalBore = Module(new InternalBore)
     dut.in := true.B
     chisel3.assert(dut.out === true.B)


### PR DESCRIPTION


### Summary
Scala 3 widens the DUT type here to Module. Add explicit `val dut: Type` annotations so that .sources/.sinks members on Top stay visible under Scala 3's tighter override-val widening
<!--
Describe what this PR changes and why it's needed.
If necessary, describe any future work this change adds or any negative effects of this change (tech debt, code smells).
-->

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Move BoringUtilsSpec to /src/test/scala/
<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->
