### PR TITLE
Support OpaqueTypes in Lookupable

### DIFF
--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -9,7 +9,7 @@ import scala.annotation.implicitNotFound
 import scala.collection.mutable.HashMap
 import chisel3._
 import chisel3.experimental.dataview.{isView, reify, reifyIdentityView}
-import chisel3.internal.firrtl.ir.{Arg, ILit, Index, LitIndex, ModuleIO, Slot, ULit}
+import chisel3.internal.firrtl.ir.{Arg, ILit, Index, LitIndex, ModuleIO, OpaqueSlot, Slot, ULit}
 import chisel3.internal.{throwException, Builder, ViewParent}
 import chisel3.internal.binding.{AggregateViewBinding, ChildBinding, CrossModuleBinding, ViewBinding, ViewWriteability}
 
@@ -260,7 +260,8 @@ object Lookupable {
     def unrollCoordinates(res: List[Arg], d: Data): (List[Arg], Data) = d.binding.get match {
       case ChildBinding(parent) =>
         d.getRef match {
-          case arg @ (_: Slot | _: Index | _: LitIndex | _: ModuleIO) => unrollCoordinates(arg :: res, parent)
+          case arg @ (_: Slot | _: Index | _: LitIndex | _: ModuleIO | _: OpaqueSlot) =>
+            unrollCoordinates(arg :: res, parent)
           case other => err(s"unrollCoordinates failed for '$arg'! Unexpected arg '$other'")
         }
       case _ => (res, d)
@@ -274,6 +275,7 @@ object Lookupable {
             case (LitIndex(_, n), vec: Vec[_])    => vec.apply(n)
             case (Index(_, ILit(n)), vec: Vec[_]) => vec.apply(n.toInt)
             case (ModuleIO(_, name), rec: Record) => rec._elements(name)
+            case (OpaqueSlot(_), rec: Record)     => rec._elements("")
             case (arg, _)                         => err(s"Unexpected Arg '$arg' applied to '$d'! Root was '$start'.")
           }
           applyCoordinates(coor.tail, next)

--- a/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
+++ b/core/src/main/scala/chisel3/experimental/hierarchy/core/Lookupable.scala
@@ -452,7 +452,7 @@ object Lookupable {
       def definitionLookup[A](that: A => B, definition: Definition[A]): C = {
         val ret = that(definition.proto)
         if (isView(ret)) {
-          ??? // TODO!!!!!!  cloneViewToContext(ret, instance, ioMap, instance.getInnerDataContext)
+          cloneViewToContext(ret, definition.cache, None, definition.getInnerDataContext)
         } else {
           doLookupData(ret, definition.cache, None, definition.getInnerDataContext)
         }

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -347,6 +347,20 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
+    it("(1.p): should work on views (e.g. FlatIO) containing OpaqueTypes") {
+      class Top extends Module {
+        val defn = Definition(new HasFlatIOWithOpaque)
+        mark(defn.io.x, "x")
+      }
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|HasFlatIOWithOpaque>x"
+             |CHECK-NEXT: "tag":"x"
+             |""".stripMargin
+        )
+    }
   }
   describe("(2): Annotations on designs not in the same chisel compilation") {
     // Extract the built `AddTwo` module for use in other tests.
@@ -865,7 +879,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
   }
   describe("(7): @instantiable and @public should compose with DataView") {
     import chisel3.experimental.dataview._
-    ignore("(7.a): should work on simple Views") {
+    it("(7.a): should work on simple Views") {
       @instantiable
       class MyModule extends RawModule {
         val in = IO(Input(UInt(8.W)))

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -329,6 +329,24 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
+    it("(1.o): should work on OpaqueTypes") {
+      class Top extends Module {
+        val defn = Definition(new HasOpaqueType)
+        mark(defn.in, "in")
+        mark(defn.wire, "wire")
+      }
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|HasOpaqueType>in"
+             |CHECK-NEXT: "tag":"in"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|HasOpaqueType>wire"
+             |CHECK-NEXT: "tag":"wire"
+             |""".stripMargin
+        )
+    }
   }
   describe("(2): Annotations on designs not in the same chisel compilation") {
     // Extract the built `AddTwo` module for use in other tests.

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
@@ -432,11 +432,11 @@ object Examples {
 
   @instantiable
   class HasOpaqueType extends Module {
-    @public val in   = IO(Input(new OpaqueRecord))
-    @public val out  = IO(Output(new OpaqueRecord))
+    @public val in = IO(Input(new OpaqueRecord))
+    @public val out = IO(Output(new OpaqueRecord))
     @public val wire = Wire(new OpaqueRecord)
     wire := in
-    out  := wire
+    out := wire
   }
 
   class OpaqueRecordBundle extends Bundle {

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
@@ -439,6 +439,15 @@ object Examples {
     out  := wire
   }
 
+  class OpaqueRecordBundle extends Bundle {
+    val x = new OpaqueRecord
+  }
+
+  @instantiable
+  class HasFlatIOWithOpaque extends RawModule {
+    @public val io = FlatIO(new OpaqueRecordBundle)
+  }
+
   // For test 9.c in DefinitionSpec - testing .toDefinition on Instance from imported Definition
   @instantiable
   class BarForImport extends RawModule {

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/Examples.scala
@@ -5,8 +5,9 @@ package chiselTests.experimental.hierarchy
 import chisel3._
 import chisel3.util.{SRAM, Valid}
 import chisel3.experimental.hierarchy._
-import chisel3.experimental.{attach, Analog, BaseModule}
+import chisel3.experimental.{attach, Analog, BaseModule, OpaqueType}
 import chisel3.reflect.DataMirror
+import scala.collection.immutable.SeqMap
 
 object Examples {
   import Annotations._
@@ -422,6 +423,20 @@ object Examples {
     val wire = Wire(UInt(8.W))
     @public val simple = UserDefinedType("foo", wire, inst0)
     @public val parameterized = ParameterizedUserDefinedType(List(1, 2, 3), inst1)
+  }
+
+  class OpaqueRecord extends Record with OpaqueType {
+    private val underlying = UInt(8.W)
+    val elements = SeqMap("" -> underlying)
+  }
+
+  @instantiable
+  class HasOpaqueType extends Module {
+    @public val in   = IO(Input(new OpaqueRecord))
+    @public val out  = IO(Output(new OpaqueRecord))
+    @public val wire = Wire(new OpaqueRecord)
+    wire := in
+    out  := wire
   }
 
   // For test 9.c in DefinitionSpec - testing .toDefinition on Instance from imported Definition

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -331,6 +331,25 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
              |""".stripMargin
         )
     }
+    it("(1.o): should work on OpaqueTypes") {
+      class Top extends Module {
+        val definition = Definition(new HasOpaqueType)
+        val i0 = Instance(definition)
+        mark(i0.in, "in")
+        mark(i0.wire, "wire")
+      }
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|Top/i0:HasOpaqueType>in"
+             |CHECK-NEXT: "tag":"in"
+             |CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|Top/i0:HasOpaqueType>wire"
+             |CHECK-NEXT: "tag":"wire"
+             |""".stripMargin
+        )
+    }
   }
   describe("(2) Annotations on designs not in the same chisel compilation") {
     // Extract the built `AddTwo` module for use in other tests.

--- a/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
+++ b/src/test/scala-2/chiselTests/experimental/hierarchy/InstanceSpec.scala
@@ -350,6 +350,21 @@ class InstanceSpec extends AnyFunSpec with Matchers with Utils with FileCheck {
              |""".stripMargin
         )
     }
+    it("(1.p): should work on views (e.g. FlatIO) containing OpaqueTypes") {
+      class Top extends Module {
+        val definition = Definition(new HasFlatIOWithOpaque)
+        val i0 = Instance(definition)
+        mark(i0.io.x, "x")
+      }
+      ChiselStage
+        .emitCHIRRTL(new Top)
+        .fileCheck()(
+          """|CHECK:      "class":"chiselTests.experimental.hierarchy.Annotations$MarkAnnotation"
+             |CHECK-NEXT: "target":"~|Top/i0:HasFlatIOWithOpaque>x"
+             |CHECK-NEXT: "tag":"x"
+             |""".stripMargin
+        )
+    }
   }
   describe("(2) Annotations on designs not in the same chisel compilation") {
     // Extract the built `AddTwo` module for use in other tests.


### PR DESCRIPTION
### Summary

When cloning to context a `Data` that is a child of some `Aggregate`, Lookupable has to clone the root `Data` and then return the equivalent child (potentially deeply nested) which involves walking up and then back down the Aggregate hierarchy. Previously this did not properly support `OpaqueTypes` now it does.

### Release Notes

Fix bug in `Lookupable` for `OpaqueTypes`

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: Claude Code (Claude Sonnet 4.6)
- Merge strategy (defaults to squash): squash
- Milestone: 

