### PR TITLE
Vendor com.lihaoyi:::unroll-plugin:0.3.0

### DIFF
--- a/svsim/package.mill
+++ b/svsim/package.mill
@@ -15,17 +15,21 @@ object `package` extends Module {
 trait Svsim extends ChiselCrossModule with HasCommonOptions with ScalafmtModule {
 
   def moduleDir = super.moduleDir / os.up
+  def unrollPluginModule = unroll.plugin(_scalaVersion)
 
   override def scalacOptions = Task {
     super.scalacOptions() ++
+      Seq(s"-Xplugin:${unrollPluginModule.jar().path}") ++
       Option.when(!v.isScala3(crossScalaVersion))(
         "-Xsource-features:case-apply-copy-access"
       )
   }
 
-  def compileMvnDeps = Seq(mvn"com.lihaoyi::unroll-annotation:0.3.0")
+  override def scalacPluginClasspath = Task {
+    super.scalacPluginClasspath() ++ Seq(unrollPluginModule.jar())
+  }
 
-  def scalacPluginMvnDeps = Seq(mvn"com.lihaoyi:::unroll-plugin:0.3.0")
+  def compileMvnDeps = Seq(mvn"com.lihaoyi::unroll-annotation:0.3.0")
 
   object test extends SbtTests with TestModule.ScalaTest with ScalafmtModule {
     def mvnDeps = Seq(v.scalatest, v.scalacheck)

--- a/unroll/LICENSE
+++ b/unroll/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Li Haoyi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/unroll/README.md
+++ b/unroll/README.md
@@ -1,0 +1,20 @@
+# Unroll Fork
+
+`unroll/plugin` contains a locally vendored fork of the upstream `com-lihaoyi/unroll`
+compiler plugin.
+
+Upstream project:
+- https://github.com/com-lihaoyi/unroll
+
+Licensing:
+- The code under `unroll/plugin` retains the upstream MIT license.
+- See `unroll/LICENSE` for the license text.
+- Modifications to vendored code will retain the MIT license so they can be upstreamed as necessary.
+
+Local use in this repository:
+- This fork is built by `unroll/package.mill` as the local `unroll-plugin` compiler plugin.
+- The published `unroll-annotation` dependency is still consumed from Maven.
+
+Provenance:
+- This subtree was imported from the upstream unroll project and may contain local modifications for Chisel's build and integration needs.
+- This subtree was imported from commit c9fd7e1ce9a92fe4ab15cd12fb61facc3aed8f2c (tag 0.3.0).

--- a/unroll/package.mill
+++ b/unroll/package.mill
@@ -1,0 +1,37 @@
+package build.unroll
+
+import mill._
+import mill.api.Cross
+import mill.scalalib._
+
+import build._
+
+object `package` extends Module {
+  // https://github.com/com-lihaoyi/mill/issues/3693
+  object plugin extends Cross[UnrollPlugin](v.scalaCrossVersions.map(v.scalaCrossToVersion))
+}
+
+trait UnrollPlugin extends CrossSbtModule {
+  override def artifactName = "unroll-plugin"
+
+  def moduleDir = super.moduleDir / os.up
+
+  // Compiler plugins are built against concrete Scala versions.
+  override def crossFullScalaVersion = true
+
+  override def sources = Task.Sources {
+    val base = moduleDir / "plugin"
+    if (v.isScala3(crossScalaVersion)) base / "src-3"
+    else base / "src-2"
+  }
+
+  override def resources = Task.Sources(moduleDir / "plugin" / "resources")
+
+  override def mvnDeps = Task {
+    val annotation = mvn"com.lihaoyi::unroll-annotation:0.3.0"
+    val compiler =
+      if (v.isScala3(crossScalaVersion)) v.scala3Compiler(crossScalaVersion)
+      else v.scala2Compiler(crossScalaVersion)
+    super.mvnDeps() ++ Seq(annotation, compiler)
+  }
+}

--- a/unroll/plugin/resources/plugin.properties
+++ b/unroll/plugin/resources/plugin.properties
@@ -1,0 +1,1 @@
+pluginClass=unroll.UnrollPluginScala3

--- a/unroll/plugin/resources/scalac-plugin.xml
+++ b/unroll/plugin/resources/scalac-plugin.xml
@@ -1,0 +1,4 @@
+<plugin>
+    <name>unroll</name>
+    <classname>unroll.UnrollPluginScala2</classname>
+</plugin>

--- a/unroll/plugin/src-2/UnrollPhaseScala2.scala
+++ b/unroll/plugin/src-2/UnrollPhaseScala2.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package unroll
 
 import scala.tools.nsc.symtab.Flags

--- a/unroll/plugin/src-2/UnrollPhaseScala2.scala
+++ b/unroll/plugin/src-2/UnrollPhaseScala2.scala
@@ -1,0 +1,330 @@
+package unroll
+
+import scala.tools.nsc.symtab.Flags
+import scala.tools.nsc.transform.{Transform, TypingTransformers}
+import scala.tools.nsc.{Global, Phase}
+import tools.nsc.plugins.PluginComponent
+
+class UnrollPhaseScala2(val global: Global) extends PluginComponent with TypingTransformers with Transform {
+
+  import global._
+
+  val runsAfter = List("pickler")
+
+  override val runsBefore = List("refchecks")
+
+  val phaseName = "unroll"
+
+  override def newTransformer(unit: global.CompilationUnit): global.Transformer = {
+    new UnrollTransformer(unit)
+  }
+
+  private def isValidUnrolledMethod(method: Symbol, origin: Position) = {
+    val isCtor = method.isConstructor
+
+    def explanation = {
+      def what = if (isCtor) s"a class constructor" else s"method ${method.name}"
+      val prefix = s"Cannot unroll parameters of $what"
+      if (isLocalMethod(method))
+        s"$prefix because it is a local method"
+      else if (!method.isEffectivelyFinal && !method.owner.isEffectivelyFinal)
+        s"$prefix because it can be overridden"
+      else if (method.owner.companionClass.isCaseClass)
+        s"$prefix of a case class companion object: please annotate the class constructor instead"
+      else
+        s"$prefix of a case class: please annotate the class constructor instead"
+    }
+
+    if (isCtor) true
+    else if (isLocalMethod(method)
+      || !method.isEffectivelyFinal && !method.owner.isEffectivelyFinal
+      || method.owner.companionClass.isCaseClass && method.name == nme.apply
+      || method.owner.isCaseClass && method.name == nme.copy) {
+        globalError(origin, explanation)
+        false
+      } else true
+  }
+
+  def findUnrollAnnotations(params: Seq[Symbol]): Seq[Int] = {
+    params.toList.zipWithIndex.collect {
+      case (v, i) if hasUnrollAnnotation(v) && isValidUnrolledMethod(v.owner, v.pos) => i
+    }
+  }
+
+  private def hasUnrollAnnotation(symbol: Symbol) =
+    symbol.annotations.exists(_.tpe =:= typeOf[com.lihaoyi.unroll])
+
+  private def methodHasUnroll(method: Symbol) =
+    method.paramss.exists(_.exists(hasUnrollAnnotation))
+
+  def copyValDef(vd: ValDef) = {
+    val newMods = vd.mods.copy(flags = vd.mods.flags ^ Flags.DEFAULTPARAM)
+    newStrictTreeCopier.ValDef(vd, newMods, vd.name, vd.tpt, EmptyTree)
+      .setSymbol(vd.symbol)
+  }
+
+  def copySymbol(owner: Symbol, s: Symbol) = {
+    val newSymbol = owner.newValueParameter(s.name.toTermName)
+    newSymbol.setInfo(s.tpe)
+    newSymbol
+  }
+
+  implicit class Setter[T <: Tree](t: T){
+    def set(s: Symbol) = t.setType(s.tpe).setSymbol(s)
+  }
+  def generateSingleForwarder(implDef: ImplDef,
+                              defdef: DefDef,
+                              paramIndex: Int,
+                              nextParamIndex: Int,
+                              nextSymbol: Symbol,
+                              annotatedParamListIndex: Int,
+                              paramLists: List[List[ValDef]]) = {
+
+    val forwarderDefSymbol = defdef.symbol.owner.newMethod(defdef.name)
+    val symbolReplacements = defdef
+      .vparamss
+      .flatten
+      .map { p => p.symbol -> copySymbol(forwarderDefSymbol, p.symbol) }
+      .toMap ++ {
+      defdef.symbol.tpe match{
+        case MethodType(originalParams, result) => Nil
+        case PolyType(tparams, MethodType(originalParams, result)) =>
+          // Not sure why this is necessary, but the `originalParams` here
+          // is different from `defdef.vparamss`, and we need both
+          originalParams.map(p => (p, copySymbol(forwarderDefSymbol, p)))
+      }
+    }
+
+    def forwarderMethodType0(t: Type, n: Int): Type = t match{
+      case MethodType(originalParams, result) =>
+        val forwarderParams = originalParams.map(symbolReplacements)
+        if (n == annotatedParamListIndex) MethodType(forwarderParams.take(paramIndex), result)
+        else MethodType(forwarderParams, forwarderMethodType0(result, n + 1))
+
+      case PolyType(tparams, res) => PolyType(tparams, forwarderMethodType0(res, n))
+    }
+
+    val forwarderMethodType = forwarderMethodType0(defdef.symbol.tpe, 0)
+
+    forwarderDefSymbol.setInfo(forwarderMethodType)
+
+    val newParamLists = paramLists
+      .zipWithIndex
+      .map{ case (paramList, i) =>
+        if (i != annotatedParamListIndex) paramList
+        else paramList.take(paramIndex)
+      }
+      .map(_.map(copyValDef))
+
+
+    val defaultOffset = paramLists
+      .iterator
+      .take(annotatedParamListIndex)
+      .map(_.size)
+      .sum
+
+    val forwardedValueParams = newParamLists(annotatedParamListIndex).map(p => Ident(p.name).set(p.symbol))
+
+    val nestedForwarderMethodTypes = Seq
+      .iterate(nextSymbol.tpe, defdef.vparamss.length + 1){
+        case MethodType(args, res) => res
+        case PolyType(tparams, MethodType(args, res)) => res
+      }
+      .drop(1)
+
+    val defaultCalls = Range(paramIndex, nextParamIndex).map{n =>
+      val mangledName = defdef.name.toString + "$default$" + (defaultOffset + n + 1)
+
+      val defaultOwner =
+        if (defdef.symbol.isConstructor) implDef.symbol.companionModule
+        else implDef.symbol
+
+      val defaultMember = defaultOwner.tpe.member(TermName(scala.reflect.NameTransformer.encode(mangledName)))
+      newParamLists.take(annotatedParamListIndex).map(_.map( p => Ident(p.name).set(p.symbol)))
+        .zip(nestedForwarderMethodTypes)
+        .foldLeft(Ident(mangledName).setSymbol(defaultMember).set(defaultMember).set(defaultMember): Tree) {
+          case (lhs, (ps, methodType)) => Apply(fun = lhs, args = ps).setType(methodType)
+        }
+
+    }
+
+    val forwarderCallArgs = newParamLists.zipWithIndex.map{case (v, i) =>
+      if (i == annotatedParamListIndex) forwardedValueParams.take(nextParamIndex) ++ defaultCalls
+      else v.map( p => Ident(p.name).set(p.symbol))
+    }
+
+    val forwarderThis = This(defdef.symbol.owner).set(defdef.symbol.owner)
+
+    val forwarderInner =
+      if (defdef.symbol.isConstructor) Super(forwarderThis, typeNames.EMPTY).set(defdef.symbol.owner)
+      else forwarderThis
+
+    val forwarderCall0 = forwarderCallArgs
+      .zip(nestedForwarderMethodTypes)
+      .foldLeft(Select(forwarderInner, defdef.name).set(nextSymbol): Tree){
+        case (lhs, (ps, methodType)) => Apply(fun = lhs, args = ps).setType(methodType)
+      }
+
+    val forwarderCall =
+      if (!defdef.symbol.isConstructor) forwarderCall0
+      else Block(List(forwarderCall0), Literal(Constant(())).setType(typeOf[Unit]))
+
+    val forwarderDef = treeCopy.DefDef(
+      defdef,
+      mods = defdef.mods,
+      name = defdef.name,
+      tparams = defdef.tparams,
+      vparamss = newParamLists,
+      tpt = defdef.tpt,
+      rhs = if (nextParamIndex == -1) EmptyTree else forwarderCall
+    ).set(forwarderDefSymbol)
+
+    // No idea why this `if` guard is necessary, but without it we end up missing
+    // some generated forwarders on trait methods inherited by static objects
+    if (defdef.symbol.owner.isTrait && !defdef.symbol.isAbstract) {
+      defdef.symbol.owner.info.asInstanceOf[ClassInfoType].decls.enter(forwarderDefSymbol)
+    }
+
+    val (fromSyms, toSyms) = symbolReplacements.toList.unzip
+    forwarderDef.substituteSymbols(fromSyms, toSyms).asInstanceOf[DefDef]
+  }
+
+  private object LintInnerMethods extends Traverser {
+    override def traverse(tree: Tree): Unit = {
+      tree match {
+        case method: DefDef =>
+          if (methodHasUnroll(method.symbol)) isValidUnrolledMethod(method.symbol, method.pos)
+          traverseChildren(method.rhs)
+        case _ => ()
+      }
+    }
+
+    final def traverseChildren(tree: Tree): Unit = super.traverse(tree)
+  }
+
+  private def isLocalMethod(sym: Symbol): Boolean = {
+    sym.ownerChain.tail.exists(_.isMethod) || sym.isLocalToBlock
+  }
+
+  class UnrollTransformer(unit: global.CompilationUnit) extends TypingTransformer(unit) {
+    def generateDefForwarders(implDef: ImplDef): List[(Option[Symbol], Seq[DefDef])] = {
+      implDef.impl.body.collect{ case defdef: DefDef =>
+        LintInnerMethods.traverseChildren(defdef.rhs)
+
+        val annotatedOpt =
+          if (defdef.symbol.isCaseCopy && defdef.symbol.name.toString == "copy") {
+            Some(defdef.symbol.owner.primaryConstructor)
+          } else if (defdef.symbol.isCaseApplyOrUnapply && defdef.symbol.name.toString == "apply"){
+            val classConstructor = defdef.symbol.owner.companionClass.primaryConstructor
+            if (classConstructor == NoSymbol) None
+            else Some(classConstructor)
+          } else {
+            Some(defdef.symbol)
+          }
+
+        // Somehow the "apply" methods of case class companions defined within local scopes
+        // do not have companion class primary constructor symbols, so we just skip them here
+        try {
+          if (annotatedOpt.isEmpty) (None, Nil)
+          else {
+            annotatedOpt.get.tpe.paramss
+              .zipWithIndex
+              .flatMap{case (annotatedParamList, paramListIndex) =>
+                val annotationIndices = findUnrollAnnotations(annotatedParamList)
+                if (annotationIndices.isEmpty) None
+                else Some((annotatedParamList, annotationIndices, paramListIndex))
+              } match{
+              case Nil => (None, Nil)
+              case Seq((annotatedParamList, annotationIndices, paramListIndex)) =>
+                if (defdef.symbol.isAbstract) {
+                  (Some(defdef.symbol),
+                  (Seq(-1) ++ annotationIndices ++ Seq(annotatedParamList.length)).sliding(2).toList.foldLeft((Seq.empty[DefDef], defdef.symbol)) {
+                    case ((defdefs, nextSymbol), Seq(paramIndex, nextParamIndex)) =>
+                      val forwarderDef = generateSingleForwarder(
+                        implDef,
+                        defdef,
+                        nextParamIndex,
+                        paramIndex,
+                        nextSymbol,
+                        paramListIndex,
+                        defdef.vparamss
+                      )
+                      (forwarderDef +: defdefs, forwarderDef.symbol)
+                  }._1)
+                }
+                else {
+                  (None,
+                  (annotationIndices :+ annotatedParamList.length).sliding(2).toList.reverse.foldLeft((Seq.empty[DefDef], defdef.symbol)){
+                    case ((defdefs, nextSymbol), Seq(paramIndex, nextParamIndex)) =>
+                      val forwarderDef =  generateSingleForwarder(
+                        implDef,
+                        defdef,
+                        paramIndex,
+                        nextParamIndex,
+                        nextSymbol,
+                        paramListIndex,
+                        defdef.vparamss
+                      )
+                      (forwarderDef +: defdefs, forwarderDef.symbol)
+                  }._1)
+                }
+
+              case multiple => sys.error("Multiple")
+            }
+          }
+        }catch{case e: Throwable =>
+          throw new Exception(
+            s"Failed to generate unrolled defs for $defdef in ${implDef.symbol} in ${implDef.symbol.pos}",
+            e
+          )
+
+        }
+      }
+    }
+
+    override def transform(tree: global.Tree): global.Tree = {
+      tree match{
+        case md: ModuleDef =>
+          val (removed0, allNewMethodsLists) = generateDefForwarders(md).unzip
+          val removed = removed0.flatten.toSet
+          val allNewMethods = allNewMethodsLists.flatten
+          val classInfoType = md.symbol.moduleClass.info.asInstanceOf[ClassInfoType]
+          val newClassInfoType = classInfoType.copy(decls = newScopeWith(allNewMethods.map(_.symbol) ++ classInfoType.decls:_*))
+
+          md.symbol.moduleClass.setInfo(newClassInfoType)
+          super.transform(
+            treeCopy.ModuleDef(
+              md,
+              mods = md.mods,
+              name = md.name,
+              impl = treeCopy.Template(
+                md.impl,
+                parents = md.impl.parents,
+                self = md.impl.self,
+                body = md.impl.body.filter(t => !removed.contains(t.symbol)) ++ allNewMethods
+              )
+            )
+          )
+        case cd: ClassDef =>
+          val (removed0, allNewMethodsLists) = generateDefForwarders(cd).unzip
+          val removed = removed0.flatten.toSet
+          val allNewMethods = allNewMethodsLists.flatten
+          super.transform(
+            treeCopy.ClassDef(
+              cd,
+              mods = cd.mods,
+              name = cd.name,
+              tparams = cd.tparams,
+              impl = treeCopy.Template(
+                cd.impl,
+                parents = cd.impl.parents,
+                self = cd.impl.self,
+                body = cd.impl.body.filter(t => !removed.contains(t.symbol)) ++ allNewMethods
+              )
+            )
+          )
+        case _ => super.transform(tree)
+      }
+    }
+  }
+}

--- a/unroll/plugin/src-2/UnrollPluginScala2.scala
+++ b/unroll/plugin/src-2/UnrollPluginScala2.scala
@@ -1,0 +1,9 @@
+package unroll
+
+import tools.nsc.Global
+
+class UnrollPluginScala2(val global: Global) extends tools.nsc.plugins.Plugin {
+  val name = "unroll"
+  val description = "Plugin to unroll default methods for binary compatibility"
+  val components = List(new UnrollPhaseScala2(this.global))
+}

--- a/unroll/plugin/src-2/UnrollPluginScala2.scala
+++ b/unroll/plugin/src-2/UnrollPluginScala2.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package unroll
 
 import tools.nsc.Global

--- a/unroll/plugin/src-3/UnrollPhaseScala3.scala
+++ b/unroll/plugin/src-3/UnrollPhaseScala3.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package unroll
 
 import dotty.tools.dotc.*

--- a/unroll/plugin/src-3/UnrollPhaseScala3.scala
+++ b/unroll/plugin/src-3/UnrollPhaseScala3.scala
@@ -1,0 +1,350 @@
+package unroll
+
+import dotty.tools.dotc.*
+import plugins.*
+import core.*
+import Contexts.*
+import Symbols.*
+import Flags.*
+import SymDenotations.*
+import Decorators.*
+import ast.Trees.*
+import ast.tpd
+import StdNames.nme
+import Names.*
+import Constants.Constant
+import dotty.tools.dotc.core.NameKinds.DefaultGetterName
+import dotty.tools.dotc.core.Types.{MethodType, NamedType, PolyType, Type}
+import dotty.tools.dotc.core.Symbols
+
+import scala.language.implicitConversions
+import dotty.tools.dotc.util.SrcPos
+
+class UnrollPhaseScala3() extends PluginPhase {
+  import tpd._
+
+  val phaseName = "unroll2"
+
+  override val runsAfter = Set(transform.Pickler.name)
+
+  def copyParam(p: ValDef, parent: Symbol)(using Context) = {
+    implicitly[Context].typeAssigner.assignType(
+      cpy.ValDef(p)(p.name, p.tpt, p.rhs),
+      Symbols.newSymbol(parent, p.name, p.symbol.flags, p.symbol.info)
+    )
+  }
+
+  def copyParam2(p: TypeDef, parent: Symbol)(using Context) = {
+    implicitly[Context].typeAssigner.assignType(
+      cpy.TypeDef(p)(p.name, p.rhs),
+      Symbols.newSymbol(parent, p.name, p.symbol.flags, p.symbol.info)
+    )
+  }
+
+  /**
+   * Adapted from:
+   * - https://github.com/scala/scala3/pull/21693/files#diff-367e32065f51ed46353fdaaf526ab7e7899404b219d24d5b1054fce7f376dfe5R127
+   * - https://github.com/scala/scala3/pull/21693/files#diff-e054695755ff26925ae51361df0f7cd4940bc1fd7ceb658023d0dc38c18178c3R3412
+   * - https://github.com/scala/scala3/pull/22926/files#diff-367e32065f51ed46353fdaaf526ab7e7899404b219d24d5b1054fce7f376dfe5R135
+   */
+  private def isValidUnrolledMethod(method: Symbol, origin: SrcPos)(using Context) = {
+    val isCtor = method.isConstructor
+
+    def explanation =
+      def what = if isCtor then i"a ${if method.owner.is(Trait) then "trait" else "class"} constructor" else i"method ${method.name}"
+      val prefix = s"Cannot unroll parameters of $what"
+      if method.isLocal then
+        i"$prefix because it is a local method"
+      else if !method.isEffectivelyFinal then
+        i"$prefix because it can be overridden"
+      else if isCtor && method.owner.is(Trait) then
+        i"implementation restriction: $prefix"
+      else if method.owner.companionClass.is(CaseClass) then
+        i"$prefix of a case class companion object: please annotate the class constructor instead"
+      else
+        i"$prefix of a case class: please annotate the class constructor instead"
+
+    if method.name.is(DefaultGetterName) then false
+    else if method.isLocal
+      || !method.isEffectivelyFinal
+      || isCtor && method.owner.is(Trait)
+      || method.owner.companionClass.is(CaseClass) && (method.name == nme.apply || method.name == nme.fromProduct)
+      || method.owner.is(CaseClass) && method.name == nme.copy then
+        report.error(explanation, origin)
+        false
+    else true
+  }
+
+
+  // if `annotatedMethod` is a case class apply, case class copy or case class fromProduct then `params` actually comes from the case class' primary constructor
+  // but we still need to check the actual annotated method hence the two-step check
+  def findUnrollAnnotations(params: List[Symbol], specialCasedMethod: Option[Symbol])(using Context): List[Int] = {
+
+    specialCasedMethod.foreach { annotatedMethod => 
+      if methodHasUnroll(annotatedMethod) then isValidUnrolledMethod(annotatedMethod, annotatedMethod.sourcePos)
+    }
+      
+    params
+      .zipWithIndex
+      .collect {
+        case (v, i) if hasUnrollAnnotation(v) && isValidUnrolledMethod(v.owner, v.sourcePos) =>
+          i
+      }
+  }
+
+  private def methodHasUnroll(method: Symbol)(using Context) =
+    method.paramSymss.exists(_.exists(hasUnrollAnnotation))
+
+  private def hasUnrollAnnotation(sym: Symbol)(using Context) = 
+    sym.annotations.exists(_.symbol.fullName.toString == "com.lihaoyi.unroll")
+
+  def isTypeClause(p: ParamClause) = p.headOption.exists(_.isInstanceOf[TypeDef])
+  def generateSingleForwarder(defdef: DefDef,
+                              prevMethodType: Type,
+                              paramIndex: Int,
+                              nextParamIndex: Int,
+                              nextSymbol: Symbol,
+                              annotatedParamListIndex: Int,
+                              paramLists: List[ParamClause],
+                              isCaseApply: Boolean)
+                             (using Context) = {
+
+    def truncateMethodType0(tpe: Type, n: Int): Type = {
+      tpe match{
+        case pt: PolyType => PolyType(pt.paramNames, pt.paramInfos, truncateMethodType0(pt.resType, n + 1))
+        case mt: MethodType =>
+          if (n == annotatedParamListIndex) MethodType(mt.paramInfos.take(paramIndex), mt.resType)
+          else MethodType(mt.paramInfos, truncateMethodType0(mt.resType, n + 1))
+      }
+    }
+
+    val truncatedMethodType = truncateMethodType0(prevMethodType, 0)
+    val forwarderDefSymbol = Symbols.newSymbol(
+      defdef.symbol.owner,
+      defdef.name,
+      defdef.symbol.flags &~
+      HasDefaultParams &~
+      (if (nextParamIndex == -1) Flags.EmptyFlags else Deferred) |
+      Invisible,
+      truncatedMethodType
+    )
+
+    val newParamLists: List[ParamClause] = paramLists.zipWithIndex.map{ case (ps, i) =>
+      if (i == annotatedParamListIndex) ps.take(paramIndex).map(p => copyParam(p.asInstanceOf[ValDef], forwarderDefSymbol))
+      else {
+        if (isTypeClause(ps)) ps.map(p => copyParam2(p.asInstanceOf[TypeDef], forwarderDefSymbol))
+        else ps.map(p => copyParam(p.asInstanceOf[ValDef], forwarderDefSymbol))
+      }
+    }
+
+    val defaultOffset = paramLists
+      .iterator
+      .take(annotatedParamListIndex)
+      .filter(!isTypeClause(_))
+      .map(_.size)
+      .sum
+
+    val defaultCalls = Range(paramIndex, nextParamIndex).map(n =>
+      val inner = if (defdef.symbol.isConstructor) {
+        ref(defdef.symbol.owner.companionModule)
+          .select(DefaultGetterName(defdef.name, n + defaultOffset))
+      } else if (isCaseApply) {
+        ref(defdef.symbol.owner.companionModule)
+          .select(DefaultGetterName(termName("<init>"), n + defaultOffset))
+      } else {
+        This(defdef.symbol.owner.asClass)
+          .select(DefaultGetterName(defdef.name, n + defaultOffset))
+      }
+
+      newParamLists
+        .take(annotatedParamListIndex)
+        .map(_.map(p => ref(p.symbol)))
+        .foldLeft[Tree](inner){
+          case (lhs: Tree, newParams) =>
+            if (newParams.headOption.exists(_.isInstanceOf[TypeTree])) TypeApply(lhs, newParams)
+            else Apply(lhs, newParams)
+        }
+    )
+
+    val forwarderInner: Tree = This(defdef.symbol.owner.asClass).select(nextSymbol)
+
+    val forwarderCallArgs =
+      newParamLists.zipWithIndex.map{case (ps, i) =>
+        if (i == annotatedParamListIndex) ps.map(p => ref(p.symbol)).take(nextParamIndex) ++ defaultCalls
+        else ps.map(p => ref(p.symbol))
+      }
+
+    lazy val forwarderCall0 = forwarderCallArgs.foldLeft[Tree](forwarderInner){
+      case (lhs: Tree, newParams) =>
+        if (newParams.headOption.exists(_.isInstanceOf[TypeTree])) TypeApply(lhs, newParams)
+        else Apply(lhs, newParams)
+    }
+
+    lazy val forwarderCall =
+      if (!defdef.symbol.isConstructor) forwarderCall0
+      else Block(List(forwarderCall0), Literal(Constant(())))
+
+    val forwarderDef = implicitly[Context].typeAssigner.assignType(
+      cpy.DefDef(defdef)(
+        name = forwarderDefSymbol.name,
+        paramss = newParamLists,
+        tpt = defdef.tpt,
+        rhs = if (nextParamIndex == -1) EmptyTree else forwarderCall
+      ),
+      forwarderDefSymbol
+    )
+
+    forwarderDef
+  }
+
+  def generateFromProduct(startParamIndices: List[Int], paramCount: Int, defdef: DefDef)(using Context) = {
+    // Handle both Block(stmts, Apply(...)) and direct Apply(...) forms
+    // In some Scala 3 versions, the rhs is a Block, in others it's directly an Apply
+    val (stmts, select, args) = defdef.rhs match {
+      case Block(stmts, Apply(select, args)) => (stmts, select, args)
+      case Apply(select, args) => (Nil, select, args)
+    }
+    cpy.DefDef(defdef)(
+      name = defdef.name,
+      paramss = defdef.paramss,
+      tpt = defdef.tpt,
+      rhs = Match(
+        ref(defdef.paramss.head.head.asInstanceOf[ValDef].symbol).select(termName("productArity")),
+        startParamIndices.map { paramIndex =>
+          CaseDef(
+            Literal(Constant(paramIndex)),
+            EmptyTree,
+            Block(
+              stmts.take(paramIndex),
+                Apply(
+                select,
+                args.take(paramIndex) ++
+                  Range(paramIndex, paramCount).map(n =>
+                    ref(defdef.symbol.owner.companionModule)
+                      .select(DefaultGetterName(defdef.symbol.owner.primaryConstructor.name.toTermName, n))
+                  )
+              )
+            )
+          )
+        } ++ Seq(
+          CaseDef(
+            EmptyTree,
+            EmptyTree,
+            defdef.rhs
+          )
+        )
+      )
+    ).setDefTree
+  }
+
+  def generateSyntheticDefs(tree: Tree)(using Context): (Option[Symbol], Seq[Tree]) = tree match{
+    case defdef: DefDef if defdef.paramss.nonEmpty =>
+      import dotty.tools.dotc.core.NameOps.isConstructorName
+
+      LintInnerMethods.traverseChildren(defdef.rhs)
+
+      val isCaseCopy =
+        defdef.name.toString == "copy" && defdef.symbol.owner.is(CaseClass)
+
+      val isCaseApply =
+        defdef.name.toString == "apply" && defdef.symbol.owner.companionClass.is(CaseClass)
+
+      val isCaseFromProduct = defdef.name.toString == "fromProduct" && defdef.symbol.owner.companionClass.is(CaseClass)
+
+      val annotated =
+        if (isCaseCopy) defdef.symbol.owner.primaryConstructor
+        else if (isCaseApply) defdef.symbol.owner.companionClass.primaryConstructor
+        else if (isCaseFromProduct) defdef.symbol.owner.companionClass.primaryConstructor
+        else defdef.symbol
+
+      val specialCasedMethod = Option.when(isCaseCopy || isCaseApply || isCaseFromProduct)(defdef.symbol)
+
+      annotated
+        .paramSymss
+        .zipWithIndex
+        .flatMap{case (paramClause, paramClauseIndex) =>
+          val annotationIndices = findUnrollAnnotations(paramClause, specialCasedMethod)
+          if (annotationIndices.isEmpty) None
+          else Some((paramClauseIndex, annotationIndices))
+        }  match{
+        case Nil => (None, Nil)
+        case Seq((paramClauseIndex, annotationIndices)) =>
+          val paramCount = annotated.paramSymss(paramClauseIndex).size
+          if (isCaseFromProduct) {
+            (Some(defdef.symbol), Seq(generateFromProduct(annotationIndices, paramCount, defdef)))
+          } else {
+            if (defdef.symbol.is(Deferred)){
+              (
+                Some(defdef.symbol),
+                (-1 +: annotationIndices :+ paramCount).sliding(2).toList.foldLeft((Seq.empty[DefDef], defdef.symbol)) {
+                  case ((defdefs, nextSymbol), Seq(paramIndex, nextParamIndex)) =>
+                    val forwarder = generateSingleForwarder(
+                      defdef,
+                      defdef.symbol.info,
+                      nextParamIndex,
+                      paramIndex,
+                      nextSymbol,
+                      paramClauseIndex,
+                      defdef.paramss,
+                      isCaseApply
+                    )
+                    (forwarder +: defdefs, forwarder.symbol)
+                }._1
+              )
+
+            }else{
+
+              (
+                None,
+                (annotationIndices :+ paramCount).sliding(2).toList.reverse.foldLeft((Seq.empty[DefDef], defdef.symbol)){
+                  case ((defdefs, nextSymbol), Seq(paramIndex, nextParamIndex)) =>
+                    val forwarder = generateSingleForwarder(
+                      defdef,
+                      defdef.symbol.info,
+                      paramIndex,
+                      nextParamIndex,
+                      nextSymbol,
+                      paramClauseIndex,
+                      defdef.paramss,
+                      isCaseApply
+                    )
+                    (forwarder +: defdefs, forwarder.symbol)
+                }._1
+              )
+            }
+          }
+
+        case multiple => sys.error("Cannot have multiple parameter lists containing `@unroll` annotation")
+      }
+
+    case _ => (None, Nil)
+  }
+
+  private object LintInnerMethods extends TreeTraverser {
+    override def traverse(tree: Tree)(using Context): Unit =
+      tree match {
+        case method: DefDef =>
+          if methodHasUnroll(method.symbol) then isValidUnrolledMethod(method.symbol, method.sourcePos)
+          traverseChildren(method.rhs)
+        case _ => ()
+      }
+    override def traverseChildren(tree: Tree)(using Context): Unit = super.traverseChildren(tree)
+  }
+
+  override def transformTemplate(tmpl: tpd.Template)(using Context): tpd.Tree = {
+
+    val (removed0, generatedDefs) = tmpl.body.map(generateSyntheticDefs).unzip
+    val (None, generatedConstr) = generateSyntheticDefs(tmpl.constr)
+    val removed = removed0.flatten
+
+    super.transformTemplate(
+      cpy.Template(tmpl)(
+        tmpl.constr,
+        tmpl.parents,
+        tmpl.derived,
+        tmpl.self,
+        tmpl.body.filter(t => !removed.contains(t.symbol)) ++ generatedDefs.flatten ++ generatedConstr
+      )
+    )
+  }
+}

--- a/unroll/plugin/src-3/UnrollPluginScala3.scala
+++ b/unroll/plugin/src-3/UnrollPluginScala3.scala
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 package unroll
 
 import dotty.tools.dotc.plugins._

--- a/unroll/plugin/src-3/UnrollPluginScala3.scala
+++ b/unroll/plugin/src-3/UnrollPluginScala3.scala
@@ -1,0 +1,9 @@
+package unroll
+
+import dotty.tools.dotc.plugins._
+
+class UnrollPluginScala3 extends StandardPlugin {
+  val name: String = "unroll"
+  override val description: String = "Count method calls"
+  override def init(options: List[String]): List[PluginPhase] = List(new UnrollPhaseScala3())
+}


### PR DESCRIPTION


### Summary

Bring unroll-plugin in tree so we can more easily cross-build against versions of Scala without waiting for upstream to publish.

Imported from tag 0.3.0 (c9fd7e1ce9a92fe4ab15cd12fb61facc3aed8f2c).

Unroll is not a particularly active repo (see https://github.com/com-lihaoyi/unroll/pull/18), which is fine, but it does limit our ability to bump Scala. In particular, we'd like the Scala 3 port to bump to 3.3.8. We'd also like to test against newer versions of Scala (3.8.4 and 3.9.0-RC1). I'd especially like to be able to provide feedback on Scala release candidates as we will soon be in the position of caring about the latest 3.3 and eventually 3.9 releases.

I don't vendor code lightly, but unroll-plugin is also quite stable. Furthermore, `@unroll` is a feature of Scala itself starting in 3.7 so once we bump to 3.9 (the next LTS) we can drop the use of this plugin and remove the code.

### Release Notes

Vendored implementation of `com.lihaoyi:::unroll-plugin`. This is invisible to users because it is a compile-time dependency.

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: OpenCode (GPT-5.4)
- Merge strategy (defaults to squash): squash
- Milestone: 

