### PR TITLE
[Scala3] Move util.scala

### DIFF
--- a/src/main/scala-3/chisel3/util/util.scala
+++ b/src/main/scala-3/chisel3/util/util.scala
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3
+
+/** The util package provides extensions to core chisel for common hardware components and utility
+  * functions
+  */
+package object util {
+
+  /** Synonyms, moved from main package object - maintain scope. */
+  type ValidIO[+T <: Data] = chisel3.util.Valid[T]
+  val ValidIO = chisel3.util.Valid
+}


### PR DESCRIPTION
### Summary

Add Scala 3 util.scala from `src/main/scala-2`. Scala 3 does not allow name clashes in separate files as in DecoupledIO with the one in Decoupled.scala, so delete it

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Add ValidIO alias from `chisel3.util` to Scala3

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

<!--
### Development notes
- AI tool(s) used: 
- Merge strategy (defaults to squash): 
- Milestone: 
-->
