### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/build-scala-cli-example.yml
+++ b/.github/workflows/build-scala-cli-example.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Need to fetch full history for deriving version
         with:
           fetch-depth: 0
@@ -32,9 +32,9 @@ jobs:
           dir=$(dirname $(which firtool))
           echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
       - name: Cache Scala-CLI
-        uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
       - name: Setup Scala-CLI
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@8db5313925605c20e292348c1749e80dac7eed0f # v1.16.0
         with:
           jvm: adoptium:17
       - name: Generate Chisel Scala CLI Example

--- a/.github/workflows/build-scala-cli-example.yml
+++ b/.github/workflows/build-scala-cli-example.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         # Need to fetch full history for deriving version
         with:
           fetch-depth: 0
@@ -32,9 +32,9 @@ jobs:
           dir=$(dirname $(which firtool))
           echo "CHISEL_FIRTOOL_PATH=$dir" >> "$GITHUB_ENV"
       - name: Cache Scala-CLI
-        uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
       - name: Setup Scala-CLI
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@30de070d5e5cf2ed93c79009c9a3b69e7bead234 # v1.17.0
         with:
           jvm: adoptium:17
       - name: Generate Chisel Scala CLI Example

--- a/.github/workflows/build-scala-cli-example.yml
+++ b/.github/workflows/build-scala-cli-example.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Scala-CLI
         uses: VirtusLab/scala-cli-setup@30de070d5e5cf2ed93c79009c9a3b69e7bead234 # v1.17.0
         with:
-          jvm: adoptium:17
+          jvm: temurin:17
       - name: Generate Chisel Scala CLI Example
         shell: bash
         run: |

--- a/.github/workflows/build-slang/action.yml
+++ b/.github/workflows/build-slang/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - id: cache-slang
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/slang
         key: slang-${{ runner.os }}-${{ inputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Cache Scala
-        uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@8db5313925605c20e292348c1749e80dac7eed0f # v1.16.0
         with:
           jvm: temurin:17
       - name: Publish
@@ -108,7 +108,7 @@ jobs:
       - name: Untar built website
         run: tar zxf website.tar.gz
       - name: Deploy Website to GitHub Pages (From Main Branch)
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Cache Scala
-        uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@30de070d5e5cf2ed93c79009c9a3b69e7bead234 # v1.17.0
         with:
           jvm: temurin:17
       - name: Publish
@@ -108,7 +108,7 @@ jobs:
       - name: Untar built website
         run: tar zxf website.tar.gz
       - name: Deploy Website to GitHub Pages (From Main Branch)
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build

--- a/.github/workflows/install-espresso/action.yml
+++ b/.github/workflows/install-espresso/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - id: cache-espresso
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: /usr/local/bin/espresso
         key: espresso-${{ runner.os }}-${{ inputs.version }}

--- a/.github/workflows/install-filecheck/action.yml
+++ b/.github/workflows/install-filecheck/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - id: cache-filecheck
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: FileCheck
         key: filecheck-${{ runner.os }}-${{ inputs.version }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Build Release Notes
         id: release-notes
-        uses: mikepenz/release-changelog-builder-action@bcae7115752d4ed746ff92feb666574428a79415 # v6.2.1
+        uses: mikepenz/release-changelog-builder-action@c9bcd8238b6f41e05561348339429d360b1c0247 # v6.2.3
         with:
           configuration: .github/workflows/config/release-notes.json
           failOnError: true
@@ -45,7 +45,7 @@ jobs:
         run: echo "$CHANGELOG" >> $GITHUB_STEP_SUMMARY
       - name: Upload Release Notes (on release)
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body: ${{ steps.release-notes.outputs.changelog }}
       - name: Error on uncategorized PRs

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Build Release Notes
         id: release-notes
-        uses: mikepenz/release-changelog-builder-action@bcae7115752d4ed746ff92feb666574428a79415 # v6.2.1
+        uses: mikepenz/release-changelog-builder-action@cb021f9b36a51a7c6f18e4679b6fa2cb77a1260c # v6.3.0
         with:
           configuration: .github/workflows/config/release-notes.json
           failOnError: true
@@ -45,7 +45,7 @@ jobs:
         run: echo "$CHANGELOG" >> $GITHUB_STEP_SUMMARY
       - name: Upload Release Notes (on release)
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           body: ${{ steps.release-notes.outputs.changelog }}
       - name: Error on uncategorized PRs

--- a/.github/workflows/scala-cli-example.yml
+++ b/.github/workflows/scala-cli-example.yml
@@ -29,6 +29,6 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload To Release Page
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: chisel-example.scala

--- a/.github/workflows/scala-cli-example.yml
+++ b/.github/workflows/scala-cli-example.yml
@@ -29,6 +29,6 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload To Release Page
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           files: chisel-example.scala

--- a/.github/workflows/setup-oss-cad-suite/action.yml
+++ b/.github/workflows/setup-oss-cad-suite/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - id: cache-oss-cad-suite
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: oss-cad-suite
         key: oss-cad-suite-${{ runner.os }}-${{ inputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
@@ -92,11 +92,11 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@8db5313925605c20e292348c1749e80dac7eed0f # v1.16.0
         with:
           jvm: adoptium:17
       - name: Install FileCheck
@@ -138,7 +138,7 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
@@ -155,7 +155,7 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
@@ -174,7 +174,7 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
@@ -209,7 +209,7 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
@@ -243,7 +243,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
@@ -260,7 +260,7 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           # Need full history to correctly determine SNAPSHOT version
@@ -268,13 +268,13 @@ jobs:
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Cache Scala
-        uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@8db5313925605c20e292348c1749e80dac7eed0f # v1.16.0
         with:
           jvm: adoptium:17
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Install CIRCT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
@@ -58,7 +58,7 @@ jobs:
           sudo apt install llvm-19-tools
           echo "/usr/lib/llvm-19/bin" >> $GITHUB_PATH
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -92,11 +92,11 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@30de070d5e5cf2ed93c79009c9a3b69e7bead234 # v1.17.0
         with:
           jvm: adoptium:17
       - name: Install FileCheck
@@ -138,11 +138,11 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -155,11 +155,11 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -174,7 +174,7 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
@@ -182,7 +182,7 @@ jobs:
       - name: Install Espresso
         uses: ./.github/workflows/install-espresso
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -209,11 +209,11 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -225,13 +225,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -243,11 +243,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'adopt'
           java-version: ${{ inputs.jvm }}
@@ -260,7 +260,7 @@ jobs:
     if: ${{ inputs.scala == '2.13' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
           # Need full history to correctly determine SNAPSHOT version
@@ -268,13 +268,13 @@ jobs:
       - name: Install Tabby OSS Cad Suite
         uses: ./.github/workflows/setup-oss-cad-suite
       - name: Cache Scala
-        uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
       - name: Setup Scala
-        uses: VirtusLab/scala-cli-setup@14e5155ee896fcc200f66f92c9eb7a3dd9b58e0d # v1.12.5
+        uses: VirtusLab/scala-cli-setup@30de070d5e5cf2ed93c79009c9a3b69e7bead234 # v1.17.0
         with:
           jvm: adoptium:17
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Install CIRCT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v6
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ inputs.jvm }}
       - name: Install CIRCT
         id: install-circt
@@ -144,7 +144,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v6
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ inputs.jvm }}
       - name: Check Binary Compatibility with MiMa
         run: ./mill unipublish[${{ inputs.scala}}].mimaReportBinaryIssues
@@ -161,7 +161,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v6
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ inputs.jvm }}
       - name: Check Build Script Formatting
         run: ./mill --meta-level 1 mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll sources
@@ -184,7 +184,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v6
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ inputs.jvm }}
       - name: Install CIRCT
         id: install-circt
