### PR TITLE
[Scala3] Property API fixes

### DIFF
--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -153,7 +153,8 @@ object ClassType {
   def unsafeGetClassTypeByName(name: String): ClassType = ClassType(name)
 }
 
-trait AnyClassType
+sealed trait AnyClassType
+private[chisel3] trait AnyClassTypeUnsealed extends AnyClassType
 
 object AnyClassType {
   implicit val classTypeProvider: ClassTypeProvider[AnyClassType] = ClassTypeProvider(fir.AnyRefPropertyType)

--- a/core/src/main/scala/chisel3/properties/Class.scala
+++ b/core/src/main/scala/chisel3/properties/Class.scala
@@ -153,7 +153,7 @@ object ClassType {
   def unsafeGetClassTypeByName(name: String): ClassType = ClassType(name)
 }
 
-sealed trait AnyClassType
+trait AnyClassType
 
 object AnyClassType {
   implicit val classTypeProvider: ClassTypeProvider[AnyClassType] = ClassTypeProvider(fir.AnyRefPropertyType)

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -283,7 +283,7 @@ sealed trait Property[T] extends Element { self =>
     * `asInstanceOf[Property[ClassType] with AnyClassType]` casts (and `convertUnderlying` bridges) used
     * for class-reference properties succeed under Scala 3. The static type is unchanged.
     */
-  override def cloneType: this.type = new Property[T] with AnyClassType {
+  override def cloneType: this.type = new Property[T] with AnyClassTypeUnsealed {
     val tpe = self.tpe
   }.asInstanceOf[this.type]
 
@@ -740,9 +740,10 @@ object Property {
 
   private[chisel3] def makeWithValueOpt[T](implicit _tpe: PropertyType[T]): Property[_tpe.Type] = {
     // Mixes in `AnyClassType` (a no-member marker) so the phantom
-    // `asInstanceOf[Property[ClassType] with AnyClassType]` casts and `convertUnderlying` bridges used
-    // for class-reference properties succeed under Scala 3. The static return type is unchanged.
-    new Property[_tpe.Type] with AnyClassType {
+    // `asInstanceOf[Property[ClassType] with AnyClassType]` casts and
+    // `convertUnderlying` bridges used for class-reference properties
+    // succeed under Scala 3. The static return type is unchanged.
+    new Property[_tpe.Type] with AnyClassTypeUnsealed {
       val tpe: chisel3.properties.PropertyType[T] = _tpe
     }
   }

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -278,8 +278,12 @@ sealed trait Property[T] extends Element { self =>
   }
 
   /** Clone type by simply constructing a new Property[T].
+    *
+    * The instance mixes in `AnyClassType` (a no-member marker) so that the phantom
+    * `asInstanceOf[Property[ClassType] with AnyClassType]` casts (and `convertUnderlying` bridges) used
+    * for class-reference properties succeed under Scala 3. The static type is unchanged.
     */
-  override def cloneType: this.type = new Property[T] {
+  override def cloneType: this.type = new Property[T] with AnyClassType {
     val tpe = self.tpe
   }.asInstanceOf[this.type]
 
@@ -735,7 +739,10 @@ object Property {
   }
 
   private[chisel3] def makeWithValueOpt[T](implicit _tpe: PropertyType[T]): Property[_tpe.Type] = {
-    new Property[_tpe.Type] {
+    // Mixes in `AnyClassType` (a no-member marker) so the phantom
+    // `asInstanceOf[Property[ClassType] with AnyClassType]` casts and `convertUnderlying` bridges used
+    // for class-reference properties succeed under Scala 3. The static return type is unchanged.
+    new Property[_tpe.Type] with AnyClassType {
       val tpe: chisel3.properties.PropertyType[T] = _tpe
     }
   }

--- a/src/test/scala/chiselTests/properties/AnyClassTypeSpec.scala
+++ b/src/test/scala/chiselTests/properties/AnyClassTypeSpec.scala
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chiselTests.properties
+
+import chisel3._
+import chisel3.properties.{AnyClassType, Class, Property}
+import chisel3.testing.scalatest.FileCheck
+import circt.stage.ChiselStage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AnyClassTypeSpec extends AnyFlatSpec with Matchers with FileCheck {
+  behavior.of("AnyClassType")
+
+  it should "build a Property[Seq[AnyClassType]] from object references via asAnyClassType" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val myClassA = Class.unsafeGetDynamicObject("MyClassA")
+        val myClassB = Class.unsafeGetDynamicObject("MyClassB")
+        val out = IO(Output(Property[Seq[AnyClassType]]()))
+        out :#= Property(Seq(myClassA.getReference.asAnyClassType, myClassB.getReference.asAnyClassType))
+      })
+      .fileCheck()(
+        """|CHECK: output out : List<AnyRef>
+           |CHECK: propassign out, List<AnyRef>(myClassA, myClassB)
+           |""".stripMargin
+      )
+  }
+
+  it should "build a single-element Property[Seq[AnyClassType]] via asAnyClassType" in {
+    ChiselStage
+      .emitCHIRRTL(new RawModule {
+        val myClass = Class.unsafeGetDynamicObject("MyClass")
+        val out = IO(Output(Property[Seq[AnyClassType]]()))
+        out :#= Property(Seq(myClass.getReference.asAnyClassType))
+      })
+      .fileCheck()(
+        """|CHECK: output out : List<AnyRef>
+           |CHECK: propassign out, List<AnyRef>(myClass)
+           |""".stripMargin
+      )
+  }
+}


### PR DESCRIPTION
### Summary

Mixin `AnyClassType` to property types so the phantom casts of form `asInstanceOf[Property[ClassType] with AnyClassType]` used for class-reference properties work under Scala 3

### Release Notes
Update Property API types to mixin `AnyClassType` 

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

### Development notes
- AI tool(s) used: Claude Code + Claude Opus 4.7
