### PR TITLE
[core] Make `.squeeze` emit explicit truncation instead of implicit width coercion

### DIFF
--- a/core/src/main/scala/chisel3/connectable/Alignment.scala
+++ b/core/src/main/scala/chisel3/connectable/Alignment.scala
@@ -2,8 +2,8 @@
 
 package chisel3.connectable
 
-import chisel3.{Aggregate, Data, DontCare, SpecifiedDirection}
-import chisel3.experimental.Analog
+import chisel3.{Aggregate, Bits, Data, DontCare, SInt, SpecifiedDirection}
+import chisel3.experimental.{Analog, SourceInfo}
 import chisel3.reflect.DataMirror
 import chisel3.internal.binding.{ChildBinding, TopBinding}
 
@@ -148,6 +148,23 @@ private[chisel3] case class ConnectableAlignment(base: Connectable[Data], align:
             }
           case (l, r) => None
         }.getOrElse(None)
+    }
+
+  // Return a truncated replacement for r if r is squeezed, wider than l, and both widths are known.
+  final def squeezeTruncationSite(o: ConnectableAlignment, l: Data, r: Data)(
+    implicit sourceInfo: SourceInfo
+  ): Option[Data] =
+    (l, r) match {
+      case (l: Bits, r: Bits) if base.squeezed.contains(r) || o.base.squeezed.contains(r) =>
+        (l.widthOption, r.widthOption) match {
+          case (Some(lw), Some(rw)) if lw < rw =>
+            r match {
+              case s: SInt => Some(s.take(lw).asSInt)
+              case _ => Some(r.take(lw))
+            }
+          case _ => None
+        }
+      case _ => None
     }
 
   // Whether the current member is waived

--- a/core/src/main/scala/chisel3/connectable/Alignment.scala
+++ b/core/src/main/scala/chisel3/connectable/Alignment.scala
@@ -162,6 +162,11 @@ private[chisel3] case class ConnectableAlignment(base: Connectable[Data], align:
               case s: SInt => Some(s.take(lw).asSInt)
               case _ => Some(r.take(lw))
             }
+          case (Some(lw), None) =>
+            r match {
+              case s: SInt => Some(s.pad(lw).take(lw).asSInt)
+              case _ => Some(r.pad(lw).take(lw))
+            }
           case _ => None
         }
       case _ => None

--- a/core/src/main/scala/chisel3/connectable/Connection.scala
+++ b/core/src/main/scala/chisel3/connectable/Connection.scala
@@ -223,7 +223,10 @@ private[chisel3] object Connection {
                 case other        => throw new Exception(other.toString)
               }
               val lAndROpt = alignment.computeLandR(consumer, producer, connectionOp)
-              lAndROpt.foreach { case (l, r) => connect(l, r) }
+              lAndROpt.foreach { case (l, r) =>
+                val truncatedR = conAlign.squeezeTruncationSite(proAlign, l, r).getOrElse(r)
+                connect(l, truncatedR)
+              }
           }
         case other => throw new Exception(other.toString + " " + connectionOp)
       }

--- a/docs/src/explanations/connectable.md
+++ b/docs/src/explanations/connectable.md
@@ -573,7 +573,7 @@ chisel3.docs.emitSystemVerilog(new Example11)
 Non-`Connectable` operators implicitly truncate if a component with a larger width is connected to a component with a smaller width.
 `Connectable` operators disallow this implicit truncation behavior and require the driven component to be equal or larger in width that the sourcing component.
 
