### PR TITLE
[Scala3] BundlePhase bugfixes

### DIFF
--- a/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
+++ b/plugin/src/main/scala-3/chisel3/internal/plugin/BundlePhase.scala
@@ -269,7 +269,7 @@ class ChiselBundlePhase extends PluginPhase {
     if (
       ChiselTypeHelpers.isRecord(record.tpe)
       && record.isClassDef
-      && !record.symbol.flags.is(Flags.Abstract)
+      && !record.symbol.flags.isOneOf(Flags.AbstractOrTrait)
     ) {
       val isBundle: Boolean = ChiselTypeHelpers.isBundle(record.tpe)
       val thiz:     tpd.This = tpd.This(record.symbol.asClass)
@@ -292,7 +292,7 @@ class ChiselBundlePhase extends PluginPhase {
           record.symbol,
           Names.termName("_usingPlugin"),
           Flags.Method | Flags.Override | Flags.Protected,
-          defn.BooleanType
+          MethodType(Nil, Nil, defn.BooleanType)
         )
         tpd.DefDef(
           isPluginSym.asTerm,


### PR DESCRIPTION
### Summary

Internal testing revealed bugs in the plugin with complex Bundle uses. Specifically, traits with Bundle mixins were throwing `java.lang.AssertionError: assertion failed: 'new' call to non-constructor: $init$` errors. The output type of `_usingPlugin` was also causing minor issues

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->
Fix Scala 3 BundlePhase, allowing using traits with Bundle mixins 

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: Claude Code + Claude Opus 4.7