@@ -215,7 +215,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v6
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ inputs.jvm }}
       - name: JMH
         run: ./mill benchmark.runJmh
@@ -233,7 +233,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v6
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ inputs.jvm }}
       - name: Compile
         run: ./mill stdlib.cross[${{ matrix.scala }}].compile
@@ -249,7 +249,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v6
         with:
-          distribution: 'adopt'
+          distribution: temurin
           java-version: ${{ inputs.jvm }}
       - name: Compile
         run: ./mill unipublish[${{ matrix.scala }}].publishLocal


### PR DESCRIPTION


### Summary

Mostly trying to bump Node since we're getting deprecation warnings now.

Update Github Actions to:

- VirtusLab/scala-cli-setup: v1.12.5 => [v1.17.0](https://github.com/VirtusLab/scala-cli-setup/releases/tag/v1.17.0)
- actions/cache: v5 => [v6](https://github.com/actions/cache/releases/tag/v6.1.0)
- actions/checkout: v6 => [v7](https://github.com/actions/checkout/releases/tag/v7.0.1)
- actions/setup-java: v5 => [v6](https://github.com/actions/setup-java/releases/tag/v6.0.1)
- actions/setup-node: v6 => [v7](https://github.com/actions/setup-node/releases/tag/v7.0.0)
- coursier/cache-action: v8.1.0 => [v8.1.1](https://github.com/coursier/cache-action/releases/tag/v8.1.1)
- mikepenz/release-changelog-builder-action: v6.2.1 => [v6.3.0](https://github.com/mikepenz/release-changelog-builder-action/releases/tag/v6.3.0)
- peaceiris/actions-gh-pages: v4.0.0 => [v4.1.0](https://github.com/peaceiris/actions-gh-pages/releases/tag/v4.1.0)
- softprops/action-gh-release: v3.0.0 => [v3.0.3](https://github.com/softprops/action-gh-release/releases/tag/v3.0.3)

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->


### Development notes
- AI tool(s) used: No AI used this time but used the script previously generated by AI in https://github.com/chipsalliance/chisel/pull/5269
- Merge strategy (defaults to squash): squash
