### PR TITLE
Always print stderr from firtool in CIRCT phase

### DIFF
--- a/src/main/scala/circt/stage/phases/CIRCT.scala
+++ b/src/main/scala/circt/stage/phases/CIRCT.scala
@@ -282,6 +282,7 @@ class CIRCT extends Phase {
     val result = stdoutStream.toString
     logger.info(result)
     val errors = stderrStream.toString
+    if (errors.nonEmpty) logger.warn(errors)
     if (exitValue != 0)
       throw new Exceptions.FirtoolNonZeroExitCode(binary, exitValue, result, errors)
     val finalAnnotations = if (split) {


### PR DESCRIPTION
### Summary

Always print the stderr from firtool in CIRCT phase

### Release Notes

As firtool now warns on implicit truncation, this is likely to be extremely noisy for any users who use `ChiselStage` to invoke firtool.

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: OpenCode (GPT-5.6 Luna)
- Merge strategy (defaults to squash): squash
- Milestone: 7.x

