### PR TITLE
Fix @public constructor vals in Scala 2

### DIFF
--- a/macros/src/main/scala-2/chisel3/internal/InstantiableMacro.scala
+++ b/macros/src/main/scala-2/chisel3/internal/InstantiableMacro.scala
@@ -10,9 +10,15 @@ private[chisel3] object instantiableMacro {
 
   def impl(c: whitebox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
-    def processBody(stats: Seq[Tree]): (Seq[Tree], Iterable[Tree]) = {
+    def processBody(stats: Seq[Tree], paramss: List[List[ValDef]]): (Seq[Tree], Iterable[Tree]) = {
       val extensions = scala.collection.mutable.ArrayBuffer.empty[Tree]
       extensions += q"implicit val mg: chisel3.internal.MacroGenerated = new chisel3.internal.MacroGenerated {}"
+      paramss.flatten.foreach { param =>
+        if (param.mods.hasFlag(c.universe.Flag.PARAMACCESSOR) &&
+            param.mods.annotations.toString.contains("new public()")) {
+          extensions += atPos(param.pos)(q"def ${param.name} = ___module._lookup(_.${param.name})")
+        }
+      }
       // Note the triple `_` prefixing `module` is to avoid conflicts if a user marks a 'val module'
       //  with @public; in this case, the lookup code is ambiguous between the generated `def module`
       //  function and the argument to the generated implicit class.
@@ -60,7 +66,7 @@ private[chisel3] object instantiableMacro {
         case q"$mods class $tpname[..$tparams] $ctorMods(...$paramss) extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =>
           val defname = TypeName(tpname.toString + c.freshName())
           val instname = TypeName(tpname.toString + c.freshName())
-          val (newStats, extensions) = processBody(stats)
+          val (newStats, extensions) = processBody(stats, paramss)
           val argTParams = tparams.map(_.name)
           val allParents =
             if (hasIsInstantiable(parents)) parents
@@ -76,7 +82,7 @@ private[chisel3] object instantiableMacro {
         case q"$mods trait $tpname[..$tparams] extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =>
           val defname = TypeName(tpname.toString + c.freshName())
           val instname = TypeName(tpname.toString + c.freshName())
-          val (newStats, extensions) = processBody(stats)
+          val (newStats, extensions) = processBody(stats, Nil)
           val argTParams = tparams.map(_.name)
           val allParents =
             if (hasIsInstantiable(parents)) parents

--- a/macros/src/main/scala-2/chisel3/internal/InstantiableMacro.scala
+++ b/macros/src/main/scala-2/chisel3/internal/InstantiableMacro.scala
@@ -14,8 +14,10 @@ private[chisel3] object instantiableMacro {
       val extensions = scala.collection.mutable.ArrayBuffer.empty[Tree]
       extensions += q"implicit val mg: chisel3.internal.MacroGenerated = new chisel3.internal.MacroGenerated {}"
       paramss.flatten.foreach { param =>
-        if (param.mods.hasFlag(c.universe.Flag.PARAMACCESSOR) &&
-            param.mods.annotations.toString.contains("new public()")) {
+        if (
+          param.mods.hasFlag(c.universe.Flag.PARAMACCESSOR) &&
+          param.mods.annotations.toString.contains("new public()")
+        ) {
           extensions += atPos(param.pos)(q"def ${param.name} = ___module._lookup(_.${param.name})")
         }
       }

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -550,14 +550,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         )
     }
     it("(3.k): should expose public constructor vals") {
-      """
       @instantiable
       class Foo(@public val x: Int, @public val y: Int = 0) extends Module
       class Top extends Module {
         val definition = Definition(new Foo(1))
-        definition.x
+        definition.x should be(1)
+        definition.y should be(0)
+        val instance = Instance(definition)
+        instance.x should be(1)
+        instance.y should be(0)
       }
-      """ should compile
+      ChiselStage.emitCHIRRTL(new Top) should include("module Foo :")
     }
     it("(3.l): should work on unimplemented vals in abstract classes/traits") {
       class Top() extends Module {

--- a/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
+++ b/src/test/scala/chiselTests/experimental/hierarchy/DefinitionSpec.scala
@@ -549,7 +549,17 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.k): should work on unimplemented vals in abstract classes/traits") {
+    it("(3.k): should expose public constructor vals") {
+      """
+      @instantiable
+      class Foo(@public val x: Int, @public val y: Int = 0) extends Module
+      class Top extends Module {
+        val definition = Definition(new Foo(1))
+        definition.x
+      }
+      """ should compile
+    }
+    it("(3.l): should work on unimplemented vals in abstract classes/traits") {
       class Top() extends Module {
         val i = Definition(new ConcreteHasBlah())
         def f(d: Definition[HasBlah]): Unit = {
@@ -566,7 +576,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.l): should work on eithers") {
+    it("(3.m): should work on eithers") {
       class Top() extends Module {
         val i = Definition(new HasEither())
         i.x.map(x => mark(x, "xright")).left.map(x => mark(x, "xleft"))
@@ -584,7 +594,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.m): should work on tuple2") {
+    it("(3.n): should work on tuple2") {
       class Top() extends Module {
         val i = Definition(new HasTuple2())
         mark(i.xy._1, "x")
@@ -602,7 +612,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.n): should work on Mems/SyncReadMems") {
+    it("(3.o): should work on Mems/SyncReadMems") {
       class Top() extends Module {
         val i = Definition(new HasMems())
         mark(i.mem, "Mem")
@@ -620,7 +630,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.o): should not create memory ports") {
+    it("(3.p): should not create memory ports") {
       class Top() extends Module {
         val i = Definition(new HasMems())
         i.mem(0) := 100.U // should be illegal!
@@ -631,7 +641,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
         "Cannot create a memory port in a different module (Top) than where the memory is (HasMems)."
       )
     }
-    it("(3.p): should work on HasTarget") {
+    it("(3.q): should work on HasTarget") {
       class Top() extends Module {
         val i = Definition(new HasHasTarget)
         mark(i.x, "x")
@@ -645,7 +655,7 @@ class DefinitionSpec extends AnyFunSpec with Matchers with FileCheck {
              |""".stripMargin
         )
     }
-    it("(3.q): should work on Tuple5 with a Module in it") {
+    it("(3.r): should work on Tuple5 with a Module in it") {
       class Top() extends Module {
         val defn = Definition(new HasTuple5())
         val (3, w: UInt, "hi", inst: Instance[AddOne], l) = defn.tup


### PR DESCRIPTION
### Summary

Assisted by gpt-5.6-luna.

This

```scala
@instantiable
class MyModule(@public val params: MyParams) extends Module {
  // ...
}
```

does not create accessors for `params` in Scala 2 and this fails to compile as a result

```scala
val m = Instance(new MyModule(MyParams()))
m.params
```

with

```
value selectDynamic is not a member of
chisel3.experimental.hierarchy.core.Definition[MyModule]
```

<!--
Describe what this PR changes and why it's needed.
If necessary, describe any future work this change adds or any negative effects of this change (tech debt, code smells).
-->

### Release Notes
<!--
The title of your PR will be included in the release notes in addition to any text in this section.
Please be sure to elaborate on any API changes or deprecations and any impact on backend code generation.
-->

- Fix `@public` constructor `val`s in Scala 2.

<!--
Uncomment the following optional section if you need to add more details. Delete the fields you don't need.

If you used AI on this PR, please see our AI Tool Use Policy: https://www.chisel-lang.org/docs/developers/ai-tool-policy
-->

<!--
### Development notes
- AI tool(s) used:
- Merge strategy (defaults to squash):
- Milestone:
-->
