### PR TITLE
[core] Improve Clock Domain assertion messages

### DIFF
--- a/core/src/main/scala/chisel3/domains/ClockDomain.scala
+++ b/core/src/main/scala/chisel3/domains/ClockDomain.scala
@@ -44,6 +44,26 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
       */
     object Rational extends Type
 
+    /** Return a boilerplate prelude string for assertions involving two domains.
+      */
+    private def assertPrelude(A: domain.Type, B: domain.Type): Property[String] = {
+      val A_name = A.field.name.asInstanceOf[Property[String]]
+      val A_source = A.field.source.asInstanceOf[Property[String]]
+      val A_relationship = A.field.relationship.asInstanceOf[Property[String]]
+      val B_name = B.field.name.asInstanceOf[Property[String]]
+      val B_source = B.field.source.asInstanceOf[Property[String]]
+      val B_relationship = B.field.relationship.asInstanceOf[Property[String]]
+      Property("Clock domain '") ++ A_name ++ Property(
+        "' (with relationship '"
+      ) ++ A_relationship ++ Property("' to clock domain '") ++ A_source ++ Property(
+        "') and clock domain '"
+      ) ++ B_name ++ Property(
+        "' (with relationship '"
+      ) ++ B_relationship ++ Property("' to clock domain '") ++ B_source ++ Property(
+        "')"
+      )
+    }
+
     /** Generate an assertion that two domains have a synchronous relationship.
       *
       * This is a building block of writing safe clock domain synchronizers.
@@ -58,7 +78,11 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
       val B_relationship = B.field.relationship.asInstanceOf[Property[String]]
       val sync = Property(ClockDomain.Relationship.Synchronous.toString)
       (A_source === B_source && A_relationship === sync && B_relationship === sync)
-        .assert("input and output must have the same clock source and be synchronous")
+        .assert(
+          assertPrelude(A, B) ++ Property(
+            " are not synchronously related to each other.  They must have the same clock domain source and a synchronous relationship."
+          )
+        )
     }
 
     /** Generate an assertion that two domains have a rational or synchronous relationship.
@@ -76,7 +100,11 @@ object ClockDomain extends Domain()(sourceInfo = UnlocatableSourceInfo) {
       val sync = Property(ClockDomain.Relationship.Synchronous.toString)
       val rational = Property(ClockDomain.Relationship.Rational.toString)
       (A_source === B_source && (A_relationship === sync || A_relationship === rational) && (B_relationship === sync || B_relationship === rational))
-        .assert("input and output must have the same clock source and be synchronous or rational")
+        .assert(
+          assertPrelude(A, B) ++ Property(
+            " are not synchronously or rationally related to each other.  They must have the same clock domain source and a synchronous or rational relationship."
+          )
+        )
     }
 
   }

--- a/src/test/scala/chiselTests/DomainSpec.scala
+++ b/src/test/scala/chiselTests/DomainSpec.scala
@@ -529,4 +529,45 @@ class DomainSpec extends AnyFlatSpec with Matchers with FileCheck {
       }
   }
 
+  behavior of "Clock Domains"
+
+  they should "check that two domains are synchronous" in {
+
+    class Foo extends RawModule {
+      val A = ClockDomain("A")
+      val B = ClockDomain.rational(A, "_4to3")
+      ClockDomain.Relationship.assertSynchronous(A, B)
+    }
+
+    intercept[Exception] {
+      ChiselStage.emitSystemVerilog(
+        new Foo,
+        firtoolOpts =
+          Array("-default-layer-specialization=disable", "-domain-mode=infer-all", "-output-final-mlir", "/dev/null")
+      )
+    }.getMessage should include(
+      "Clock domain 'A' (with relationship 'synchronous' to clock domain 'A') and clock domain 'A_4to3' (with relationship 'rational' to clock domain 'A') are not synchronously related to each other.  They must have the same clock domain source and a synchronous relationship."
+    )
+
+  }
+
+  they should "check that two domains are rational" in {
+
+    class Foo extends RawModule {
+      val A = ClockDomain("A")
+      val B = ClockDomain("B")
+      ClockDomain.Relationship.assertRational(A, B)
+    }
+
+    intercept[Exception] {
+      ChiselStage.emitSystemVerilog(
+        new Foo,
+        firtoolOpts =
+          Array("-default-layer-specialization=disable", "-domain-mode=infer-all", "-output-final-mlir", "/dev/null")
+      )
+    }.getMessage should include(
+      "Clock domain 'A' (with relationship 'synchronous' to clock domain 'A') and clock domain 'B' (with relationship 'synchronous' to clock domain 'B') are not synchronously or rationally related to each other.  They must have the same clock domain source and a synchronous or rational relationship."
+    )
+  }
+
 }


### PR DESCRIPTION
Using the new property assert that takes a property string message, build
up a greatly improved assertion message when a rational or synchronous
assertion check fails.  This is intended to assists with debugging when
clock domains are misconfigured during compilation or when running
`domaintool`.

#### Release Notes

- Improve the Clock Domain property assertion messages.
