### PR TITLE
[core] Adds `:%=` explicit truncating connecting operator for Bits (UInt/SInt)

### DIFF
--- a/core/src/main/scala/chisel3/Bits.scala
+++ b/core/src/main/scala/chisel3/Bits.scala
@@ -226,7 +226,12 @@ sealed abstract class Bits(private[chisel3] val width: Width) extends BitsIntf {
   }
 }
 
-object Bits extends UIntFactory
+object Bits extends UIntFactory {
+
+  /** Provides :%= for Bits (UInt/SInt) */
+  implicit class ConnectableBitsDefault[T <: Bits](consumer: T)
+      extends connectable.ConnectableBitsOperators[T](consumer)
+}
 
 /** A data type for unsigned integers, represented as a binary bitvector. Defines arithmetic operations between other
   * integer types.

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -902,10 +902,6 @@ object Data {
   /** Provides :<=, :>=, :<>=, and :#= between consumer and producer of the same T <: Data */
   implicit class ConnectableDefault[T <: Data](consumer: T) extends connectable.ConnectableOperators[T](consumer)
 
-  /** Provides :%= for Bits (UInt/SInt) */
-  implicit class ConnectableBitsDefault[T <: Bits](consumer: T)
-      extends connectable.ConnectableBitsOperators[T](consumer)
-
   /** Provides :<>=, :<=, :>=, and :#= between a (consumer: Vec) and (producer: Seq) */
   implicit class ConnectableVecDefault[T <: Data](consumer: Vec[T])
       extends connectable.ConnectableVecOperators[T](consumer)

--- a/core/src/main/scala/chisel3/Data.scala
+++ b/core/src/main/scala/chisel3/Data.scala
@@ -902,6 +902,10 @@ object Data {
   /** Provides :<=, :>=, :<>=, and :#= between consumer and producer of the same T <: Data */
   implicit class ConnectableDefault[T <: Data](consumer: T) extends connectable.ConnectableOperators[T](consumer)
 
+  /** Provides :%= for Bits (UInt/SInt) */
+  implicit class ConnectableBitsDefault[T <: Bits](consumer: T)
+      extends connectable.ConnectableBitsOperators[T](consumer)
+
   /** Provides :<>=, :<=, :>=, and :#= between a (consumer: Vec) and (producer: Seq) */
   implicit class ConnectableVecDefault[T <: Data](consumer: Vec[T])
       extends connectable.ConnectableVecOperators[T](consumer)

--- a/core/src/main/scala/chisel3/connectable/Connectable.scala
+++ b/core/src/main/scala/chisel3/connectable/Connectable.scala
@@ -236,6 +236,20 @@ object Connectable {
     *  - If the types of consumer and producer also have identical relative flips, then we can emit FIRRTL.<= as it is a stricter version of chisel3.:<>=
     *  - "turk-duck-en" is a dish where a turkey is stuffed with a duck, which is stuffed with a chicken; `:<>=` is a `:=` stuffed with a `<>`
     *
+    * @group connection
+    *
+    * @define colonPercentEq The explicit "truncating connection operator" between a `Bits` consumer and producer.
+    *
+    * For `consumer :%= producer`, the producer is always squeezed before connecting, so a width mismatch
+    * truncates instead of erroring out. This is identical to calling `consumer :#= producer.squeeze`.
+    *
+    * Symbol reference:
+    *  - ':' is the consumer side
+    *  - '=' is the producer side
+    *  - '%' means the producer is squeezed, so explicit truncation is allowed
+    *
+    * $chiselTypeRestrictions
+    *
     * @define chiselTypeRestrictions The following restrictions apply:
     *  - The Chisel type of consumer and producer must be the "same shape" recursively:
     *    - All ground types are the same (UInt and UInt are same, SInt and UInt are not), but widths can be different (implicit trunction/padding occurs)

--- a/core/src/main/scala/chisel3/connectable/Connectable.scala
+++ b/core/src/main/scala/chisel3/connectable/Connectable.scala
@@ -410,6 +410,17 @@ object Connectable {
     final def :#=(producer: DontCare.type)(implicit sourceInfo: SourceInfo): Unit = {
       connect(consumer, producer, ColonHashEq)
     }
+  }
 
+  implicit class ConnectableBitsOpExtension[T <: Bits](consumer: Connectable[T]) extends ConnectableDocs {
+
+    /** $colonPercentEq
+    * @group connection
+    * @param producer the right-hand-side of the connection
+    */
+    final def :%=[S <: Bits](lProducer: => S)(implicit evidence: T =:= S, sourceInfo: SourceInfo): Unit = {
+      val producer = prefix(consumer.base) { lProducer }
+      consumer :#= producer.squeeze
+    }
   }
 }

