### PR TITLE
[core] Add domain.domainOf API

### DIFF
--- a/core/src/main/scala/chisel3/domain/package.scala
+++ b/core/src/main/scala/chisel3/domain/package.scala
@@ -2,6 +2,7 @@
 
 package chisel3
 
+import chisel3.experimental.requireIsHardware
 import chisel3.internal.Builder
 import chisel3.internal.firrtl.ir
 import chisel3.experimental.SourceInfo
@@ -40,6 +41,21 @@ package object domain {
     Builder.pushOp(
       ir.DefPrim(sourceInfo, source.cloneType, ir.PrimOp.UnsafeDomainCast, source.ref +: domains.map(_.ref): _*)
     )
+  }
+
+  /** For a hardware type [[Data]], get the domain type of that wire for a given
+    * domain kind.
+    *
+    * @param a some hardware
+    * @param kind a kind of domain
+    * @return the domain type of `a`
+    */
+  def domainOf(a: Data, kind: => domain.Type)(implicit sourceInfo: SourceInfo): domain.Type = {
+    requireIsHardware(a)
+    val _Domain = Wire(kind)
+    val _a = WireInit(a)
+    Module.currentModule.get.associate(_a, _Domain)
+    _Domain
   }
 
 }

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -3,7 +3,7 @@
 package chiselTests
 
 import chisel3._
-import chisel3.domain.{Domain, Field}
+import chisel3.domain.{domainOf, Domain, Field}
 import chisel3.domains.ClockDomain
 import chisel3.experimental.dataview._
 import chisel3.properties.Property
@@ -440,5 +440,39 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
     intercept[IllegalArgumentException] {
       ChiselStage.elaborate(new Foo)
     }.getMessage should include("cannot associate a port or wire with zero domains")
+  }
+
+  behavior of "The domainOf API"
+
+  it should "return the type of a port" in {
+    class Foo extends RawModule {
+      val a = IO(Input(Bool()))
+      val A = IO(Input(ClockDomain.Type()))
+      val B = IO(Output(ClockDomain.Type()))
+      associate(a, A)
+
+      domain.define(B, domainOf(a, ClockDomain.Type()))
+    }
+
+    // Test that domain port `B` is connected to domain port `A`.
+    //
+    // Note: this test is slightly brittle as the temporary wire is left in.  It
+    // is fine if this, in a later version of `firtool` does a direct
+    // connection.
+    ChiselStage
+      .emitFIRRTLDialect(new Foo, firtoolOpts = Array("-domain-mode=infer-all"))
+      .fileCheck() {
+        """|CHECK:      %[[D:.+]] = firrtl.wire : !firrtl.domain
+           |CHECK-NEXT: firrtl.domain.define %[[D]], %A
+           |CHECK-NEXT: firrtl.domain.define %B, %[[D]]
+           |firrtl.domain.define
+           |""".stripMargin
+      }
+  }
+
+  it should "error if the domain of a non-hardware type is queried" in {
+    intercept[ExpectedHardwareException] {
+      domainOf(Bool(), ClockDomain.Type())
+    }
   }
 }


### PR DESCRIPTION
Add an API which can be used to get the domain of a hardware type for a
given domain kind.  This is intended to be used in situations where you
need to record a domain relationship, but do not know how to find the
source domain.

E.g., consider the case of a clock divider using a register.  You want to
say that the output of the register is on a new clock domain synchronous
to the source.  However, you don't actually know what the source clock
domain is.  This allows you to express that by getting the `domainOf` the
input.

### Release Notes

Add `domainOf` API which allows for returning the domain of a hardware type for a specific domain kind.  E.g., this lets you return the clock domain of a wire.
