### PR TITLE
[build] Ignore generated website API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target/
 *.v
 test_run_dir
 build/
+website/static/api/
 *~
 \#*\#
 .\#*


### PR DESCRIPTION
### Summary

Ignore generated website API documentation under `website/static/api/` so local documentation builds do not leave untracked files.


### Development notes
- AI tool(s) used: OpenCode (GPT-5.6 Terra)
- Merge strategy (defaults to squash): squash