### PR TITLE
[Scala3] Accept multi-arg is() in switch macro; move tests

### DIFF
--- a/src/main/scala-3/chisel3/util/Switch.scala
+++ b/src/main/scala-3/chisel3/util/Switch.scala
@@ -37,10 +37,12 @@ private object SwitchMacros {
       case Inlined(_, _, Block(head, tail)) => head :+ tail
     }
 
-    // List of params and blocks as in `is(params) { block }`
+    // List of params and blocks as in `is(params) { block }`. The
+    // parameter list may have one Iterable arg, one Element arg, or
+    // multiple Element args (the `is(v: T, vr: T*)` overload).
     val isCallExprs: List[Expr[(Iterable[T], () => Any)]] = statements.flatMap {
-      case Apply(Apply(fun, List(paramArg)), List(blockArg)) if isApplySymbol(fun.symbol) =>
-        Some(buildIsCallExpr[T](paramArg, blockArg))
+      case Apply(Apply(fun, paramArgs), List(blockArg)) if isApplySymbol(fun.symbol) =>
+        Some(buildIsCallExpr[T](paramArgs, blockArg))
 
       case term =>
         report.errorAndAbort(
@@ -65,14 +67,27 @@ private object SwitchMacros {
 
   private def buildIsCallExpr[T <: Element: Type](
     using Quotes
-  )(paramArg: quotes.reflect.Term, blockArg: quotes.reflect.Term): Expr[(Iterable[T], () => Any)] = {
+  )(paramArgs: List[quotes.reflect.Term], blockArg: quotes.reflect.Term): Expr[(Iterable[T], () => Any)] = {
     import quotes.reflect.*
 
-    val paramsExpr: Expr[Iterable[T]] = paramArg.asExpr match {
-      case '{ $iter: Iterable[T] } => iter
-      case '{ $elem: T }           => '{ Seq($elem) }
-      case other =>
-        report.errorAndAbort(s"is() parameter must be an Element or Iterable[Element], got: ${other.show}")
+    // Unwrap any vararg wrappers added by the typer (`Typed(SeqLiteral(...), Repeated)`).
+    val flatArgs: List[Term] = paramArgs.flatMap {
+      case Typed(Repeated(elems, _), _) => elems
+      case Repeated(elems, _)           => elems
+      case other                        => List(other)
+    }
+
+    val paramsExpr: Expr[Iterable[T]] = flatArgs match {
+      case List(single) =>
+        single.asExpr match {
+          case '{ $iter: Iterable[T] } => iter
+          case '{ $elem: T }           => '{ Seq($elem) }
+          case other =>
+            report.errorAndAbort(s"is() parameter must be an Element or Iterable[Element], got: ${other.show}")
+        }
+      case multi =>
+        val elemExprs = multi.map(_.asExprOf[T])
+        '{ Seq(${ Varargs(elemExprs) }*) }
     }
 
     val blockExpr: Expr[() => Any] = blockArg.asExpr match {

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -202,13 +202,13 @@ class SIntOpsSpec extends AnyPropSpec with Matchers with ShiftRightWidthBehavior
   }
 
   property("Static right-shift should have a minimum width of 1") {
-    testShiftRightWidthBehavior(SInt)(chiselMinWidth = 1, firrtlMinWidth = 1)
+    testShiftRightWidthBehavior(BitsFactory.sintFactory)(chiselMinWidth = 1, firrtlMinWidth = 1)
   }
 
   property("Static right-shift should have width of 0 in Chisel and 1 in FIRRTL with --use-legacy-width") {
     val args = Array("--use-legacy-width")
 
-    testShiftRightWidthBehavior(SInt)(chiselMinWidth = 0, firrtlMinWidth = 1, args = args)
+    testShiftRightWidthBehavior(BitsFactory.sintFactory)(chiselMinWidth = 0, firrtlMinWidth = 1, args = args)
 
     // Focused test to show the mismatch
     class TestModule extends Module {

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -213,13 +213,22 @@ class UIntLitZeroWidthTester extends Module {
   stop()
 }
 
-trait ShiftRightWidthBehavior extends WidthHelpers {
-  // The UInt and SInt objects don't share a type, so make one up that they can conform to structurally
-  type BitsFactory[T <: Bits] = {
-    def apply():         T
-    def apply(w: Width): T
+trait BitsFactory[T <: Bits] {
+  def apply():         T
+  def apply(w: Width): T
+}
+object BitsFactory {
+  val uintFactory: BitsFactory[UInt] = new BitsFactory[UInt] {
+    def apply():         UInt = UInt()
+    def apply(w: Width): UInt = UInt(w)
   }
+  val sintFactory: BitsFactory[SInt] = new BitsFactory[SInt] {
+    def apply():         SInt = SInt()
+    def apply(w: Width): SInt = SInt(w)
+  }
+}
 
+trait ShiftRightWidthBehavior extends WidthHelpers {
   def testShiftRightWidthBehavior[T <: Bits](
     factory: BitsFactory[T]
   )(chiselMinWidth: Int, firrtlMinWidth: Int, args: Iterable[String] = Nil): Unit = {
@@ -551,13 +560,13 @@ class UIntOpsSpec extends AnyPropSpec with Matchers with LogUtils with ShiftRigh
   }
 
   property("Static right-shift should have a minimum width of 0") {
-    testShiftRightWidthBehavior(UInt)(chiselMinWidth = 0, firrtlMinWidth = 0)
+    testShiftRightWidthBehavior(BitsFactory.uintFactory)(chiselMinWidth = 0, firrtlMinWidth = 0)
   }
 
   property("Static right-shift should have width of 0 in Chisel and 1 in FIRRTL with --use-legacy-width") {
     val args = Array("--use-legacy-width")
 
-    testShiftRightWidthBehavior(UInt)(chiselMinWidth = 0, firrtlMinWidth = 1, args = args)
+    testShiftRightWidthBehavior(BitsFactory.uintFactory)(chiselMinWidth = 0, firrtlMinWidth = 1, args = args)
 
     // Focused test to show the mismatch
     class TestModule extends Module {


### PR DESCRIPTION
### Summary

This was missing in the Scala 3 implementation of the switch macro and causing issues with UInt/SInt op tests

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Add support for multi-arg is() statements inside the switch macros. Cross run UIntOpsSpec, SIntOpsSpec

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

### Development notes
- AI tool(s) used: Claude Code + Claude Opus 4.7
