### PR TITLE
Revise Intellectual Property Policy section of project charter

### DIFF
--- a/PROJECT_CHARTER.md
+++ b/PROJECT_CHARTER.md
@@ -83,21 +83,17 @@ g. Responsibilities. The TSC will be responsible for all aspects of oversight re
 
 ---
 
-7. Intellectual Property Policy
+## 7. Intellectual Property Policy
 
-a. Collaborators acknowledge that the copyright in all new contributions will be retained by the copyright holder as independent works of authorship and that no contributor or copyright holder will be required to assign copyrights to the Project.
-
-b. Except as described in Section 7.c., all contributions to the Project are subject to the following:
-
-- i. All new inbound code contributions to the Project must be made using [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0) (the “Project License”).
-- ii. All new inbound code contributions must also be accompanied by a [Developer Certificate of Origin](http://developercertificate.org) sign-off in the source code system that is submitted through a TSC-approved contribution process.
-- iii. All outbound code will be made available under the Project License.
-- iv. Documentation will be received and made available by the Project under the Project License.
-- v. The Project may seek to integrate and contribute back to other open source projects (“Upstream Projects”), conforming to all license requirements of those projects.
-
-c. The TSC may approve the use of an alternative license or licenses for inbound or outbound contributions on an exception basis. License exceptions must be approved by a two-thirds vote of the entire TSC.
-
-d. Contributed files should contain license information, such as SPDX short form identifiers, indicating the open source license or licenses pertaining to the file.
+- a. Collaborators acknowledge that the copyright in all new contributions will be retained by the copyright holder as independent works of authorship and that no contributor or copyright holder will be required to assign copyrights to the Project.
+- b. Except as described in Section 7.c., all contributions to the Project are subject to the following:
+  - i. All new inbound code contributions to the Project must be made using Apache License, Version 2.0 available at http://www.apache.org/licenses/LICENSE-2.0, except for contributions to sv-tests, which can also be made under the Internet Systems Consortium (ISC) license, available at https://opensource.org/license/isc-license-txt. Collectively, those licenses will be called "Project Licenses".
+  - ii. All new inbound code contributions, whether as a self-employed individual or an individual employed by a corporation, must be made pursuant to a binding Contributor License Agreement in the form approved by the TSC. Self-employed individual contributors must agree to the ICLA (in the form approved by the TSC), and individuals employed by an organization must have that organization agree to the CCLA (in the form approved by the TSC).
+  - iii. All outbound code will be made available under the Project Licenses.
+  - iv. Documentation will be received and made available by the Project under the Creative Commons Attribution 4.0 International License (available at http://creativecommons.org/licenses/by/4.0/).
+  - v. The Project may seek to integrate and contribute back to other open source projects ("Upstream Projects"). In such cases, the Project will conform to all license requirements of the Upstream Projects, including dependencies, leveraged by the Project. Upstream Project code contributions not stored within the Project's main code repository will comply with the contribution process and license terms for the applicable Upstream Project.
+- c. The TSC may approve the use of an alternative license or licenses for inbound or outbound contributions on an exception basis. To request an exception, please describe the contribution, the alternative open source license(s), and the justification for using an alternative open source license for the Project. License exceptions must be approved by a two-thirds vote of the entire TSC.
+- d. Contributed files should contain license information, such as SPDX short form identifiers, indicating the open source license or licenses pertaining to the file.
 
 ---
 


### PR DESCRIPTION
https://github.com/chipsalliance/chisel/issues/5415

### Summary

The CHIPS board recently updated the charter to clarify and improve the IP guidance. SV Tools was the first project to have the improved and more accurate text. We'd like to roll out this text to the other technical charters.These changes do not have to go through LF approval or a board vote. They probably need an approval of the project's TSC if one exists.