### PR TITLE
[debug] Inline enum variants into debug var/subfield intrinsics

### DIFF
--- a/core/src/main/scala/chisel3/debug/DebugMetaEmitter.scala
+++ b/core/src/main/scala/chisel3/debug/DebugMetaEmitter.scala
@@ -21,7 +21,6 @@ private[chisel3] object DebugIntrinsics {
   }
 
   private class ComponentDebugEmitter extends LazyLogging {
-    private val emittedEnums = mutable.HashSet.empty[String]
     private val emittedIds = mutable.HashSet.empty[HasId]
 
     private val ctorExtractor = new CtorParamExtractor
@@ -113,7 +112,6 @@ private[chisel3] object DebugIntrinsics {
       // CIRCT's CirctDebugVarConverter matches leaves to the root by exact equality.
       val childParent: Option[String] = parent.orElse(Some(signalRef(target)))
       val subCmds: Seq[Command] = target match {
-        case e:      EnumType => createEnumDefIntrinsic(e, si).toSeq
         case record: Record =>
           record.elements.values.flatMap(createIntrinsic(_, childParent, si)).toSeq
         case vecLike: VecLike[_] =>
@@ -131,30 +129,13 @@ private[chisel3] object DebugIntrinsics {
       (fqn, fqn.split("\\.").last)
     }
 
-    private def createEnumDefIntrinsic(e: EnumType, si: SourceInfo): Option[Command] = {
-      val (fqn, simple) = enumNames(e)
-      if (!emittedEnums.add(fqn)) return None
+    // The width is what stops the downstream IntegerAttr from defaulting to i64.
+    private def enumVariantsParams(e: EnumType): Seq[(String, Param)] = {
       val variants = e.factory.allWithNames.map { case (v, name) => EnumVariant(name, v.litValue.toString) }
-      // Pass the enum's actual bit-width so LowerIntrinsics can build
-      // variantsMap with an IntegerAttr of matching width (otherwise
-      // it falls back to i64 and downstream consumers like EmitUHDI
-      // surface `underlyingTypeRef: "uint64"` for what is in fact a
-      // tiny enum). getWidth is always known for a Chisel EnumType.
       val widthParam: Seq[(String, Param)] =
         if (e.width.known) Seq("width" -> IntParam(BigInt(e.width.get)))
         else Nil
-      Some(
-        DefIntrinsic(
-          si,
-          "circt_debug_enumdef",
-          Nil,
-          Seq(
-            "typeName" -> StringParam(simple),
-            "fqn" -> StringParam(fqn),
-            "variants" -> StringParam(json.write(variants))
-          ) ++ widthParam
-        )
-      )
+      ("variants" -> StringParam(json.write(variants))) +: widthParam
     }
 
     private def createIntrinsic(target: BaseModule, si: SourceInfo): Seq[Command] = Seq(
@@ -184,7 +165,8 @@ private[chisel3] object DebugIntrinsics {
       val enumParam: Seq[(String, Param)] = target match {
         case e: EnumType =>
           val (fqn, simple) = enumNames(e)
-          Seq("enumTypeName" -> StringParam(simple), "enumFqn" -> StringParam(fqn))
+          Seq("enumTypeName" -> StringParam(simple), "enumFqn" -> StringParam(fqn)) ++
+            enumVariantsParams(e)
         case _ => Nil
       }
       val parentParam = parent.map("parent" -> StringParam(_)).toSeq

--- a/docs/src/explanations/intrinsics.md
+++ b/docs/src/explanations/intrinsics.md
@@ -60,8 +60,11 @@ The following intrinsics are emitted:
   and `name`.
 - `circt_debug_subfield` - one per Bundle/Vec element, linked to its parent via
   a `parent` attribute.
-- `circt_debug_enumdef` - one per `ChiselEnum` type (emitted once per circuit),
-  listing all variants and their literal values.
+
+A `ChiselEnum`-typed `circt_debug_var`/`circt_debug_subfield` additionally
+carries its enum metadata inline: `enumTypeName`, `enumFqn`, a JSON-encoded
+`variants` string listing all variants and their literal values, and the
+underlying bit `width`.
 
 Emission is opt-in and off by default. Enable it by passing
 `--with-experimental-debug-intrinsics` on the command line, or by adding

--- a/src/test/scala/chisel3/debug/DebugDataTypesSpec.scala
+++ b/src/test/scala/chisel3/debug/DebugDataTypesSpec.scala
@@ -113,9 +113,6 @@ class DebugDataTypesSpec extends AnyFunSpec with Matchers {
     val DTE = Some("DebugTestEnum")
     val DTE2 = Some("DebugTestEnum2")
 
-    checkAt(chirrtl, "should emit enumdef once per enum type")(
-      Seq(enumDefPattern("DebugTestEnum"), enumDefPattern("DebugTestEnum2"))
-    )
     checkAt(chirrtl, "should annotate enum port with enumTypeName")(
       Seq(varPattern("IO[DebugTestEnum]", "e", DTE), varPattern("IO[DebugTestEnum2]", "e2", DTE2))
     )

--- a/src/test/scala/chisel3/debug/DebugTestCircuits.scala
+++ b/src/test/scala/chisel3/debug/DebugTestCircuits.scala
@@ -29,7 +29,9 @@ object DebugTestUtils extends Matchers {
   }
 
   private def attrPart(name: String, value: String): String = s"""[^)]*$name\\s*=\\s*"${q(value)}""""
-  private def enumPart(et:   Option[String]):        String = et.fold("")(attrPart("enumTypeName", _))
+  // An enum node carries its variants inline (typeName + variants JSON + width).
+  private def enumPart(et: Option[String]): String =
+    et.fold("")(tn => attrPart("enumTypeName", tn) + """[^)]*variants\s*=\s*"""" + """[^)]*width\s*=""")
 
   private def intrinsic(kind: String, attrs: String*): String =
     s"""intrinsic\\(circt_debug_$kind<${attrs.mkString}"""
@@ -46,7 +48,6 @@ object DebugTestUtils extends Matchers {
       enumPart(enumTypeName)
     )
 
-  def enumDefPattern(typeName:    String): String = intrinsic("enumdef", attrPart("typeName", typeName))
   def moduleInfoPattern(typeName: String): String = intrinsic("moduleinfo", attrPart("typeName", typeName))
 
   // Collapse whitespace so regex helpers ignore line wrapping.


### PR DESCRIPTION
### Summary

Drop the separate `circt_debug_enumdef` intrinsic. A ChiselEnum-typed `circt_debug_var`/`circt_debug_subfield` now carries its variants (JSON) and bit width inline alongside `enumTypeName`/`enumFqn`, so every enum use site is self-contained and no per-circuit dedup is needed. This removes an outlier intrinsic and matches the CIRCT side, which resolves enum metadata from the var/subfield itself rather than a staged `enumdef` table.

<!--
Describe what this PR changes and why it's needed.
If necessary, describe any future work this change adds or any negative effects of this change (tech debt, code smells).
-->

### Type of Improvement

Interal

### Desired Merge Strategy

Rebase: You will rebase the PR onto master and it will be merged with a merge commit.

### Release Notes

Drop the separate `circt_debug_enumdef` intrinsic. A ChiselEnum-typed `circt_debug_var`/`circt_debug_subfield` now carries its variants (JSON) and bit width inline alongside `enumTypeName`/`enumFqn`

<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

<!--
### Development notes
- AI tool(s) used: 
- Merge strategy (defaults to squash): 
- Milestone: 
-->
