### PR TITLE
lit: Drop argument to ShTest, hard error in LLVM 24+.

### DIFF
--- a/lit/tests/ErrorCarat.sc
+++ b/lit/tests/ErrorCarat.sc
@@ -1,4 +1,4 @@
-// RUN: JDK_JAVA_OPTIONS='-Dchisel.project.root=' not scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION --scala-option="-Xplugin:%SCALAPLUGINJARS" %s | FileCheck %s
+// RUN: env JDK_JAVA_OPTIONS='-Dchisel.project.root=' not scala-cli --server=false --java-home=%JAVAHOME --extra-jars=%RUNCLASSPATH --scala-version=%SCALAVERSION --scala-option="-Xplugin:%SCALAPLUGINJARS" %s | FileCheck %s
 // SPDX-License-Identifier: Apache-2.0
 
 import chisel3._

--- a/lit/tests/lit.cfg.py
+++ b/lit/tests/lit.cfg.py
@@ -4,7 +4,7 @@ from lit.llvm import llvm_config
 from lit.llvm.subst import ToolSubst
 
 config.name = 'CHISEL'
-config.test_format = lit.formats.ShTest(True)
+config.test_format = lit.formats.ShTest()
 config.suffixes = [".sc"]
 config.substitutions = [
     ('%SCALAVERSION', config.scala_version),


### PR DESCRIPTION
Controls use of external shell, use internal shell now.

### Summary

Fix build against latest CIRCT Nightly, see: https://github.com/chipsalliance/chisel/actions/runs/33083862476/job/98559579638#step:9:699 :

```
[451] lit: /home/runner/.local/lib/python3.12/site-packages/lit/TestingConfig.py:164: fatal: unable to parse config file '/home/runner/work/chisel/chisel/lit/tests/lit.cfg.py', traceback: Traceback (most recent call last):
[451]   File "/home/runner/.local/lib/python3.12/site-packages/lit/TestingConfig.py", line 153, in load_from_path
[451]     exec(compile(data, path, "exec"), cfg_globals, None)
[451]   File "/home/runner/work/chisel/chisel/lit/tests/lit.cfg.py", line 7, in <module>
[451]     config.test_format = lit.formats.ShTest(True)
[451]                          ^^^^^^^^^^^^^^^^^^^^^^^^
[451]   File "/home/runner/.local/lib/python3.12/site-packages/lit/formats/shtest.py", line 27, in __init__
[451]     raise ValueError(
[451] ValueError: execute_external=True is deprected as of LLVM-23 and the option will be removed in LLVM-24. Please move to using the internal shell (execute_external=False). If you still need to force external execution to allow time for migration, set force_execute_external=True
```

This change is safe on LLVM 23, so sending this to main.  This moves to use the internal shell.

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

<!--
### Development notes
- AI tool(s) used: 
- Merge strategy (defaults to squash): 
- Milestone: 
-->
