### PR TITLE
Bump OSS CAD suite to make #5418 fail in CI

### DIFF
--- a/.github/workflows/setup-oss-cad-suite/action.yml
+++ b/.github/workflows/setup-oss-cad-suite/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'version to install'
     required: false
-    default: '2023-06-21'
+    default: '2026-02-03'
 
 runs:
   using: composite


### PR DESCRIPTION
### Summary

Bump version of OSS CAD suite. Pickup the first nightly build of Verilator that makes #5418 fail.

### Development notes
As we expect CI to fail, this PR cannot merge until #5418 is fixed.