### PR TITLE
[Scala3] Move TestingDirectorySpec

### DIFF
--- a/src/test/scala/chiselTests/testing/scalatest/TestingDirectorySpec.scala
+++ b/src/test/scala/chiselTests/testing/scalatest/TestingDirectorySpec.scala
@@ -5,10 +5,9 @@ package chiselTests.testing.scalatest
 import chisel3._
 import chisel3.simulator.SimulatorAPI
 import chisel3.testing.scalatest.TestingDirectory
-import java.nio.file.FileSystems
+import java.nio.file.{FileSystems, Files, Path}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import scala.reflect.io.Directory
 
 class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI with TestingDirectory {
 
@@ -16,28 +15,48 @@ class TestingDirectorySpec extends AnyFunSpec with Matchers with SimulatorAPI wi
     stop()
   }
 
+  private def deleteRecursively(path: Path): Unit = {
+    if (Files.exists(path)) {
+      if (Files.isDirectory(path)) {
+        val stream = Files.newDirectoryStream(path)
+        try stream.forEach(deleteRecursively)
+        finally stream.close()
+      }
+      Files.delete(path)
+    }
+  }
+
+  private def deepFiles(path: Path): Seq[Path] = {
+    if (!Files.exists(path)) Nil
+    else {
+      val stream = Files.walk(path)
+      try {
+        val out = scala.collection.mutable.ListBuffer.empty[Path]
+        stream.forEach(p => if (Files.isRegularFile(p)) out += p)
+        out.toSeq
+      } finally stream.close()
+    }
+  }
+
   /** Check that the directory structure and the files contained within make sense
     * for a Chiselsim/svsim build.
     */
   private def checkDirectoryStructure[A](dir: String, subDirs: String*): Unit = {
 
-    val directory = Directory(
-      FileSystems.getDefault
-        .getPath(
-          dir,
-          subDirs: _*
-        )
-        .toFile
-    )
-    directory.deleteRecursively()
+    val directory: Path = FileSystems.getDefault
+      .getPath(
+        dir,
+        subDirs: _*
+      )
+    deleteRecursively(directory)
 
     simulate(new Foo) { _ => }
 
-    val allFiles = directory.deepFiles.toSeq.map(_.toString).toSet
+    val allFiles = deepFiles(directory).map(_.toString).toSet
     for (
       file <- Seq(
-        directory.toFile.toString + "/workdir-verilator/Makefile",
-        directory.toFile.toString + "/primary-sources/Foo.sv"
+        directory.toString + "/workdir-verilator/Makefile",
+        directory.toString + "/primary-sources/Foo.sv"
       )
     ) {
       info(s"found expected file: '$file'")


### PR DESCRIPTION
Summary
Replace Scala 2 only scala.reflect.io.Directory with local helpers built on java.nio.file

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Add local helpers to TestingDirectorySpec to replace Scala 2-only scala.reflect.io.Directory 
<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: Claude Code + Claude Opus 4.7
