### PR TITLE
[core] Add LTL always operator

### DIFF
--- a/src/main/scala-2/chisel3/ltl/LTLIntf.scala
+++ b/src/main/scala-2/chisel3/ltl/LTLIntf.scala
@@ -92,6 +92,9 @@ private[chisel3] trait PropertyIntf { self: Property =>
   /** See [[Property.eventually]]. */
   def eventually(implicit sourceInfo: SourceInfo): Property = _eventuallyImpl
 
+  /** See [[Property.always]]. */
+  def always(implicit sourceInfo: SourceInfo): Property = _alwaysImpl
+
   /** See [[Property.and]]. */
   def and(other: Property)(implicit sourceInfo: SourceInfo): Property = _andPropImpl(other)
 
@@ -243,8 +246,23 @@ private[chisel3] trait PropertyObjIntf { self: Property.type =>
     * infinite number of cycles.
     *
     * Equivalent to `s_eventually prop` in SVA.
+    *
+    * This is the dual of `always`: `eventually(prop)` is equivalent to
+    * `not(always(not(prop)))`.
     */
   def eventually(prop: Property)(implicit sourceInfo: SourceInfo): Property = _eventually(prop)
+
+  /** Indicate that a property holds at all points in time. This is a *weak*
+    * always, so the property trivially holds by only being checked over a
+    * finite number of cycles. It does not require the property to hold beyond
+    * the available trace.
+    *
+    * Equivalent to `always prop` in SVA.
+    *
+    * This is the dual of `eventually`: `always(prop)` is defined as
+    * `not(eventually(not(prop)))`.
+    */
+  def always(prop: Property)(implicit sourceInfo: SourceInfo): Property = _always(prop)
 
   /** Form the conjunction of two properties. Equivalent to
     * `arg0 and arg1 and ... and argN` in SVA.

--- a/src/main/scala-3/chisel3/ltl/LTLIntf.scala
+++ b/src/main/scala-3/chisel3/ltl/LTLIntf.scala
@@ -92,6 +92,9 @@ private[chisel3] trait PropertyIntf { self: Property =>
   /** See [[Property.eventually]]. */
   def eventually(using SourceInfo): Property = _eventuallyImpl
 
+  /** See [[Property.always]]. */
+  def always(using SourceInfo): Property = _alwaysImpl
+
   /** See [[Property.and]]. */
   def and(other: Property)(using SourceInfo): Property = _andPropImpl(other)
 
@@ -243,8 +246,23 @@ private[chisel3] trait PropertyObjIntf { self: Property.type =>
     * infinite number of cycles.
     *
     * Equivalent to `s_eventually prop` in SVA.
+    *
+    * This is the dual of `always`: `eventually(prop)` is equivalent to
+    * `not(always(not(prop)))`.
     */
   def eventually(prop: Property)(using SourceInfo): Property = _eventually(prop)
+
+  /** Indicate that a property holds at all points in time. This is a *weak*
+    * always, so the property trivially holds by only being checked over a
+    * finite number of cycles. It does not require the property to hold beyond
+    * the available trace.
+    *
+    * Equivalent to `always prop` in SVA.
+    *
+    * This is the dual of `eventually`: `always(prop)` is defined as
+    * `not(eventually(not(prop)))`.
+    */
+  def always(prop: Property)(using SourceInfo): Property = _always(prop)
 
   /** Form the conjunction of two properties. Equivalent to
     * `arg0 and arg1 and ... and argN` in SVA.

--- a/src/main/scala/chisel3/ltl/LTL.scala
+++ b/src/main/scala/chisel3/ltl/LTL.scala
@@ -234,6 +234,8 @@ sealed trait Property extends PropertyIntf {
 
   protected def _eventuallyImpl(implicit sourceInfo: SourceInfo): Property = Property._eventually(this)
 
+  protected def _alwaysImpl(implicit sourceInfo: SourceInfo): Property = Property._always(this)
+
   protected def _andPropImpl(other: Property)(implicit sourceInfo: SourceInfo): Property = Property._and(this, other)
 
   protected def _orPropImpl(other: Property)(implicit sourceInfo: SourceInfo): Property = Property._or(this, other)
@@ -267,6 +269,9 @@ object Property extends PropertyObjIntf {
 
   protected def _eventually(prop: Property)(implicit sourceInfo: SourceInfo): Property =
     OpaqueProperty(LTLEventuallyIntrinsic(prop.inner))
+
+  protected def _always(prop: Property)(implicit sourceInfo: SourceInfo): Property =
+    not(eventually(not(prop)))
 
   protected def _and(arg0: Property, argN: Property*)(implicit sourceInfo: SourceInfo): Property = {
     var lhs = arg0

--- a/src/test/scala/chiselTests/LTLSpec.scala
+++ b/src/test/scala/chiselTests/LTLSpec.scala
@@ -276,6 +276,30 @@ class LTLSpec extends AnyFlatSpec with Matchers with ChiselSim with FileCheck {
     ChiselStage.emitSystemVerilog(new EventuallyMod)
   }
 
+  class AlwaysMod extends RawModule {
+    implicit val info: SourceInfo = SourceLine("Foo.scala", 1, 2)
+    val a = IO(Input(Bool()))
+    val p0: Property = a.always
+    val p1: Property = Property.always(a)
+  }
+  it should "support property always operation" in {
+    val sourceLoc = "@[Foo.scala 1:2]"
+    ChiselStage
+      .emitCHIRRTL(new AlwaysMod)
+      .fileCheck()(
+        s"""|CHECK: node [[N0:.*]] = intrinsic(circt_ltl_not : UInt<1>, a) $sourceLoc
+            |CHECK: node [[E0:.*]] = intrinsic(circt_ltl_eventually : UInt<1>, [[N0]]) $sourceLoc
+            |CHECK: intrinsic(circt_ltl_not : UInt<1>, [[E0]]) $sourceLoc
+            |CHECK: node [[N1:.*]] = intrinsic(circt_ltl_not : UInt<1>, a) $sourceLoc
+            |CHECK: node [[E1:.*]] = intrinsic(circt_ltl_eventually : UInt<1>, [[N1]]) $sourceLoc
+            |CHECK: intrinsic(circt_ltl_not : UInt<1>, [[E1]]) $sourceLoc
+            |""".stripMargin
+      )
+  }
+  it should "compile property always operation" in {
+    ChiselStage.emitSystemVerilog(new AlwaysMod)
+  }
+
   class BasicVerifMod extends RawModule {
     implicit val info: SourceInfo = SourceLine("Foo.scala", 1, 2)
     val a = IO(Input(Bool()))


### PR DESCRIPTION
Add an `always` operator to the LTL property library as syntactic sugar around `not(eventually(not(p)))`. This is a weak always, dual to the strong `eventually`, and maps to `always prop` in SVA.