### PR TITLE
[ci] Bump circt/update-circt to 1.1.2

### DIFF
--- a/.github/workflows/cd-circt.yml
+++ b/.github/workflows/cd-circt.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: 'circt/update-circt'
-        uses: circt/update-circt@eacb8963f4f0872649ef5bb3245894929ddebe58 # v1.1.1
+        uses: circt/update-circt@747595acaf8443b3f8eac6d97bd43c158504a7b5 # v1.1.2
         with:
           user: chiselbot
           email: chiselbot@users.noreply.github.com


### PR DESCRIPTION
Bump the CD workflow to use a newer version of the circt/update-circt
action which transitively bumps the peter-evans/create-pull-request action
to avoid Node 20 deprecations.