-If implicit truncation behavior is desired, then `Connectable` provides a `squeeze` mechanism which will allow the connection to continue with implicit truncation.
+If truncation behavior is desired, then `Connectable` provides a `squeeze` mechanism which will allow the connection to continue, truncating with an explicit bit extraction (e.g. `bits(...)`) in the emitted FIRRTL rather than relying on FIRRTL's own implicit width coercion. 
 
 ```scala mdoc:silent
 import scala.collection.immutable.SeqMap
@@ -592,10 +592,7 @@ This generates the following Verilog, where `p` is truncated prior to driving `c
 chisel3.docs.emitSystemVerilog(new Example14)
 ```
 
-For `UInt`/`SInt`, the producer side of the connection can often have complex expressions on the
-right-hand side which makes the `.squeeze` API not great at displaying a truncating connection.
-`:%=` is a more visible alternative defined for only `UInt`/`SInt`:
-`c :%= p` is equivalent to `c :#= p.squeeze`.
+For `UInt/SInt, :%=` is a more visible alternative defined for only `UInt/SInt`, letting you skip the explicit `.squeeze` call at the connection site: `c :%= p` is equivalent to `c :#= p.squeeze`.
 
 ```scala mdoc:silent
 

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -7,6 +7,7 @@ import chisel3.experimental.{Analog, OpaqueType}
 import chisel3.experimental.BundleLiterals._
 import chisel3.experimental.VecLiterals._
 import chisel3.reflect.DataMirror
+import chisel3.testing.scalatest.FileCheck
 import circt.stage.ChiselStage
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -101,7 +102,7 @@ object ConnectableSpec {
 
 }
 
-class ConnectableSpec extends AnyFunSpec with Matchers {
+class ConnectableSpec extends AnyFunSpec with Matchers with FileCheck {
   import ConnectableSpec._
 
   def testCheck(firrtl: String, matches: Seq[String], nonMatches: Seq[String]): String = {
@@ -1130,15 +1131,15 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         val out = IO(new NestedDecoupled(false))
         out :<>= in.squeezeEach { case d: Decoupled => Seq(d.data) }
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "connect out.foo.valid, in.foo.valid",
-          "connect in.foo.ready, out.foo.ready",
-          "bits(in.foo.data, 7, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[node:.*]] = bits(in.foo.data, 7, 0)
+             |CHECK: connect out.foo.data, [[node]]
+             |CHECK: connect in.foo.ready, out.foo.ready
+             |CHECK: connect out.foo.valid, in.foo.valid
+             |""".stripMargin
+        )
     }
     it("(5.b) Squeeze works on UInt") {
       class MyModule extends Module {
@@ -1146,13 +1147,13 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         val out = IO(UInt(1.W))
         out :<>= in.squeeze
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "bits(in, 0, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[node:.*]] = bits(in, 0, 0)
+             |CHECK: connect out, [[node]]
+             |""".stripMargin
+        )
     }
     it("(5.c) BundleMap example can use programmatic squeezing") {
       class MyModule extends Module {
@@ -1173,15 +1174,15 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         // Programmatic
         BundleMap.waive(out) :<>= BundleMap.waive(in).squeezeAll
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "connect out.valid, in.valid",
-          "connect in.ready, out.ready",
-          "bits(in.data.b, 1, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[node:.*]] = bits(in.data.b, 1, 0)
+             |CHECK: connect out.data.b, [[node]]
+             |CHECK: connect in.ready, out.ready
+             |CHECK: connect out.valid, in.valid
+             |""".stripMargin
+        )
     }
     it(
       "(5.e) Mismatched aggregate containing backpressure must be squeezed only if actually connecting and requiring implicit truncation"
@@ -1200,15 +1201,17 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         // Should error, unless waived
         out3.squeezeAll :>= in3
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "bits(out3.v[0].ready, 0, 0)",
-          "bits(out3.v[1].ready, 0, 0)",
-          "bits(out3.v[2].ready, 0, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[node0:.*]] = bits(out3.v[0].ready, 0, 0)
+             |CHECK: connect in3.v[0].ready, [[node0]]
+             |CHECK: node [[node1:.*]] = bits(out3.v[1].ready, 0, 0)
+             |CHECK: connect in3.v[1].ready, [[node1]]
+             |CHECK: node [[node2:.*]] = bits(out3.v[2].ready, 0, 0)
+             |CHECK: connect in3.v[2].ready, [[node2]]
+             |""".stripMargin
+        )
     }
     it("(5.f) Squeeze works on OpaqueType") {
       class OpaqueRecord(width: Int) extends Record with OpaqueType {
@@ -1220,13 +1223,13 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         val out = IO(Output(new OpaqueRecord(2)))
         out :<>= in.squeeze
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "bits(in, 1, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[node:.*]] = bits(in, 1, 0)
+             |CHECK: connect out, [[node]]
+             |""".stripMargin
+        )
     }
     it("(5.g) Squeeze works on nested OpaqueType fields") {
       class OpaqueRecord(width: Int) extends Record with OpaqueType {
@@ -1247,14 +1250,15 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         out :<>= inA.squeeze(_.opaque)
         out :<>= inB.squeezeEach { case d: OpaqueRecord => Seq(d) }
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "bits(inA.opaque, 1, 0)",
-          "bits(inB.opaque, 1, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[nodeA:.*]] = bits(inA.opaque, 1, 0)
+             |CHECK: connect out.opaque, [[nodeA]]
+             |CHECK: node [[nodeB:.*]] = bits(inB.opaque, 1, 0)
+             |CHECK: connect out.opaque, [[nodeB]]
+             |""".stripMargin
+        )
     }
     it("(5.h) Squeeze all as") {
       class NestedDecoupled1 extends Bundle { val foo = new Decoupled(true) }
@@ -1280,13 +1284,13 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         val out = IO(UInt(1.W))
         out :%= in
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "bits(in, 0, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[node:.*]] = bits(in, 0, 0)
+             |CHECK: connect out, [[node]]
+             |""".stripMargin
+        )
     }
     it("(5.j) :%= truncates a SInt without needing .squeeze") {
       class MyModule extends Module {
@@ -1294,13 +1298,47 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         val out = IO(SInt(1.W))
         out :%= in
       }
-      testCheck(
-        ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
-        Seq(
-          "bits(in, 0, 0)"
-        ),
-        Nil
-      )
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[node0:.*]] = bits(in, 0, 0)
+             |CHECK: node [[node1:.*]] = asSInt([[node0]])
+             |CHECK: connect out, [[node1]]
+             |""".stripMargin
+        )
+    }
+    it("(5.k) :%= truncates a UInt with an unknown/inferred producer width") {
+      class MyModule extends Module {
+        val out = IO(UInt(2.W))
+        val w = Wire(UInt())
+        w := 7.U
+        out :%= w
+      }
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[pad:.*]] = pad(w, 2)
+             |CHECK: node [[node:.*]] = bits([[pad]], 1, 0)
+             |CHECK: connect out, [[node]]
+             |""".stripMargin
+        )
+    }
+    it("(5.l) :%= truncates a SInt with an unknown/inferred producer width") {
+      class MyModule extends Module {
+        val out = IO(SInt(2.W))
+        val w = Wire(SInt())
+        w := 7.S
+        out :%= w
+      }
+      ChiselStage
+        .emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error"))
+        .fileCheck()(
+          """|CHECK: node [[pad:.*]] = pad(w, 2)
+             |CHECK: node [[bits:.*]] = bits([[pad]], 1, 0)
+             |CHECK: node [[node:.*]] = asSInt([[bits]])
+             |CHECK: connect out, [[node]]
+             |""".stripMargin
+        )
     }
   }
   describe("(E): Connectable excluding") {
@@ -2124,14 +2162,15 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
           out :<>= in
         }
 
-        testCheck(
-          ChiselStage.emitCHIRRTL(new MyModule()),
-          Seq(
-            "connect out.bar, in.bar",
-            "bits(in.foo, 0, 0)"
-          ),
-          Nil
-        )
+        ChiselStage
+          .emitCHIRRTL(new MyModule())
+          .fileCheck()(
+            """|CHECK: connect out.bar, in.bar
+               |CHECK: node [[node:.*]] = bits(in.foo, 0, 0)
+               |CHECK: connect out.foo, [[node]]
+               |""".stripMargin
+          )
+
       }
 
       it("(9.b.2) allows the user to customize the squeeze behavior of the Connectable for their class as consumer") {
@@ -2164,14 +2203,15 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
           out :<>= in
         }
 
-        testCheck(
-          ChiselStage.emitCHIRRTL(new MyModule()),
-          Seq(
-            "connect out.bundle.bar, in.bundle.bar",
-            "bits(in.bundle.foo, 0, 0)"
-          ),
-          Nil
-        )
+        ChiselStage
+          .emitCHIRRTL(new MyModule())
+          .fileCheck()(
+            """|CHECK: connect out.bundle.bar, in.bundle.bar
+               |CHECK: node [[node:.*]] = bits(in.bundle.foo, 0, 0)
+               |CHECK: connect out.bundle.foo, [[node]]
+               |""".stripMargin
+          )
+
       }
     }
 

--- a/src/test/scala/chiselTests/ConnectableSpec.scala
+++ b/src/test/scala/chiselTests/ConnectableSpec.scala
@@ -1135,7 +1135,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         Seq(
           "connect out.foo.valid, in.foo.valid",
           "connect in.foo.ready, out.foo.ready",
-          "connect out.foo.data, in.foo.data"
+          "bits(in.foo.data, 7, 0)"
         ),
         Nil
       )
@@ -1149,7 +1149,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       testCheck(
         ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
         Seq(
-          "connect out, in"
+          "bits(in, 0, 0)"
         ),
         Nil
       )
@@ -1178,7 +1178,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
         Seq(
           "connect out.valid, in.valid",
           "connect in.ready, out.ready",
-          "connect out.data.b, in.data.b"
+          "bits(in.data.b, 1, 0)"
         ),
         Nil
       )
@@ -1203,9 +1203,9 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       testCheck(
         ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
         Seq(
-          "connect in3.v[0].ready, out3.v[0].ready",
-          "connect in3.v[1].ready, out3.v[1].ready",
-          "connect in3.v[2].ready, out3.v[2].ready"
+          "bits(out3.v[0].ready, 0, 0)",
+          "bits(out3.v[1].ready, 0, 0)",
+          "bits(out3.v[2].ready, 0, 0)"
         ),
         Nil
       )
@@ -1223,7 +1223,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       testCheck(
         ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
         Seq(
-          "connect out, in"
+          "bits(in, 1, 0)"
         ),
         Nil
       )
@@ -1250,8 +1250,8 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       testCheck(
         ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
         Seq(
-          "connect out.opaque, inA.opaque",
-          "connect out.opaque, inB.opaque"
+          "bits(inA.opaque, 1, 0)",
+          "bits(inB.opaque, 1, 0)"
         ),
         Nil
       )
@@ -1283,7 +1283,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       testCheck(
         ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
         Seq(
-          "connect out, in"
+          "bits(in, 0, 0)"
         ),
         Nil
       )
@@ -1297,7 +1297,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
       testCheck(
         ChiselStage.emitCHIRRTL({ new MyModule() }, args = Array("--full-stacktrace", "--throw-on-first-error")),
         Seq(
-          "connect out, in"
+          "bits(in, 0, 0)"
         ),
         Nil
       )
@@ -2128,7 +2128,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
           ChiselStage.emitCHIRRTL(new MyModule()),
           Seq(
             "connect out.bar, in.bar",
-            "connect out.foo, in.foo"
+            "bits(in.foo, 0, 0)"
           ),
           Nil
         )
@@ -2168,7 +2168,7 @@ class ConnectableSpec extends AnyFunSpec with Matchers {
           ChiselStage.emitCHIRRTL(new MyModule()),
           Seq(
             "connect out.bundle.bar, in.bundle.bar",
-            "connect out.bundle.foo, in.bundle.foo"
+            "bits(in.bundle.foo, 0, 0)"
           ),
           Nil
         )


### PR DESCRIPTION
### Summary


Follow up work on #5456: `.squeeze` would suppress Chisel's width-mismatch error and let the resulting `connect out, in` rely on FIRRTL's implicit width coercion to truncate. This truncation would not be seen in the emitted FIRRTL. Thus, we make the bit extraction explicit in `.squeeze` when a squeezed connection has both consumer and producer with statically known widths.

Note: unknown-width cases will still silently fall through to implicit coercion.

### Development notes
- AI tool(s) used: claude-code: sonnet-5

