### PR TITLE
Properly escape Property assert messages

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -274,7 +274,7 @@ private[chisel3] object Serializer {
     case PropAssign(info, loc, exp) =>
       b ++= "propassign "; serialize(loc, ctx, info); b ++= ", "; serialize(exp, ctx, info); serialize(info)
     case PropertyAssert(info, cond, msg) =>
-      b ++= "propassert "; serialize(cond, ctx, info); b ++= ", \""; b ++= msg; b += '"'; serialize(info)
+      b ++= "propassert "; serialize(cond, ctx, info); b ++= ", "; b ++= fir.StringLit(msg).escape; serialize(info)
     case Attach(info, locs) =>
       b ++= "attach ("
       serializeArgs(locs, ctx, info)

--- a/src/test/scala-2/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertySpec.scala
@@ -133,6 +133,14 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
     chirrtl should include(s"""propassign propOut, String("$input")""")
   }
 
+  it should "escape special characters in Property assertion messages" in {
+    ChiselStage.emitSystemVerilog(new RawModule {
+      val a = Property("foo")
+      val b = Property("foo")
+      (a === b).assert("name must be \"foo\"")
+    })
+  }
+
   it should "support Boolean as a Property type" in {
     val chirrtl = ChiselStage.emitCHIRRTL(new RawModule {
       val boolProp = IO(Input(Property[Boolean]()))


### PR DESCRIPTION
### Summary

Fixes https://github.com/chipsalliance/chisel/issues/5450

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: OpenCode (GPT-5.6 Terra)
- Merge strategy (defaults to squash): squash
- Milestone: 7.x

