### PR TITLE
[core] Add domain.Mux

### DIFF
--- a/core/src/main/scala/chisel3/domain/Mux.scala
+++ b/core/src/main/scala/chisel3/domain/Mux.scala
@@ -31,11 +31,12 @@ object Mux {
     outDomains: domain.Type*
   )(implicit sourceInfo: SourceInfo): A = {
     val out = Wire(chiselTypeOf(outT))
-    Module.currentModule.get.associate(out, Seq(outDomain) ++ outDomains: _*)
+    val domains = outDomain +: outDomains
+    Module.currentModule.get.associate(out, domains: _*)
     out := chisel3.Mux(
-      domain.unsafeCast(sel, Seq(outDomain) ++ outDomains:  _*),
-      domain.unsafeCast(outT, Seq(outDomain) ++ outDomains: _*),
-      domain.unsafeCast(outF, Seq(outDomain) ++ outDomains: _*)
+      domain.unsafeCast(sel, domains:  _*),
+      domain.unsafeCast(outT, domains: _*),
+      domain.unsafeCast(outF, domains: _*)
     )
     out
   }

--- a/core/src/main/scala/chisel3/domain/Mux.scala
+++ b/core/src/main/scala/chisel3/domain/Mux.scala
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package chisel3.domain
+
+import chisel3._
+import chisel3.experimental.SourceInfo
+
+/** A (glitchy) domain-aware mux
+  *
+  * Muxes any `Data` and associates the muxed output with a _new_ domain
+  * supplied by the caller (e.g. `ClockDomain("_muxed")`).  This is intended to
+  * be used as a very basic domain mux, e.g., as a clock mux.  However, this can
+  * also be used to mux multiple signals at once, e.g., to mux between both a
+  * clock/reset pair and have the resulting pair be on the same domain.
+  *
+  * @param sel       the mux select
+  * @param outT      the value selected when `sel` is true
+  * @param outF      the value selected when `sel` is false
+  * @param outDomain the output domain to associate the muxed output with
+  * @return the muxed output data and the output domain it was associated with
+  *
+  * @note This is a glitchy!  This is not safe to use if `sel` will change while
+  * `outT` or `outF` are toggling.
+  */
+object Mux {
+  def apply[A <: Data](
+    sel:       Bool,
+    outT:      A,
+    outF:      A,
+    outDomain: domain.Type
+  )(implicit sourceInfo: SourceInfo): (A, domain.Type) = {
+    val out = Wire(chiselTypeOf(outT))
+    Module.currentModule.get.associate(out, outDomain)
+    out :<= chisel3.Mux(
+      domain.unsafeCast(sel, outDomain),
+      domain.unsafeCast(outT, outDomain),
+      domain.unsafeCast(outF, outDomain)
+    )
+    (out, outDomain)
+  }
+}

--- a/core/src/main/scala/chisel3/domain/Mux.scala
+++ b/core/src/main/scala/chisel3/domain/Mux.scala
@@ -13,10 +13,10 @@ import chisel3.experimental.SourceInfo
   * also be used to mux multiple signals at once, e.g., to mux between both a
   * clock/reset pair and have the resulting pair be on the same domain.
   *
-  * @param sel       the mux select
-  * @param outT      the value selected when `sel` is true
-  * @param outF      the value selected when `sel` is false
-  * @param outDomain the output domain to associate the muxed output with
+  * @param sel      the mux select
+  * @param t        the value selected when `sel` is true
+  * @param f        the value selected when `sel` is false
+  * @param domains  the output domains to associate the muxed output with
   * @return the muxed output data and the output domain it was associated with
   *
   * @note This is a glitchy!  This is not safe to use if `sel` will change while
@@ -24,19 +24,17 @@ import chisel3.experimental.SourceInfo
   */
 object Mux {
   def apply[A <: Data](
-    sel:        Bool,
-    outT:       A,
-    outF:       A,
-    outDomain:  domain.Type,
-    outDomains: domain.Type*
+    sel:     Bool,
+    t:       A,
+    f:       A,
+    domains: domain.Type*
   )(implicit sourceInfo: SourceInfo): A = {
-    val out = Wire(chiselTypeOf(outT))
-    val domains = outDomain +: outDomains
+    val out = Wire(chiselTypeOf(t))
     Module.currentModule.get.associate(out, domains: _*)
     out := chisel3.Mux(
-      domain.unsafeCast(sel, domains:  _*),
-      domain.unsafeCast(outT, domains: _*),
-      domain.unsafeCast(outF, domains: _*)
+      domain.unsafeCast(sel, domains: _*),
+      domain.unsafeCast(t, domains:   _*),
+      domain.unsafeCast(f, domains:   _*)
     )
     out
   }

--- a/core/src/main/scala/chisel3/domain/Mux.scala
+++ b/core/src/main/scala/chisel3/domain/Mux.scala
@@ -24,18 +24,19 @@ import chisel3.experimental.SourceInfo
   */
 object Mux {
   def apply[A <: Data](
-    sel:       Bool,
-    outT:      A,
-    outF:      A,
-    outDomain: domain.Type
-  )(implicit sourceInfo: SourceInfo): (A, domain.Type) = {
+    sel:        Bool,
+    outT:       A,
+    outF:       A,
+    outDomain:  domain.Type,
+    outDomains: domain.Type*
+  )(implicit sourceInfo: SourceInfo): A = {
     val out = Wire(chiselTypeOf(outT))
-    Module.currentModule.get.associate(out, outDomain)
-    out :<= chisel3.Mux(
-      domain.unsafeCast(sel, outDomain),
-      domain.unsafeCast(outT, outDomain),
-      domain.unsafeCast(outF, outDomain)
+    Module.currentModule.get.associate(out, Seq(outDomain) ++ outDomains: _*)
+    out := chisel3.Mux(
+      domain.unsafeCast(sel, Seq(outDomain) ++ outDomains:  _*),
+      domain.unsafeCast(outT, Seq(outDomain) ++ outDomains: _*),
+      domain.unsafeCast(outF, Seq(outDomain) ++ outDomains: _*)
     )
-    (out, outDomain)
+    out
   }
 }

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -475,4 +475,31 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
       domainOf(Bool(), ClockDomain.Type())
     }
   }
