### PR TITLE
[scala3] Fix return type of .pad

### DIFF
--- a/core/src/main/scala-3/chisel3/BitsIntf.scala
+++ b/core/src/main/scala-3/chisel3/BitsIntf.scala
@@ -189,6 +189,8 @@ private[chisel3] trait BitsIntf extends ToBoolable { self: Bits =>
 
 private[chisel3] trait UIntIntf { self: UInt =>
 
+  override def pad(that: Int)(using SourceInfo): UInt = _padImpl(that)
+
   // TODO: refactor to share documentation with Num or add independent scaladoc
   /** Unary negation (constant width)
     *
@@ -388,6 +390,8 @@ private[chisel3] trait UIntIntf { self: UInt =>
 }
 
 private[chisel3] trait SIntIntf { self: SInt =>
+
+  override def pad(that: Int)(using SourceInfo): SInt = _padImpl(that)
 
   /** Unary negation (constant width)
     *

--- a/src/test/scala/chiselTests/SIntOps.scala
+++ b/src/test/scala/chiselTests/SIntOps.scala
@@ -257,6 +257,9 @@ class SIntOpsSpec extends AnyPropSpec with Matchers with ShiftRightWidthBehavior
   }
 
   property("Calling .pad on a SInt literal should maintain the literal value") {
+    // Check that pad preserves the concrete return type for SInt.
+    val paddedLiteral: SInt = (-5).S.pad(6)
+
     -5.S.getWidth should be(4)
     -5.S.pad(2).litValue should be(-5)
     -5.S.pad(2).getWidth should be(4)

--- a/src/test/scala/chiselTests/UIntOps.scala
+++ b/src/test/scala/chiselTests/UIntOps.scala
@@ -642,6 +642,10 @@ class UIntOpsSpec extends AnyPropSpec with Matchers with LogUtils with ShiftRigh
   }
 
   property("Calling .pad on a UInt literl should maintain the literal value") {
+    // Check that pad preserves the concrete return type for UInt and Bits.
+    val paddedLiteral: UInt = 5.U.pad(4)
+    val paddedBits:    Bits = (5.U: Bits).pad(4)
+
     5.U.getWidth should be(3)
     5.U.pad(2).litValue should be(5)
     5.U.pad(2).getWidth should be(3)


### PR DESCRIPTION
### Summary

<!--
Describe what this PR changes and why it's needed.
If necessary, describe any future work this change adds or any negative effects of this change (tech debt, code smells).
-->

### Release Notes

Previously, in Scala 3, the return type of `.pad` was `Bits` for all subtypes. Now calling `pad` on a `UInt` returns a `UInt` and on an `SInt` returns an `SInt`. This is now consistent with Scala 2.

### Development notes
- AI tool(s) used: GPT-5.6 Luna
- Merge strategy (defaults to squash): squash