--- a/core/src/main/scala/chisel3/connectable/package.scala
+++ b/core/src/main/scala/chisel3/connectable/package.scala
@@ -151,4 +151,12 @@ package object connectable {
       }
     }
   }
+
+  /** ConnectableBits Typeclass defines the :%= operator on UInt and SInt: an explicit truncating connection operator
+  *
+  * @param consumer the left-hand-side of the connection
+  */
+  implicit class ConnectableBitsOperators[T <: Bits](consumer: T)
+      extends Connectable.ConnectableBitsOpExtension(Data.makeConnectableDefault(consumer))
+
 }

--- a/docs/src/explanations/connectable.md
+++ b/docs/src/explanations/connectable.md
@@ -592,6 +592,28 @@ This generates the following Verilog, where `p` is truncated prior to driving `c
 chisel3.docs.emitSystemVerilog(new Example14)
 ```
 
+For `UInt`/`SInt`, the producer side of the connection can often have complex expressions on the
+right-hand side which makes the `.squeeze` API not great at displaying a truncating connection.
+`:%=` is a more visible alternative defined for only `UInt`/`SInt`:
+`c :%= p` is equivalent to `c :#= p.squeeze`.
+
+```scala mdoc:silent
+import scala.collection.immutable.SeqMap
+
+class Example14b extends RawModule {
+  val p = IO(Flipped(UInt(4.W)))
+  val c = IO(UInt(3.W))
+
+  c :%= p
+}
+```
+This generates the same truncating behavior as `Example14` above, but without needing
+to call `.squeeze` explicitly:
+
+```scala mdoc:verilog
+chisel3.docs.emitSystemVerilog(new Example14b)
+```
+
 ### Excluding members from any operator on a Connectable
 
 If a user wants to always exclude a field from a connect, use the `.exclude` mechanism which will never connect the field (as if it didn't exist to the connection).

--- a/docs/src/explanations/connectable.md
+++ b/docs/src/explanations/connectable.md
@@ -598,7 +598,6 @@ right-hand side which makes the `.squeeze` API not great at displaying a truncat
 `c :%= p` is equivalent to `c :#= p.squeeze`.
 
 ```scala mdoc:silent
-import scala.collection.immutable.SeqMap
 
 class Example14b extends RawModule {
   val p = IO(Flipped(UInt(4.W)))

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -1274,6 +1274,34 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         Nil
       )
     }
+    it("(5.i) :%= truncates a UInt without needing .squeeze") {
+      class MyModule extends Module {
+        val in = IO(Flipped(UInt(3.W)))
+        val out = IO(UInt(1.W))
+        out :%= in
+      }
+      testCheck(
+        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
+        Seq(
+          "connect out, in"
+        ),
+        Nil
+      )
+    }
+    it("(5.j) :%= truncates a SInt without needing .squeeze") {
+      class MyModule extends Module {
+        val in = IO(Flipped(SInt(3.W)))
+        val out = IO(SInt(1.W))
+        out :%= in
+      }
+      testCheck(
+        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
+        Seq(
+          "connect out, in"
+        ),
+        Nil
+      )
+    }
   }
   describe("(E): Connectable excluding") {
     import scala.collection.immutable.SeqMap


### PR DESCRIPTION
### Summary

This PR adds `:%=`, an explicit truncating connector operator restricted to just `UInt` and `SInt`. It is important to note that the operators behaviour is equivalent to `consumer := producer.squeeze`.  Our motivation for the introduction of this operator is such that the producer right-hand-side can get very long so `.squeeze` does not do a good job at signaling a truncating connection incomparison to this change.

To clarify, no new truncation semantics are introduced in this PR.

