### PR TITLE
Remove internal uses of os-lib

### DIFF
--- a/core/src/main/scala/chisel3/experimental/ExtModule.scala
+++ b/core/src/main/scala/chisel3/experimental/ExtModule.scala
@@ -23,19 +23,27 @@ private[chisel3] object BlackBoxHelpers {
   implicit class BlackBoxInlineAnnoHelpers(anno: BlackBoxInlineAnno.type) extends LazyLogging {
 
     /** Generate a BlackBoxInlineAnno from a Java Resource and a module name. */
-    def fromResource(resourceName: String, moduleName: ModuleName) = try {
-      val blackBoxFile = os.resource / os.RelPath(resourceName.dropWhile(_ == '/'))
-      val contents = os.read(blackBoxFile)
+    def fromResource(resourceName: String, moduleName: ModuleName): BlackBoxInlineAnno = {
+      // Resources are looked up relative to the root of the classpath, so drop any leading slashes.
+      val relativeResource = resourceName.dropWhile(_ == '/')
+      val stream = Thread.currentThread().getContextClassLoader.getResourceAsStream(relativeResource)
+      if (stream == null) {
+        throw new BlackBoxNotFoundException(resourceName, s"Unable to find resource '$resourceName'!")
+      }
+      val contents =
+        try {
+          scala.io.Source.fromInputStream(stream)(scala.io.Codec.UTF8).mkString
+        } finally {
+          stream.close()
+        }
       if (contents.size > BigInt(2).pow(20)) {
         val message =
           s"Black box resource $resourceName, which will be converted to an inline annotation, is greater than 1 MiB." +
             "This may affect compiler performance. Consider including this resource via a black box path."
         logger.warn(message)
       }
-      BlackBoxInlineAnno(moduleName, blackBoxFile.last, contents)
-    } catch {
-      case e: os.ResourceNotFoundException =>
-        throw new BlackBoxNotFoundException(resourceName, e.getMessage)
+      val fileName = relativeResource.split('/').last
+      BlackBoxInlineAnno(moduleName, fileName, contents)
     }
   }
 }

--- a/core/src/main/scala/chisel3/internal/CIRCTConverter.scala
+++ b/core/src/main/scala/chisel3/internal/CIRCTConverter.scala
@@ -9,7 +9,7 @@ import chisel3.assume.Assume
 import chisel3.cover.Cover
 import chisel3.internal.firrtl.ir._
 
-@deprecated("There no CIRCTConverter anymore, use circtpanamaconverter directly", "Chisel 6.0")
+@deprecated("There is no CIRCTConverter, use normal APIs through CIRCTStage", "Chisel 7.0")
 abstract class CIRCTConverter {
   val mlirStream:         Writable
   val firrtlStream:       Writable

--- a/src/main/scala-2/chisel3/experimental/util/SerializableModuleElaborator.scala
+++ b/src/main/scala-2/chisel3/experimental/util/SerializableModuleElaborator.scala
@@ -19,8 +19,11 @@ trait SerializableModuleElaborator {
     * Implementation of a config API to serialize the [[SerializableModuleParameter]]
     * @example
     * {{{
-    *  def config(parameter: MySerializableModuleParameter) =
-    *    os.write.over(os.pwd / "config.json", configImpl(parameter))
+    *  def config(parameter: MySerializableModuleParameter): Unit = {
+    *    val out = java.nio.file.Files.newOutputStream(java.nio.file.Paths.get("config.json"))
+    *    try configImpl(parameter).writeBytesTo(out)
+    *    finally out.close()
+    *  }
     * }}}
     */
   def configImpl[P <: SerializableModuleParameter: universe.TypeTag](
@@ -35,10 +38,16 @@ trait SerializableModuleElaborator {
     * @return A tuple of Readable, where the first is the firrtl and the second is the serializable annotations
     * @example
     * {{{
-    *  def design(parameter: os.Path) = {
-    *    val (firrtl, annos) = designImpl[MySerializableModule, MySerializableModuleParameter](os.read.stream(parameter))
-    *    os.write.over(os.pwd / "GCD.fir", firrtl)
-    *    os.write.over(os.pwd / "GCD.anno.json", annos)
+    *  def design(parameter: java.nio.file.Path): Unit = {
+    *    val input = new String(java.nio.file.Files.readAllBytes(parameter), java.nio.charset.StandardCharsets.UTF_8)
+    *    val (firrtl, annos) = designImpl[MySerializableModule, MySerializableModuleParameter](input)
+    *    writeReadable(firrtl, java.nio.file.Paths.get("GCD.fir"))
+    *    writeReadable(annos, java.nio.file.Paths.get("GCD.anno.json"))
+    *  }
+    *  def writeReadable(data: geny.Readable, path: java.nio.file.Path): Unit = {
+    *    val out = java.nio.file.Files.newOutputStream(path)
+    *    try data.writeBytesTo(out)
+    *    finally out.close()
     *  }
     * }}}
     */

--- a/src/main/scala/chisel3/testing/FileCheck.scala
+++ b/src/main/scala/chisel3/testing/FileCheck.scala
@@ -4,8 +4,10 @@ package chisel3.testing
 
 import firrtl.options.StageUtils.dramaticMessage
 import java.io.{ByteArrayOutputStream, IOException, PrintWriter}
-import java.nio.file.{Files, StandardOpenOption}
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
 import scala.Console.{withErr, withOut}
+import scala.io.Source
 import scala.util.control.NoStackTrace
 import scala.sys.process._
 
@@ -89,27 +91,36 @@ trait FileCheck {
       // Filecheck needs to have the thing to check in a file.
       //
       // TODO: This could be made ephemeral or use a named pipe?
-      val dir = os.FilePath(testingDirectory.getDirectory).resolveFrom(os.pwd)
-      os.makeDir.all(dir)
-      val tempDir = os.temp.dir(dir = dir, deleteOnExit = false)
-      val checkFile = tempDir / "check"
-      val inputFile = tempDir / "input"
-      os.write.over(target = checkFile, data = check, createFolders = true)
-      os.write.over(target = inputFile, data = input, createFolders = true)
+      val dir = testingDirectory.getDirectory.toAbsolutePath.normalize()
+      Files.createDirectories(dir)
+      val tempDir = Files.createTempDirectory(dir, "")
+      val checkFile = tempDir.resolve("check")
+      val inputFile = tempDir.resolve("input")
+      Files.write(checkFile, check.getBytes(StandardCharsets.UTF_8))
+      Files.write(inputFile, input.getBytes(StandardCharsets.UTF_8))
 
-      val extraArgs = os.Shellable(fileCheckArgs)
+      val command = Seq("FileCheck", checkFile.toString) ++ fileCheckArgs
       val stdoutStream, stderrStream = new java.io.ByteArrayOutputStream
       val stdoutWriter = new PrintWriter(stdoutStream)
       val stderrWriter = new PrintWriter(stderrStream)
-      val result =
+      val processIO = new ProcessIO(
+        // Feed the input file to FileCheck's stdin.
+        in = { stdin =>
+          try Files.copy(inputFile, stdin)
+          finally stdin.close()
+        },
+        out = { stdout =>
+          try Source.fromInputStream(stdout).getLines().foreach(stdoutWriter.println)
+          finally stdout.close()
+        },
+        err = { stderr =>
+          try Source.fromInputStream(stderr).getLines().foreach(stderrWriter.println)
+          finally stderr.close()
+        }
+      )
+      val exitCode =
         try {
-          os.proc("FileCheck", checkFile, extraArgs)
-            .call(
-              stdin = inputFile,
-              stdout = os.ProcessOutput.Readlines(stdoutWriter.println),
-              stderr = os.ProcessOutput.Readlines(stderrWriter.println),
-              check = false
-            )
+          Process(command).run(processIO).exitValue()
         } catch {
           case a: IOException if a.getMessage.startsWith("Cannot run program") =>
             throw new FileCheck.Exceptions.NotFound(a.getMessage)
@@ -117,15 +128,27 @@ trait FileCheck {
       stdoutWriter.close()
       stderrWriter.close()
 
-      result match {
-        case os.CommandResult(_, 0, _) => os.remove.all(tempDir)
-        case os.CommandResult(command, exitCode, _) =>
-          throw new FileCheck.Exceptions.NonZeroExitCode(
-            s"cat $inputFile | ${command.mkString(" ")}",
-            exitCode,
-            stderrStream.toString
-          )
+      if (exitCode == 0) {
+        deleteRecursively(tempDir)
+      } else {
+        throw new FileCheck.Exceptions.NonZeroExitCode(
+          s"cat $inputFile | ${command.mkString(" ")}",
+          exitCode,
+          stderrStream.toString
+        )
       }
+    }
+
+    /** Recursively delete a file or directory and its contents. */
+    private def deleteRecursively(path: Path): Unit = {
+      if (Files.isDirectory(path)) {
+        val stream = Files.newDirectoryStream(path)
+        try {
+          val it = stream.iterator()
+          while (it.hasNext) deleteRecursively(it.next())
+        } finally stream.close()
+      }
+      Files.deleteIfExists(path)
     }
 
   }

--- a/src/main/scala/chisel3/util/experimental/SlangUtils.scala
+++ b/src/main/scala/chisel3/util/experimental/SlangUtils.scala
@@ -12,18 +12,30 @@ object SlangUtils {
 
   /** Use Slang to parse Verilog into Json AST. */
   def getVerilogAst(verilog: String): Value = {
-    val astFile = os.temp()
-    os.proc(
+    import scala.sys.process._
+    import java.nio.charset.StandardCharsets
+    import java.nio.file.Files
+    val astFile = Files.createTempFile("slang", ".json")
+    val verilogFile = Files.createTempFile("slang", ".sv")
+    astFile.toFile.deleteOnExit()
+    verilogFile.toFile.deleteOnExit()
+    Files.write(verilogFile, verilog.getBytes(StandardCharsets.UTF_8))
+    val command = Seq(
       "slang",
-      os.temp(verilog),
+      verilogFile.toString,
       "--single-unit",
       "--ignore-unknown-modules",
       "--compat",
       "vcs",
       "--ast-json",
-      astFile
-    ).call()
-    ujson.read(os.read(astFile))
+      astFile.toString
+    )
+    val stderr = new StringBuilder
+    val exitCode = command.!(ProcessLogger(_ => (), line => stderr.append(line).append('\n')))
+    if (exitCode != 0) {
+      throw new ChiselException(s"slang exited with non-zero exit code $exitCode:\n${stderr.toString}")
+    }
+    ujson.read(new String(Files.readAllBytes(astFile), StandardCharsets.UTF_8))
   }
 
   /** Extract IO from Verilog AST. */

--- a/src/main/scala/chisel3/util/experimental/decode/EspressoMinimizer.scala
+++ b/src/main/scala/chisel3/util/experimental/decode/EspressoMinimizer.scala
@@ -79,9 +79,13 @@ object EspressoMinimizer extends Minimizer with LazyLogging {
                     |""".stripMargin)
     val output =
       try {
-        os.proc("espresso").call(stdin = input).out.chunks.mkString
+        import scala.sys.process._
+        val stdin = new java.io.ByteArrayInputStream(input.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+        (Process("espresso") #< stdin).!!
       } catch {
-        case e: java.io.IOException if e.getMessage.contains("error=2, No such file or directory") =>
+        case e: java.io.IOException
+            if e.getMessage.contains("Cannot run program") ||
+              e.getMessage.contains("error=2, No such file or directory") =>
           throw EspressoNotFoundException
       }
     logger.trace(s"""espresso output table:

--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -194,12 +194,15 @@ class CIRCT extends Phase {
     }
 
     // FIRRTL is serialized either in memory or to a file
-    val input: Either[Iterable[String], os.Path] =
+    val input: Either[Iterable[String], java.nio.file.Path] =
       if (circtOptions.dumpFir) {
-        val td = os.Path(stageOptions.targetDir, os.pwd)
+        val td = java.nio.file.Paths.get(stageOptions.targetDir).toAbsolutePath.normalize()
         val filename = firrtlOptions.outputFileName.getOrElse(circuitName)
-        val firPath = td / s"$filename.fir"
-        os.write.over(firPath, serialization, createFolders = true)
+        val firPath = td.resolve(s"$filename.fir")
+        java.nio.file.Files.createDirectories(firPath.getParent)
+        val writer = java.nio.file.Files.newBufferedWriter(firPath)
+        try serialization.foreach(writer.write)
+        finally writer.close()
         Right(firPath)
       } else {
         Left(serialization)
@@ -264,15 +267,29 @@ class CIRCT extends Phase {
     val stdoutStream, stderrStream = new java.io.ByteArrayOutputStream
     val stdoutWriter = new java.io.PrintWriter(stdoutStream)
     val stderrWriter = new java.io.PrintWriter(stderrStream)
-    val stdin: os.ProcessInput = input match {
-      case Left(it) => (it: os.Source) // Static cast to apply implicit conversion
-      case Right(_) => os.Pipe
-    }
-    val stdout = os.ProcessOutput.Readlines(stdoutWriter.println)
-    val stderr = os.ProcessOutput.Readlines(stderrWriter.println)
+    val processIO = new ProcessIO(
+      // When the FIRRTL is kept in memory (Left), pipe it to firtool's stdin.  When it was dumped to
+      // a file (Right), firtool reads it from the file argument, so we leave stdin empty.
+      in = { stdin =>
+        input.left.foreach { serialization =>
+          val writer = new java.io.OutputStreamWriter(stdin, java.nio.charset.StandardCharsets.UTF_8)
+          try serialization.foreach(writer.write)
+          finally writer.close()
+        }
+        stdin.close()
+      },
+      out = { stdout =>
+        try scala.io.Source.fromInputStream(stdout).getLines().foreach(stdoutWriter.println)
+        finally stdout.close()
+      },
+      err = { stderr =>
+        try scala.io.Source.fromInputStream(stderr).getLines().foreach(stderrWriter.println)
+        finally stderr.close()
+      }
+    )
     val exitValue =
       try {
-        os.proc(cmd).call(check = false, stdin = stdin, stdout = stdout, stderr = stderr).exitCode
+        Process(cmd).run(processIO).exitValue()
       } catch {
         case a: java.io.IOException if a.getMessage().startsWith("Cannot run program") =>
           throw new Exceptions.FirtoolNotFound(a.getMessage())


### PR DESCRIPTION

### Summary

Remove uses of os-lib so that we can remove the dependency in 8.x.

### Release Notes

Chisel should have as few dependencies as possible so that it does not unnecessarily burden downstream users with transitive dependencies. This was motivated by the fact that we can't bump os-lib to 0.11 because it requires Java 11 and we still support Java 8. It's not fair to Chisel users to be stuck on os-lib 0.11. The best way to deal with this is to just not have unnecessary dependencies like os-lib.

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: Claude Code (Claude Opus 4.8)
- Merge strategy (defaults to squash): squash
- Milestone: 7.x

