### PR TITLE
[core] Add Debug Layer, put printfs in them

### DIFF
--- a/core/src/main/scala/chisel3/SimLog.scala
+++ b/core/src/main/scala/chisel3/SimLog.scala
@@ -49,7 +49,7 @@ sealed trait SimLog extends SimLogIntf {
     _filename.foreach(Printable.checkScope(_, "SimLog filename "))
 
     when(!Module.reset.asBool) {
-      layer.block(layers.Verification, skipIfAlreadyInBlock = true, skipIfLayersEnabled = true) {
+      layer.block(layers.Verification.Debug, skipIfAlreadyInBlock = true, skipIfLayersEnabled = true) {
         Builder.pushCommand(Flush(sourceInfo, _filename, clock.ref))
       }
     }
@@ -81,7 +81,7 @@ sealed trait SimLog extends SimLogIntf {
     Printable.checkScope(pable, "printf ")
     _filename.foreach(Printable.checkScope(_, "SimLog filename "))
 
-    layer.block(layers.Verification, skipIfAlreadyInBlock = true, skipIfLayersEnabled = true) {
+    layer.block(layers.Verification.Debug, skipIfAlreadyInBlock = true, skipIfLayersEnabled = true) {
       Builder.pushCommand(Printf(printfId, sourceInfo, _filename, clock.ref, pable))
     }
     printfId

--- a/core/src/main/scala/chisel3/layers/Layers.scala
+++ b/core/src/main/scala/chisel3/layers/Layers.scala
@@ -58,4 +58,14 @@ object Verification
         _sourceInfo = UnlocatableSourceInfo
       )
       with HasTemporalInlineLayer
+
+  /** The [[chisel3.layer.Layer]] where all printfs will be placed.  This layer
+    * _does not_ have a child temporal layer as it is not expected to be
+    * useful.
+    */
+  object Debug
+      extends Layer(LayerConfig.Extract(CustomOutputDir(Paths.get("verification", "debug"))))(
+        _parent = implicitly[Layer],
+        _sourceInfo = UnlocatableSourceInfo
+      )
 }

--- a/core/src/main/scala/chisel3/layers/package.scala
+++ b/core/src/main/scala/chisel3/layers/package.scala
@@ -17,7 +17,8 @@ package object layers {
     Verification.Assume,
     Verification.Assume.Temporal,
     Verification.Cover,
-    Verification.Cover.Temporal
+    Verification.Cover.Temporal,
+    Verification.Debug
   )
 
 }

--- a/docs/src/explanations/layers.md
+++ b/docs/src/explanations/layers.md
@@ -251,8 +251,9 @@ chisel3.layers.Verification                          (Extract)
 │   └── chisel3.layers.Verification.Assert.Temporal  (Inline)
 ├── chisel3.layers.Verification.Assume               (Extract)
 │   └── chisel3.layers.Verification.Assume.Temporal  (Inline)
-└── chisel3.layers.Verification.Cover                (Extract)
-    └── chisel3.layers.Verification.Cover.Temporal   (Inline)
+├── chisel3.layers.Verification.Cover                (Extract)
+│   └── chisel3.layers.Verification.Cover.Temporal   (Inline)
+└── chisel3.layers.Verification.Debug                (Extract)
 ```
 
 These built-in layers are dual purpose.  First, these layers match the common
@@ -264,10 +265,10 @@ not fully supported by simulation tools.  Second, the Chisel standard library
 uses them for a number of its APIs.  _Unless otherwise wrapped in a different
 layer block, the following operations are automatically placed in layers_:
 
-* Prints are placed in the `Verification` layer
 * Assertions are placed in the `Verification.Assert` layer
 * Assumptions are placed in the `Verification.Assume` layer
 * Covers are placed in the `Verification.Cover` layer
+* Prints are placed in the `Verification.Debug` layer
 
 At this time, no operations are automatically placed in `Temporal` layers.  The
 `Temporal` layer is up to the user to use as needed.
@@ -552,21 +553,22 @@ circt.stage.ChiselStage.emitSystemVerilog(
 ### Design Verification Example
 
 Consider a use case where a design or design verification engineer would like to
-add some asserts and debug prints to a module.  The logic necessary for the
-asserts and debug prints requires additional computation.  All of this code
-should selectively included at Verilog elaboration time (not at Chisel
-elaboration time).  The engineer can use three layers to do this.
+add some asserts and prints to a module.  The prints are for the creation of an
+execution trace.  The logic necessary for the asserts and prints requires
+additional computation.  All of this code should selectively included at Verilog
+elaboration time (not at Chisel elaboration time).  The engineer can use three
+layers to do this.
 
 There are three layers used in this example:
 
 1. The built-in `Verification` layer
 1. The built-in `Assert` layer which is nested under the built-in `Verification`
    layer
-1. A user-defined `Debug` layer which is also nested under the built-in
+1. A user-defined `Trace` layer which is also nested under the built-in
    `Verification` layer
 
 The `Verification` layer can be used to store common logic used by both the
-`Assert` and `Debug` layers.  The latter two layers allow for separation of,
+`Assert` and `Trace` layers.  The latter two layers allow for separation of,
 respectively, assertions from prints.
 
 One way to write this in Scala is the following:
@@ -579,7 +581,7 @@ import chisel3.layers.Verification
 // User-defined layers are declared here.  Built-in layers do not need to be declared.
 object UserDefined {
   implicit val root: Layer = Verification
-  object Debug extends Layer(LayerConfig.Inline)
+  object Trace extends Layer(LayerConfig.Inline)
 }
 
 class Foo extends Module {
@@ -601,7 +603,7 @@ class Foo extends Module {
     }
 
     // This adds a `Debug` layer block.
-    block(UserDefined.Debug) {
+    block(UserDefined.Trace) {
       printf("a: %x, a_d0: %x", a, a_d0)
     }
 
@@ -618,13 +620,21 @@ following filenames.  One file is created for each extract layer:
 1. `layers_Foo_Verification_Assert.sv`
 
 Additionally, the resulting SystemVerilog will be sensitive to the preprocessor
-define `layer$Verification$Debug` due to the one inline layer we added.
+define `layer$Verification$Trace` due to the one inline layer we added.
 
 A user can then include any combination of these files in their design to
 include the optional functionality described by the `Verification` or
 `Verification.Assert` layers and enable debugging by setting the preprocessor
 macro.  The `Verification.Assert` bind file automatically includes the
 `Verification` bind file for the user.
+
+:::note
+
+By default, a Chisel `printf` will be put in the `Verification.Debug` extract
+layer.  This default behavior was changed in the above example by putting the
+`printf` inside the user-defined `Trace` inline layer.
+
+:::
 
 #### Implementation Notes
 

--- a/src/test/scala/chiselTests/LayerSpec.scala
+++ b/src/test/scala/chiselTests/LayerSpec.scala
@@ -504,13 +504,16 @@ class LayerSpec extends AnyFlatSpec with Matchers with FileCheck with ChiselSim 
 
     info("default layers are emitted")
     chirrtl.fileCheck() {
-      s"""|CHECK:      layer Verification, bind, "verification" :
+      s"""|CHECK-NOT:  layer
+          |CHECK:      layer Verification, bind, "verification" :
           |CHECK-NEXT:   layer Assert, bind, "verification${sep}assert" :
           |CHECK-NEXT:     layer Temporal, inline :
           |CHECK-NEXT:   layer Assume, bind, "verification${sep}assume" :
           |CHECK-NEXT:     layer Temporal, inline :
           |CHECK-NEXT:   layer Cover, bind, "verification${sep}cover" :
           |CHECK-NEXT:     layer Temporal, inline :
+          |CHECK-NEXT:   layer Debug, bind, "verification${sep}debug" :
+          |CHECK-NOT:    layer
           |""".stripMargin
     }
 

--- a/src/test/scala/chiselTests/Printf.scala
+++ b/src/test/scala/chiselTests/Printf.scala
@@ -106,4 +106,18 @@ class PrintfSpec extends AnyFlatSpec with Matchers with FileCheck {
         """CHECK: printf(clock, UInt<1>(0h1), "%0d %0x %5d %13b %c %5x\n", in, in, in, in, in, in)"""
       )
   }
+
+  "printf" should "be emitted in the Debug layer" in {
+    class Foo extends Module {
+      printf("hello")
+    }
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck()(
+        """|CHECK:      layerblock Verification :
+           |CHECK-NEXT:   layerblock Debug :
+           |CHECK-NEXT:     printf
+           |""".stripMargin
+      )
+  }
 }

--- a/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/SeparateElaborationSpec.scala
@@ -541,7 +541,7 @@ class SeparateElaborationSpec extends AnyFunSpec with Matchers with Utils with T
         .fileCheck()(
           """|CHECK: circuit Foo :
              |CHECK: layer A, bind
-             |CHECK: extmodule Bar knownlayer Verification, Verification.Assert, Verification.Assert.Temporal, Verification.Assume, Verification.Assume.Temporal, Verification.Cover, Verification.Cover.Temporal, A :
+             |CHECK: extmodule Bar knownlayer Verification, Verification.Assert, Verification.Assert.Temporal, Verification.Assume, Verification.Assume.Temporal, Verification.Cover, Verification.Cover.Temporal, Verification.Debug, A :
              |""".stripMargin
         )
     }

--- a/src/test/scala/circtTests/stage/ChiselStageSpec.scala
+++ b/src/test/scala/circtTests/stage/ChiselStageSpec.scala
@@ -143,6 +143,10 @@ object ChiselStageSpec {
       define(out, ProbeValue(a))
     }
   }
+
+  class LayerRemappingTestPrintf extends Module {
+    printf("hello")
+  }
 }
 
 /** A fixture used that exercises features of the Trace API.
@@ -1324,6 +1328,19 @@ class ChiselStageSpec extends AnyFunSpec with Matchers with chiselTests.LogUtils
       chirrtl should include("output out : Probe<UInt<1>, B>")
       chirrtl should include("layer B")
       chirrtl should include("layerblock B")
+    }
+
+    it("should allow remapping of printfs in Verification.Debug to Verification") {
+      ChiselStage
+        .emitCHIRRTL(
+          new ChiselStageSpec.LayerRemappingTestPrintf,
+          Array("--remap-layer", "chisel3.layers.Verification$Debug$,chisel3.layers.Verification$")
+        )
+        .fileCheck("-implicit-check-not='layerblock Debug'") {
+          """|CHECK:      layerblock Verification :
+             |CHECK-NEXT:   printf
+             |""".stripMargin
+        }
     }
 
     it("should suppress source info with --no-source-info") {


### PR DESCRIPTION
Add a new `Verification.Debug` layer which is intended to store all
"debugging" collateral.  Automatically put `printf`s into this layer.
Previously, `printf`s were put into the `Verification` layer.

Splitting `printf`s out is motivated by users wanting to have the ability
to synthesize asserts, but _not_ synthesize prints.  With the old
factoring, there is no ability to do this because of the dependency of the
`Verification.Assert` layer on the `Verification` layer.  This is related
to problems with approaches to remove the guarding of printfs with marco
defines (`` `ifndef SYNTHESIS``) [[1]].

[1]: https://github.com/llvm/circt/pull/10526

Note: this is a reapplication of a revert due to me fat-fingering
branches.

#### Release Notes

- Add a new `Verification.Debug` layer which will house all "debug" related collateral.
- Move `printf`s into the `Verification.Debug` layer, instead of having them in the `Verification` layer.  This allow for better factoring at Verilog elaboration time to compile with asserts and _without_ prints.  This is important for some FPGA flows.
- If you need the _old_ behavior and want to have printfs in the `Verification` layer, you can run `ChiselStage` with: `--remap-layer chisel3.layers.Verification$Debug$,chisel3.layers.Verification$`.