### PR TITLE
[core] Add Property[String] assertion message

### DIFF
--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -193,7 +193,7 @@ private[chisel3] object Converter {
     case PropAssign(info, loc, exp) =>
       fir.PropAssign(convert(info), convert(loc, ctx, info), convert(exp, ctx, info))
     case PropertyAssert(info, cond, msg) =>
-      fir.PropertyAssert(convert(info), convert(cond, ctx, info), convert(msg, ctx, info))
+      fir.PropertyAssertExpression(convert(info), convert(cond, ctx, info), convert(msg, ctx, info))
     case Attach(info, locs) =>
       fir.Attach(convert(info), locs.map(l => convert(l, ctx, info)))
     case DefInvalid(info, arg) =>

--- a/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Converter.scala
@@ -193,7 +193,7 @@ private[chisel3] object Converter {
     case PropAssign(info, loc, exp) =>
       fir.PropAssign(convert(info), convert(loc, ctx, info), convert(exp, ctx, info))
     case PropertyAssert(info, cond, msg) =>
-      fir.PropertyAssert(convert(info), convert(cond, ctx, info), msg)
+      fir.PropertyAssert(convert(info), convert(cond, ctx, info), convert(msg, ctx, info))
     case Attach(info, locs) =>
       fir.Attach(convert(info), locs.map(l => convert(l, ctx, info)))
     case DefInvalid(info, arg) =>

--- a/core/src/main/scala/chisel3/internal/firrtl/IR.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/IR.scala
@@ -482,7 +482,7 @@ private[chisel3] object ir {
 
   case class Connect(sourceInfo: SourceInfo, loc: Arg, exp: Arg) extends Command
   case class PropAssign(sourceInfo: SourceInfo, loc: Node, exp: Arg) extends Command
-  case class PropertyAssert(sourceInfo: SourceInfo, condition: Arg, message: String) extends Command
+  case class PropertyAssert(sourceInfo: SourceInfo, condition: Arg, message: Arg) extends Command
   case class Attach(sourceInfo: SourceInfo, locs: Seq[Node]) extends Command
   case class Stop(id: stop.Stop, sourceInfo: SourceInfo, clock: Arg, ret: Int) extends Definition
 

--- a/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
+++ b/core/src/main/scala/chisel3/internal/firrtl/Serializer.scala
@@ -274,7 +274,7 @@ private[chisel3] object Serializer {
     case PropAssign(info, loc, exp) =>
       b ++= "propassign "; serialize(loc, ctx, info); b ++= ", "; serialize(exp, ctx, info); serialize(info)
     case PropertyAssert(info, cond, msg) =>
-      b ++= "propassert "; serialize(cond, ctx, info); b ++= ", "; b ++= fir.StringLit(msg).escape; serialize(info)
+      b ++= "propassert "; serialize(cond, ctx, info); b ++= ", "; serialize(msg, ctx, info); serialize(info)
     case Attach(info, locs) =>
       b ++= "attach ("
       serializeArgs(locs, ctx, info)

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -628,6 +628,13 @@ object PropertySequenceOps {
       def concat(lhs: Property[S[U]], rhs: Property[S[U]])(implicit sourceInfo: SourceInfo) =
         binOp(sourceInfo, fir.ListConcatOp, lhs, rhs)
     }
+
+  // Ensure that `++` is available for `Property[String]`.
+  implicit val stringOps: PropertySequenceOps[Property[String]] =
+    new PropertySequenceOps[Property[String]] {
+      def concat(lhs: Property[String], rhs: Property[String])(implicit sourceInfo: SourceInfo) =
+        binOp(sourceInfo, fir.StringConcatOp, lhs, rhs)
+    }
 }
 
 /** Typeclass for Property string operations.

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -348,13 +348,32 @@ sealed trait Property[T] extends Element { self =>
 
   /** Assert that this boolean property holds (only available for Property[Boolean])
     *
+    * This can be used to build up interpolated string messages as opposed to
+    * purely static messages.
+    *
+    * @param message a string property message
+    */
+  final def assert[U](message: Property[U])(
+    implicit evT: T =:= Boolean,
+    evU:          U =:= String,
+    sourceInfo:   SourceInfo
+  ): Unit = {
+    PropertyBooleanOps.assert(this.asInstanceOf[Property[Boolean]], message.asInstanceOf[Property[String]])
+  }
+
+  /** Assert that this boolean property holds (only available for Property[Boolean])
+    *
+    * This is a legacy method that supports a constant assertion message.  If
+    * you need an interpolated message, use the alternative assert that takes a
+    * `Property[String]` message.
+    *
     * @param message the assertion message
     */
   final def assert(message: String)(
-    implicit ev: T =:= Boolean,
-    sourceInfo:  SourceInfo
+    implicit evT: T =:= Boolean,
+    sourceInfo:   SourceInfo
   ): Unit = {
-    PropertyBooleanOps.assert(this.asInstanceOf[Property[Boolean]], message)
+    PropertyBooleanOps.assert(this.asInstanceOf[Property[Boolean]], Property[String](message))
   }
 
   /** Property equality comparison
@@ -685,12 +704,12 @@ object PropertyBooleanOps {
     * @param cond the boolean property condition
     * @param message the assertion message to display if the assertion fails
     */
-  def assert(cond: Property[Boolean], message: String)(implicit sourceInfo: SourceInfo): Unit =
+  def assert(cond: Property[Boolean], message: Property[String])(implicit sourceInfo: SourceInfo): Unit =
     Builder.referenceUserContainer match {
       case rm: RawModule =>
-        rm.addCommand(firrtl.ir.PropertyAssert(sourceInfo, cond.ref, message))
+        rm.addCommand(firrtl.ir.PropertyAssert(sourceInfo, cond.ref, message.ref))
       case cls: Class =>
-        cls.addCommand(firrtl.ir.PropertyAssert(sourceInfo, cond.ref, message))
+        cls.addCommand(firrtl.ir.PropertyAssert(sourceInfo, cond.ref, message.ref))
     }
 }
 

--- a/core/src/main/scala/chisel3/properties/Property.scala
+++ b/core/src/main/scala/chisel3/properties/Property.scala
@@ -711,6 +711,14 @@ object PropertyBooleanOps {
     * @param cond the boolean property condition
     * @param message the assertion message to display if the assertion fails
     */
+  def assert(cond: Property[Boolean], message: String)(implicit sourceInfo: SourceInfo): Unit =
+    assert(cond, Property[String](message))
+
+  /** Assert that a boolean property holds
+    *
+    * @param cond the boolean property condition
+    * @param message a string property to evaluate and display if the assertion fails
+    */
   def assert(cond: Property[Boolean], message: Property[String])(implicit sourceInfo: SourceInfo): Unit =
     Builder.referenceUserContainer match {
       case rm: RawModule =>

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -421,7 +421,12 @@ case class Connect(info: Info, loc: Expression, expr: Expression) extends Statem
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class PropAssign(info: Info, loc: Expression, expr: Expression) extends Statement with HasInfo with UseSerializer
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
-case class PropertyAssert(info: Info, condition: Expression, message: Expression)
+case class PropertyAssert(info: Info, condition: Expression, message: String)
+    extends Statement
+    with HasInfo
+    with UseSerializer
+@deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
+case class PropertyAssertExpression(info: Info, condition: Expression, message: Expression)
     extends Statement
     with HasInfo
     with UseSerializer

--- a/firrtl/src/main/scala/firrtl/ir/IR.scala
+++ b/firrtl/src/main/scala/firrtl/ir/IR.scala
@@ -421,7 +421,7 @@ case class Connect(info: Info, loc: Expression, expr: Expression) extends Statem
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
 case class PropAssign(info: Info, loc: Expression, expr: Expression) extends Statement with HasInfo with UseSerializer
 @deprecated("All APIs in package firrtl are deprecated.", "Chisel 7.0.0")
-case class PropertyAssert(info: Info, condition: Expression, message: String)
+case class PropertyAssert(info: Info, condition: Expression, message: Expression)
     extends Statement
     with HasInfo
     with UseSerializer

--- a/firrtl/src/main/scala/firrtl/ir/Serializer.scala
+++ b/firrtl/src/main/scala/firrtl/ir/Serializer.scala
@@ -275,6 +275,10 @@ object Serializer {
     case DefNode(info, name, value)  => b ++= "node "; b ++= legalize(name); b ++= " = "; s(value); s(info)
     case Connect(info, loc, expr)    => b ++= "connect "; s(loc); b ++= ", "; s(expr); s(info)
     case PropAssign(info, loc, expr) => b ++= "propassign "; s(loc); b ++= ", "; s(expr); s(info)
+    case PropertyAssert(info, condition, message) =>
+      b ++= "propassert "; s(condition); b ++= ", "; s(StringPropertyLiteral(StringLit(message))); s(info)
+    case PropertyAssertExpression(info, condition, message) =>
+      b ++= "propassert "; s(condition); b ++= ", "; s(message); s(info)
     case c: Conditionally => b ++= sIt(c).mkString
     case EmptyStmt => b ++= "skip"
     case bb: Block => b ++= sIt(bb).mkString

--- a/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
+++ b/firrtl/src/test/scala/firrtlTests/SerializerSpec.scala
@@ -265,6 +265,16 @@ class SerializerSpec extends AnyFlatSpec with Matchers {
     Serializer.serialize(probeRelease) should be("release(clock, cond, outProbe)")
   }
 
+  it should "serialize property assertion string messages as string property literals" in {
+    val assertion = PropertyAssert(NoInfo, Reference("condition"), "message")
+    Serializer.serialize(assertion) should be("propassert condition, String(\"message\")")
+  }
+
+  it should "serialize property assertion expression messages" in {
+    val assertion = PropertyAssertExpression(NoInfo, Reference("condition"), Reference("message"))
+    Serializer.serialize(assertion) should be("propassert condition, message")
+  }
+
   it should "support emitting domain defines" in {
     val define = DomainDefine(NoInfo, Reference("foo"), Reference("bar"))
     Serializer.serialize(define) should be("domain_define foo = bar")

--- a/release.mill
+++ b/release.mill
@@ -46,6 +46,7 @@ trait Unipublish extends ChiselCrossModule with ChiselPublishModule with Mima {
   override def mimaBinaryIssueFilters = super.mimaBinaryIssueFilters() ++ Seq(
     // chisel3.internal.firrtl.ir is package private
     ProblemFilter.exclude[DirectMissingMethodProblem]("chisel3.internal.firrtl.ir*"),
+    ProblemFilter.exclude[IncompatibleMethTypeProblem]("chisel3.internal.firrtl.ir*"),
     ProblemFilter.exclude[IncompatibleResultTypeProblem]("chisel3.internal.firrtl.ir*"),
     ProblemFilter.exclude[MissingTypesProblem]("chisel3.internal.firrtl.ir*"),
     ProblemFilter.exclude[MissingClassProblem]("chisel3.internal.firrtl.ir*"),

--- a/src/test/scala-2/chiselTests/properties/PropertySpec.scala
+++ b/src/test/scala-2/chiselTests/properties/PropertySpec.scala
@@ -950,8 +950,8 @@ class PropertySpec extends AnyFlatSpec with Matchers with FileCheck {
 
   it should "not support expressions involving Property types that don't provide a typeclass instance" in {
     assertTypeError("""
-      val a = Property[String]()
-      val b = Property[String]()
+      val a = Property[Int]()
+      val b = Property[Int]()
       a ++ b
     """)
   }

--- a/src/test/scala/chiselTests/properties/PropertyAssertSpec.scala
+++ b/src/test/scala/chiselTests/properties/PropertyAssertSpec.scala
@@ -17,11 +17,15 @@ class PropertyAssertSpec extends AnyFlatSpec with Matchers with FileCheck {
     ChiselStage
       .emitCHIRRTL(new RawModule {
         val prop = IO(Input(Property[Boolean]()))
+        val message = IO(Input(Property[String]()))
         prop.assert("must be true")
+        prop.assert(message)
       })
       .fileCheck() {
         """|CHECK: input prop : Bool
-           |CHECK: propassert prop, "must be true"
+           |CHECK: input message : String
+           |CHECK: propassert prop, String("must be true")
+           |CHECK: propassert prop, message
            |""".stripMargin
       }
   }
@@ -32,21 +36,28 @@ class PropertyAssertSpec extends AnyFlatSpec with Matchers with FileCheck {
         Definition(new Class {
           override def desiredName = "TestClass"
           val prop = IO(Input(Property[Boolean]()))
+          val message = IO(Input(Property[String]()))
           prop.assert("must be true")
+          prop.assert(message)
         })
       })
       .fileCheck() {
         """|CHECK: class TestClass :
            |CHECK: input prop : Bool
-           |CHECK: propassert prop, "must be true"
+           |CHECK: input message : String
+           |CHECK: propassert prop, String("must be true")
+           |CHECK: propassert prop, message
            |""".stripMargin
       }
   }
 
   it should "compile to SystemVerilog" in {
-    ChiselStage.emitSystemVerilog(new RawModule {
+    class Foo extends RawModule {
       val prop = IO(Input(Property[Boolean]()))
+      val username = IO(Input(Property[String]()))
       prop.assert("must be true")
-    })
+      prop.assert(Property("Hello ") ++ username ++ Property("!"))
+    }
+    ChiselStage.emitSystemVerilog(new Foo)
   }
 }


### PR DESCRIPTION
Add an alternative property assertion API which takes a `Property[String]`
message.  This builds towards allowing for string interpolation in
property assertion messages.  Due to the limited availability of property
operations, this is relatively limited in power and very verbose.  More
operations (e.g., number to string formatting) and better ergonomics are
planned.

Assisted-by: pi.dev:gpt-5.6-luna


#### Release Notes

- Add a property assertion API which takes a property string message (as opposed
  to a Scala string) to allow for more dynamic assertion messages.  The existing
  Scala string assert message API is preserved.
