### PR TITLE
[scala3] Cross-compiling the compiler plugin for Scala 3.9.0

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -41,7 +41,8 @@ object v extends Module {
     val scala213: Seq[String] = 0.to(18).map("2.13." + _)
     val scala33:  Seq[String] = 7.to(8).map("3.3." + _)
     val scala38:  Seq[String] = 0.to(4).map("3.8." + _)
-    scala213 ++ scala33 ++ scala38
+    val scala39:  Seq[String] = 0.to(0).map("3.9." + _)
+    scala213 ++ scala33 ++ scala38 ++ scala39
   }
 
   val scalaCrossVersions = Seq("2.13", "3")


### PR DESCRIPTION
### Summary

Chisel users using Scala 3 will now be able to use 3.9.0

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->