+
+  behavior of "The domain.Mux API"
+
+  it should "allow connection of two muxed outputs" in {
+    class Bar extends Bundle {
+      val x = Bool()
+      val y = Bool()
+    }
+    class Foo extends RawModule {
+      val A, B, SEL = IO(Input(ClockDomain.Type()))
+      val OUT = IO(Output(ClockDomain.Type()))
+      val a = IO(Input(new Bar))
+      associate(a, A)
+      val b = IO(Input(new Bar))
+      associate(b, B)
+      val sel = IO(Input(Bool()))
+      associate(sel, SEL)
+      val out = IO(Output(Bool()))
+      associate(out, OUT)
+
+      private val (pair, _) = domain.Mux(sel, a, b, ClockDomain("a_b_muxed"))
+
+      out :<= pair.x ^ pair.y
+    }
+
+    ChiselStage.emitSystemVerilog(new Foo, firtoolOpts = Array("--domain-mode=infer-all"))
+  }
 }

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -16,19 +16,22 @@ import scala.annotation.nowarn
 
 class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
 
+  object PowerDomain extends Domain {
+
+    override def fields = Seq(
+      ("name", Field.String),
+      ("voltage", Field.Integer),
+      ("alwaysOn", Field.Boolean)
+    )
+
+    def apply(name: String, voltage: Int, alwaysOn: Boolean): domain.Type =
+      PowerDomain(Property(name), Property(voltage), Property(alwaysOn))
+
+  }
+
   behavior of "Domains"
 
   they should "emit FIRRTL for internal and user-defined domains" in {
-
-    object PowerDomain extends Domain {
-
-      override def fields = Seq(
-        ("name", Field.String),
-        ("voltage", Field.Integer),
-        ("alwaysOn", Field.Boolean)
-      )
-
-    }
 
     class Foo extends RawModule {
       val A = IO(Input(ClockDomain.Type()))
@@ -486,20 +489,44 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
     class Foo extends RawModule {
       val A, B, SEL = IO(Input(ClockDomain.Type()))
       val OUT = IO(Output(ClockDomain.Type()))
-      val a = IO(Input(new Bar))
+      val a, b = IO(Input(new Bar))
       associate(a, A)
-      val b = IO(Input(new Bar))
       associate(b, B)
       val sel = IO(Input(Bool()))
       associate(sel, SEL)
       val out = IO(Output(Bool()))
       associate(out, OUT)
 
-      private val (pair, _) = domain.Mux(sel, a, b, ClockDomain("a_b_muxed"))
+      private val pair = domain.Mux(sel, a, b, ClockDomain("a_b_muxed"))
 
       out :<= pair.x ^ pair.y
     }
 
     ChiselStage.emitSystemVerilog(new Foo, firtoolOpts = Array("--domain-mode=infer-all"))
   }
+
+  it should "allow for multiple casts of different domain kinds" in {
+    class Foo extends RawModule {
+      val CLOCK_A, CLOCK_B = IO(Input(ClockDomain.Type()))
+      val POWER_A, POWER_B = IO(Input(PowerDomain.Type()))
+      val a, b, sel = IO(Input(Bool()))
+      val out = IO(Output(Bool()))
+
+      out :<= domain.Mux(sel, a, b, ClockDomain("clock_a_b_muxed"), PowerDomain("power_a_b_muxed", 42, false))
+    }
+
+    ChiselStage
+      .emitCHIRRTL(new Foo)
+      .fileCheck() {
+        """|CHECK-LABEL: module Foo :
+           |CHECK:         domain [[clock:.+]] of ClockDomain
+           |CHECK-NEXT:    domain [[power:.+]] of PowerDomain
+           |CHECK:         node [[sel:.+]] = unsafe_domain_cast(sel, [[clock]], [[power]])
+           |CHECK-NEXT:    node [[a:.+]] = unsafe_domain_cast(a, [[clock]], [[power]])
+           |CHECK-NEXT:    node [[b:.+]] = unsafe_domain_cast(b, [[clock]], [[power]])
+           |CHECK-NEXT:    mux([[sel]], [[a]], [[b]])
+           |""".stripMargin
+      }
+  }
+
 }


### PR DESCRIPTION
Add a new API, `domain.Mux`.  This behaves just like a normal `Mux`, but
it allows for glitchy muxing between any values of different domains.
This is intended to be a primitive for building glitchy clock muxes which
are used in some testing environments.

Assisted-by: pi.dev:claude-opus-4-8

#### Release Notes

Add `domain.Mux` API for generating basic, glitchy muxes between values of
different domains.  E.g., this can be used to build a glitchy clock mux.
